### PR TITLE
Increase vDSO clock update frequency  to fix `__vdso_time`

### DIFF
--- a/kernel/comps/time/src/clocksource.rs
+++ b/kernel/comps/time/src/clocksource.rs
@@ -98,9 +98,17 @@ impl ClockSource {
             (self.read_cycles(), last_instant, last_cycles)
         };
 
-        let delta_nanos = {
-            let delta_cycles = instant_cycles - last_cycles;
-            self.cycles_to_nanos_lossy(delta_cycles)
+        let delta_nanos = match instant_cycles.checked_sub(last_cycles) {
+            Some(delta) => self.cycles_to_nanos_lossy(delta),
+            None => {
+                ostd::warn!(
+                    "The clock source becomes not reliable since TSC \
+                    has moved backwards from {} to {}",
+                    last_cycles,
+                    instant_cycles
+                );
+                0
+            }
         };
         let duration = Duration::from_nanos(delta_nanos);
         (last_instant + duration, instant_cycles)

--- a/kernel/comps/time/src/tsc.rs
+++ b/kernel/comps/time/src/tsc.rs
@@ -66,14 +66,13 @@ fn update_clocksource() {
 static TSC_UPDATE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 fn init_timer() {
-    // The `max_delay_secs` should be set as `clock.max_delay_secs() >> 1` or something much smaller than `max_delay_secs`.
-    // This is because the initialization of this timer occurs during system startup,
-    // and the system will also undergo other initialization processes, during which time interrupts are disabled.
-    // This results in the actual trigger time of the timer being delayed by about 5 seconds compared to the set time.
-    // If without KVM, the delayed time will be larger.
-    // TODO: This is a temporary solution, and should be modified in the future.
-    let max_delay_secs = CLOCK.get().unwrap().max_delay_secs() >> 1;
-    let delay_counts = TIMER_FREQ * max_delay_secs;
+    // This must be frequent enough to provide values accurate to the second
+    // for the time fields in vDSO. We choose 10 Hz, which results in a
+    // worst-case staleness of ~100 ms.
+    // TODO: Implement a more complete and efficient timekeeping mechanism,
+    // then align this update frequency with Linux.
+    const VDSO_UPDATE_FREQ: u64 = 10;
+    let delay_counts = TIMER_FREQ / VDSO_UPDATE_FREQ;
 
     let update = move || {
         let counter = TSC_UPDATE_COUNTER.fetch_add(1, Ordering::Relaxed);

--- a/kernel/src/vdso.rs
+++ b/kernel/src/vdso.rs
@@ -274,9 +274,7 @@ impl Vdso {
         data.update_high_res_instant(instant, instant_cycles);
 
         // Update begins.
-        self.data_frame
-            .write_once(vdso_data_field_offset!(seq), &1)
-            .unwrap();
+        self.begin_update_data_frame(&mut data);
 
         self.data_frame
             .write_val(vdso_data_field_offset!(last_cycles), &instant_cycles)
@@ -286,11 +284,7 @@ impl Vdso {
         }
 
         // Update finishes.
-        // FIXME: To synchronize with the vDSO library, this needs to be an atomic write with the
-        // Release memory order.
-        self.data_frame
-            .write_once(vdso_data_field_offset!(seq), &0)
-            .unwrap();
+        self.finish_update_data_frame(&mut data);
     }
 
     fn update_coarse_res_instant(&self, instant: Instant) {
@@ -299,19 +293,22 @@ impl Vdso {
         data.update_coarse_res_instant(instant);
 
         // Update begins.
-        self.data_frame
-            .write_once(vdso_data_field_offset!(seq), &1)
-            .unwrap();
+        self.begin_update_data_frame(&mut data);
 
         for clock_id in COARSE_RES_CLOCK_IDS {
             self.update_data_frame_instant(clock_id, &mut data);
         }
 
         // Update finishes.
-        // FIXME: To synchronize with the vDSO library, this needs to be an atomic write with the
-        // Release memory order.
+        self.finish_update_data_frame(&mut data);
+    }
+
+    fn begin_update_data_frame(&self, data: &mut VdsoData) {
+        debug_assert!(data.seq.is_multiple_of(2));
+
+        data.seq = data.seq.wrapping_add(1);
         self.data_frame
-            .write_once(vdso_data_field_offset!(seq), &0)
+            .write_once(vdso_data_field_offset!(seq), &data.seq)
             .unwrap();
     }
 
@@ -329,6 +326,17 @@ impl Vdso {
             .unwrap();
         self.data_frame
             .write_val(nanos_info_offset, &data.basetime[clock_index].nanos_info)
+            .unwrap();
+    }
+
+    fn finish_update_data_frame(&self, data: &mut VdsoData) {
+        debug_assert!(!data.seq.is_multiple_of(2));
+
+        data.seq = data.seq.wrapping_add(1);
+        // FIXME: To synchronize with the vDSO library, this needs to be an atomic write with the
+        // Release memory order.
+        self.data_frame
+            .write_once(vdso_data_field_offset!(seq), &data.seq)
             .unwrap();
     }
 }


### PR DESCRIPTION
#3459 is because __vdso_time directly reads basetime from vDSO, which has accurate seconds in Linux. This increases clock update frequency to provide accurate seconds.

Fixes #3459