### PR TITLE
Replace `cfg_if` with `cfg_select`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,6 @@ dependencies = [
  "atomic-integer-wrapper",
  "bitflags 1.3.2",
  "bitvec",
- "cfg-if",
  "component",
  "const_format",
  "controlled",
@@ -314,7 +313,6 @@ version = "0.1.0"
 dependencies = [
  "align_ext",
  "bitflags 1.3.2",
- "cfg-if",
  "component",
  "fdt",
  "int-to-c-enum",
@@ -1144,7 +1142,6 @@ dependencies = [
 name = "linux-bzimage-setup"
 version = "0.18.0"
 dependencies = [
- "cfg-if",
  "linux-boot-params",
  "log",
  "tdx-guest",
@@ -1364,7 +1361,6 @@ dependencies = [
  "bit_field",
  "bitflags 1.3.2",
  "bitvec",
- "cfg-if",
  "fdt",
  "gimli 0.28.1",
  "iced-x86",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,6 @@ time = { version = "0.3", default-features = false, features = ["alloc"] }
 # External dependencies for both safe and unsafe crates
 bitflags = "1.3"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
-cfg-if = "1.0"
 inherit-methods-macro = { git = "https://github.com/asterinas/inherit-methods-macro", rev = "98f7e3e", version = "0.1.0" }
 intrusive-collections = { version = "0.9.6", features = ["nightly"] }
 libflate = { version = "2.3.0", default-features = false }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -30,7 +30,6 @@ aster-virtio.workspace = true
 atomic-integer-wrapper.workspace = true
 bitflags.workspace = true
 bitvec.workspace = true
-cfg-if.workspace = true
 component.workspace = true
 const_format.workspace = true
 controlled.workspace = true

--- a/kernel/comps/pci/Cargo.toml
+++ b/kernel/comps/pci/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 [dependencies]
 align_ext.workspace = true
 bitflags.workspace = true
-cfg-if.workspace = true
 component.workspace = true
 int-to-c-enum.workspace = true
 ostd.workspace = true

--- a/kernel/src/net/uts_ns.rs
+++ b/kernel/src/net/uts_ns.rs
@@ -191,20 +191,12 @@ impl UtsName {
     };
 
     /// The machine name.
-    pub const MACHINE: &str = {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "x86_64")] {
-                "x86_64"
-            } else if #[cfg(target_arch = "riscv64")] {
-                "riscv64"
-            } else if #[cfg(target_arch = "loongarch64")] {
-                "loongarch64"
-            } else if #[cfg(target_arch = "aarch64")] {
-                "aarch64"
-            } else {
-                compile_error!("unsupported target")
-            }
-        }
+    pub const MACHINE: &str = cfg_select! {
+        target_arch = "x86_64" => "x86_64",
+        target_arch = "riscv64" => "riscv64",
+        target_arch = "loongarch64" => "loongarch64",
+        target_arch = "aarch64" => "aarch64",
+        _ => compile_error!("unsupported target"),
     };
 }
 

