### PR TITLE
Support clone-family ptrace-event-stops

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md
@@ -110,7 +110,6 @@ Supported requests:
 Limitations:
 * Only the main thread of a process can act as the tracer.
 * `PTRACE_PEEKUSER` and `PTRACE_POKEUSER` only support offsets for general-purpose registers.
-* If a tracee has clone-family options (`PTRACE_O_TRACEFORK`, `PTRACE_O_TRACEVFORK`, `PTRACE_O_TRACEVFORKDONE`, or `PTRACE_O_TRACECLONE`) and then performs a clone-family operation that would trigger a ptrace event, the clone-family operation returns `EOPNOTSUPP`.
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/ptrace.2.html).

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -12,7 +12,7 @@ use ostd::{
 
 use super::{
     Credentials, Pid, Process, pid_table,
-    posix_thread::{AsPosixThread, PosixThreadBuilder},
+    posix_thread::{AsPosixThread, PosixThreadBuilder, ptrace::PtraceEvent},
     rlimit::ResourceLimits,
     signal::{constants::SIGCHLD, sig_disposition::SigDispositions, sig_num::SigNum},
 };
@@ -32,7 +32,7 @@ use crate::{
         stats::PROCESS_CREATION_COUNTER,
     },
     sched::Nice,
-    thread::{AsThread, Tid},
+    thread::{AsThread, Thread, Tid},
     vm::vmar::{Vmar, VmarHandle},
 };
 
@@ -238,16 +238,6 @@ impl CloneArgs {
             );
         }
 
-        // TODO: Support clone-family ptrace events and remove this check.
-        if !clone_flags.contains(CloneFlags::CLONE_UNTRACED)
-            && ctx.posix_thread.needs_ptrace_clone_stop(self)
-        {
-            return_errno_with_message!(
-                Errno::EOPNOTSUPP,
-                "ptrace clone events are not supported currently"
-            );
-        }
-
         Ok(())
     }
 }
