### PR TITLE
Add support for generating Asterinas kernel ISO installer images

### DIFF
--- a/.github/workflows/test_iso_image.yml
+++ b/.github/workflows/test_iso_image.yml
@@ -35,3 +35,38 @@ jobs:
       - name : Run Asterinas NixOS
         run: |
           make run_nixos NIXOS_TEST_SUITE=hello
+
+  iso-test-asterinas-kernel:
+    runs-on: ubuntu-4-cores-150GB-ssd
+    container:
+      image: asterinas/asterinas:0.18.0-20260618
+      options: -v /dev:/dev --privileged
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Asterinas NixOS ISO installer image with Asterinas kernel
+        run: |
+          AUTO_INSTALL=false USE_ASTERINAS_KERNEL=true make iso NIXOS_TEST_SUITE=hello
+      - name: Run ISO image with Asterinas kernel
+        run: |
+          set -e
+          mkfifo qemu.input
+          (
+            sleep 900
+            echo uname -a
+            sleep 10
+            echo poweroff
+          ) > qemu.input &
+          input_pid=$!
+          trap 'kill "${input_pid}" 2>/dev/null || true; rm -f qemu.input' EXIT
+
+          ENABLE_KVM=0 timeout 30m make run_iso < qemu.input || true
+          if ! grep -a -q "Linux nixos 5.13.0 .* x86_64 GNU/Linux" qemu.log; then
+            echo "Test ISO failed"
+            echo "===== qemu.log ====="
+            tail --lines 200 qemu.log
+            echo "===== qemu-serial.log ====="
+            tail --lines 200 qemu-serial.log || true
+            exit 1
+          fi
+          echo "Test ISO succeeds!"

--- a/book/src/distro/README.md
+++ b/book/src/distro/README.md
@@ -32,11 +32,11 @@ using the Asterinas NixOS installer ISO.
     docker run -it --privileged --network=host ubuntu:latest bash
     ```
 
-2. Inside the container, install QEMU:
+2. Inside the container, install QEMU and OVMF:
 
     ```bash
     apt update
-    apt install -y qemu-system-x86 qemu-utils
+    apt install -y qemu-system-x86 qemu-utils ovmf
     ```
 
 3. Download the latest Asterinas NixOS installer ISO from [GitHub Releases](https://github.com/asterinas/asterinas/releases).
@@ -54,12 +54,17 @@ one is the installer CD-ROM and the other is the target disk:
     ```bash
     export INSTALLER_ISO=/path/to/your/downloaded/installer.iso
     qemu-system-x86_64 \
+    -bios /usr/share/qemu/OVMF.fd \
     -cpu host -m 8G -enable-kvm \
+    -machine q35,kernel-irqchip=split \
     -drive file="$INSTALLER_ISO",media=cdrom -boot d \
-    -drive if=virtio,format=raw,file=aster_nixos_disk.img \
+    -drive if=none,format=raw,id=hd0,file=aster_nixos_disk.img \
+    -device virtio-blk-pci,drive=hd0,disable-legacy=on,disable-modern=off \
     -chardev stdio,id=mux,mux=on,logfile=qemu.log \
     -device virtio-serial-pci -device virtconsole,chardev=mux \
     -serial chardev:mux -monitor chardev:mux \
+    -netdev user,id=net0 \
+    -device virtio-net-pci,netdev=net0,disable-legacy=on,disable-modern=off,mrg_rxbuf=off,ctrl_rx=off,ctrl_rx_extra=off,ctrl_vlan=off,ctrl_vq=off,ctrl_guest_offloads=off,ctrl_mac_addr=off,event_idx=off,queue_reset=off,guest_announce=off,indirect_desc=off \
     -nographic
     ```
 
@@ -103,14 +108,15 @@ to customize the NixOS system to be installed:
     ```bash
     qemu-system-x86_64 \
     -cpu host -m 8G -enable-kvm \
+    -machine q35,kernel-irqchip=split \
     -bios /usr/share/qemu/OVMF.fd \
     -drive if=none,format=raw,id=x0,file=aster_nixos_disk.img \
     -device virtio-blk-pci,drive=x0,disable-legacy=on,disable-modern=off \
     -chardev stdio,id=mux,mux=on,logfile=qemu.log \
     -device virtio-serial-pci -device virtconsole,chardev=mux \
     -serial chardev:mux -monitor chardev:mux \
-    -device virtio-net-pci,netdev=net0,disable-legacy=on,disable-modern=off \
     -netdev user,id=net0 \
