### PR TITLE
Support mount propagation for shared rootfs setup

### DIFF
--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -564,9 +564,11 @@ pub trait Inode: Any + FileOps + Send + Sync {
             // Read/write DACs are always overridable.
             perm -= Permission::MAY_READ | Permission::MAY_WRITE;
 
-            // Executable DACs are overridable when there is at least one exec bit set.
+            // Directory search permissions are overridable. For non-directory
+            // executable files, Linux still requires at least one exec bit.
             if perm.may_exec() {
-                if mode.is_owner_executable()
+                if self.type_() == InodeType::Dir
+                    || mode.is_owner_executable()
                     || mode.is_group_executable()
                     || mode.is_other_executable()
                 {

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -433,6 +433,7 @@ impl Path {
             recursive,
             MountNsFileCopying::Copy,
         )?;
+        new_mount.set_bind_master(&self.mount, recursive);
         new_mount.graft_mount_tree(dst_path);
         Ok(())
     }

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -42,7 +42,15 @@ pub enum MountPropType {
     /// do not propagate to or from the private mounts.
     #[default]
     Private,
-    // TODO: Implement other propagation types.
+    /// A shared mount propagates mount and unmount events to its peer group.
+    Shared,
+    /// A slave mount receives propagation from its master but does not
+    /// propagate events back. Asterinas currently tracks the master only for
+    /// bind clones and does not support full peer groups yet.
+    Slave,
+    /// An unbindable mount cannot be used as a source for bind mounts.
+    Unbindable,
+    // TODO: Implement peer groups, master/slave links, and unbindable checks.
 }
 
 static ID_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();
@@ -194,6 +202,8 @@ pub struct Mount {
     source: Option<String>,
     /// The parent mount node.
     parent: RwLock<Option<Weak<Mount>>>,
+    /// The source mount from which this mount was cloned by a bind mount.
+    bind_master: RwLock<Option<Weak<Mount>>>,
     /// Child mount nodes which are mounted on one dentry of self.
     pub(super) children: RwLock<HashMap<DentryKey, Arc<Self>>>,
     /// The associated mount namespace.
@@ -251,6 +261,7 @@ impl Mount {
             id,
             root_dentry: Dentry::new_root(fs.root_inode()),
             mountpoint: RwLock::new(None),
+            bind_master: RwLock::new(None),
             fs,
             source,
             parent: RwLock::new(parent_mount),
@@ -306,6 +317,7 @@ impl Mount {
         )?;
         self.children.write().insert(key, child_mount.clone());
         child_mount.set_mountpoint(mountpoint);
+        child_mount.propagate_graft_to_bind_clones(&Path::new(self.this(), mountpoint.clone()));
 
         Ok(child_mount)
     }
@@ -337,17 +349,20 @@ impl Mount {
         new_ns: &Weak<MountNamespace>,
     ) -> Result<Arc<Self>> {
         let id = alloc_mount_id()?;
+        let bind_master = self.bind_master.read().clone();
+        let propagation = *self.propagation.read();
 
         Ok(Arc::new_cyclic(|weak_self| Self {
             id,
             root_dentry: root_dentry.clone(),
             mountpoint: RwLock::new(None),
+            bind_master: RwLock::new(bind_master.clone()),
             fs: self.fs.clone(),
             source: self.source.clone(),
             parent: RwLock::new(None),
             children: RwLock::new(HashMap::new()),
             mnt_ns: new_ns.clone(),
-            propagation: RwLock::new(MountPropType::default()),
+            propagation: RwLock::new(propagation),
             flags: AtomicPerMountFlags::new(self.flags.load(Ordering::Relaxed)),
             this: weak_self.clone(),
         }))
@@ -411,6 +426,20 @@ impl Mount {
         Ok(new_root_mount)
     }
 
+    /// Records the mount whose events should propagate into this bind clone.
+    pub(super) fn set_bind_master(&self, master: &Arc<Mount>, recursive: bool) {
+        *self.bind_master.write() = Some(Arc::downgrade(master));
+        if !recursive {
+            return;
+        }
+
+        let mut worklist: VecDeque<Arc<Mount>> = self.children.read().values().cloned().collect();
+        while let Some(mount) = worklist.pop_front() {
+            *mount.bind_master.write() = Some(Arc::downgrade(master));
+            worklist.extend(mount.children.read().values().cloned());
+        }
+    }
+
     /// Sets the propagation type of this mount.
     pub(super) fn set_propagation(&self, prop: MountPropType, recursive: bool) {
         *self.propagation.write() = prop;
@@ -456,6 +485,67 @@ impl Mount {
     pub(super) fn graft_mount_tree(&self, target_path: &Path) {
         self.detach_from_parent();
         self.attach_to_path(target_path);
+        self.propagate_graft_to_bind_clones(target_path);
+    }
+
+    /// Grafts the mount node tree without further propagation.
+    fn graft_propagated_mount_tree(&self, target_path: &Path) {
+        self.detach_from_parent();
+        self.attach_to_path(target_path);
+    }
+
+    /// Propagates a newly grafted mount to slave/shared bind clones.
+    ///
+    /// Kata's virtio-fs setup bind-mounts a writable shared directory to a
+    /// read-only export directory and then mounts container rootfs trees under
+    /// the writable side. The later mount events must become visible through the
+    /// exported bind clone.
+    fn propagate_graft_to_bind_clones(&self, target_path: &Path) {
+        let Some(mnt_ns) = target_path.mount_node().mnt_ns().upgrade() else {
+            return;
+        };
+
+        let mut worklist = VecDeque::new();
+        worklist.push_back(mnt_ns.root().clone());
+
+        while let Some(mount) = worklist.pop_front() {
+            worklist.extend(mount.children.read().values().cloned());
+
+            if Arc::ptr_eq(&mount, target_path.mount_node()) {
+                continue;
+            }
+
+            let prop = *mount.propagation.read();
+            if !matches!(prop, MountPropType::Shared | MountPropType::Slave) {
+                continue;
+            }
+
+            let Some(master) = mount.bind_master.read().as_ref().and_then(Weak::upgrade) else {
+                continue;
+            };
+            if !Arc::ptr_eq(&master, target_path.mount_node()) {
+                continue;
+            }
+            if !target_path
+                .dentry()
+                .is_equal_or_descendant_of(mount.root_dentry())
+            {
+                continue;
+            }
+
+            let Ok(propagated_mount) = self.clone_mount_tree(
+                self.root_dentry(),
+                &Arc::downgrade(&mnt_ns),
+                true,
+                MountNsFileCopying::Copy,
+            ) else {
+                continue;
+            };
+            propagated_mount.graft_propagated_mount_tree(&Path::new(
+                mount.clone(),
+                target_path.dentry().clone(),
+            ));
+        }
     }
 
     /// Gets a child mount node from the mountpoint if any.

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::format;
+
 use super::SyscallReturn;
 use crate::{
     fs::{
@@ -34,6 +36,41 @@ pub fn sys_mount(
         "src_name_addr = 0x{:x}, dst_name = {:?}, fstype = 0x{:x}, flags = {:?}, data_addr = 0x{:x}",
         src_name_addr, dst_name, fs_type_addr, mount_flags, data_addr,
     );
+    let src_name_for_log = if src_name_addr == 0 {
+        "<null>".into()
+    } else {
+        ctx.user_space()
+            .read_cstring(src_name_addr, MAX_FILENAME_LEN)
+            .map(|src| src.to_string_lossy().into_owned())
+            .unwrap_or_else(|err| format!("<read-error:{err:?}>"))
+    };
+    let fs_type_for_log = if fs_type_addr == 0 {
+        "<null>".into()
+    } else {
+        ctx.user_space()
+            .read_cstring(fs_type_addr, MAX_FILENAME_LEN)
+            .map(|fs_type| fs_type.to_string_lossy().into_owned())
+            .unwrap_or_else(|err| format!("<read-error:{err:?}>"))
+    };
+    if fs_type_for_log == "overlay" {
+        let data_for_log = if data_addr == 0 {
+            "<null>".into()
+        } else {
+            ctx.user_space()
+                .read_cstring(data_addr, MAX_FILENAME_LEN)
+                .map(|data| data.to_string_lossy().into_owned())
+                .unwrap_or_else(|err| format!("<read-error:{err:?}>"))
+        };
+        debug!(
+            "sys_mount: src={:?}, dst={:?}, fstype={:?}, flags={:?}, data={:?}",
+            src_name_for_log, dst_name, fs_type_for_log, mount_flags, data_for_log
+        );
+    } else {
+        debug!(
+            "sys_mount: src={:?}, dst={:?}, fstype={:?}, flags={:?}",
+            src_name_for_log, dst_name, fs_type_for_log, mount_flags
+        );
+    }
 
     let dst_path = {
         let dst_name = dst_name.to_string_lossy();
@@ -115,6 +152,7 @@ fn do_bind_mount(
         let src_name = ctx
             .user_space()
             .read_cstring(src_name_addr, MAX_FILENAME_LEN)?;
+        debug!("do_bind_mount: src={:?}, recursive={}", src_name, recursive);
         let src_name = src_name.to_string_lossy();
         let fs_path = FsPath::from_fd_at(AT_FDCWD, &src_name, EmptyPathStr::Reject)?;
         ctx.thread_local
@@ -124,7 +162,9 @@ fn do_bind_mount(
             .lookup(&fs_path)?
     };
 
-    src_path.bind_mount_to(&dst_path, recursive, ctx)?;
+    let bind_result = src_path.bind_mount_to(&dst_path, recursive, ctx);
+    debug!("do_bind_mount: result={:?}", bind_result);
+    bind_result?;
     Ok(())
 }
 
@@ -152,9 +192,18 @@ fn do_change_type(target_path: Path, flags: MountFlags, ctx: &Context) -> Result
         );
     }
 
+    let recursive = flags.contains(MountFlags::MS_REC);
     if flags.contains(MountFlags::MS_PRIVATE) {
-        let recursive = flags.contains(MountFlags::MS_REC);
         target_path.set_mount_propagation(MountPropType::Private, recursive, ctx)?;
+        Ok(())
+    } else if flags.contains(MountFlags::MS_SHARED) {
+        target_path.set_mount_propagation(MountPropType::Shared, recursive, ctx)?;
+        Ok(())
+    } else if flags.contains(MountFlags::MS_SLAVE) {
+        target_path.set_mount_propagation(MountPropType::Slave, recursive, ctx)?;
+        Ok(())
+    } else if flags.contains(MountFlags::MS_UNBINDABLE) {
+        target_path.set_mount_propagation(MountPropType::Unbindable, recursive, ctx)?;
         Ok(())
     } else {
         return_errno_with_message!(Errno::EINVAL, "the mount propagation type is unsupported");


### PR DESCRIPTION
This PR adds mount propagation handling needed by Linux-compatible shared rootfs setup.

## Changes

- Add support for propagation flags such as shared, slave, and private in the mount path.
- Propagate bind mounts in the VFS mount tree where Linux-compatible runtime setup expects it.

Part of #3430.