### PR TITLE
Add `mincore` syscall

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -47,7 +47,7 @@ which are summarized in the table below.
 | 24      | sched_yield            | ✅             | 💯 |
 | 25      | mremap                 | ✅             | [⚠️](syscall-flag-coverage/memory-management/#mremap) |
 | 26      | msync                  | ✅             | [⚠️](syscall-flag-coverage/memory-management/#msync) |
-| 27      | mincore                | ❌             | N/A |
+| 27      | mincore                | ✅             | 💯 |
 | 28      | madvise                | ✅             | [⚠️](syscall-flag-coverage/memory-management/#madvise) |
 | 29      | shmget                 | ❌             | N/A |
 | 30      | shmat                  | ❌             | N/A |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/fully_covered.scml
@@ -1,2 +1,5 @@
 // Change data segment size
 brk(addr);
+
+// Query which pages of a mapping are resident in memory
+mincore(addr, length, vec);

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -70,6 +70,7 @@ macro_rules! import_generic_syscall_entries {
             lseek::sys_lseek,
             madvise::sys_madvise,
             memfd_create::sys_memfd_create,
+            mincore::sys_mincore,
             mkdir::sys_mkdirat,
             mknod::sys_mknodat,
             mmap::sys_mmap,
@@ -382,6 +383,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_FADVISE64 = 223              => sys_fadvise64(args[..4]);
             SYS_MPROTECT = 226               => sys_mprotect(args[..3]);
             SYS_MSYNC = 227                  => sys_msync(args[..3]);
+            SYS_MINCORE = 232                => sys_mincore(args[..3]);
             SYS_MADVISE = 233                => sys_madvise(args[..3]);
             SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
             SYS_WAIT4 = 260                  => sys_wait4(args[..4]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -70,6 +70,7 @@ use super::{
     lseek::sys_lseek,
     madvise::sys_madvise,
     memfd_create::sys_memfd_create,
+    mincore::sys_mincore,
     mkdir::{sys_mkdir, sys_mkdirat},
     mknod::{sys_mknod, sys_mknodat},
     mmap::sys_mmap,
@@ -207,6 +208,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SELECT = 23            => sys_select(args[..5]);
     SYS_MREMAP = 25            => sys_mremap(args[..5]);
     SYS_MSYNC = 26             => sys_msync(args[..3]);
+    SYS_MINCORE = 27           => sys_mincore(args[..3]);
     SYS_SCHED_YIELD = 24       => sys_sched_yield(args[..0]);
     SYS_MADVISE = 28           => sys_madvise(args[..3]);
     SYS_DUP = 32               => sys_dup(args[..1]);

--- a/kernel/src/syscall/mincore.rs
+++ b/kernel/src/syscall/mincore.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use align_ext::AlignExt;
+use ostd::mm::VmIo;
+
+use super::SyscallReturn;
+use crate::{prelude::*, vm::vmar::VMAR_CAP_ADDR};
+
+pub fn sys_mincore(addr: Vaddr, len: usize, vec: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
+    debug!("addr = 0x{:x}, len = {}, vec = 0x{:x}", addr, len, vec);
+
+    if !addr.is_multiple_of(PAGE_SIZE) {
+        return_errno_with_message!(Errno::EINVAL, "the mapping address is not aligned");
+    }
+    if len == 0 {
+        return Ok(SyscallReturn::Return(0));
+    }
+    if VMAR_CAP_ADDR.checked_sub(addr).is_none_or(|gap| gap < len) {
+        // FIXME: Linux returns `ENOMEM` if `(addr + len).align_up(PAGE_SIZE)` overflows. Here, we
+        // perform a stricter validation.
+        return_errno_with_message!(Errno::ENOMEM, "the mapping range is not in userspace");
+    }
+    let addr_range = addr..(addr + len).align_up(PAGE_SIZE);
+
+    let user_space = ctx.user_space();
+    let vmar = user_space.vmar();
+
+    let query_guard = vmar.query(addr_range.clone());
+    if !query_guard.is_fully_mapped() {
+        return_errno_with_message!(
+            Errno::ENOMEM,
+            "the range contains pages that are not mapped"
+        );
+    }
+
+    // Stream the result in fixed-size chunks rather than allocating a single
+    // buffer sized by the user-controlled range.
+    const CHUNK_PAGES: usize = 256;
+    let mut chunk = [0u8; CHUNK_PAGES];
+
+    for mapping in query_guard.iter() {
+        let range =
+            mapping.map_to_addr().max(addr_range.start)..mapping.map_end().min(addr_range.end);
+        debug_assert!(range.start.is_multiple_of(PAGE_SIZE));
+        debug_assert!(range.end.is_multiple_of(PAGE_SIZE));
+
+        let mut chunk_start = range.start;
+        while chunk_start < range.end {
+            let chunk_end = (chunk_start + CHUNK_PAGES * PAGE_SIZE).min(range.end);
+            let chunk_view = &mut chunk[..(chunk_end - chunk_start) / PAGE_SIZE];
+            chunk_view.fill(0);
+
+            mapping.fill_mincore_vec(vmar.vm_space(), chunk_start..chunk_end, chunk_view)?;
+
+            let vec_offset = vec + (chunk_start - addr_range.start) / PAGE_SIZE;
+            ctx.user_space().write_slice(vec_offset, chunk_view)?;
+
+            chunk_start = chunk_end;
+        }
+    }
+
+    Ok(SyscallReturn::Return(0))
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -83,6 +83,7 @@ mod listxattr;
 mod lseek;
 mod madvise;
 mod memfd_create;
+mod mincore;
 mod mkdir;
 mod mknod;
 mod mmap;

--- a/kernel/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/src/vm/page_cache/vmo/mod.rs
@@ -261,6 +261,19 @@ impl Vmo {
             .map(|(_, page)| page)
     }
 
+    /// Returns whether the page at the target offset in the VMO has been committed.
+    pub fn is_committed_page(&self, offset: usize) -> bool {
+        if offset >= self.size() {
+            return false;
+        }
+
+        let page_idx = offset / PAGE_SIZE;
+        let guard = disable_preempt();
+        let mut cursor = self.pages.cursor(&guard, page_idx as u64);
+
+        cursor.load().is_some()
+    }
+
     fn try_commit_with_cursor(
         &self,
         cursor: &mut Cursor<'_, CachePage>,

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -221,6 +221,57 @@ impl VmMapping {
         cursor.map_iomem(io_mem, io_page_prop, self.map_size.get(), vmo_offset);
     }
 
+    /// Fills a `mincore` result vector for the specified sub-range.
+    pub fn fill_mincore_vec(
+        &self,
+        vm_space: &VmSpace,
+        range: Range<Vaddr>,
+        vec: &mut [u8],
+    ) -> Result<()> {
+        debug_assert!(range.start.is_multiple_of(PAGE_SIZE));
+        debug_assert!(range.end.is_multiple_of(PAGE_SIZE));
+        debug_assert!(range.start >= self.map_to_addr);
+        debug_assert!(range.end <= self.map_end());
+        debug_assert_eq!(range.len() / PAGE_SIZE, vec.len());
+
+        let preempt_guard = disable_preempt();
+        let mut cursor = vm_space.cursor(&preempt_guard, &range)?;
+        let end_va = range.end;
+        let mut remain_size = range.len();
+        while let Some(mapped_va) = cursor.find_next(remain_size) {
+            let (va, Some(_item)) = cursor.query().unwrap() else {
+                panic!("Found mapped page but query failed");
+            };
+            debug_assert_eq!(mapped_va, va.start);
+
+            let idx = (mapped_va - range.start) / PAGE_SIZE;
+            vec[idx] = 1;
+
+            if mapped_va + PAGE_SIZE == end_va {
+                break;
+            }
+            cursor.jump(mapped_va + PAGE_SIZE).unwrap();
+            remain_size = end_va - cursor.virt_addr();
+        }
+
+        if let MappedMemory::Vmo(vmo) = &self.mapped_mem {
+            // For file-backed mappings, a page is considered resident
+            // if its page cache is already committed,
+            // even when the page is not mapped in the page table yet.
+            //
+            // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/mm/mincore.c#L84>
+            for (idx, page_addr) in range.step_by(PAGE_SIZE).enumerate() {
+                if vec[idx] == 1 {
+                    continue;
+                }
+
+                vec[idx] = vmo.is_committed_frame(page_addr - self.map_to_addr).into();
+            }
+        }
+
+        Ok(())
+    }
+
     /// Prints the mapping information in the format of `/proc/[pid]/maps`.
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/task_mmu.c#L304-L359>
@@ -881,6 +932,12 @@ impl MappedVmo {
         self.vmo
             .try_commit_page(self.offset + page_offset)
             .map(|frame| frame.into())
+    }
+
+    /// Returns whether there is a committed frame at the input offset in the mapped VMO.
+    fn is_committed_frame(&self, page_offset: usize) -> bool {
+        debug_assert!(page_offset.is_multiple_of(PAGE_SIZE));
+        self.vmo.is_committed_page(self.offset + page_offset)
     }
 
     /// Commits a page at a specific page index.

--- a/test/initramfs/src/regression/memory/mmap/mmap_and_mincore.c
+++ b/test/initramfs/src/regression/memory/mmap/mmap_and_mincore.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define PAGE_SIZE 4096
+#define FILE_NAME "/tmp/mincore_test.txt"
+
+FN_TEST(anonymous_residency)
+{
+	unsigned char *anon_addr =
+		TEST_SUCC(mmap(NULL, PAGE_SIZE * 2, PROT_READ | PROT_WRITE,
+			       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+
+	unsigned char vec[2] = { 0xff, 0xff };
+
+	TEST_RES(mincore(anon_addr, PAGE_SIZE * 2, vec),
+		 _ret == 0 && (vec[0] & 1) == 0 && (vec[1] & 1) == 0);
+
+	anon_addr[0] = 'x';
+	vec[0] = vec[1] = 0xff;
+	TEST_RES(mincore(anon_addr, PAGE_SIZE * 2, vec),
+		 _ret == 0 && (vec[0] & 1) == 1 && (vec[1] & 1) == 0);
+
+	anon_addr[PAGE_SIZE] = 'y';
+	vec[0] = vec[1] = 0xff;
+	TEST_RES(mincore(anon_addr, PAGE_SIZE * 2, vec),
+		 _ret == 0 && (vec[0] & 1) == 1 && (vec[1] & 1) == 1);
+
+	TEST_SUCC(munmap(anon_addr, PAGE_SIZE * 2));
+}
+END_TEST()
+
+FN_TEST(filebacked_page_cache_residency)
+{
+	unsigned char *file_addr;
+	int file_fd =
+		TEST_SUCC(open(FILE_NAME, O_RDWR | O_CREAT | O_TRUNC, 0666));
+	TEST_SUCC(ftruncate(file_fd, PAGE_SIZE * 2));
+	TEST_SUCC(write(file_fd, "a", 1));
+	file_addr = TEST_SUCC(
+		mmap(NULL, PAGE_SIZE * 2, PROT_READ, MAP_SHARED, file_fd, 0));
+
+	unsigned char vec[2] = { 0xff, 0xff };
+
+	// For file-backed mappings, a page is considered resident
+	// if its page cache is already committed,
+	// even when the page is not mapped in the page table yet.
+	TEST_RES(mincore(file_addr, PAGE_SIZE * 2, vec),
+		 _ret == 0 && (vec[0] & 1) == 1 && (vec[1] & 1) == 0);
+
+	TEST_SUCC(munmap(file_addr, PAGE_SIZE * 2));
+	TEST_SUCC(close(file_fd));
+	TEST_SUCC(unlink(FILE_NAME));
+}
+END_TEST()
+
+FN_TEST(large_range_residency)
+{
+	static unsigned char vec[10000];
+	size_t pages = sizeof(vec);
+	size_t size = pages * PAGE_SIZE;
+
+	unsigned char *addr =
+		TEST_SUCC(mmap(NULL, size, PROT_READ | PROT_WRITE,
+			       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+
+	// Make only the first and last pages resident.
+	addr[0] = 'a';
+	addr[(pages - 1) * PAGE_SIZE] = 'b';
+
+	for (size_t i = 0; i < pages; i++)
+		vec[i] = 0xff;
+
+	TEST_RES(mincore(addr, size, vec),
+		 _ret == 0 && (vec[0] & 1) == 1 && (vec[pages - 1] & 1) == 1);
+
+	// Every other page must be reported non-resident.
+	int middle_all_zero = 1;
+	for (size_t i = 1; i < pages - 1; i++)
+		middle_all_zero = middle_all_zero && ((vec[i] & 1) == 0);
+	TEST_RES(middle_all_zero, _ret == 1);
+
+	TEST_SUCC(munmap(addr, size));
+}
+END_TEST()

--- a/test/initramfs/src/regression/memory/run_test.sh
+++ b/test/initramfs/src/regression/memory/run_test.sh
@@ -13,3 +13,4 @@ set -e
 ./mmap/mmap_readahead
 ./mmap/mmap_shared_filebacked
 ./mmap/mmap_vmrss
+./mmap/mmap_and_mincore


### PR DESCRIPTION
Our Asterinas NixOS keeps to warn me that `mincore` is not implemented, which is a bit annoying, so this PR adds it.

The `mincore` syscall reports which pages of a mapping are resident in memory. Counterintuitively, [in Linux](https://elixir.bootlin.com/linux/v6.16.5/source/mm/mincore.c#L84), for file-backed mappings, a page is considered resident if its page cache is already committed, even when the page is not mapped in the page table yet.

Reference: https://man7.org/linux/man-pages/man2/mincore.2.html