+    -device virtio-net-pci,netdev=net0,disable-legacy=on,disable-modern=off,mrg_rxbuf=off,ctrl_rx=off,ctrl_rx_extra=off,ctrl_vlan=off,ctrl_vq=off,ctrl_guest_offloads=off,ctrl_mac_addr=off,event_idx=off,queue_reset=off,guest_announce=off,indirect_desc=off \
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
     -nographic -display vnc=127.0.0.1:21
     ```

--- a/distro/aster_nixos_installer/default.nix
+++ b/distro/aster_nixos_installer/default.nix
@@ -43,6 +43,7 @@ in pkgs.stdenv.mkDerivation {
     cp -L ${etc-nixos}/${config-file-name} $out/etc_nixos/configuration.nix
     cp -r ${etc-nixos}/modules $out/etc_nixos/modules
     cp -r ${etc-nixos}/overlays $out/etc_nixos/overlays
+    cp -r ${etc-nixos}/pkgs $out/etc_nixos/pkgs
     ln -s ${aster-kernel} $out/kernel
   '';
 }

--- a/distro/aster_nixos_installer/templates/aster-nixos-install
+++ b/distro/aster_nixos_installer/templates/aster-nixos-install
@@ -89,17 +89,57 @@ else
     BOOT_DEVICE="${DISK}1"
     ROOT_DEVICE="${DISK}2"
 fi
-if [ ! -b "${BOOT_DEVICE}" ] && [ ! -b "${ROOT_DEVICE}" ]; then
+
+partition_info() {
+    awk -v name="${1#/dev/}" '$4 == name {print $1, $2}' /proc/partitions
+}
+
+partition_exists() {
+    [ -n "$(partition_info "$1")" ]
+}
+
+ensure_partition_device() {
+    DEVICE_PATH="$1"
+    PARTITION_INFO=$(partition_info "${DEVICE_PATH}")
+    if [ -z "${PARTITION_INFO}" ]; then
+        echo "Error: Partition ${DEVICE_PATH} does not exist in /proc/partitions" >&2
+        exit 1
+    fi
+
+    set -- ${PARTITION_INFO}
+    EXPECTED_MAJOR=$(printf '%x' "$1")
+    EXPECTED_MINOR=$(printf '%x' "$2")
+
+    if [ -b "${DEVICE_PATH}" ]; then
+        DEVICE_MAJOR=$(stat -c '%t' "${DEVICE_PATH}")
+        DEVICE_MINOR=$(stat -c '%T' "${DEVICE_PATH}")
+        if [ "${DEVICE_MAJOR}" = "${EXPECTED_MAJOR}" ] && [ "${DEVICE_MINOR}" = "${EXPECTED_MINOR}" ]; then
+            return
+        fi
+        rm -f "${DEVICE_PATH}"
+    fi
+
+    mknod "${DEVICE_PATH}" b "$1" "$2"
+}
+
+if ! partition_exists "${BOOT_DEVICE}" || ! partition_exists "${ROOT_DEVICE}"; then
+    rm -f "${BOOT_DEVICE}" "${ROOT_DEVICE}"
     parted ${DISK} -- mklabel gpt
     parted ${DISK} -- mkpart ESP fat32 1MB 512MB
     parted ${DISK} -- mkpart root ext2 512MB 100%
     parted ${DISK} -- set 1 esp on
+    partx -a ${DISK} 2>/dev/null || true
     echo "partition finished"
+
+    ensure_partition_device "${BOOT_DEVICE}"
+    ensure_partition_device "${ROOT_DEVICE}"
 
     mkfs.fat -F 32 -n boot "${BOOT_DEVICE}"
     mkfs.ext2 -L nixos "${ROOT_DEVICE}"
     echo "mkfs finished"
 else
+    ensure_partition_device "${BOOT_DEVICE}"
+    ensure_partition_device "${ROOT_DEVICE}"
     echo "Partitions ${BOOT_DEVICE} and ${ROOT_DEVICE} already exist — skipping partitioning and mkfs"
 fi
 
@@ -130,6 +170,7 @@ cp $CONFIG_PATH ${BUILD_DIR}/etc/nixos/configuration.nix
 cp @aster-configuration@ ${BUILD_DIR}/etc/nixos/aster_configuration.nix
 cp -r @aster-etc-nixos@/modules ${BUILD_DIR}/etc/nixos
 cp -r @aster-etc-nixos@/overlays ${BUILD_DIR}/etc/nixos
+cp -r @aster-etc-nixos@/pkgs ${BUILD_DIR}/etc/nixos
 
 COMMON_NIX_ARGS=(
     --option extra-substituters "@aster-substituters@"

--- a/distro/etc_nixos/modules/asterinas-base.nix
+++ b/distro/etc_nixos/modules/asterinas-base.nix
@@ -1,0 +1,43 @@
+# Asterinas NixOS base module.
+#
+# Provides common settings shared by both disk and ISO.  The universal
+# stage-1 init is defined in asterinas-stage-1-init.nix and referenced
+# by both core.nix (disk) and iso_image/default.nix (ISO).
+{ config, lib, pkgs, ... }:
+let
+  stage-1-init = import ./asterinas-stage-1-init.nix { inherit pkgs; };
+
+  initramfs = pkgs.makeInitrd {
+    contents = [
+      {
+        object = "${pkgs.busybox}/bin";
+        symlink = "/bin";
+      }
+      {
+        object = stage-1-init;
+        symlink = "/init";
+      }
+    ];
+  };
+in {
+  # Export the stage-1 init and initramfs as packages so that
+  # core.nix (disk) and iso_image (ISO) can both reference them.
+  nixpkgs.overlays = [
+    (final: prev: {
+      asterinas-stage-1-init = stage-1-init;
+      asterinas-initramfs = initramfs;
+    })
+  ];
+
+  # Common settings shared by disk and ISO.
+  boot.kernel.enable = false;
+  boot.initrd.enable = false;
+  system.activationScripts.modprobe = lib.mkForce "";
+
+  # Suppress error and warning messages of systemd.
+  # TODO: Fix errors and warnings from systemd and remove this setting.
+  environment.sessionVariables = { SYSTEMD_LOG_LEVEL = "crit"; };
+
+  # FIXME: Currently, during `nixos-rebuild`, `texinfo/install-info` encounters a `SIGBUS`.
+  documentation.info.enable = false;
+}

--- a/distro/etc_nixos/modules/asterinas-stage-1-init.nix
+++ b/distro/etc_nixos/modules/asterinas-stage-1-init.nix
@@ -1,0 +1,136 @@
+# Universal stage-1 init for Asterinas NixOS.
+# Shared by both disk and ISO boot paths.
+#
+# On Asterinas, devtmpfs is not supported, so this script explicitly creates
+# /dev device nodes using busybox mknod.  It handles two boot modes:
+#   - Disk mode: root= is present → mount root, switch_root
+#   - ISO mode:  root= is absent  → exec NixOS stage-2 init directly
+{ pkgs }:
+pkgs.writeShellScript "stage-1-init" ''
+  #!/bin/sh
+  # SPDX-License-Identifier: MPL-2.0
+
+  # Create essential /dev nodes.
+  # Asterinas does not support devtmpfs, so the NixOS mounts.sh in
+  # stage-2 cannot populate /dev via devtmpfs.
+  mknod /dev/console c 5 1 2>/dev/null;  chmod 666 /dev/console
+  mknod /dev/tty c 5 0 2>/dev/null;     chmod 666 /dev/tty
+  mknod /dev/tty0 c 4 0 2>/dev/null;    chmod 622 /dev/tty0
+  mknod /dev/ttyS0 c 4 64 2>/dev/null;  chmod 660 /dev/ttyS0
+  mknod /dev/hvc0 c 229 0 2>/dev/null;  chmod 666 /dev/hvc0
+  mknod /dev/hvc1 c 229 1 2>/dev/null;  chmod 660 /dev/hvc1
+  mknod /dev/hvc2 c 229 2 2>/dev/null;  chmod 660 /dev/hvc2
+  mknod /dev/hvc3 c 229 3 2>/dev/null;  chmod 660 /dev/hvc3
+  mknod /dev/null c 1 3 2>/dev/null;     chmod 666 /dev/null
+  mknod /dev/zero c 1 5 2>/dev/null;    chmod 666 /dev/zero
+  mknod /dev/full c 1 7 2>/dev/null;    chmod 666 /dev/full
+  mknod /dev/random c 1 8 2>/dev/null;  chmod 666 /dev/random
+  mknod /dev/urandom c 1 9 2>/dev/null; chmod 666 /dev/urandom
+  mknod /dev/ptmx c 5 2 2>/dev/null;    chmod 666 /dev/ptmx
+  mknod /dev/tty1 c 4 1 2>/dev/null;    chmod 620 /dev/tty1
+  mknod /dev/tty2 c 4 2 2>/dev/null;    chmod 620 /dev/tty2
+  mknod /dev/tty3 c 4 3 2>/dev/null;    chmod 620 /dev/tty3
+  mknod /dev/tty4 c 4 4 2>/dev/null;    chmod 620 /dev/tty4
+  mknod /dev/tty5 c 4 5 2>/dev/null;    chmod 620 /dev/tty5
+  mknod /dev/tty6 c 4 6 2>/dev/null;    chmod 620 /dev/tty6
+  mkdir -p /dev/pts /dev/shm
+
+  # Mount /proc and /sys (required by NixOS stage-2 and systemd).
+  mount -t proc none /proc
+  mount -t sysfs none /sys
+
+  # Create symlinks to proc files.
+  ln -sfn /proc/self/fd /dev/fd
+  ln -sfn /proc/self/fd/0 /dev/stdin
+  ln -sfn /proc/self/fd/1 /dev/stdout
+  ln -sfn /proc/self/fd/2 /dev/stderr
+
+  NEW_ROOT=""
+  NEW_INIT=""
+  BREAK=""
+  ARGS=""
+
+  for arg in "$@"; do
+    case "$arg" in
+      root=*)
+        NEW_ROOT=''${arg#root=}
+        ;;
+      init=*)
+        NEW_INIT=''${arg#init=}
+        ;;
+      rd.break=*)
+        BREAK=''${arg#rd.break=}
+        ;;
+      *)
+        ARGS="$ARGS $arg"
+        ;;
+    esac
+  done
+
+  if [ "$BREAK" = "1" ]; then
+    echo "Breaking into initramfs shell..."
+    exec /bin/sh
+  fi
+
+  if [ -n "$NEW_ROOT" ]; then
+    # Disk mode: mount root filesystem and switch_root.
+    mkdir /sysroot
+    mount -t ext2 "$NEW_ROOT" /sysroot
+    mount -t proc none /sysroot/proc
+    mkdir -p /sysroot/run/initramfs/dev
+    mount -o bind /dev /sysroot/run/initramfs/dev
+    mount --move /dev /sysroot/dev
+    exec switch_root /sysroot "$NEW_INIT" $ARGS
+  else
+    # ISO mode or Fallback: the root is a new ramfs to allow pivot_root.
+    TARGET_INIT=""
+    if [ -n "$NEW_INIT" ]; then
+      TARGET_INIT="$NEW_INIT"
+    else
+      for candidate in /nix/store/*/stage-2-init; do
+        if [ -f "$candidate" ] && [ -x "$candidate" ]; then
+          TARGET_INIT="$candidate"
+          break
+        fi
+      done
+      if [ -z "$TARGET_INIT" ]; then
+        for candidate in /nix/store/*/init; do
+          if [ -f "$candidate" ] && [ -x "$candidate" ]; then
+            if [ "$(readlink -f "$candidate" 2>/dev/null)" != "/bin/busybox" ]; then
+              TARGET_INIT="$candidate"
+              break
+            fi
+          fi
+        done
+      fi
+    fi
+
+    if [ -z "$TARGET_INIT" ]; then
+      echo "Error: no suitable init found."
+      exit 1
+    fi
+
+    echo "ISO Mode: preparing ramfs root at /sysroot..."
+    mkdir -p /sysroot
+    mount -t ramfs none /sysroot
+
+    echo "Copying files to ramfs root..."
+    mkdir -p /sysroot/proc /sysroot/sys /sysroot/dev /sysroot/run /sysroot/var /sysroot/tmp
+    # Create directories and files that PAM (login) expects on a real
+    # filesystem.  Without these, pam_unix.so and pam_lastlog.so fail
+    # and the login binary exits with "Error in service module".
+    mkdir -p /sysroot/var/log /sysroot/var/run
+    touch /sysroot/var/log/lastlog /sysroot/var/run/utmp /sysroot/var/log/wtmp
+    cp -a /bin /etc /lib /lib64 /nix /usr /sysroot/
+
+    echo "Moving /dev and mounting /proc and /sys..."
+    mkdir -p /sysroot/run/initramfs/dev
+    mount -o bind /dev /sysroot/run/initramfs/dev
+    mount --move /dev /sysroot/dev
+    mount -t proc none /sysroot/proc
+    mount -t sysfs none /sysroot/sys
+
+    echo "Switching root to ramfs and executing $TARGET_INIT..."
+    exec switch_root /sysroot "$TARGET_INIT" $ARGS
+  fi
+''

--- a/distro/etc_nixos/modules/core.nix
+++ b/distro/etc_nixos/modules/core.nix
@@ -4,69 +4,13 @@ let
     name = "aster-kernel-osdk-bin";
     path = config.aster_nixos.kernel;
   };
-  stage-1-init = pkgs.writeShellScript "stage-1-init" ''
-    #!/bin/sh
-    # SPDX-License-Identifier: MPL-2.0
-
-    NEW_ROOT=""
-    NEW_INIT=""
-    BREAK=""
-    ARGS=""
-
-    for arg in "$@"; do
-      case "$arg" in
-        root=*)
-          NEW_ROOT=''${arg#root=}
-          ;;
-        init=*)
-          NEW_INIT=''${arg#init=}
-          ;;
-        rd.break=*)
-          BREAK=''${arg#rd.break=}
-          ;;
-        *)
-          ARGS="$ARGS $arg"
-          ;;
-      esac
-    done
-
-    if [ "$BREAK" = "1" ]; then
-      echo "Breaking into initramfs shell..."
-      exec /bin/sh
-    fi
-
-    if [ -z "$NEW_ROOT" ] || [ -z "$NEW_INIT" ]; then
-      echo "Error: 'root=' and 'init=' parameters are required."
-      exit 1
-    fi
-
-    mkdir /sysroot
-    mount -t ext2 "$NEW_ROOT" /sysroot
-    mount -t proc none /sysroot/proc
-    mount --move /dev /sysroot/dev
-
-    exec switch_root /sysroot "$NEW_INIT" "$ARGS"
-  '';
-
-  initramfs = pkgs.makeInitrd {
-    contents = [
-      {
-        object = "${pkgs.busybox}/bin";
-        symlink = "/bin";
-      }
-      {
-        object = stage-1-init;
-        symlink = "/init";
-      }
-    ];
-  };
 in {
+  imports = [ ./asterinas-base.nix ];
+
   boot.loader.grub.enable = true;
   boot.loader.grub.efiSupport = true;
   boot.loader.grub.device = "nodev";
   boot.loader.grub.efiInstallAsRemovable = true;
-  boot.initrd.enable = false;
-  boot.kernel.enable = false;
   # Hook function will be called in stage-2-init and before running systemd.
   boot.postBootCommands = ''
     echo "Executing postBootCommands..."
@@ -74,9 +18,18 @@ in {
       ${config.aster_nixos.stage-2-hook}
     fi
   '';
-  # Suppress error and warning messages of systemd.
-  # TODO: Fix errors and warnings from systemd and remove this setting.
-  environment.sessionVariables = { SYSTEMD_LOG_LEVEL = "crit"; };
+
+  systemd.services.restore-devices = {
+    description = "Restore kernel-created block devices";
+    wantedBy = [ "sysinit.target" ];
+    before = [ "local-fs-pre.target" "systemd-tmpfiles-setup-dev.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart =
+        "${pkgs.bash}/bin/bash -c 'if [ -d /run/initramfs/dev ]; then cp -a /run/initramfs/dev/vd* /dev/ 2>/dev/null || true; cp -a /run/initramfs/dev/nvme* /dev/ 2>/dev/null || true; fi'";
+    };
+  };
   system.systemBuilderCommands = ''
     echo "PATH=/bin:/nix/var/nix/profiles/system/sw/bin ostd.log_level=${config.aster_nixos.log-level} console=${config.aster_nixos.console} -- sh /init root=/dev/vda2 init=/nix/var/nix/profiles/system/stage-2-init rd.break=${
       if config.aster_nixos.break-into-stage-1-shell then "1" else "0"
@@ -90,12 +43,12 @@ in {
     rm -rf $out/init
     ln -s /bin/busybox $out/init
     ln -s ${kernel} $out/kernel
-    ln -s ${initramfs}/initrd $out/initrd
+    ln -s ${pkgs.asterinas-initramfs}/initrd $out/initrd
   '';
-  system.activationScripts.modprobe = lib.mkForce "";
 
   nix.nixPath = options.nix.nixPath.default
     ++ [ "nixpkgs-overlays=/etc/nixos/overlays" ];
+  nix.channel.enable = false;
   nix.settings = {
     filter-syscalls = false;
     require-sigs = false;
@@ -106,7 +59,4 @@ in {
     substituters = [ "${config.aster_nixos.substituters}" ];
     trusted-public-keys = [ "${config.aster_nixos.trusted-public-keys}" ];
   };
-
-  # FIXME: Currently, during `nixos-rebuild`, `texinfo/install-info` encounters a `SIGBUS`.
-  documentation.info.enable = false;
 }

--- a/distro/etc_nixos/modules/systemd.nix
+++ b/distro/etc_nixos/modules/systemd.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
-
-{
-  systemd.package = pkgs.aster_systemd;
+let aster_systemd = import ../pkgs/systemd.nix { inherit pkgs; };
+in {
+  systemd.package = aster_systemd;
 
   # TODO: The following services currently do not work and 
   # may affect systemd startup or cause performance issues. 
@@ -11,11 +11,22 @@
   systemd.services.logrotate.enable = false;
   systemd.services.network-setup.enable = false;
   systemd.services.resolvconf.enable = false;
+  systemd.services.dhcpcd.enable = false;
   systemd.services.systemd-random-seed.enable = false;
   systemd.services.systemd-tmpfiles-clean.enable = false;
   systemd.services.systemd-tmpfiles-setup.enable = false;
   services.timesyncd.enable = false;
   services.udev.enable = false;
+
+  system.activationScripts.asterinasUnixChkpwdWrapper = {
+    deps = [ "specialfs" ];
+    text = ''
+      ${pkgs.coreutils}/bin/install -D -o 0 -g 0 -m 4755 \
+        ${pkgs.pam}/bin/unix_chkpwd \
+        /run/wrappers/bin/unix_chkpwd
+    '';
+  };
+  systemd.services.suid-sgid-wrappers.enable = false;
 
   services.getty.autologinUser = "root";
   users.users.root = {

--- a/distro/etc_nixos/pkgs/systemd.nix
+++ b/distro/etc_nixos/pkgs/systemd.nix
@@ -1,0 +1,65 @@
+# Patched systemdMinimal package for Asterinas NixOS.
+{ pkgs }:
+
+pkgs.systemdMinimal.overrideAttrs (old: {
+  patches = (old.patches or [ ]) ++ [
+    ../overlays/systemd/0001-Skip-mount-state-checking.patch
+    ../overlays/systemd/0002-Disable-loop-too-fast-warning.patch
+    ../overlays/systemd/0003-Switch-MS_SLAVE-to-MS_PRIVATE.patch
+  ];
+  postInstall = let
+    extraPostInstall = ''
+      mkdir -p "$out/example/systemd/system"
+      for svc in systemd-logind systemd-user-sessions systemd-firstboot \
+                 systemd-random-seed systemd-vconsole-setup; do
+        cat > "$out/example/systemd/system/$svc.service" <<EOF
+      [Unit]
+      Description=placeholder ''${svc} (disabled)
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/true
+      EOF
+      done
+      cat > "$out/example/systemd/system/dbus-org.freedesktop.login1.service" <<'EOF'
+      [Unit]
+      Description=placeholder dbus-org.freedesktop.login1
+      [Service]
+      Type=dbus
+      BusName=org.freedesktop.login1
+      ExecStart=/bin/true
+      EOF
+      cat > "$out/example/systemd/system/user@.service" <<'EOF'
+      [Unit]
+      Description=placeholder user@.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/bin/true
+      EOF
+      cat > "$out/example/systemd/system/user-runtime-dir@.service" <<'EOF'
+      [Unit]
+      Description=placeholder user-runtime-dir@.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/bin/mkdir -p /run/user/%i
+      EOF
+      cat > "$out/example/systemd/system/local-fs.target.wants/tmp.mount" <<'EOF'
+      # placeholder
+      EOF
+      if [ ! -e "$out/lib/systemd/systemd-bsod" ]; then
+        mkdir -p "$out/lib/systemd"
+        cat > "$out/lib/systemd/systemd-bsod" <<'STUB'
+      #!/bin/sh
+      exit 0
+      STUB
+        chmod +x "$out/lib/systemd/systemd-bsod"
+      fi
+      for unit in getty@.service serial-getty@.service; do
+        if [ -f "$out/example/systemd/system/$unit" ]; then
+          sed -i '/^ImportCredential=/d' "$out/example/systemd/system/$unit"
+        fi
+      done
+    '';
+  in (old.postInstall or "") + "\n" + extraPostInstall;
+})

--- a/distro/iso_image/default.nix
+++ b/distro/iso_image/default.nix
@@ -1,12 +1,21 @@
-{ pkgs ? import <nixpkgs> { }, autoInstall ? false, extra-substituters ? ""
-, config-file-name ? "configuration.nix", extra-trusted-public-keys ? ""
-, target_platform ? "x86_64-linux", version ? "", ... }:
+{ pkgs ? import <nixpkgs> { }, lib ? pkgs.lib, autoInstall ? false
+, extra-substituters ? "", config-file-name ? "configuration.nix"
+, extra-trusted-public-keys ? "", target_platform ? "x86_64-linux", version ? ""
+, useAsterinasKernel ? false, ... }:
 let
   installer = pkgs.callPackage ../aster_nixos_installer {
     inherit extra-substituters extra-trusted-public-keys config-file-name
       target_platform;
   };
-  configuration = {
+
+  asterinasKernel = builtins.path {
+    name = "aster-kernel-osdk-bin";
+    path = ../../target/osdk/iso_root/boot/aster-kernel-osdk-bin;
+  };
+
+  aster-systemd = import ../etc_nixos/pkgs/systemd.nix { inherit pkgs; };
+
+  baseConfiguration = {
     imports = [
       "${pkgs.path}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
       "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix"
@@ -14,17 +23,23 @@ let
 
     system.nixos.distroName = "Asterinas NixOS";
     system.nixos.label = "${version}";
-    isoImage.appendToMenuLabel = " Installer";
+    isoImage.appendToMenuLabel =
+      if useAsterinasKernel then " (Asterinas Kernel)" else " Installer";
+
+    # DNS configuration (matching disk install in configuration.nix).
+    environment.etc."resolv.conf".text = ''
+      nameserver 8.8.8.8
+    '';
 
     services.getty.autologinUser = pkgs.lib.mkForce "root";
     environment.systemPackages = [ installer ];
+
     environment.loginShellInit = ''
       if [ ! -e "$HOME/configuration.nix" ]; then
-        # Create an editable copy of configuration.nix in user's home.
         cp -L ${installer}/etc_nixos/configuration.nix $HOME && chmod u+w $HOME/configuration.nix
       fi
 
-      ${pkgs.lib.optionalString autoInstall ''
+      ${pkgs.lib.optionalString (autoInstall && !useAsterinasKernel) ''
         if [ "$(tty)" == "/dev/hvc0" ]; then
           echo "The installer automatically runs on /dev/hvc0!"
           aster-nixos-install --config $HOME/configuration.nix --disk /dev/vda --force-format-disk || true
@@ -32,5 +47,155 @@ let
         fi
       ''}
     '';
+  };
+
+  # The modified iso-image module replaces the standard NixOS iso-image.nix
+  # with one adapted for the Asterinas kernel:
+  #   - GRUB loads /boot/aster-kernel (not the Linux kernel)
+  #   - The initrd is at /boot/initrd (the cpio with NixOS closure)
+  #   - Kernel params do NOT include root= (ISO has no real root disk)
+  #   - init= points to the NixOS toplevel init directly
+  modifiedIsoImageModule = let
+    originalNix = builtins.readFile
+      "${pkgs.path}/nixos/modules/installer/cd-dvd/iso-image.nix";
+    step1 = builtins.replaceStrings [ "cfg.system.build.initialRamdisk" ]
+      [ "cfg.system.build.toplevel" ] originalNix;
+    modifiedNix = builtins.replaceStrings [
+      ''
+        params = "init=''${cfg.system.build.toplevel}/init ''${toString cfg.boot.kernelParams} ''${toString params}";''
+      ''
+        image = "/boot/''${cfg.boot.kernelPackages.kernel + "/" + cfg.system.boot.loader.kernelFile}";''
+      ''
+        initrd = "/boot/''${cfg.system.build.toplevel + "/" + cfg.system.boot.loader.initrdFile}";''
+      ''
+        LINUX /boot/''${cfg.boot.kernelPackages.kernel + "/" + cfg.system.boot.loader.kernelFile}''
+      "APPEND init=\${cfg.system.build.toplevel}/init \${toString cfg.boot.kernelParams} \${toString params}"
+      ''
+        INITRD /boot/''${cfg.system.build.toplevel + "/" + cfg.system.boot.loader.initrdFile}''
+      "lib.optionalString cfg.isoImage.showConfiguration"
+      "../../image/file-options.nix"
+      "../../../lib/make-iso9660-image.nix"
+    ] [
+      ''
+        params = "init=/init PATH=/bin:/nix/var/nix/profiles/system/sw/bin console=hvc0 ''${toString params}";''
+      ''image = "/boot/aster-kernel";''
+      ''initrd = "/boot/initrd";''
+      "LINUX /boot/aster-kernel"
+      "APPEND init=/init PATH=/bin:/nix/var/nix/profiles/system/sw/bin console=hvc0 \${toString params}"
+      "INITRD /boot/initrd"
+      "lib.optionalString true"
+      "${pkgs.path}/nixos/modules/image/file-options.nix"
+      "${pkgs.path}/nixos/lib/make-iso9660-image.nix"
+    ] step1;
+  in pkgs.writeText "iso-image-asterinas.nix" modifiedNix;
+
+  # ISO-specific kernel configuration.
+  # Imports asterinas-base.nix for the shared stage-1 init, initramfs, and
+  # common settings.  Only overrides what differs from disk: GRUB config
+  # (via modifiedIsoImageModule), fileSystems, and initrd content.
+  asterinasKernelConfig = { config, ... }:
+    let
+      stage-1-init = import ../etc_nixos/modules/asterinas-stage-1-init.nix {
+        inherit pkgs;
+      };
+    in {
+      imports = [
+        ../etc_nixos/modules/asterinas-base.nix
+        ../etc_nixos/modules/systemd.nix
+        "${modifiedIsoImageModule}"
+      ];
+
+      disabledModules =
+        [ "${pkgs.path}/nixos/modules/installer/cd-dvd/iso-image.nix" ];
+
+      isoImage.showConfiguration = false;
+
+      isoImage.contents = lib.mkAfter [
+        {
+          source = asterinasKernel;
+          target = "/boot/aster-kernel";
+        }
+        {
+          # The ISO initrd must contain the full NixOS store closure (since there
+          # is no real root disk), plus busybox and the shared stage-1 init from
+          # asterinas-base.nix.  We reference the stage-1 init via the overlay
+          # exported by asterinas-base.nix.
+          source = let
+            toplevel = config.system.build.toplevel;
+            closureInfo = pkgs.closureInfo { rootPaths = [ toplevel ]; };
+          in pkgs.runCommand "asterinas-initramfs" {
+            nativeBuildInputs = [ pkgs.cpio pkgs.gzip ];
+          } ''
+            mkdir -p root/nix/store
+            mkdir -p root/dev root/proc root/sys root/bin root/etc root/run root/var root/tmp root/usr/bin
+
+            # Copy all files from the NixOS closure.
+            while read -r path; do
+              if [ -n "$path" ]; then
+                cp -a "$path" root/nix/store/
+              fi
+            done < ${closureInfo}/store-paths
+
+            # Register all store paths so Nix can find them.
+            cp ${closureInfo}/registration root/nix/store/nix-path-registration
+
+            # Copy busybox utilities to root/bin.
+            cp -a ${pkgs.busybox}/bin/* root/bin/
+
+            # Symlink sh, bash and env for script compatibility.
+            ln -sfn ${pkgs.bash}/bin/sh root/bin/sh
+            ln -sfn ${pkgs.bash}/bin/bash root/bin/bash
+            ln -sfn ${pkgs.coreutils}/bin/env root/usr/bin/env
+
+            # Symlink lib and lib64 to glibc for dynamic linker availability.
+            ln -s ${pkgs.glibc}/lib root/lib
+            ln -s ${pkgs.glibc}/lib root/lib64
+
+            # Install the shared stage-1 init from asterinas-base.nix.
+            cp ${stage-1-init} root/init
+            chmod +x root/init
+
+            # Pack into cpio.gz format.
+            cd root
+            find . -mindepth 1 | cpio -o -H newc | gzip -9 > $out
+          '';
+          target = "/boot/initrd";
+        }
+      ];
+
+      # The ISO rootfs is the initrd itself (ramfs).  We only need noauto
+      # stubs for paths the NixOS installer might reference.
+      # We must NOT define /nix/store (or .ro-store / .rw-store) here because
+      # systemd would otherwise mount an empty ramfs over our populated Nix store.
+      fileSystems = lib.mkOverride 0 {
+        "/iso" = {
+          device = "none";
+          fsType = "ramfs";
+          options = [ "noauto" ];
+        };
+      };
+
+      # Prevent NixOS from building a Linux initrd — we provide our own
+      # (busybox stage-1 + NixOS store closure via asterinas-base.nix).
+      boot.initrd.enable = lib.mkForce false;
+      boot.initrd.availableKernelModules = lib.mkForce [ ];
+      boot.initrd.kernelModules = lib.mkForce [ ];
+    };
+
+  configuration = {
+    imports = [ baseConfiguration ]
+      ++ pkgs.lib.optionals useAsterinasKernel [ asterinasKernelConfig ];
+
+    # Force aster-systemd for the systemd package when using Asterinas kernel.
+    # The stock systemdMinimal lacks files referenced by NixOS modules
+    # (systemd-logind, systemd-user-sessions, systemd-bsod, etc.).
+    systemd.package = pkgs.lib.mkForce
+      (if useAsterinasKernel then aster-systemd else pkgs.systemd);
+
+    nixpkgs.overlays = pkgs.lib.optionals useAsterinasKernel [
+      (import ../etc_nixos/overlays/systemd/default.nix)
+      (import ../etc_nixos/overlays/switch-to-configuration-ng/default.nix)
+      (import ../etc_nixos/overlays/hello-asterinas/default.nix)
+    ];
   };
 in (pkgs.nixos configuration).config.system.build.isoImage

--- a/kernel/src/process/process/init_proc.rs
+++ b/kernel/src/process/process/init_proc.rs
@@ -56,7 +56,8 @@ pub fn spawn_init_process(
 fn create_default_init_process(argv: Vec<CString>, envp: Vec<CString>) -> Result<Arc<Process>> {
     // Linux probes the fallback init executables in this order:
     // <https://elixir.bootlin.com/linux/v6.19/source/init/main.c#L1634>.
-    const DEFAULT_INIT_EXEC_PATHS: &[&str] = &["/sbin/init", "/etc/init", "/bin/init", "/bin/sh"];
+    const DEFAULT_INIT_EXEC_PATHS: &[&str] =
+        &["/init", "/sbin/init", "/etc/init", "/bin/init", "/bin/sh"];
 
     let mut last_error = None;
 

--- a/tools/nixos/build_iso.sh
+++ b/tools/nixos/build_iso.sh
@@ -21,6 +21,7 @@ mkdir -p ${TARGET_DIR}
 nix-build ${DISTRO_DIR}/iso_image \
     --argstr target_platform "${NIX_SYSTEM}" \
     --arg autoInstall ${AUTO_INSTALL} \
+    --arg useAsterinasKernel ${USE_ASTERINAS_KERNEL:-false} \
     --argstr config-file-name "${CONFIG_FILE_NAME}" \
     --argstr extra-substituters "${RELEASE_SUBSTITUTER} ${DEV_SUBSTITUTER}" \
     --argstr extra-trusted-public-keys "${RELEASE_TRUSTED_PUBLIC_KEY} ${DEV_TRUSTED_PUBLIC_KEY}" \


### PR DESCRIPTION
## Description
This PR implements bootable ISO image generation support for Asterinas NixOS. It introduces configuration parameters and custom boot scripts to package the Asterinas kernel alongside a NixOS installation closure into a bootable ISO (utilizing a ramfs root with a pre-populated Nix store). 

This allows users and developers to test the Asterinas NixOS within QEMU VMs using a CD-ROM image.

## Key Changes

### 1. Refactored NixOS Stage-1 Init & Base Configurations
* Extracted shared configurations from `core.nix` into `asterinas-base.nix` and `asterinas-stage-1-init.nix`.
* Unified the stage-1 init script to dynamically handle two boot modes:
  * **Disk mode** (when `root=` is specified): mounts the physical root ext2 partition and performs `switch_root`.
  * **ISO mode** (when `root=` is absent): mounts a `ramfs` root filesystem, copies Nix store/system closures, and executes the stage-2 init directly.

### 2. Custom ISO Packaging (`iso_image/default.nix`)
* Added the `useAsterinasKernel` parameter to toggle between standard Linux ISO and Asterinas ISO generation.
* Created a modified version of NixOS's `iso-image.nix` to configure GRUB to load the Asterinas kernel (`aster-kernel`) and boot via the custom `initrd`.
* Packaged the full NixOS store closure into the ISO's initrd (using `closureInfo`), including the Nix database registration so Nix commands are functional upon boot.

### 3. Patched Systemd & Build Optimizations
* Updated `systemd.nix` to supply stubs and placeholder services for unsupported systemd components (`systemd-logind`, `systemd-user-sessions`, `systemd-bsod`, etc.) to prevent service startup failures in the ramfs environment.

### 4. Kernel Probe & Installation Script Updates
* Added `/init` to the default init executable fallback probe list in `init_proc.rs` to support booting directly from `initramfs`/`cpio`.
* Enhanced `aster-nixos-install` script to read `/proc/partitions` and manually create partition block device nodes (via `mknod`) if `udev` is not active in the installer environment.

---

## Verification & Testing

The ISO image was successfully built and tested in a KVM VM:
1. **Build ISO**:
   ```bash
   USE_ASTERINAS_KERNEL=true make iso
   ```
2. **Run in QEMU**:
   ```bash
   ENABLE_KVM=1 ./tools/nixos/run.sh iso
   ```
3. **Observation**:
   The VM boots correctly, enters the stage-2 shell, auto-logs into the root prompt on `hvc0`.
