### PR TITLE
Enable virtio-pci transport on RISCV64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ bittle = "0.5.6"
 const_format = "0.2.35"
 ctr = "0.8.0"
 font8x8 = { version = "0.2.5", default-features = false, features = [ "unicode" ] }
+fdt = { version = "0.1.5", features = ["pretty-printing"] }
 getset = "0.1.2"
 hashbrown = { version = "0.14.3", features = ["serde"]  }
 inventory = { git = "https://github.com/asterinas/inventory", rev = "9dce587" }

--- a/kernel/comps/pci/Cargo.toml
+++ b/kernel/comps/pci/Cargo.toml
@@ -15,7 +15,10 @@ ostd.workspace = true
 spin.workspace = true
 
 [target.loongarch64-unknown-none-softfloat.dependencies]
-fdt = { version = "0.1.5", features = ["pretty-printing"] }
+fdt.workspace = true
+
+[target.riscv64imac-unknown-none-elf.dependencies]
+fdt.workspace = true
 
 [lints]
 workspace = true

--- a/kernel/comps/pci/src/arch/riscv/mod.rs
+++ b/kernel/comps/pci/src/arch/riscv/mod.rs
@@ -2,14 +2,29 @@
 
 //! PCI bus access
 
-use core::ops::RangeInclusive;
+use alloc::vec::Vec;
+use core::{alloc::Layout, ops::RangeInclusive};
 
-use ostd::{Error, arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, warn};
+use fdt::node::FdtNode;
+use ostd::{
+    Error,
+    arch::{
+        boot::DEVICE_TREE,
+        irq::{IRQ_CHIP, InterruptSourceInFdt, MappedIrqLine},
+    },
+    io::IoMem,
+    irq::IrqLine,
+    mm::VmIoOnce,
+    prelude::Paddr,
+    sync::SpinLock,
+    warn,
+};
 use spin::Once;
 
-use crate::PciDeviceLocation;
+use crate::{PciDeviceLocation, cfg_space::PciCommonCfgOffset};
 
 static PCI_ECAM_CFG_SPACE: Once<IoMem> = Once::new();
