### PR TITLE
Make request state visible before device notification

### DIFF
--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -396,16 +396,16 @@ impl DeviceInner {
             let token = queue
                 .add_dma_bufs(&[&req_slice], outputs.as_slice())
                 .expect("add queue failed");
-            if queue.should_notify() {
-                queue.notify();
-            }
-
-            // Records the submitted request
+            // Record the submitted request before notifying the device so the
+            // driver-side state is published before the device can complete it.
             let submitted_request = SubmittedRequest::new(id as u16, bio_request);
             self.submitted_requests
                 .disable_irq()
                 .lock()
                 .insert(token, submitted_request);
+            if queue.should_notify() {
+                queue.notify();
+            }
             return;
         }
     }
@@ -466,16 +466,16 @@ impl DeviceInner {
             let token = queue
                 .add_dma_bufs(inputs.as_slice(), &[&resp_slice])
                 .expect("add queue failed");
-            if queue.should_notify() {
-                queue.notify();
-            }
-
-            // Records the submitted request
+            // Record the submitted request before notifying the device so the
+            // driver-side state is published before the device can complete it.
             let submitted_request = SubmittedRequest::new(id as u16, bio_request);
             self.submitted_requests
                 .disable_irq()
                 .lock()
                 .insert(token, submitted_request);
+            if queue.should_notify() {
+                queue.notify();
+            }
             return;
         }
     }
@@ -521,16 +521,16 @@ impl DeviceInner {
             let token = queue
                 .add_dma_bufs(&[&req_slice], &[&resp_slice])
                 .expect("add queue failed");
-            if queue.should_notify() {
-                queue.notify();
-            }
-
-            // Records the submitted request
+            // Record the submitted request before notifying the device so the
+            // driver-side state is published before the device can complete it.
             let submitted_request = SubmittedRequest::new(id as u16, bio_request);
             self.submitted_requests
                 .disable_irq()
                 .lock()
                 .insert(token, submitted_request);
+            if queue.should_notify() {
+                queue.notify();
+            }
             return;
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes a request-completion race in the Virtio block driver.

This PR is also a step for RISC-V IOMMU implementation, see #3474 .

Before this PR, the driver notified the device before recording the submitted block request in `submitted_requests`. A fast Virtio device may complete the request and raise an interrupt immediately after the notification, so the completion path can observe a used-ring entry before the driver has recorded the corresponding request metadata.

This PR changes the read, write, and flush request paths to:

1. add descriptors to the virtqueue;
2. compute whether the device should be notified;
3. record the submitted request by token;
4. notify the device.

This makes the driver's internal request state visible before the device is allowed to complete the request.

## Background

The Virtio block completion path pops a used descriptor token from the queue and then removes the corresponding request from `submitted_requests`. This assumes that every token visible in the used ring has already been inserted into the submitted-request table.

The old submission order violated that assumption:

```text
add descriptors -> notify device -> record submitted request
```

https://github.com/asterinas/asterinas/blob/a19974df7f48dda7d1f6540350d787f5d7df7860/kernel/comps/virtio/src/device/block/device.rs#L390-L409

This is racy because Virtio devices are allowed to consume available descriptors after notification. With fast backends, or with interrupt paths that deliver completion interrupts quickly, the completion handler may run before the submitted request has been recorded.

This race is a general Virtio block correctness issue. It is also important for the later RISC-V IOMMU series because the QEMU RISC-V IOMMU setup uses PCI MSI-X/AIA/IMSIC interrupt delivery, where block completion interrupts can arrive quickly once the device is notified.

## References

- Virtio 1.2 specification:
  - https://docs.oasis-open.org/virtio/virtio/v1.2/virtio-v1.2.html

The relevant Virtio behavior is that a driver makes buffers available through a virtqueue and then notifies the device. After notification, the device may consume the available buffers and report completion through the used ring.

## Main Behavior

This PR updates the Virtio block request submission paths in `kernel/comps/virtio/src/device/block/device.rs`.

For read requests, write requests, and flush requests, the driver now:

- adds the DMA buffers to the virtqueue and obtains the queue token;
- reads `queue.should_notify()` after updating the virtqueue;
- inserts the `SubmittedRequest` into `submitted_requests` before notification;
- calls `queue.notify()` only after the request has been recorded.

This preserves the existing virtqueue notification logic while fixing the ordering between driver-side bookkeeping and device notification.

## Testing

The focused branch was validated with:

```bash
cargo check -p aster-virtio --target riscv64imac-unknown-none-elf
```

## Gaps and Future Work

This PR intentionally focuses only on the Virtio block request notification ordering.

It does not add new runtime tests for the race because the failure depends on timing between device notification, request completion, and interrupt handling. The issue is therefore difficult to reproduce deterministically with a simple unit test.

This PR also does not implement the RISC-V IOMMU support itself. It is a standalone Virtio block correctness fix and serves as preparation for the later RISC-V IOMMU PRs, where fast device completion through PCI MSI-X/AIA paths makes this ordering more important.