--- a/kernel/src/process/signal/mod.rs
+++ b/kernel/src/process/signal/mod.rs
@@ -365,8 +365,8 @@ pub fn handle_user_signal(
     let fpu_context_bytes = fpu_context.as_bytes();
     supp.fpu().set(FpuContext::new());
 
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "x86_64")] {
+    cfg_select! {
+        target_arch = "x86_64" => {
             // Align the FPU context address to the 64-byte boundary so that the
             // user program can use the XSAVE/XRSTOR instructions at that address,
             // if necessary.
@@ -383,7 +383,8 @@ pub fn handle_user_signal(
 
             const UC_FP_XSTATE: u64 = 1 << 0;
             ucontext.uc_flags = UC_FP_XSTATE;
-        } else if #[cfg(target_arch = "riscv64")] {
+        }
+        target_arch = "riscv64" => {
             // Reference:
             // <https://elixir.bootlin.com/linux/v6.17.5/source/arch/riscv/include/uapi/asm/ptrace.h#L94-L98>,
             // <https://elixir.bootlin.com/linux/v6.17.5/source/arch/riscv/include/uapi/asm/ptrace.h#L69-L77>.
@@ -396,7 +397,8 @@ pub fn handle_user_signal(
                 align_of::<ucontext_t>(),
             );
             let fpu_context_addr = (ucontext_addr as usize) + size_of::<ucontext_t>();
-        } else if #[cfg(target_arch = "loongarch64")] {
+        }
+        target_arch = "loongarch64" => {
             // FIXME: It seems that we need to allocate an `sctx_info` structure.
             // Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/kernel/signal.c#L848>
             let ucontext_addr = alloc_aligned_in_user_stack(
@@ -407,7 +409,8 @@ pub fn handle_user_signal(
             // TODO: Set the flags in the context structure.
             // Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/kernel/signal.c#L805>
             let fpu_context_addr = (ucontext_addr as usize) + size_of::<ucontext_t>();
-        } else {
+        }
+        _ => {
             compile_error!("unsupported target");
         }
     }
@@ -423,11 +426,12 @@ pub fn handle_user_signal(
     let retaddr = if flags.contains(SigActionFlags::SA_RESTORER) {
         restorer_addr
     } else {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "riscv64")] {
+        cfg_select! {
+            target_arch = "riscv64" => {
                 ctx.user_space().vmar().process_vm().vdso_base()
                     + crate::vdso::__VDSO_RT_SIGRETURN_OFFSET
-            } else {
+            }
+            _ => {
                 // Note that this should already be rejected at the `rt_sigaction` system call.
                 return_errno_with_message!(
                     Errno::EINVAL,
@@ -436,12 +440,14 @@ pub fn handle_user_signal(
             }
         }
     };
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "x86_64")] {
+    cfg_select! {
+        target_arch = "x86_64" => {
             stack_pointer = write_u64_to_user_stack(stack_pointer, retaddr as u64)?;
-        } else if #[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))] {
+        }
+        any(target_arch = "riscv64", target_arch = "loongarch64") => {
             user_ctx.set_ra(retaddr);
-        } else {
+        }
+        _ => {
             compile_error!("unsupported target");
         }
     }
@@ -461,12 +467,13 @@ pub fn handle_user_signal(
         user_ctx.set_arguments(sig_num, 0, 0);
     }
     // Perform CPU architecture-dependent logic.
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "x86_64")] {
+    cfg_select! {
+        target_arch = "x86_64" => {
             // Clear the DF flag. This is to conform to x86-64 calling conventions.
             const X86_RFLAGS_DF: usize = 1 << 10; // Bit 10 is the DF flag.
             user_ctx.general_regs_mut().rflags &= !X86_RFLAGS_DF;
         }
+        _ => {},
     }
 
     Ok(())

--- a/kernel/src/process/signal/sig_disposition.rs
+++ b/kernel/src/process/signal/sig_disposition.rs
@@ -93,15 +93,17 @@ fn check_sigaction(sig_action: &SigAction) -> Result<()> {
         return Ok(());
     }
 
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "x86_64")] {
+    cfg_select! {
+        target_arch = "x86_64" => {
             // On x86-64, `SA_RESTORER` is mandatory and cannot be omitted.
             // Ref: <https://elixir.bootlin.com/linux/v6.13/source/arch/x86/kernel/signal_64.c#L172>
             return_errno_with_message!(Errno::EINVAL, "x86-64 should always use SA_RESTORER");
-        } else if #[cfg(target_arch = "riscv64")] {
+        }
+        target_arch = "riscv64" => {
             // On RISC-V, if `SA_RESTORER` is not specified, `__vdso_rt_sigreturn` will be used as a fallback.
             Ok(())
-        } else {
+        }
+        _ => {
             // FIXME: The support for user-provided signal handlers
             // without `SA_RESTORER` is arch-dependent.
             // Other archs may need to handle scenarios where `SA_RESTORER` is omitted.

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -2,13 +2,12 @@
 
 pub mod lsm;
 
-use cfg_if::cfg_if;
-
-cfg_if! {
-    if #[cfg(all(target_arch = "x86_64", feature = "cvm_guest"))] {
+cfg_select! {
+    all(target_arch = "x86_64", feature = "cvm_guest") => {
         mod tsm;
         mod tsm_mr;
     }
+    _ => {}
 }
 
 pub(super) fn init() {

--- a/kernel/src/syscall/rt_sigreturn.rs
+++ b/kernel/src/syscall/rt_sigreturn.rs
@@ -33,17 +33,15 @@ pub fn sys_rt_sigreturn(ctx: &Context, user_ctx: &mut UserContext) -> Result<Sys
     let _ = set_new_stack(stack, ctx, user_ctx.stack_pointer());
 
     // Restore the FPU context.
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "x86_64")] {
-            let fpu_context_addr = ucontext.uc_mcontext.fpu_context_addr();
-        } else if #[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))] {
+    let fpu_context_addr = cfg_select! {
+        target_arch = "x86_64" => ucontext.uc_mcontext.fpu_context_addr(),
+        any(target_arch = "riscv64", target_arch = "loongarch64") => {
             // In RISC-V/LoongArch64, the FPU context is placed directly after `ucontext_t` on the
             // signal stack.
-            let fpu_context_addr = sig_context_addr + size_of::<ucontext_t>();
-        } else {
-            compile_error!("unsupported target");
+            sig_context_addr + size_of::<ucontext_t>()
         }
-    }
+        _ => compile_error!("unsupported target"),
+    };
     let mut fpu_context = FpuContext::new();
     ctx.user_space()
         .read_bytes(fpu_context_addr, fpu_context.as_bytes_mut())?;

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -20,7 +20,6 @@ align_ext.workspace = true
 bit_field.workspace = true
 bitflags.workspace = true
 bitvec.workspace = true
-cfg-if.workspace = true
 gimli.workspace = true
 id-alloc.workspace = true
 inherit-methods-macro.workspace = true

--- a/ostd/libs/linux-bzimage/setup/Cargo.toml
+++ b/ostd/libs/linux-bzimage/setup/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfg-if.workspace = true
 linux-boot-params.workspace = true
 log.workspace = true
 uart_16550.workspace = true

--- a/ostd/libs/linux-bzimage/setup/src/x86/mod.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/mod.rs
@@ -2,21 +2,23 @@
 
 use core::arch::global_asm;
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
+cfg_select! {
+    target_arch = "x86_64" => {
         mod amd64_efi;
 
         pub use amd64_efi::alloc::alloc_at;
 
         const CFG_TARGET_ARCH_X86_64: usize = 1;
-    } else if #[cfg(target_arch = "x86")] {
+    }
+    target_arch = "x86" => {
         mod legacy_i386;
 
         pub use legacy_i386::alloc::alloc_at;
 
         const CFG_TARGET_ARCH_X86_64: usize = 0;
-    } else {
-        compile_error!("unsupported target architecture");
+    }
+    _ => {
+        compile_error!("unsupported target");
     }
 }
 

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -6,7 +6,6 @@ use alloc::boxed::Box;
 use core::arch::x86_64::{_fxrstor64, _fxsave64, _xrstor64, _xsave64};
 
 use bitflags::bitflags;