+static PCI_INTX_MAPPER: Once<PciIntxMapper> = Once::new();
 
 pub(crate) fn write32(location: &PciDeviceLocation, offset: u32, value: u32) -> Result<(), Error> {
     if offset > PCI_ECAM_MAX_OFFSET {
@@ -101,6 +116,12 @@ pub(crate) fn init() -> Option<RangeInclusive<u8>> {
         Some(0..=255)
     };
 
+    // Initialize the MMIO allocator used to assign base addresses to device BARs.
+    // On RISC-V the firmware (OpenSBI) does not perform PCI enumeration, so the
+    // OS must allocate BAR addresses within the host bridge's memory-mapped window.
+    init_mmio_allocator_from_fdt(&pci);
+    init_intx_mapper_from_fdt(&pci);
+
     let addr_start = region.starting_address as usize;
     let addr_end = addr_start.checked_add(region.size.unwrap()).unwrap();
     PCI_ECAM_CFG_SPACE.call_once(|| IoMem::acquire(addr_start..addr_end).unwrap());
@@ -108,6 +129,214 @@ pub(crate) fn init() -> Option<RangeInclusive<u8>> {
     bus_range
 }
 
+/// A simple MMIO allocator managing a linear region.
+///
+/// RISC-V platforms booted via OpenSBI do not have firmware that performs PCI
+/// enumeration, so the base addresses of PCI device BARs must be allocated by
+/// the OS within the host bridge's memory-mapped window.
+///
+/// This is a bump allocator: addresses are handed out monotonically and never
+/// reclaimed. That is intentional — BAR base addresses are assigned once during
+/// enumeration and are not freed afterwards.
+struct MmioAllocator {
+    base: Paddr,
+    size: Paddr,
+    offset: Paddr,
+}
+
+impl MmioAllocator {
+    /// Creates a new MMIO allocator with a given base and size.
+    const fn new(base: Paddr, size: Paddr) -> Self {
+        MmioAllocator {
+            base,
+            size,
+            offset: 0,
+        }
+    }
+
+    /// Allocates a physical address range with the specified alignment and size.
+    fn allocate(&mut self, layout: Layout) -> Option<Paddr> {
+        let (aligned, next_offset) = allocate_from_linear_region(
+            self.base,
+            self.size,
+            self.offset,
+            layout.align(),
+            layout.size(),
+        )?;
+
+        self.offset = next_offset;
+        Some(aligned)
+    }
+}
+
+fn allocate_from_linear_region(
+    base: Paddr,
+    region_size: Paddr,
+    offset: Paddr,
+    align: usize,
+    size: usize,
+) -> Option<(Paddr, Paddr)> {
+    let current = base.checked_add(offset)?;
+    let align_mask = align.checked_sub(1)?;
+    let aligned = current.checked_add(align_mask)? & !align_mask;
+    let aligned_offset = aligned.checked_sub(base)?;
+    let next_offset = aligned_offset.checked_add(size)?;
+
+    if next_offset > region_size {
+        return None;
+    }
+
+    Some((aligned, next_offset))
+}
+
+static MMIO_ALLOCATOR: Once<SpinLock<MmioAllocator>> = Once::new();
+
+/// Initializes the MMIO allocator from the PCIe node's "ranges" property.
+///
+/// Only the first non-prefetchable, 32-bit Memory window (`phys.hi >> 24 == 0x2`)
+/// is used; prefetchable and 64-bit windows, and any subsequent windows, are
+/// ignored. All BARs (including prefetchable and 64-bit ones) are therefore
+/// allocated from this single window.
+fn init_mmio_allocator_from_fdt(node: &FdtNode) {
+    let Some(ranges) = node.property("ranges") else {
+        warn!("PCIe node has no `ranges` property");
+        return;
+    };
+    let data = ranges.value;
+
+    const RANGE_ENTRY_SIZE: usize = 7 * size_of::<u32>();
+    for entry in data.chunks_exact(RANGE_ENTRY_SIZE) {
+        let pci_space = u32::from_be_bytes(entry[0..4].try_into().unwrap());
+        let _pci_addr = u64::from_be_bytes(entry[4..12].try_into().unwrap());
+        let cpu_addr = u64::from_be_bytes(entry[12..20].try_into().unwrap());
+        let size = u64::from_be_bytes(entry[20..28].try_into().unwrap());
+
+        // Only initialize with memory-type region.
+        if (pci_space >> 24) == 0x2 {
+            MMIO_ALLOCATOR
+                .call_once(|| SpinLock::new(MmioAllocator::new(cpu_addr as usize, size as usize)));
+            break;
+        }
+    }
+}
+
+/// Allocates an MMIO address range using the global allocator.
+pub(crate) fn alloc_mmio(layout: Layout) -> Option<Paddr> {
+    MMIO_ALLOCATOR.get()?.lock().allocate(layout)
+}
+
+pub(crate) type MappedPciIrqLine = MappedIrqLine;
+
+#[derive(Clone, Copy)]
+struct PciIntxMapEntry {
+    child_unit_address: u32,
+    child_interrupt_pin: u32,
+    interrupt_parent: u32,
+    interrupt: u32,
+}
+
+struct PciIntxMapper {
+    mask_unit_address: u32,
+    mask_interrupt_pin: u32,
+    entries: Vec<PciIntxMapEntry>,
+}
+
+fn init_intx_mapper_from_fdt(node: &FdtNode) {
+    let Some(mask) = node.property("interrupt-map-mask") else {
+        warn!("PCIe node has no `interrupt-map-mask` property");
+        return;
+    };
+    let mask = mask.value;
+    if mask.len() != 16 {
+        warn!(
+            "`interrupt-map-mask` should be 16 bytes, but found {} bytes",
+            mask.len()
+        );
+        return;
+    }
+
+    let mask_unit_address = u32::from_be_bytes(mask[0..4].try_into().unwrap());
+    let mask_interrupt_pin = u32::from_be_bytes(mask[12..16].try_into().unwrap());
+
+    let Some(interrupt_map) = node.property("interrupt-map") else {
+        warn!("PCIe node has no `interrupt-map` property");
+        return;
+    };
+
+    let mut entries = Vec::new();
+    // Each `interrupt-map` entry is laid out as:
+    //   child unit address (3 cells) + child interrupt pin (1 cell)
+    //   + interrupt parent phandle (1 cell) + parent interrupt specifier (1 cell)
+    // = 6 cells = 24 bytes.
+    //
+    // This assumes the interrupt parent is a PLIC with `#interrupt-cells = 1`, which
+    // matches ostd's `InterruptSourceInFdt` model (a single interrupt source number).
+    // A controller with multi-cell specifiers (e.g. a GIC) is not supported.
+    const ENTRY_SIZE: usize = 24;
+    let remainder = interrupt_map.value.len() % ENTRY_SIZE;
+    if remainder != 0 {
+        warn!(
+            "`interrupt-map` length is not a multiple of {ENTRY_SIZE}; {} trailing bytes dropped",
+            remainder
+        );
+    }
+    for entry in interrupt_map.value.chunks_exact(ENTRY_SIZE) {
+        let child_unit_address = u32::from_be_bytes(entry[0..4].try_into().unwrap());
+        let child_interrupt_pin = u32::from_be_bytes(entry[12..16].try_into().unwrap());
+        let interrupt_parent = u32::from_be_bytes(entry[16..20].try_into().unwrap());
+        let interrupt = u32::from_be_bytes(entry[20..24].try_into().unwrap());
+
+        entries.push(PciIntxMapEntry {
+            child_unit_address,
+            child_interrupt_pin,
+            interrupt_parent,
+            interrupt,
+        });
+    }
+
+    PCI_INTX_MAPPER.call_once(|| PciIntxMapper {
+        mask_unit_address,
+        mask_interrupt_pin,
+        entries,
+    });
+}
+
+pub(crate) fn map_intx_interrupt(location: &PciDeviceLocation) -> Result<MappedPciIrqLine, Error> {
+    let interrupt_pin = location.read8(PciCommonCfgOffset::InterruptPin as u16) as u32;
+    if interrupt_pin == 0 {
+        return Err(Error::InvalidArgs);
+    }
+
+    let unit_address = ((location.device as u32) << 11) | ((location.function as u32) << 8);
+    let mapper = PCI_INTX_MAPPER.get().ok_or(Error::InvalidArgs)?;
+    let entry = mapper
+        .entries
+        .iter()
+        .find(|entry| {
+            (entry.child_unit_address & mapper.mask_unit_address)
+                == (unit_address & mapper.mask_unit_address)
+                && (entry.child_interrupt_pin & mapper.mask_interrupt_pin)
+                    == (interrupt_pin & mapper.mask_interrupt_pin)
+        })
+        .ok_or(Error::InvalidArgs)?;
+
+    let irq_line = IrqLine::alloc()?;
+    IRQ_CHIP.get().unwrap().map_fdt_pin_to(
+        InterruptSourceInFdt {
+            interrupt_parent: entry.interrupt_parent,
+            interrupt: entry.interrupt,
+        },
+        irq_line,
+    )
+}
+
+/// The default target physical address written into each MSI-X Table entry's
+/// `Message Address` field. A device raises an MSI by writing to this address.
+///
+/// On the QEMU `virt` platform this is `0x2400_0000`, the IMSIC (Incoming MSI
+/// Controller) doorbell base defined by the RISC-V AIA. Per-vector remapping
+/// ([`construct_remappable_msix_address`]) is not yet implemented, so every
+/// vector currently shares this single address.
 pub(crate) const MSIX_DEFAULT_MSG_ADDR: u32 = 0x2400_0000;
 
 pub(crate) fn construct_remappable_msix_address(_remapping_index: u32) -> u32 {

--- a/kernel/comps/pci/src/cfg_space.rs
+++ b/kernel/comps/pci/src/cfg_space.rs
@@ -405,7 +405,10 @@ impl MemoryBar {
         // 32 bit register is considered an extension of the first (i.e., bits 63:32). Software
         // writes a value of all 1's to both registers, reads them back, and combines the result
         // into a 64-bit value."
-        #[cfg_attr(target_arch = "loongarch64", expect(unused_variables))]
+        #[cfg_attr(
+            any(target_arch = "loongarch64", target_arch = "riscv64"),
+            expect(unused_variables)
+        )]
         let (raw64, size_encoded64) = match address_length {
             AddrLen::Bits32 => (raw as u64, size_encoded as u64 | ((u32::MAX as u64) << 32)),
             AddrLen::Bits64 => {
@@ -421,14 +424,20 @@ impl MemoryBar {
         let size = decode_size(size_encoded64, BarKind::Memory);
 
         // Restore the original base address.
-        #[cfg(not(target_arch = "loongarch64"))]
+        #[cfg(not(any(target_arch = "loongarch64", target_arch = "riscv64")))]
         let base = raw64 & MEMORY_ADDRESS_MASK;
-        // In LoongArch, the BAR base address needs to be allocated manually.
-        #[cfg(target_arch = "loongarch64")]
+        // On LoongArch and RISC-V the BAR base address needs to be allocated
+        // manually, since the platform firmware does not perform PCI enumeration.
+        #[cfg(any(target_arch = "loongarch64", target_arch = "riscv64"))]
         let base = {
             use core::alloc::Layout;
-            crate::arch::alloc_mmio(Layout::from_size_align(size as usize, size as usize).unwrap())
-                .unwrap() as u64
+            let Ok(layout) = Layout::from_size_align(size as usize, size as usize) else {
+                return Err(Error::InvalidArgs);
+            };
+            let Some(base) = crate::arch::alloc_mmio(layout) else {
+                return Err(Error::InvalidArgs);
+            };
+            base as u64
         };
         match address_length {
             AddrLen::Bits32 => location.write32(offset, base as u32),
@@ -442,7 +451,7 @@ impl MemoryBar {
         // initialize all PCI devices. Consequently, the base address reported by uninitialized PCI
         // devices is zero. To address this, we may need to add the ability to manually allocate
         // the base address.
-        #[cfg(not(target_arch = "loongarch64"))]
+        #[cfg(not(any(target_arch = "loongarch64", target_arch = "riscv64")))]
         if base == 0 {
             ostd::info!(
                 "presumably uninitialized BAR {} (Memory {:?}, size={}) of PCI device {:?}",

--- a/kernel/comps/pci/src/common_device.rs
+++ b/kernel/comps/pci/src/common_device.rs
@@ -3,6 +3,8 @@
 //! PCI device common definitions or functions.
 
 use ostd::Result;
+#[cfg(target_arch = "riscv64")]
+pub use ostd::arch::irq::MappedIrqLine as MappedPciIrqLine;
 
 use crate::{
     capability::{RawCapabilities, msix::CapabilityMsixData, vendor::CapabilityVndrData},
@@ -62,6 +64,17 @@ impl PciCommonDevice {
     pub fn write_command(&self, command: Command) {
         self.location
             .write16(PciCommonCfgOffset::Command as u16, command.bits())
+    }
+
+    /// Enables legacy PCI INTx interrupts.
+    pub fn enable_intx_interrupt(&self) {
+        self.write_command(self.read_command() & !Command::INTERRUPT_DISABLE)
+    }
+
+    /// Maps the legacy PCI INTx interrupt pin to an IRQ line.
+    #[cfg(target_arch = "riscv64")]
+    pub fn map_intx_interrupt(&self) -> Result<MappedPciIrqLine> {
+        crate::arch::map_intx_interrupt(&self.location)
     }
 
     /// Reads the PCI status.

--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#[cfg(target_arch = "riscv64")]
+use alloc::vec::Vec;
 use alloc::{boxed::Box, sync::Arc};
 use core::fmt::Debug;
 
@@ -7,6 +9,8 @@ use aster_pci::{
     PciDeviceId, bus::PciDevice, cfg_space::BarAccess, common_device::PciCommonDevice,
 };
 use aster_util::{field_ptr, safe_ptr::SafePtr};
+#[cfg(target_arch = "riscv64")]
+use ostd::{arch::trap::TrapFrame, mm::VmIoOnce, sync::RwLock};
 use ostd::{
     bus::BusProbeError,
     info,
@@ -55,7 +59,68 @@ pub struct VirtioPciModernTransport {
     common_cfg: SafePtr<VirtioPciCommonCfg, IoMem>,
     device_cfg: VirtioPciCapabilityData,
     notify: VirtioPciNotify,
-    msix_manager: VirtioMsixManager,
+    interrupt: VirtioPciInterrupt,
+}
+
+enum VirtioPciInterrupt {
+    Msix(VirtioMsixManager),
+    #[cfg(target_arch = "riscv64")]
+    Intx(Arc<RwLock<VirtioPciIntxManager>>),
+}
+
+#[cfg(target_arch = "riscv64")]
+struct VirtioPciIntxManager {
+    irq: aster_pci::common_device::MappedPciIrqLine,
+    queue_callbacks: Vec<Box<IrqCallbackFunction>>,
+    cfg_callbacks: Vec<Box<IrqCallbackFunction>>,
+    isr_io_memory: IoMem,
+    isr_offset: usize,
+}
+
+#[cfg(target_arch = "riscv64")]
+impl VirtioPciIntxManager {
+    fn new(
+        irq: aster_pci::common_device::MappedPciIrqLine,
+        isr_cfg: VirtioPciCapabilityData,
+    ) -> Arc<RwLock<Self>> {
+        let intx = Arc::new(RwLock::new(Self {
+            irq,
+            queue_callbacks: Vec::new(),
+            cfg_callbacks: Vec::new(),
+            isr_io_memory: isr_cfg.memory_bar().unwrap().clone(),
+            isr_offset: isr_cfg.offset() as usize,
+        }));
+
+        let weak = Arc::downgrade(&intx);
+        let callback = move |trap_frame: &TrapFrame| {
+            let Some(intx) = weak.upgrade() else {
+                return;
+            };
+            let intx = intx.read();
+            let interrupt_status = intx.isr_io_memory.read_once::<u8>(intx.isr_offset).unwrap();
+            if interrupt_status & 0x01 != 0 {
+                for callback in intx.queue_callbacks.iter() {
+                    callback(trap_frame);
+                }
+            }
+            if interrupt_status & 0x02 != 0 {
+                for callback in intx.cfg_callbacks.iter() {
+                    callback(trap_frame);
+                }
+            }
+        };
+
+        intx.write().irq.on_active(callback);
+        intx
+    }
+
+    fn register_queue_callback(&mut self, func: Box<IrqCallbackFunction>) {
+        self.queue_callbacks.push(func);
+    }
+
+    fn register_cfg_callback(&mut self, func: Box<IrqCallbackFunction>) {
+        self.cfg_callbacks.push(func);
+    }
 }
 
 impl Debug for VirtioPciModernTransport {
@@ -218,32 +283,41 @@ impl VirtioTransport for VirtioPciModernTransport {
         if index >= self.num_queues() {
             return Err(VirtioTransportError::InvalidArgs);
         }
-        let (vector, irq) = if single_interrupt {
-            if let Some(unused_irq) = self.msix_manager.pop_unused_irq() {
-                unused_irq
-            } else {
-                warn!(
-                    "{:?}: `single_interrupt` ignored: no more IRQ lines available",
-                    self.device_type()
+        let device_type = self.device_type;
+        match &mut self.interrupt {
+            VirtioPciInterrupt::Msix(msix_manager) => {
+                let (vector, irq) = if single_interrupt {
+                    if let Some(unused_irq) = msix_manager.pop_unused_irq() {
+                        unused_irq
+                    } else {
+                        warn!(
+                            "{:?}: `single_interrupt` ignored: no more IRQ lines available",
+                            device_type
+                        );
+                        msix_manager.shared_irq_line()
+                    }
+                } else {
+                    msix_manager.shared_irq_line()
+                };
+                irq.on_active(func);
+                field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
+                    .write_once(&index)
+                    .unwrap();
+                debug_assert_eq!(
+                    field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
+                        .read_once()
+                        .unwrap(),
+                    index
                 );
-                self.msix_manager.shared_irq_line()
+                field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_msix_vector)
+                    .write_once(&vector)
+                    .unwrap();
             }
-        } else {
-            self.msix_manager.shared_irq_line()
-        };
-        irq.on_active(func);
-        field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-            .write_once(&index)
-            .unwrap();
-        debug_assert_eq!(
-            field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_select)
-                .read_once()
-                .unwrap(),
-            index
-        );
-        field_ptr!(&self.common_cfg, VirtioPciCommonCfg, queue_msix_vector)
-            .write_once(&vector)
-            .unwrap();
+            #[cfg(target_arch = "riscv64")]
+            VirtioPciInterrupt::Intx(intx_manager) => {
+                intx_manager.write().register_queue_callback(func);
+            }
+        }
         Ok(())
     }
 
@@ -251,8 +325,16 @@ impl VirtioTransport for VirtioPciModernTransport {
         &mut self,
         func: Box<IrqCallbackFunction>,
     ) -> Result<(), VirtioTransportError> {
-        let (_, irq) = self.msix_manager.config_msix_irq();
-        irq.on_active(func);
+        match &mut self.interrupt {
+            VirtioPciInterrupt::Msix(msix_manager) => {
+                let (_, irq) = msix_manager.config_msix_irq();
+                irq.on_active(func);
+            }
+            #[cfg(target_arch = "riscv64")]
+            VirtioPciInterrupt::Intx(intx_manager) => {
+                intx_manager.write().register_cfg_callback(func);
+            }
+        }
         Ok(())
     }
 
@@ -287,6 +369,7 @@ impl VirtioPciModernTransport {
         let mut notify = None;
         let mut common_cfg = None;
         let mut device_cfg = None;
+        let mut isr_cfg = None;
         let (vndr_caps, bar_manager) = common_device.iter_vndr_capability_with_bar_manager();
         for vndr_cap in vndr_caps {
             let data = VirtioPciCapabilityData::new(bar_manager, vndr_cap);
@@ -301,7 +384,9 @@ impl VirtioPciModernTransport {
                         io_memory: data.memory_bar().unwrap().clone(),
                     });
                 }
-                VirtioPciCpabilityType::IsrCfg => {}
+                VirtioPciCpabilityType::IsrCfg => {
+                    isr_cfg = Some(data);
+                }
                 VirtioPciCpabilityType::DeviceCfg => {
                     device_cfg = Some(data);
                 }
@@ -312,9 +397,9 @@ impl VirtioPciModernTransport {
         let common_cfg = common_cfg.unwrap();
         let device_cfg = device_cfg.unwrap();
 
-        // TODO: Support interrupt without MSI-X.
-        let msix = common_device.acquire_msix_capability().unwrap().unwrap();
-        let msix_manager = VirtioMsixManager::new(msix);
+        let Ok(interrupt) = create_interrupt_manager(&mut common_device, isr_cfg) else {
+            return Err((BusProbeError::ConfigurationSpaceError, common_device));
+        };
 
         Ok(Self {
             device_type,
@@ -322,7 +407,32 @@ impl VirtioPciModernTransport {
             common_cfg,
             device_cfg,
             notify,
-            msix_manager,
+            interrupt,
         })
     }
+}
+
+fn create_interrupt_manager(
+    common_device: &mut PciCommonDevice,
+    #[cfg_attr(not(target_arch = "riscv64"), expect(unused_variables))] isr_cfg: Option<
+        VirtioPciCapabilityData,
+    >,
+) -> Result<VirtioPciInterrupt, VirtioTransportError> {
+    #[cfg(target_arch = "riscv64")]
+    {
+        if let Some(isr_cfg) = isr_cfg
+            && let Ok(mapped_irq) = common_device.map_intx_interrupt()
+        {
+            common_device.enable_intx_interrupt();
+            return Ok(VirtioPciInterrupt::Intx(VirtioPciIntxManager::new(
+                mapped_irq, isr_cfg,
+            )));
+        }
+    }
+
+    if let Ok(Some(msix)) = common_device.acquire_msix_capability() {
+        return Ok(VirtioPciInterrupt::Msix(VirtioMsixManager::new(msix)));
+    }
+
+    Err(VirtioTransportError::DeviceStatusError)
 }

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -15,6 +15,7 @@
 #  - VIRTIOFS: "off" or "on";
 #  - VIRTIOFS_TAG: mount tag for virtio-fs device;
 #  - VIRTIOFS_SOCKET: vhost-user socket path for the virtio-fs server.
+#  - VIRTIO_PCI: "off" or "on" (RISC-V only; "on" attaches virtio devices over PCI instead of MMIO);
 #  - CONSOLE: "hvc0" to enable virtio console;
 #  - SMP: number of CPUs;
 #  - MEM: amount of memory, e.g. "8G";
@@ -70,6 +71,21 @@ else
 fi
 
 if [ "$1" = "riscv" ]; then
+    if [ "${VIRTIO_PCI:-off}" = "on" ]; then
+        VIRTIO_DEVICE_ARGS="\
+        -device virtio-blk-pci,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off \
+        -device virtio-blk-pci,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off \
+        -device virtio-keyboard-pci,disable-legacy=on,disable-modern=off \
+        -device virtio-serial-pci,disable-legacy=on,disable-modern=off \
+        "
+    else
+        VIRTIO_DEVICE_ARGS="\
+        -device virtio-blk-device,drive=x1 \
+        -device virtio-blk-device,drive=x0 \
+        -device virtio-keyboard-device \
+        -device virtio-serial-device \
+        "
+    fi
     # NOTE: The `/etc/profile.d/init.sh` assumes that `ext2.img` appears as the first block device (`/dev/vda`).
     # The ordering below ensures `x1` (ext2.img) is discovered before `x0`, maintaining this assumption.
     # TODO: Once UUID-based mounting is implemented, this strict ordering will no longer be required.
@@ -85,10 +101,7 @@ if [ "$1" = "riscv" ]; then
         -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
         -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
         -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
-        -device virtio-blk-device,drive=x1 \
-        -device virtio-blk-device,drive=x0 \
-        -device virtio-keyboard-device \
-        -device virtio-serial-device \
+        $VIRTIO_DEVICE_ARGS \
         $CONSOLE_ARGS \
     "
     echo $QEMU_ARGS


### PR DESCRIPTION
# Motivation

The virtio-pci modern transport was unusable on RISC-V64 for two reasons:

1. **Early panic during probe** at `common_cfg.memory_bar().unwrap()`. Device BARs were never programmed: unlike x86 (where SeaBIOS performs PCI enumeration) or the existing LoongArch path, RISC-V PCI initialization only mapped the ECAM configuration space and left every device BAR uninitialized. RISC-V boots via OpenSBI, which performs no PCI enumeration.
2. **No usable interrupt path.** QEMU's `virt` machine exposes only a PLIC (no IMSIC/APLIC), so MSI-X writes are never delivered — the device's completion interrupt never reaches the CPU, and any block I/O hangs.

The broader goal of this work is to **enable testing of the RISC-V IOMMU DMA-remapping driver**. The IOMMU translates DMA for PCI devices, so exercising it requires a working virtio-pci device that performs DMA — which did not exist on RISC-V64 before this PR. Bringing up virtio-pci (with identity-mapped DMA for now) removes that blocker and is the prerequisite for the IOMMU validation that follows.

# What this PR does

**1. OS-side PCI BAR allocation** (`riscv/mod.rs`, `cfg_space.rs`, `Cargo.toml`)
  - Port the LoongArch MMIO bump allocator into the RISC-V PCI arch module (`MmioAllocator` + `alloc_mmio`), initialized from the host bridge's `ranges` DT property.
  - Extend the `cfg` gates in `cfg_space.rs` from `loongarch64` to `any(loongarch64, riscv64)` so RISC-V takes the manual BAR-allocation path instead of expecting a firmware-programmed base.
  - Add the `fdt` dependency under `[target.riscv64imac-unknown-none-elf]`.

**2. Legacy INTx interrupt delivery** (`riscv/mod.rs`, `common_device.rs`, `device.rs`) 
Since RISC-V `virt` has no IMSIC, MSI-X cannot be delivered, so the transport falls back to legacy INTx routed through the PLIC:
  - `map_intx_interrupt()`: parse the host bridge's `interrupt-map` / `interrupt-map-mask` to resolve a device's INTx pin to a PLIC interrupt source, then map it to an `IrqLine` via `IRQ_CHIP`.
  - `VirtioPciIntxManager`: a shared, level-triggered INTx line with ISR-register-driven dispatch (bit 0 = queue, bit 1 = config-change; reading the ISR register also deasserts INTx).
  - `create_interrupt_manager()` prefers INTx on RISC-V64 and falls back to MSI-X on other architectures.

**3. QEMU switch** (`tools/qemu_args.sh`)
  - Add a `VIRTIO_PCI=on|off` switch (default `off` = MMIO) for the RISC-V scheme that attaches virtio devices as `virtio-*-pci` instead of `virtio-*-device`.

# How to test

```bash
# Boot smoke test
TARGET_ARCH=riscv64 VIRTIO_PCI=on LOG_LEVEL=info AUTO_TEST=boot make run_kernel

# Interactive shell
TARGET_ARCH=riscv64 VIRTIO_PCI=on make run_kernel
```