@@ -292,15 +282,32 @@ impl CloneFlags {
 /// but this may not be the expected behavior.
 pub fn clone_child(
     ctx: &Context,
-    parent_context: &UserContext,
+    parent_context: &mut UserContext,
     clone_args: CloneArgs,
 ) -> Result<Tid> {
     clone_args.check(ctx)?;
 
+    let ptrace_event_on_clone = |child: &Arc<Thread>| {
+        (!clone_args.flags.contains(CloneFlags::CLONE_UNTRACED))
+            .then(|| {
+                ctx.posix_thread
+                    .ptrace_event_on_clone(&clone_args, child, ctx)
+            })
+            .flatten()
+    };
+    let ptrace_may_stop_on = |ptrace_event: Option<PtraceEvent>, user_ctx: &mut UserContext| {
+        if let Some(event) = ptrace_event {
+            ctx.posix_thread.ptrace_may_stop_on(event, ctx, user_ctx);
+        }
+    };
+
     if clone_args.flags.contains(CloneFlags::CLONE_THREAD) {
         let child_task = clone_child_task(ctx, parent_context, clone_args)?;
         let child_thread = child_task.as_thread().unwrap();
+
+        let ptrace_event = ptrace_event_on_clone(child_thread);
         child_thread.run();
+        ptrace_may_stop_on(ptrace_event, parent_context);
 
         let child_tid = child_thread.as_posix_thread().unwrap().tid();
         Ok(child_tid)
@@ -345,7 +352,9 @@ pub fn clone_child(
             child_process.status().set_vfork_child(true);
         }
 
+        let ptrace_event = ptrace_event_on_clone(&child_process.main_thread());
         child_process.run();
+        ptrace_may_stop_on(ptrace_event, parent_context);
 
         PROCESS_CREATION_COUNTER
             .get()
@@ -353,13 +362,20 @@ pub fn clone_child(
             // Race conditions are fine as we don't really care which CPU creates a process.
             .add_on_cpu(CpuId::current_racy(), 1);
 
-        if child_process.status().is_vfork_child() {
+        let child_pid = child_process.pid();
+
+        if clone_args.flags.contains(CloneFlags::CLONE_VFORK) {
             let cond = || (!child_process.status().is_vfork_child()).then_some(());
             let current = ctx.process.as_ref();
             current.children_wait_queue().wait_until(cond);
+
+            ctx.posix_thread.ptrace_may_stop_on(
+                PtraceEvent::VforkDone(child_pid),
+                ctx,
+                parent_context,
+            );
         }
 
-        let child_pid = child_process.pid();
         Ok(child_pid)
     }
 }

--- a/kernel/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/src/process/posix_thread/ptrace/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         signal::{
             DequeuedSignal, PauseReason,
             c_types::siginfo_t,
-            constants::{CLD_TRAPPED, SIGCHLD, SIGKILL, SIGTRAP},
+            constants::{CLD_TRAPPED, SIGCHLD, SIGKILL, SIGSTOP, SIGTRAP},
             signals::{kernel::KernelSignal, raw::RawSignal, user::UserSignal},
         },
     },
@@ -115,11 +115,22 @@ impl PosixThread {
         }
     }
 
-    /// Returns whether a clone-family ptrace event would be required for `clone_args`.
-    pub(in crate::process) fn needs_ptrace_clone_stop(&self, clone_args: &CloneArgs) -> bool {
+    /// Returns the clone-family ptrace event corresponding to `clone_args`,
+    /// and makes the current tracer to automatically start tracing the newly
+    /// cloned `child`.
+    ///
+    /// Does nothing and returns `None` if:
+    ///  - the current thread is not being traced, or
+    ///  - the corresponding ptrace option is disabled.
+    pub(in crate::process) fn ptrace_event_on_clone(
+        &self,
+        clone_args: &CloneArgs,
+        child: &Arc<Thread>,
+        ctx: &Context,
+    ) -> Option<PtraceEvent> {
         self.tracee_status
             .get()
-            .is_some_and(|status| status.needs_clone_stop(clone_args))
+            .and_then(|status| status.ptrace_event_on_clone(clone_args, child, ctx))
     }
 
     /// Returns the ptrace-stop status changes for the `wait` syscall.
@@ -264,7 +275,12 @@ impl PosixThread {
     ///
     /// Panics if `tracer_thread` and `self` do not point to the same thread,
     /// or if `tracee_thread` is not a POSIX thread.
-    pub fn attach_to(&self, tracer_thread: &Arc<Thread>, tracee_thread: Arc<Thread>) -> Result<()> {
+    pub fn attach_to(
+        &self,
+        tracer_thread: &Arc<Thread>,
+        tracee_thread: Arc<Thread>,
+        init_options: Option<PtraceOptions>,
+    ) -> Result<()> {
         debug_assert!(core::ptr::eq(
             tracer_thread.as_posix_thread().unwrap(),
             self
@@ -283,6 +299,9 @@ impl PosixThread {
 
         let tracee = tracee_thread.as_posix_thread().unwrap();
         tracee.set_tracer(Arc::downgrade(tracer_thread))?;
+        if let Some(init_options) = init_options {
+            tracee.get_tracee_status().unwrap().state.lock().options = init_options;
+        }
         tracees.insert(tracee.tid(), tracee_thread);
 
         Ok(())
@@ -542,23 +561,42 @@ impl TraceeStatus {
         PtraceStopResult::Continued(signal)
     }
 
-    fn needs_clone_stop(&self, clone_args: &CloneArgs) -> bool {
+    fn ptrace_event_on_clone(
+        &self,
+        clone_args: &CloneArgs,
+        child_thread: &Arc<Thread>,
+        ctx: &Context,
+    ) -> Option<PtraceEvent> {
+        // Hold the lock first to avoid race conditions.
         let state = self.state.lock();
-        if state.tracer().is_none() {
-            return false;
+        debug_assert!(!self.is_ptrace_stopped());
+        let tracer_thread = state.tracer()?;
+
+        let child = child_thread.as_posix_thread().unwrap();
+        let child_tid = child.tid();
+        let event = if clone_args.flags.contains(CloneFlags::CLONE_VFORK) {
+            PtraceEvent::Vfork(child_tid)
+        } else if clone_args.exit_signal == Some(SIGCHLD) {
+            PtraceEvent::Fork(child_tid)
+        } else {
+            PtraceEvent::Clone(child_tid)
+        };
+
+        if !state.options.contains(event.option()) {
+            return None;
         }
+
         let options = state.options;
+        drop(state);
 
-        if clone_args.flags.contains(CloneFlags::CLONE_VFORK) {
-            return options.contains(PtraceOptions::PTRACE_O_TRACEVFORK)
-                || options.contains(PtraceOptions::PTRACE_O_TRACEVFORKDONE);
-        }
+        let tracer = tracer_thread.as_posix_thread().unwrap();
+        tracer
+            .attach_to(&tracer_thread, child_thread.clone(), Some(options))
+            .unwrap();
 
-        if clone_args.exit_signal == Some(SIGCHLD) {
-            return options.contains(PtraceOptions::PTRACE_O_TRACEFORK);
-        }
+        child.enqueue_signal(Box::new(UserSignal::new_kill(SIGSTOP, ctx)));
 
-        options.contains(PtraceOptions::PTRACE_O_TRACECLONE)
+        Some(event)
     }
 
     fn is_ptrace_stopped(&self) -> bool {

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -376,7 +376,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_BRK = 214                    => sys_brk(args[..1]);
             SYS_MUNMAP = 215                 => sys_munmap(args[..2]);
             SYS_MREMAP = 216                 => sys_mremap(args[..5]);
-            SYS_CLONE = 220                  => sys_clone(args[..5], &user_ctx);
+            SYS_CLONE = 220                  => sys_clone(args[..5], &mut user_ctx);
             SYS_EXECVE = 221                 => sys_execve(args[..3], &mut user_ctx);
             SYS_MMAP = 222                   => sys_mmap(args[..6]);
             SYS_FADVISE64 = 223              => sys_fadvise64(args[..4]);
@@ -400,7 +400,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_STATX = 291                  => sys_statx(args[..5]);
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
-            SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
+            SYS_CLONE3 = 435                 => sys_clone3(args[..2], &mut user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);
             SYS_PIDFD_GETFD = 438            => sys_pidfd_getfd(args[..3]);
             SYS_FACCESSAT2 = 439             => sys_faccessat2(args[..4]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -233,9 +233,9 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SOCKETPAIR = 53        => sys_socketpair(args[..4]);
     SYS_SETSOCKOPT = 54        => sys_setsockopt(args[..5]);
     SYS_GETSOCKOPT = 55        => sys_getsockopt(args[..5]);
-    SYS_CLONE = 56             => sys_clone(args[..5], &user_ctx);
-    SYS_FORK = 57              => sys_fork(args[..0], &user_ctx);
-    SYS_VFORK = 58             => sys_vfork(args[..0], &user_ctx);
+    SYS_CLONE = 56             => sys_clone(args[..5], &mut user_ctx);
+    SYS_FORK = 57              => sys_fork(args[..0], &mut user_ctx);
+    SYS_VFORK = 58             => sys_vfork(args[..0], &mut user_ctx);
     SYS_EXECVE = 59            => sys_execve(args[..3], &mut user_ctx);
     SYS_EXIT = 60              => sys_exit(args[..1], &mut user_ctx);
     SYS_WAIT4 = 61             => sys_wait4(args[..4]);
@@ -415,7 +415,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
-    SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
+    SYS_CLONE3 = 435           => sys_clone3(args[..2], &mut user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);
     SYS_PIDFD_GETFD = 438      => sys_pidfd_getfd(args[..3]);
     SYS_FACCESSAT2 = 439       => sys_faccessat2(args[..4]);

--- a/kernel/src/syscall/clone.rs
+++ b/kernel/src/syscall/clone.rs
@@ -20,7 +20,7 @@ pub fn sys_clone(
     child_tidptr: Vaddr,
     tls: u64,
     ctx: &Context,
-    parent_context: &UserContext,
+    parent_context: &mut UserContext,
 ) -> Result<SyscallReturn> {
     let args = CloneArgs::for_clone(clone_flags, parent_tidptr, child_tidptr, tls, new_sp)?;
     debug!("clone args = {:x?}", args);
@@ -33,7 +33,7 @@ pub fn sys_clone3(
     clong_args_addr: Vaddr,
     size: usize,
     ctx: &Context,
-    parent_context: &UserContext,
+    parent_context: &mut UserContext,
 ) -> Result<SyscallReturn> {
     debug!(
         "clone args addr = 0x{:x}, size = 0x{:x}",

--- a/kernel/src/syscall/fork.rs
+++ b/kernel/src/syscall/fork.rs
@@ -8,13 +8,13 @@ use crate::{
     process::{CloneArgs, clone_child},
 };
 
-pub fn sys_fork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallReturn> {
+pub fn sys_fork(ctx: &Context, parent_context: &mut UserContext) -> Result<SyscallReturn> {
     let clone_args = CloneArgs::for_fork();
     let child_pid = clone_child(ctx, parent_context, clone_args)?;
     Ok(SyscallReturn::Return(child_pid as _))
 }
 
-pub fn sys_vfork(ctx: &Context, parent_context: &UserContext) -> Result<SyscallReturn> {
+pub fn sys_vfork(ctx: &Context, parent_context: &mut UserContext) -> Result<SyscallReturn> {
     let clone_args = CloneArgs::for_vfork();
     let child_pid = clone_child(ctx, parent_context, clone_args)?;
     Ok(SyscallReturn::Return(child_pid as _))

--- a/kernel/src/syscall/ptrace.rs
+++ b/kernel/src/syscall/ptrace.rs
@@ -164,7 +164,7 @@ fn do_ptrace_attach(tracer_thread: &Arc<Thread>, tracee_thread: Arc<Thread>) -> 
 
     tracee.check_alien_access_from(tracer, AlienAccessMode::ATTACH_WITH_REAL_CREDS)?;
 
-    tracer.attach_to(tracer_thread, tracee_thread)
+    tracer.attach_to(tracer_thread, tracee_thread, None)
 }
 
 fn parse_ptrace_injected_signal(data: usize) -> Result<Option<SigNum>> {

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -69,6 +69,9 @@ pub fn create_new_user_task(
             crate::init::on_first_process_startup(&ctx);
         }
 
+        // Handle any signals already pending before the first return to user space.
+        handle_pending_signal(user_mode.context_mut(), &ctx);
+
         while !current_thread.is_exited() {
             // Execute the user code
             let return_reason = user_mode.execute(has_kernel_event_fn);

--- a/test/initramfs/src/regression/process/ptrace/set_options.c
+++ b/test/initramfs/src/regression/process/ptrace/set_options.c
@@ -184,9 +184,6 @@ FN_TEST(ptrace_trace_exit)
 }
 END_TEST()
 
-// TODO: Support clone-family ptrace events and remove this guard.
-#ifndef __asterinas__
-
 #define CLEANUP_GRAND_CHILD(notify_sig)                             \
 	pid_t grand_child = eventmsg;                               \
 	TEST_RES(waitpid(grand_child, &status, 0),                  \
@@ -310,5 +307,3 @@ FN_TEST(ptrace_trace_vfork_both)
 	CLEANUP_CHILD();
 }
 END_TEST()
-
-#endif


### PR DESCRIPTION
This PR adds support for the clone-family ptrace-event-stops (`PTRACE_EVENT_{FORK,VFORK,VFORK_DONE,CLONE}`): the tracee enters the matching event-stop and the new child is auto-attached to the tracer and stopped with `SIGSTOP`.

This PR also includes a cleaner fix than #3203. A freshly cloned thread should handle its pending signals before its first return to user space, else a cloned child who exits immediately may skip the SIGSTOP-delivery-stop.

Enables the clone-family cases in `set_options.c` on Asterinas.

Required for #2323.