### PR TITLE
Fix StatfsTest.InternalDevShm

### DIFF
--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -15,11 +15,11 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
 
     let dev_path = path_resolver.lookup(&FsPath::try_from("/dev")?)?;
 
-    // Create the "shm" directory under "/dev" and mount a ramfs on it.
+    // Create the "shm" directory under "/dev" and mount a tmpfs on it.
     let shm_path =
         dev_path.new_fs_child("shm", InodeType::Dir, chmod!(InodeMode::S_ISVTX, a+rwx))?;
     shm_path.mount(
-        RamFs::new(),
+        RamFs::new_tmpfs(),
         PerMountFlags::default(),
         Some("tmpfs".to_string()),
         ctx,

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -66,7 +66,7 @@ impl RamFs {
 
     // TODO: Remove this tmpfs-specific constructor once `TmpFs` no longer
     // aliases `RamFs`.
-    pub(in crate::fs) fn new_tmpfs() -> Arc<Self> {
+    pub fn new_tmpfs() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for tmpfs");
         let sb = {
             let mut super_block =

--- a/test/initramfs/src/conformance/gvisor/blocklists/statfs_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/statfs_test
@@ -1,3 +1,1 @@
-FstatfsTest.InternalDevShm
-StatfsTest.InternalDevShm
 StatFsTest.MountFlags


### PR DESCRIPTION
Fix FstatfsTest.InternalDevShm, StatfsTest.InternalDevShm

gVisor's StatfsTest.InternalDevShm test expects /dev/shm to return the tmpfs filesystem type (magic number 0x01021994). The previous implementation used regular ramfs (magic number 0x858458f6), causing the test to fail. By mounting /dev/shm as tmpfs, the statfs syscall now returns the correct filesystem type.