-use cfg_if::cfg_if;
 use ostd_pod::{FromZeros, IntoBytes};
 use spin::Once;
 use x86::bits64::segmentation::{rdfsbase, rdgsbase, swapgs, wrfsbase, wrgsbase};
@@ -28,8 +27,8 @@ use crate::{
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
 };
 
-cfg_if! {
-    if #[cfg(feature = "cvm_guest")] {
+cfg_select! {
+    feature = "cvm_guest" => {
         mod tdx;
 
         use tdx::VirtualizationExceptionHandler;

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -2,7 +2,6 @@
 
 use core::ops::Range;
 
-use cfg_if::cfg_if;
 pub(crate) use util::{
     __atomic_cmpxchg_fallible, __atomic_load_fallible, __memcpy_fallible, __memset_fallible,
 };
@@ -179,12 +178,13 @@ macro_rules! parse_flags {
 }
 
 impl PageTableEntry {
-    cfg_if! {
-        if #[cfg(feature = "cvm_guest")] {
+    cfg_select! {
+        feature = "cvm_guest" => {
             const PHYS_ADDR_MASK_LVL1: usize = 0x7_ffff_ffff_f000;
             const PHYS_ADDR_MASK_LVL2: usize = 0x7_ffff_ffe0_0000;
             const PHYS_ADDR_MASK_LVL3: usize = 0x7_ffff_c000_0000;
-        } else {
+        }
+        _ => {
             const PHYS_ADDR_MASK_LVL1: usize = 0xf_ffff_ffff_f000;
             const PHYS_ADDR_MASK_LVL2: usize = 0xf_ffff_ffe0_0000;
             const PHYS_ADDR_MASK_LVL3: usize = 0xf_ffff_c000_0000;

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -20,7 +20,6 @@ pub(super) mod gdt;
 mod idt;
 mod syscall;
 
-use cfg_if::cfg_if;
 use spin::Once;
 
 use super::cpu::context::GeneralRegs;
@@ -35,8 +34,8 @@ use crate::{
     mm::MAX_USERSPACE_VADDR,
 };
 
-cfg_if! {
-    if #[cfg(feature = "cvm_guest")] {
+cfg_select! {
+    feature = "cvm_guest" => {
         use tdx_guest::{tdcall, handle_virtual_exception};
         use crate::arch::tdx_guest::TrapFrameWrapper;
     }

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -289,8 +289,8 @@ mod is_used {
     //!
     //! [`copy_bsp_for_ap`]: super::copy_bsp_for_ap
 
-    cfg_if::cfg_if! {
-        if #[cfg(debug_assertions)] {
+    cfg_select! {
+        debug_assertions => {
             use core::sync::atomic::{AtomicBool, Ordering};
 
             static IS_USED: AtomicBool = AtomicBool::new(false);
@@ -302,7 +302,8 @@ mod is_used {
             pub fn debug_assert_false() {
                 debug_assert!(!IS_USED.load(Ordering::Relaxed));
             }
-        } else {
+        }
+        _ => {
             pub fn debug_set_true() {}
 
             pub fn debug_assert_false() {}

--- a/ostd/src/io/mod.rs
+++ b/ostd/src/io/mod.rs
@@ -13,14 +13,15 @@ pub use self::io_mem::IoMem;
 #[cfg_attr(target_arch = "loongarch64", expect(unused_imports))]
 pub(crate) use self::io_mem::{IoMemAllocatorBuilder, Sensitive};
 
-cfg_if::cfg_if!(
-    if #[cfg(target_arch = "x86_64")] {
+cfg_select! {
+    target_arch = "x86_64" => {
         mod io_port;
 
         pub use self::io_port::IoPort;
         pub(crate) use self::io_port::{reserve_io_port_range, sensitive_io_port, RawIoPortRange};
     }
-);
+    _ => {},
+}
 
 /// Initializes the static allocator based on builder.
 ///

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -4,7 +4,6 @@
 
 use crate::early_println;
 
-extern crate cfg_if;
 extern crate gimli;
 
 /// The default panic handler for OSTD based kernels.
@@ -119,22 +118,17 @@ pub fn print_stack_trace() {
         // Print the first 8 general registers for any architecture. The register number follows
         // the DWARF standard.
         for i in 0..8u16 {
-            let reg_i = _Unwind_GetGR(unwind_ctx, i as i32);
-            cfg_if::cfg_if! {
-                if #[cfg(target_arch = "x86_64")] {
-                    let reg_name = gimli::X86_64::register_name(Register(i)).unwrap_or("unknown");
-                } else if #[cfg(target_arch = "riscv64")] {
-                    let reg_name = gimli::RiscV::register_name(Register(i)).unwrap_or("unknown");
-                } else if #[cfg(target_arch = "aarch64")] {
-                    let reg_name = gimli::AArch64::register_name(Register(i)).unwrap_or("unknown");
-                } else {
-                    let reg_name = "unknown";
-                }
-            }
+            let reg_name = cfg_select! {
+                target_arch = "x86_64" => gimli::X86_64::register_name(Register(i)),
+                target_arch = "riscv64" => gimli::RiscV::register_name(Register(i)),
+                target_arch = "aarch64" => gimli::AArch64::register_name(Register(i)),
+                _ => None,
+            };
+            let reg_val = _Unwind_GetGR(unwind_ctx, i as i32);
             if i.is_multiple_of(4) {
                 early_print!("\n    ");
             }
-            early_print!(" {} {:#18x};", reg_name, reg_i);
+            early_print!(" {} {:#18x};", reg_name.unwrap_or("unknown"), reg_val);
         }
         early_print!("\n\n");
         UnwindReasonCode::NO_REASON


### PR DESCRIPTION
There is no need to use the third-party `cfg_if` dependency anymore. Rust 1.95 now has stable built-in support for [`cfg_select`](https://doc.rust-lang.org/beta/std/macro.cfg_select.html).

Example:

```rust
    pub const MACHINE: &str = {
        cfg_if::cfg_if! {
            if #[cfg(target_arch = "x86_64")] {
                "x86_64"
            } else if #[cfg(target_arch = "riscv64")] {
                "riscv64"
            } else if #[cfg(target_arch = "loongarch64")] {
                "loongarch64"
            } else if #[cfg(target_arch = "aarch64")] {
                "aarch64"
            } else {
                compile_error!("unsupported target")
            }
        }
    };
```

can be converted to:

```rust
    pub const MACHINE: &str = cfg_select! {
        target_arch = "x86_64" => "x86_64",
        target_arch = "riscv64" => "riscv64",
        target_arch = "loongarch64" => "loongarch64",
        target_arch = "aarch64" => "aarch64",
        _ => compile_error!("unsupported target"),
    };
```

