### PR TITLE
Fix virtio device initialization sequence

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -36,7 +36,7 @@ use crate::{
     },
     id_alloc::SyncIdAlloc,
     queue::VirtQueue,
-    transport::{ConfigManager, VirtioTransport},
+    transport::{ConfigManager, DeviceTransport},
 };
 
 /// The number of minor device numbers allocated for each virtio disk,
@@ -82,8 +82,8 @@ impl BlockDevice {
     }
 
     /// Creates a new VirtIO-Block driver and registers it.
-    pub(crate) fn init(transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let device = DeviceInner::init(transport)?;
+    pub(crate) fn init(device_transport: DeviceTransport) -> Result<(), VirtioDeviceError> {
+        let device = DeviceInner::init(device_transport)?;
 
         let index = NR_BLOCK_DEVICE.fetch_add(1, Ordering::Relaxed);
         let id = DeviceId::new(
@@ -199,7 +199,7 @@ struct DeviceInner {
     config_manager: ConfigManager<VirtioBlockConfig>,
     features: BlockFeatures,
     queue: SpinLock<VirtQueue>,
-    transport: SpinLock<Box<dyn VirtioTransport>>,
+    transport: SpinLock<DeviceTransport>,
     block_requests: Arc<DmaStream>,
     block_responses: Arc<DmaStream>,
     id_allocator: SyncIdAlloc,
@@ -210,13 +210,14 @@ impl DeviceInner {
     const QUEUE_SIZE: u16 = 64;
 
     /// Creates and inits the device.
-    fn init(mut transport: Box<dyn VirtioTransport>) -> Result<Arc<Self>, VirtioDeviceError> {
-        let config_manager = VirtioBlockConfig::new_manager(transport.as_ref());
+    fn init(mut device_transport: DeviceTransport) -> Result<Arc<Self>, VirtioDeviceError> {
+        let config_manager = VirtioBlockConfig::new_manager(device_transport.as_ref());
 
         let config = config_manager.read_config();
         debug!("virio_blk_config = {:?}", config);
 
-        let features = BlockFeatures::negotiated_with_device(transport.read_device_features());
+        let features =
+            BlockFeatures::negotiated_with_device(device_transport.read_device_features());
 
         let block_size = if features.contains(BlockFeatures::BLK_SIZE) {
             config_manager.block_size()
@@ -231,7 +232,7 @@ impl DeviceInner {
             return Err(VirtioDeviceError::UnsupportedConfig);
         }
 
-        let num_queues = transport.num_queues();
+        let num_queues = device_transport.num_queues();
         if num_queues != 1 {
             // TODO: Support Multi-Queue Block IO Queueing Mechanism
             // (`BlkFeatures::MQ`) to accelerate multi-processor requests for
@@ -241,7 +242,7 @@ impl DeviceInner {
             );
         }
 
-        let queue = VirtQueue::new(0, Self::QUEUE_SIZE, transport.as_mut())?;
+        let queue = VirtQueue::new(0, Self::QUEUE_SIZE, device_transport.as_mut())?;
 
         let block_requests =
             Arc::new(DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?);
@@ -256,7 +257,7 @@ impl DeviceInner {
             config_manager,
             features,
             queue: SpinLock::new(queue),
-            transport: SpinLock::new(transport),
+            transport: SpinLock::new(device_transport),
             block_requests,
             block_responses,
             id_allocator: SyncIdAlloc::with_capacity(Self::QUEUE_SIZE as usize),

--- a/kernel/comps/virtio/src/device/console/device.rs
+++ b/kernel/comps/virtio/src/device/console/device.rs
@@ -16,12 +16,12 @@ use super::{DEVICE_NAME, config::VirtioConsoleConfig};
 use crate::{
     device::{VirtioDeviceError, console::config::ConsoleFeatures},
     queue::VirtQueue,
-    transport::{ConfigManager, VirtioTransport},
+    transport::{ConfigManager, DeviceTransport},
 };
 
 pub struct ConsoleDevice {
     config_manager: ConfigManager<VirtioConsoleConfig>,
-    transport: SpinLock<Box<dyn VirtioTransport>>,
+    transport: SpinLock<DeviceTransport>,
     receive_queue: SpinLock<VirtQueue>,
     transmit_queue: SpinLock<VirtQueue>,
     send_buffer: DmaStream,
@@ -85,18 +85,21 @@ impl ConsoleDevice {
         features.bits()
     }
 
-    pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let config_manager = VirtioConsoleConfig::new_manager(transport.as_ref());
+    pub(crate) fn init(mut device_transport: DeviceTransport) -> Result<(), VirtioDeviceError> {
+        let config_manager = VirtioConsoleConfig::new_manager(device_transport.as_ref());
         debug!("virtio_console_config = {:?}", config_manager.read_config());
 
         const RECV0_QUEUE_INDEX: u16 = 0;
         const TRANSMIT0_QUEUE_INDEX: u16 = 1;
-        let receive_queue =
-            SpinLock::new(VirtQueue::new(RECV0_QUEUE_INDEX, 2, transport.as_mut())?);
+        let receive_queue = SpinLock::new(VirtQueue::new(
+            RECV0_QUEUE_INDEX,
+            2,
+            device_transport.as_mut(),
+        )?);
         let transmit_queue = SpinLock::new(VirtQueue::new(
             TRANSMIT0_QUEUE_INDEX,
             2,
-            transport.as_mut(),
+            device_transport.as_mut(),
         )?);
 
         let send_buffer = DmaStream::alloc(1, false).map_err(VirtioDeviceError::ResourceAlloc)?;
@@ -105,7 +108,7 @@ impl ConsoleDevice {
 
         let device = Arc::new(Self {
             config_manager,
-            transport: SpinLock::new(transport),
+            transport: SpinLock::new(device_transport),
             receive_queue,
             transmit_queue,
             send_buffer,
@@ -131,6 +134,8 @@ impl ConsoleDevice {
         transport.finish_init();
         drop(transport);
 
+        Self::notify_receive_queue(&mut device.receive_queue.disable_irq().lock());
+
         aster_console::register_device(DEVICE_NAME.to_string(), device);
 
         Ok(())
@@ -155,6 +160,7 @@ impl ConsoleDevice {
         drop(callbacks);
 
         self.activate_receive_buffer(&mut receive_queue);
+        Self::notify_receive_queue(&mut receive_queue);
     }
 
     fn activate_receive_buffer(&self, receive_queue: &mut VirtQueue) {
@@ -168,7 +174,9 @@ impl ConsoleDevice {
             // <https://lore.kernel.org/qemu-devel/20240707111940.232549-3-lrh2000@pku.edu.cn/T/#u>.
             .add_output_bufs(&[&Slice::new(&self.receive_buffer, 0..1)])
             .unwrap();
+    }
 
+    fn notify_receive_queue(receive_queue: &mut VirtQueue) {
         if receive_queue.should_notify() {
             receive_queue.notify();
         }

--- a/kernel/comps/virtio/src/device/entropy/device.rs
+++ b/kernel/comps/virtio/src/device/entropy/device.rs
@@ -22,7 +22,7 @@ use ostd::{
 use crate::{
     device::{VirtioDeviceError, entropy},
     queue::VirtQueue,
-    transport::VirtioTransport,
+    transport::DeviceTransport,
 };
 
 static ENTROPY_DEVICE_ID: AtomicUsize = AtomicUsize::new(0);
@@ -44,7 +44,7 @@ const ENTROPY_BUFFER_SIZE: usize = PAGE_SIZE;
 
 /// Entropy devices, which supply high-quality randomness for guest use.
 pub struct EntropyDevice {
-    transport: SpinLock<Box<dyn VirtioTransport>>,
+    transport: SpinLock<DeviceTransport>,
     inner: SpinLock<EntropyDeviceInner, LocalIrqDisabled>,
     /// A filled DMA buffer drained by user-space reads.
     cache: Mutex<EntropyCache>,
@@ -52,12 +52,14 @@ pub struct EntropyDevice {
 }
 
 impl EntropyDevice {
-    pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let queue = VirtQueue::new(0, ENTROPY_QUEUE_SIZE, transport.as_mut())?;
+    pub(crate) fn init(mut device_transport: DeviceTransport) -> Result<(), VirtioDeviceError> {
+        let queue = VirtQueue::new(0, ENTROPY_QUEUE_SIZE, device_transport.as_mut())?;
+        let inner = EntropyDeviceInner::new(queue)?;
+        let cache = EntropyCache::new()?;
         let device = Arc::new(EntropyDevice {
-            transport: SpinLock::new(transport),
-            inner: SpinLock::new(EntropyDeviceInner::new(queue)?),
-            cache: Mutex::new(EntropyCache::new()?),
+            transport: SpinLock::new(device_transport),
+            inner: SpinLock::new(inner),
+            cache: Mutex::new(cache),
             wait_queue: WaitQueue::new(),
         });
 

--- a/kernel/comps/virtio/src/device/filesystem/device/mod.rs
+++ b/kernel/comps/virtio/src/device/filesystem/device/mod.rs
@@ -12,7 +12,7 @@ mod session;
 mod virtio_ops;
 mod waiter;
 
-use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use aster_fuse::{
@@ -35,7 +35,7 @@ use waiter::{FuseWaiter, ReplyBufs};
 pub use self::session::{AttrVersion, FuseSession};
 use crate::{
     device::filesystem::pool::{FuseDataBuf, FuseReplyBuf, FuseRequestBuf, SizeClassedDmaPool},
-    transport::VirtioTransport,
+    transport::DeviceTransport,
 };
 
 static FILESYSTEM_DEVICES: Once<SpinLock<Vec<Arc<FileSystemDevice>>, LocalIrqDisabled>> =
@@ -49,7 +49,7 @@ static FILESYSTEM_DEVICES: Once<SpinLock<Vec<Arc<FileSystemDevice>>, LocalIrqDis
 /// guards. The request path takes virtio-fs locks in this order:
 /// VFS sleepable guard -> selected request queue `SpinLock`.
 pub struct FileSystemDevice {
-    transport: SpinLock<Box<dyn VirtioTransport>, LocalIrqDisabled>,
+    transport: SpinLock<DeviceTransport, LocalIrqDisabled>,
     hiprio_queue: Arc<FsRequestQueue>,
     request_queues: Vec<Arc<FsRequestQueue>>,
     to_device_pool: Arc<SizeClassedDmaPool<ToDevice>>,
@@ -61,7 +61,7 @@ pub struct FileSystemDevice {
 
 impl FileSystemDevice {
     fn new(
-        transport: Box<dyn VirtioTransport>,
+        transport: DeviceTransport,
         hiprio_queue: Arc<FsRequestQueue>,
         request_queues: Vec<Arc<FsRequestQueue>>,
         tag: String,

--- a/kernel/comps/virtio/src/device/filesystem/device/virtio_ops.rs
+++ b/kernel/comps/virtio/src/device/filesystem/device/virtio_ops.rs
@@ -25,7 +25,7 @@ use crate::{
         },
     },
     queue::VirtQueue,
-    transport::VirtioTransport,
+    transport::{DeviceTransport, VirtioTransport},
 };
 
 impl FileSystemDevice {
@@ -39,12 +39,12 @@ impl FileSystemDevice {
     }
 
     /// Initializes one virtio-fs device from its virtio transport.
-    pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let config_manager = VirtioFsConfig::new_manager(transport.as_ref());
+    pub(crate) fn init(mut device_transport: DeviceTransport) -> Result<(), VirtioDeviceError> {
+        let config_manager = VirtioFsConfig::new_manager(device_transport.as_ref());
         let config = config_manager.read_config();
 
         let negotiated_features = FileSystemFeatures::from_bits_truncate(Self::negotiate_features(
-            transport.read_device_features(),
+            device_transport.read_device_features(),
         ));
         let notify_supported = negotiated_features.contains(FileSystemFeatures::NOTIFICATION);
         // Queue layout:
@@ -53,7 +53,7 @@ impl FileSystemDevice {
         // - Remaining queues: request queues.
         let request_queue_start_idx = if notify_supported { 2 } else { 1 };
 
-        let total_queues = transport.num_queues();
+        let total_queues = device_transport.num_queues();
         if total_queues <= request_queue_start_idx {
             return Err(VirtioDeviceError::UnsupportedConfig);
         }
@@ -69,20 +69,22 @@ impl FileSystemDevice {
         }
 
         let device = {
-            let hiprio_queue =
-                FsRequestQueue::new(Self::new_queue(HIPRIO_QUEUE_INDEX, transport.as_mut())?);
+            let hiprio_queue = FsRequestQueue::new(Self::new_queue(
+                HIPRIO_QUEUE_INDEX,
+                device_transport.as_mut(),
+            )?);
 
             let mut request_queues = Vec::with_capacity(request_queue_count);
             for idx in 0..request_queue_count {
                 let queue_index = request_queue_start_idx + idx as u16;
                 request_queues.push(FsRequestQueue::new(Self::new_queue(
                     queue_index,
-                    transport.as_mut(),
+                    device_transport.as_mut(),
                 )?));
             }
 
             Arc::new(Self::new(
-                transport,
+                device_transport,
                 hiprio_queue,
                 request_queues,
                 config.parse_tag().to_string(),

--- a/kernel/comps/virtio/src/device/input/device.rs
+++ b/kernel/comps/virtio/src/device/input/device.rs
@@ -28,7 +28,7 @@ use ostd_pod::IntoBytes;
 
 use super::{InputConfigSelect, QUEUE_EVENT, QUEUE_STATUS, VirtioInputConfig, VirtioInputEvent};
 use crate::{
-    device::VirtioDeviceError, dma_buf::DmaBuf, queue::VirtQueue, transport::VirtioTransport,
+    device::VirtioDeviceError, dma_buf::DmaBuf, queue::VirtQueue, transport::DeviceTransport,
 };
 
 bitflags! {
@@ -65,7 +65,7 @@ pub struct InputDevice {
     event_queue: SpinLock<VirtQueue>,
     status_queue: VirtQueue,
     event_table: EventTable,
-    transport: SpinLock<Box<dyn VirtioTransport>>,
+    transport: SpinLock<DeviceTransport>,
     device_name: String,
     device_phys: String,
     device_uniq: String,
@@ -76,9 +76,9 @@ pub struct InputDevice {
 impl InputDevice {
     /// Create a new VirtIO-Input driver.
     /// msix_vector_left should at least have one element or n elements where n is the virtqueue amount
-    pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let mut event_queue = VirtQueue::new(QUEUE_EVENT, QUEUE_SIZE, transport.as_mut())?;
-        let status_queue = VirtQueue::new(QUEUE_STATUS, QUEUE_SIZE, transport.as_mut())?;
+    pub(crate) fn init(mut device_transport: DeviceTransport) -> Result<(), VirtioDeviceError> {
+        let mut event_queue = VirtQueue::new(QUEUE_EVENT, QUEUE_SIZE, device_transport.as_mut())?;
+        let status_queue = VirtQueue::new(QUEUE_STATUS, QUEUE_SIZE, device_transport.as_mut())?;
 
         let event_table = EventTable::new(QUEUE_SIZE as usize)?;
         for i in 0..event_table.num_events() {
@@ -87,17 +87,13 @@ impl InputDevice {
             assert_eq!(token as usize, i);
         }
 
-        if event_queue.should_notify() {
-            event_queue.notify();
-        }
-
         let device = {
             let mut device = Self {
-                config: VirtioInputConfig::new(transport.as_mut()),
+                config: VirtioInputConfig::new(device_transport.as_ref()),
                 event_queue: SpinLock::new(event_queue),
                 status_queue,
                 event_table,
-                transport: SpinLock::new(transport),
+                transport: SpinLock::new(device_transport),
                 // Default name, will be updated with actual device name from config.
                 device_name: "virtio_input".to_string(),
                 // Physical path for virtio devices.
@@ -136,7 +132,6 @@ impl InputDevice {
             debug!("input device config space change");
         }
         transport.register_cfg_callback(Box::new(config_space_change))?;
-        transport.finish_init();
         drop(transport);
 
         // Register with the input subsystem.
@@ -148,10 +143,16 @@ impl InputDevice {
             let device = device.clone();
             move |_: &TrapFrame| device.handle_irq(&registered_device)
         };
-        transport
-            .register_queue_callback(QUEUE_EVENT, Box::new(handle_input), false)
-            .unwrap();
+        transport.register_queue_callback(QUEUE_EVENT, Box::new(handle_input), false)?;
+        transport.finish_init();
         drop(transport);
+
+        {
+            let mut event_queue = device.event_queue.disable_irq().lock();
+            if event_queue.should_notify() {
+                event_queue.notify();
+            }
+        }
 
         Ok(())
     }

--- a/kernel/comps/virtio/src/device/network/device.rs
+++ b/kernel/comps/virtio/src/device/network/device.rs
@@ -18,7 +18,7 @@ use crate::{
         },
     },
     queue::{self, VirtQueue},
-    transport::{ConfigManager, VirtioTransport},
+    transport::{ConfigManager, DeviceTransport},
 };
 
 pub struct NetworkDevice {
@@ -34,7 +34,7 @@ pub struct NetworkDevice {
     tx_buffers: Vec<Option<TxBuffer>>,
     rx_buffers: SlotVec<RxBuffer>,
     new_rx_buffer: Option<RxBuffer>,
-    transport: Box<dyn VirtioTransport>,
+    transport: DeviceTransport,
     poll_stat: PollStatistics,
 }
 
@@ -70,22 +70,22 @@ impl NetworkDevice {
         network_features.bits()
     }
 
-    pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let config_manager = VirtioNetConfig::new_manager(transport.as_ref());
+    pub(crate) fn init(mut device_transport: DeviceTransport) -> Result<(), VirtioDeviceError> {
+        let config_manager = VirtioNetConfig::new_manager(device_transport.as_ref());
         let config = config_manager.read_config();
         debug!("virtio_net_config = {:?}", config);
         let mac_addr = config.mac;
         let features = NetworkFeatures::from_bits_truncate(Self::negotiate_features(
-            transport.read_device_features(),
+            device_transport.read_device_features(),
         ));
         debug!("features = {:?}", features);
 
         let caps = init_caps(&features, &config);
 
-        let mut send_queue = VirtQueue::new(QUEUE_SEND, QUEUE_SIZE, transport.as_mut())?;
+        let mut send_queue = VirtQueue::new(QUEUE_SEND, QUEUE_SIZE, device_transport.as_mut())?;
         send_queue.disable_callback();
 
-        let mut recv_queue = VirtQueue::new(QUEUE_RECV, QUEUE_SIZE, transport.as_mut())?;
+        let mut recv_queue = VirtQueue::new(QUEUE_RECV, QUEUE_SIZE, device_transport.as_mut())?;
 
         let tx_buffers = (0..QUEUE_SIZE).map(|_| None).collect();
 
@@ -99,11 +99,6 @@ impl NetworkDevice {
             assert_eq!(rx_buffers.put(rx_buffer) as u16, i);
         }
 
-        if recv_queue.should_notify() {
-            debug!("notify receive queue");
-            recv_queue.notify();
-        }
-
         let mut device = Self {
             config_manager,
             caps,
@@ -114,7 +109,7 @@ impl NetworkDevice {
             tx_buffers,
             rx_buffers,
             new_rx_buffer: None,
-            transport,
+            transport: device_transport,
             poll_stat: PollStatistics::new(),
         };
 
@@ -142,6 +137,11 @@ impl NetworkDevice {
             .register_queue_callback(QUEUE_RECV, Box::new(handle_recv_event), true)?;
 
         device.transport.finish_init();
+
+        if device.recv_queue.should_notify() {
+            debug!("notify receive queue");
+            device.recv_queue.notify();
+        }
 
         aster_network::register_device(
             super::DEVICE_NAME.to_string(),

--- a/kernel/comps/virtio/src/device/socket/device.rs
+++ b/kernel/comps/virtio/src/device/socket/device.rs
@@ -23,7 +23,7 @@ use crate::{
             queue::{EventQueue, RxQueue, TxQueue},
         },
     },
-    transport::{ConfigManager, VirtioTransport},
+    transport::{ConfigManager, DeviceTransport},
 };
 
 /// Socket devices, which facilitate data transfer between the guest and device without using the
@@ -36,7 +36,7 @@ pub struct SocketDevice {
     rx_callback: Once<fn()>,
     event_queue: SpinLock<EventQueue, BottomHalfDisabled>,
     event_callback: Once<fn()>,
-    transport: SpinLock<Box<dyn VirtioTransport>>,
+    transport: SpinLock<DeviceTransport>,
 }
 
 impl SocketDevice {
@@ -46,13 +46,13 @@ impl SocketDevice {
     }
 
     /// Initializes a virtio-vsock device from `transport` and registers it globally.
-    pub(crate) fn init(mut transport: Box<dyn VirtioTransport>) -> Result<(), VirtioDeviceError> {
-        let config_manager = VirtioVsockConfig::new_manager(transport.as_ref());
+    pub(crate) fn init(mut device_transport: DeviceTransport) -> Result<(), VirtioDeviceError> {
+        let config_manager = VirtioVsockConfig::new_manager(device_transport.as_ref());
         let guest_cid = VirtioVsockConfig::read_guest_cid(&config_manager);
 
-        let tx_queue = TxQueue::new(transport.as_mut())?;
-        let rx_queue = RxQueue::new(transport.as_mut())?;
-        let event_queue = EventQueue::new(transport.as_mut())?;
+        let tx_queue = TxQueue::new(device_transport.as_mut())?;
+        let rx_queue = RxQueue::new(device_transport.as_mut())?;
+        let event_queue = EventQueue::new(device_transport.as_mut())?;
 
         let device = Arc::new(Self {
             config_manager,
@@ -62,7 +62,7 @@ impl SocketDevice {
             rx_callback: Once::new(),
             event_queue: SpinLock::new(event_queue),
             event_callback: Once::new(),
-            transport: SpinLock::new(transport),
+            transport: SpinLock::new(device_transport),
         });
 
         let mut transport = device.transport.lock();
@@ -87,6 +87,9 @@ impl SocketDevice {
         transport.register_cfg_callback(Box::new(config_space_change))?;
         transport.finish_init();
         drop(transport);
+
+        device.rx_queue.lock().notify_if_needed();
+        device.event_queue.lock().notify_if_needed();
 
         // Reload the guest CID after initialization to prevent race conditions if the CID changes
         // at the same time.

--- a/kernel/comps/virtio/src/device/socket/queue.rs
+++ b/kernel/comps/virtio/src/device/socket/queue.rs
@@ -82,9 +82,7 @@ impl TxQueue {
             self.inflight[token as usize] = Some(packet);
         }
 
-        if self.queue.should_notify() {
-            self.queue.notify();
-        }
+        self.notify_if_needed();
     }
 
     /// Tries to submit `packet` to the inflight queue immediately, or returns a guard for
@@ -102,11 +100,15 @@ impl TxQueue {
         debug_assert!(self.inflight[token as usize].is_none());
         self.inflight[token as usize] = Some(packet);
 
+        self.notify_if_needed();
+
+        Ok(())
+    }
+
+    fn notify_if_needed(&mut self) {
         if self.queue.should_notify() {
             self.queue.notify();
         }
-
-        Ok(())
     }
 }
 
@@ -163,10 +165,6 @@ impl RxQueue {
             assert_eq!(buffers.put(buffer) as u16, index);
         }
 
-        if queue.should_notify() {
-            queue.notify();
-        }
-
         Ok(Self {
             queue,
             buffers,
@@ -200,11 +198,15 @@ impl RxQueue {
         debug_assert_eq!(new_token, token);
         self.buffers.put_at(new_token as usize, new_packet);
 
+        self.notify_if_needed();
+
+        Some(packet)
+    }
+
+    pub(super) fn notify_if_needed(&mut self) {
         if self.queue.should_notify() {
             self.queue.notify();
         }
-
-        Some(packet)
     }
 }
 
@@ -224,10 +226,6 @@ impl EventQueue {
         let buffer = DmaStream::alloc_uninit(1, false).map_err(VirtioDeviceError::ResourceAlloc)?;
         let token = queue.add_output_bufs(&[&buffer]).unwrap();
         debug_assert_eq!(token, 0);
-
-        if queue.should_notify() {
-            queue.notify();
-        }
 
         Ok(Self { queue, buffer })
     }
@@ -257,10 +255,14 @@ impl EventQueue {
         let token = self.queue.add_output_bufs(&[&self.buffer]).unwrap();
         debug_assert_eq!(token, 0);
 
+        self.notify_if_needed();
+
+        event_id
+    }
+
+    pub(super) fn notify_if_needed(&mut self) {
         if self.queue.should_notify() {
             self.queue.notify();
         }
-
-        event_id
     }
 }

--- a/kernel/comps/virtio/src/lib.rs
+++ b/kernel/comps/virtio/src/lib.rs
@@ -23,7 +23,7 @@ use ostd::{error, warn};
 use spin::Once;
 use transport::{DeviceStatus, mmio::VIRTIO_MMIO_DRIVER, pci::VIRTIO_PCI_DRIVER};
 
-use crate::transport::VirtioTransport;
+use crate::transport::{DeviceTransport, VirtioTransport};
 
 // Set this crate's log prefix for `ostd::log`.
 macro_rules! __log_prefix {
@@ -52,7 +52,12 @@ fn virtio_component_init() -> Result<(), ComponentInitError> {
     device::socket::init();
 
     while let Some(mut transport) = pop_device_transport() {
-        // Reset device
+        let device_type = transport.device_type();
+
+        // Follow VirtIO 1.3, 3.1.1 "Driver Requirements: Device Initialization".
+        // Reference: <https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html#x1-1230001>
+
+        // Reset the device.
         transport
             .write_device_status(DeviceStatus::empty())
             .unwrap();
@@ -60,29 +65,48 @@ fn virtio_component_init() -> Result<(), ComponentInitError> {
             spin_loop();
         }
 
-        // Set to acknowledge
+        // Set `ACKNOWLEDGE` to report that the guest OS has noticed the device.
+        transport
+            .write_device_status(DeviceStatus::ACKNOWLEDGE)
+            .unwrap();
+
+        // Set `DRIVER` to report that the guest OS knows how to drive the device.
         transport
             .write_device_status(DeviceStatus::ACKNOWLEDGE | DeviceStatus::DRIVER)
             .unwrap();
-        // negotiate features
+
+        // Negotiate the feature subset supported by the driver.
         negotiate_features(&mut transport);
 
         if !transport.is_legacy_version() {
-            // change to features ok status
+            // Set `FEATURES_OK` to report that feature negotiation is complete.
             let status =
                 DeviceStatus::ACKNOWLEDGE | DeviceStatus::DRIVER | DeviceStatus::FEATURES_OK;
             transport.write_device_status(status).unwrap();
+
+            let status = transport.read_device_status();
+            if !status.contains(DeviceStatus::FEATURES_OK) {
+                error!(
+                    "Device rejected negotiated features, device type: {:?}",
+                    device_type
+                );
+                transport
+                    .write_device_status(status | DeviceStatus::FAILED)
+                    .unwrap();
+                continue;
+            }
         }
 
-        let device_type = transport.device_type();
-        let res = match transport.device_type() {
-            VirtioDeviceType::Block => BlockDevice::init(transport),
-            VirtioDeviceType::Console => ConsoleDevice::init(transport),
-            VirtioDeviceType::Entropy => EntropyDevice::init(transport),
-            VirtioDeviceType::Input => InputDevice::init(transport),
-            VirtioDeviceType::Network => NetworkDevice::init(transport),
-            VirtioDeviceType::Socket => SocketDevice::init(transport),
-            VirtioDeviceType::FileSystem => FileSystemDevice::init(transport),
+        let device_transport = DeviceTransport::new(transport);
+
+        let res = match device_type {
+            VirtioDeviceType::Block => BlockDevice::init(device_transport),
+            VirtioDeviceType::Console => ConsoleDevice::init(device_transport),
+            VirtioDeviceType::Entropy => EntropyDevice::init(device_transport),
+            VirtioDeviceType::Input => InputDevice::init(device_transport),
+            VirtioDeviceType::Network => NetworkDevice::init(device_transport),
+            VirtioDeviceType::Socket => SocketDevice::init(device_transport),
+            VirtioDeviceType::FileSystem => FileSystemDevice::init(device_transport),
             _ => {
                 warn!("Found unimplemented device: {:?}", device_type);
                 Ok(())

--- a/kernel/comps/virtio/src/transport/mod.rs
+++ b/kernel/comps/virtio/src/transport/mod.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::{boxed::Box, sync::Arc};
-use core::fmt::Debug;
+use core::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 use aster_pci::cfg_space::BarAccess;
 use aster_util::safe_ptr::SafePtr;
@@ -45,17 +48,6 @@ pub trait VirtioTransport: Sync + Send + Debug {
 
     /// Set device status.
     fn write_device_status(&mut self, status: DeviceStatus) -> Result<(), VirtioTransportError>;
-
-    // Set to driver ok status
-    fn finish_init(&mut self) {
-        self.write_device_status(
-            DeviceStatus::ACKNOWLEDGE
-                | DeviceStatus::DRIVER
-                | DeviceStatus::FEATURES_OK
-                | DeviceStatus::DRIVER_OK,
-        )
-        .unwrap();
-    }
 
     /// Get access to the device config memory.
     fn device_config_mem(&self) -> Option<IoMem>;
@@ -250,6 +242,69 @@ bitflags::bitflags! {
         /// Indicates that the device has experienced an error from which it
         /// can’t recover.
         const DEVICE_NEEDS_RESET = 64;
+    }
+}
+
+/// A wrapper around [`Box<dyn VirtioTransport>`] that sets the device status to FAILED
+/// on drop unless [`Self::finish_init`] has been called.
+///
+/// This ensures that the FAILED status bit is set whenever a device initialization
+/// is aborted before completion, as required by the VirtIO specification.
+///
+/// The `DeviceTransport` is stored in the device struct and held for the device's
+/// lifetime. During initialization it acts as a sentinel: if init fails (the struct
+/// is dropped without [`finish_init`] being called), [`Drop`] sets `FAILED`. Once
+/// `finish_init` is called, the FAILED bit is no longer set on drop.
+#[derive(Debug)]
+pub struct DeviceTransport {
+    inner: Box<dyn VirtioTransport>,
+    is_completed: bool,
+}
+
+impl DeviceTransport {
+    /// Creates a new wrapper around `transport`.
+    ///
+    /// The wrapper will set the device status to [`DeviceStatus::FAILED`] on drop
+    /// unless [`Self::finish_init`] is called first.
+    pub fn new(transport: Box<dyn VirtioTransport>) -> Self {
+        Self {
+            inner: transport,
+            is_completed: false,
+        }
+    }
+
+    /// Marks initialization as complete and sets the device status to `DRIVER_OK`.
+    ///
+    /// After this call, the wrapper will NOT set `FAILED` on drop.
+    pub fn finish_init(&mut self) {
+        self.is_completed = true;
+        let status = self.inner.read_device_status() | DeviceStatus::DRIVER_OK;
+        self.inner.write_device_status(status).unwrap();
+    }
+}
+
+impl Deref for DeviceTransport {
+    type Target = Box<dyn VirtioTransport>;
+
+    fn deref(&self) -> &Box<dyn VirtioTransport> {
+        &self.inner
+    }
+}
+
+impl DerefMut for DeviceTransport {
+    fn deref_mut(&mut self) -> &mut Box<dyn VirtioTransport> {
+        &mut self.inner
+    }
+}
+
+impl Drop for DeviceTransport {
+    fn drop(&mut self) {
+        if !self.is_completed {
+            let status = self.inner.read_device_status();
+            let _ = self
+                .inner
+                .write_device_status(status | DeviceStatus::FAILED);
+        }
     }
 }
 

--- a/kernel/comps/virtio/src/transport/pci/legacy.rs
+++ b/kernel/comps/virtio/src/transport/pci/legacy.rs
@@ -244,14 +244,6 @@ impl VirtioTransport for VirtioPciLegacyTransport {
         Ok(())
     }
 
-    // Set to driver ok status
-    fn finish_init(&mut self) {
-        self.write_device_status(
-            DeviceStatus::ACKNOWLEDGE | DeviceStatus::DRIVER | DeviceStatus::DRIVER_OK,
-        )
-        .unwrap();
-    }
-
     fn max_queue_size(&self, idx: u16) -> Result<u16, VirtioTransportError> {
         self.config_bar
             .write_once(QUEUE_SELECT_OFFSET, idx)


### PR DESCRIPTION
## Summary

This PR updates VirtIO device initialization to follow the sequence required by VirtIO 1.3 section 3.1.1.

This fixes initialization that previously worked on QEMU (more lenient) but failed on Firecracker VMM, which strictly follows the VirtIO specification. The change improves compatibility with strict VMMs.

This PR is also a step towards supporting Asterinas as a guest kernel in Firecracker microVMs, see #3429 .

  - Set `ACKNOWLEDGE` and `DRIVER` in separate steps.
  - Re-read device status after setting `FEATURES_OK`.
  - Mark the device as `FAILED` and stop initializing it if any of the steps go wrong.
  - Move initial receive/event queue notifications until after `DRIVER_OK` is set.


> Reference: https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html#x1-1230001
