### PR TITLE
Fix inode append and memfd seal races

### DIFF
--- a/kernel/src/device/evdev/file.rs
+++ b/kernel/src/device/evdev/file.rs
@@ -17,7 +17,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
@@ -396,7 +396,7 @@ impl FileOps for EvdevFile {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/device/fb.rs
+++ b/kernel/src/device/fb.rs
@@ -13,7 +13,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{Mappable, PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -447,7 +447,7 @@ impl FileOps for FbHandle {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {
@@ -457,6 +457,9 @@ impl FileOps for FbHandle {
 
         let io_mem = self.framebuffer.io_mem();
         let size = io_mem.size();
+        let WriteOffset::Absolute(offset) = offset else {
+            return_errno_with_message!(Errno::EINVAL, "append write is not supported");
+        };
         if offset >= size {
             return_errno_with_message!(
                 Errno::ENOSPC,

--- a/kernel/src/device/mem/file.rs
+++ b/kernel/src/device/mem/file.rs
@@ -4,7 +4,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -118,7 +118,7 @@ impl FileOps for MemFile {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/device/misc/hwrng.rs
+++ b/kernel/src/device/misc/hwrng.rs
@@ -13,7 +13,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -127,7 +127,7 @@ impl FileOps for HwRngFile {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -59,7 +59,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -167,7 +167,7 @@ impl FileOps for TdxGuestFile {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/device/pty/file.rs
+++ b/kernel/src/device/pty/file.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -72,7 +72,7 @@ impl FileOps for PtySlaveFile {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -14,7 +14,10 @@ use crate::{
             AccessMode, OpenArgs, PerOpenFileOps, SettableStatusFlags, StatusFlags,
             file_table::FdFlags, mkmod,
         },
-        vfs::{inode::FileOps, path::FsPath},
+        vfs::{
+            inode::{FileOps, WriteOffset},
+            path::FsPath,
+        },
     },
     prelude::*,
     process::{
@@ -120,7 +123,7 @@ impl FileOps for PtyMaster {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -12,7 +12,10 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::{inode::FileOps, path::PathResolver},
+        vfs::{
+            inode::{FileOps, WriteOffset},
+            path::PathResolver,
+        },
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -159,7 +162,7 @@ impl FileOps for OpenBlockFile {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {
@@ -169,6 +172,9 @@ impl FileOps for OpenBlockFile {
         }
 
         let device_size = self.0.metadata().nr_sectors * SECTOR_SIZE;
+        let WriteOffset::Absolute(offset) = offset else {
+            return_errno_with_message!(Errno::EINVAL, "append write is not supported");
+        };
         if offset >= device_size {
             return_errno_with_message!(
                 Errno::ENOSPC,

--- a/kernel/src/device/tty/file.rs
+++ b/kernel/src/device/tty/file.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -39,7 +39,7 @@ impl<D: TtyDriver> FileOps for TtyFile<D> {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/device/tty/vt/file.rs
+++ b/kernel/src/device/tty/vt/file.rs
@@ -15,7 +15,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -96,7 +96,7 @@ impl FileOps for VtFile {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -15,7 +15,7 @@ use crate::{
     fs::{
         utils::DirentVisitor,
         vfs::{
-            inode::{FallocMode, FileOps},
+            inode::{FallocMode, FileOps, WriteOffset},
             inode_ext::InodeExt,
             path::Path,
             range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
@@ -286,13 +286,18 @@ impl FileLike for InodeHandle {
         let status_flags = self.status_flags();
 
         if !is_offset_aware {
-            return file_ops.write_at(0, reader, status_flags);
+            return file_ops.write_at(WriteOffset::Absolute(0), reader, status_flags);
         }
 
         let mut offset = self.offset.lock();
+        let write_offset = if status_flags.contains(StatusFlags::O_APPEND) {
+            WriteOffset::Append
+        } else {
+            WriteOffset::Absolute(*offset)
+        };
 
-        let len = file_ops.write_at(*offset, reader, status_flags)?;
-        if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
+        let len = file_ops.write_at(write_offset, reader, status_flags)?;
+        if status_flags.contains(StatusFlags::O_APPEND) {
             *offset = self.path().size();
         } else {
             *offset += len;
@@ -319,8 +324,13 @@ impl FileLike for InodeHandle {
         }
 
         let status_flags = self.status_flags();
+        let write_offset = if status_flags.contains(StatusFlags::O_APPEND) {
+            WriteOffset::Append
+        } else {
+            WriteOffset::Absolute(offset)
+        };
 
-        file_ops.write_at(offset, reader, status_flags)
+        file_ops.write_at(write_offset, reader, status_flags)
     }
 
     fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -291,15 +291,12 @@ impl FileLike for InodeHandle {
 
         let mut offset = self.offset.lock();
 
-        // FIXME: How can we deal with the `O_APPEND` flag if `open_file` is set?
-        if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
-            // FIXME: `O_APPEND` should ensure that new content is appended even if another process
-            // is writing to the file concurrently.
-            *offset = self.path().size();
-        }
-
         let len = file_ops.write_at(*offset, reader, status_flags)?;
-        *offset += len;
+        if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
+            *offset = self.path().size();
+        } else {
+            *offset += len;
+        }
 
         Ok(len)
     }
@@ -315,21 +312,13 @@ impl FileLike for InodeHandle {
         file_ops.read_at(offset, writer, status_flags)
     }
 
-    fn write_at(&self, mut offset: usize, reader: &mut VmReader) -> Result<usize> {
+    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
         let file_ops = self.file_ops_for_positional_io()?;
         if !self.rights.contains(Rights::WRITE) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
         }
 
         let status_flags = self.status_flags();
-
-        // FIXME: How can we deal with the `O_APPEND` flag if `open_file` is set?
-        if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
-            // If the file has the `O_APPEND` flag, the offset is ignored.
-            // FIXME: `O_APPEND` should ensure that new content is appended even if another process
-            // is writing to the file concurrently.
-            offset = self.path().size();
-        }
 
         file_ops.write_at(offset, reader, status_flags)
     }

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -19,6 +19,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{
                 Extension, FileOps, Inode, Metadata, MknodType, RenameMode, RevalidationPolicy,
+                WriteOffset,
             },
             registry::{FsCreationCtx, FsProperties, FsType},
         },
@@ -185,7 +186,7 @@ impl FileOps for RootInode {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -62,7 +62,7 @@ impl FileOps for Ptmx {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -51,7 +51,7 @@ impl FileOps for PtySlaveInode {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -701,10 +701,15 @@ impl ExfatInode {
         Ok(read_len)
     }
 
-    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+    fn write_at(
+        &self,
+        offset: usize,
+        reader: &mut VmReader,
+        status_flags: StatusFlags,
+    ) -> Result<usize> {
         let write_len = reader.remain();
         // We need to obtain the fs lock to resize the file.
-        let new_size = {
+        let (offset, new_size) = {
             let mut inner = self.inner.write();
             if inner.inode_type.is_directory() {
                 return_errno!(Errno::EISDIR)
@@ -712,7 +717,14 @@ impl ExfatInode {
 
             let file_size = inner.size;
             let file_allocated_size = inner.size_allocated;
-            let new_size = offset + write_len;
+            let offset = if status_flags.contains(StatusFlags::O_APPEND) {
+                file_size
+            } else {
+                offset
+            };
+            let new_size = offset
+                .checked_add(write_len)
+                .ok_or_else(|| Error::with_message(Errno::EINVAL, "write range overflow"))?;
             let fs = inner.fs();
             let fs_guard = fs.lock();
             if new_size > file_size {
@@ -721,7 +733,7 @@ impl ExfatInode {
                 }
                 inner.page_cache.resize(new_size, file_size)?;
             }
-            new_size.max(file_size)
+            (offset, new_size.max(file_size))
         };
 
         // Locks released here, so that file write can be parallelized.
@@ -748,19 +760,30 @@ impl ExfatInode {
         Ok(write_len)
     }
 
-    fn write_direct_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+    fn write_direct_at(
+        &self,
+        offset: usize,
+        reader: &mut VmReader,
+        status_flags: StatusFlags,
+    ) -> Result<usize> {
         let write_len = reader.remain();
         let inner = self.inner.upread();
         if inner.inode_type.is_directory() {
             return_errno!(Errno::EISDIR)
         }
+        let file_size = inner.size;
+        let file_allocated_size = inner.size_allocated;
+        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
+            file_size
+        } else {
+            offset
+        };
         if !is_block_aligned(offset) || !is_block_aligned(write_len) {
             return_errno_with_message!(Errno::EINVAL, "not block-aligned");
         }
-
-        let file_size = inner.size;
-        let file_allocated_size = inner.size_allocated;
-        let end_offset = offset + write_len;
+        let end_offset = offset
+            .checked_add(write_len)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "write range overflow"))?;
 
         let start = offset.min(file_size);
         let end = end_offset.min(file_size);
@@ -1321,9 +1344,9 @@ impl FileOps for ExfatInode {
         status_flags: StatusFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
-            self.write_direct_at(offset, reader)
+            self.write_direct_at(offset, reader, status_flags)
         } else {
-            self.write_at(offset, reader)
+            self.write_at(offset, reader, status_flags)
         }
     }
 

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -31,7 +31,10 @@ use crate::{
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata, MknodType, RenameMode, SymbolicLink},
+            inode::{
+                Extension, FileOps, Inode, Metadata, MknodType, RenameMode, SymbolicLink,
+                WriteOffset,
+            },
             path::{is_dot, is_dot_or_dotdot, is_dotdot},
         },
     },
@@ -703,7 +706,7 @@ impl ExfatInode {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {
@@ -717,11 +720,7 @@ impl ExfatInode {
 
             let file_size = inner.size;
             let file_allocated_size = inner.size_allocated;
-            let offset = if status_flags.contains(StatusFlags::O_APPEND) {
-                file_size
-            } else {
-                offset
-            };
+            let offset = offset.resolve(file_size);
             let new_size = offset
                 .checked_add(write_len)
                 .ok_or_else(|| Error::with_message(Errno::EINVAL, "write range overflow"))?;
@@ -762,9 +761,9 @@ impl ExfatInode {
 
     fn write_direct_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
-        status_flags: StatusFlags,
+        _status_flags: StatusFlags,
     ) -> Result<usize> {
         let write_len = reader.remain();
         let inner = self.inner.upread();
@@ -773,11 +772,7 @@ impl ExfatInode {
         }
         let file_size = inner.size;
         let file_allocated_size = inner.size_allocated;
-        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
-            file_size
-        } else {
-            offset
-        };
+        let offset = offset.resolve(file_size);
         if !is_block_aligned(offset) || !is_block_aligned(write_len) {
             return_errno_with_message!(Errno::EINVAL, "not block-aligned");
         }
@@ -1339,7 +1334,7 @@ impl FileOps for ExfatInode {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -22,7 +22,7 @@ use crate::{
             file_system::FileSystem,
             inode::{
                 Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RenameMode,
-                SymbolicLink,
+                SymbolicLink, WriteOffset,
             },
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
@@ -48,7 +48,7 @@ impl FileOps for Ext2Inode {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -53,9 +53,9 @@ impl FileOps for Ext2Inode {
         status_flags: StatusFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
-            self.write_direct_at(offset, reader)
+            self.write_direct_at(offset, reader, status_flags)
         } else {
-            self.write_at(offset, reader)
+            self.write_at(offset, reader, status_flags)
         }
     }
 

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -796,9 +796,12 @@ mod test {
     use ostd::prelude::ktest;
 
     use super::*;
-    use crate::fs::ext2::{
-        inode::test::read_raw_inode_from_disk,
-        test_utils::{assert_errno, create_file, default_fixture},
+    use crate::fs::{
+        ext2::{
+            inode::test::read_raw_inode_from_disk,
+            test_utils::{assert_errno, create_file, default_fixture},
+        },
+        file::StatusFlags,
     };
 
     #[ktest]
@@ -809,7 +812,8 @@ mod test {
         let old_ino = old.ino();
         let payload = vec![0x6au8; BLOCK_SIZE];
         let mut payload_reader = VmReader::from(payload.as_slice()).to_fallible();
-        old.write_direct_at(0, &mut payload_reader).unwrap();
+        old.write_direct_at(0, &mut payload_reader, StatusFlags::empty())
+            .unwrap();
 
         let free_blocks_before = f.ext2.super_block().free_blocks_count();
         root.unlink("old").unwrap();

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -802,6 +802,7 @@ mod test {
             test_utils::{assert_errno, create_file, default_fixture},
         },
         file::StatusFlags,
+        vfs::inode::WriteOffset,
     };
 
     #[ktest]
@@ -812,8 +813,12 @@ mod test {
         let old_ino = old.ino();
         let payload = vec![0x6au8; BLOCK_SIZE];
         let mut payload_reader = VmReader::from(payload.as_slice()).to_fallible();
-        old.write_direct_at(0, &mut payload_reader, StatusFlags::empty())
-            .unwrap();
+        old.write_direct_at(
+            WriteOffset::Absolute(0),
+            &mut payload_reader,
+            StatusFlags::empty(),
+        )
+        .unwrap();
 
         let free_blocks_before = f.ext2.super_block().free_blocks_count();
         root.unlink("old").unwrap();

--- a/kernel/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/file.rs
@@ -13,7 +13,7 @@ use super::{super::Ext2, FileFlags, Inode, InodeInner, io_range::IoRange};
 use crate::fs::{
     ext2::{prelude::*, utils},
     file::StatusFlags,
-    vfs::inode::FallocMode,
+    vfs::inode::{FallocMode, WriteOffset},
 };
 
 impl Inode {
@@ -41,9 +41,9 @@ impl Inode {
     /// Writes file data at `offset` through the page cache.
     pub(in crate::fs::fs_impls::ext2) fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
-        status_flags: StatusFlags,
+        _status_flags: StatusFlags,
     ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
@@ -56,11 +56,7 @@ impl Inode {
 
         let fs = self.fs()?;
         let mut inner = self.inner.write();
-        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
-            inner.file_size()
-        } else {
-            offset
-        };
+        let offset = offset.resolve(inner.file_size());
         inner.write_at(&fs, offset, reader)
     }
 
@@ -94,9 +90,9 @@ impl Inode {
     /// Direct-I/O write path with pre-allocation and rollback.
     pub(in crate::fs::fs_impls::ext2) fn write_direct_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
-        status_flags: StatusFlags,
+        _status_flags: StatusFlags,
     ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
@@ -109,11 +105,7 @@ impl Inode {
 
         let fs = self.fs()?;
         let mut inner = self.inner.write();
-        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
-            inner.file_size()
-        } else {
-            offset
-        };
+        let offset = offset.resolve(inner.file_size());
         if !is_block_aligned(offset) || !is_block_aligned(write_len) {
             // TODO: Implement a fallback mechanism.
             return_errno_with_message!(Errno::EINVAL, "not block-aligned");
@@ -514,7 +506,7 @@ mod test {
         let base_data = vec![0x44u8; BLOCK_SIZE];
 
         let mut reader = VmReader::from(base_data.as_slice()).to_fallible();
-        file.write_direct_at(0, &mut reader, StatusFlags::empty())
+        file.write_direct_at(WriteOffset::Absolute(0), &mut reader, StatusFlags::empty())
             .unwrap();
         let free_before_fail = f.ext2.super_block().free_blocks_count();
         assert_eq!(free_before_fail, 1);
@@ -522,7 +514,11 @@ mod test {
         let fail_payload = vec![0x66u8; BLOCK_SIZE * 2];
         let mut fail_reader = VmReader::from(fail_payload.as_slice()).to_fallible();
         assert_errno!(
-            file.write_direct_at(BLOCK_SIZE, &mut fail_reader, StatusFlags::empty()),
+            file.write_direct_at(
+                WriteOffset::Absolute(BLOCK_SIZE),
+                &mut fail_reader,
+                StatusFlags::empty(),
+            ),
             Errno::ENOSPC
         );
 

--- a/kernel/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/file.rs
@@ -12,6 +12,7 @@ use ostd::mm::io::util::HasVmReaderWriter;
 use super::{super::Ext2, FileFlags, Inode, InodeInner, io_range::IoRange};
 use crate::fs::{
     ext2::{prelude::*, utils},
+    file::StatusFlags,
     vfs::inode::FallocMode,
 };
 
@@ -42,6 +43,7 @@ impl Inode {
         &self,
         offset: usize,
         reader: &mut VmReader,
+        status_flags: StatusFlags,
     ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
@@ -54,6 +56,11 @@ impl Inode {
 
         let fs = self.fs()?;
         let mut inner = self.inner.write();
+        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
+            inner.file_size()
+        } else {
+            offset
+        };
         inner.write_at(&fs, offset, reader)
     }
 
@@ -89,6 +96,7 @@ impl Inode {
         &self,
         offset: usize,
         reader: &mut VmReader,
+        status_flags: StatusFlags,
     ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
@@ -99,13 +107,17 @@ impl Inode {
             return Ok(0);
         }
 
+        let fs = self.fs()?;
+        let mut inner = self.inner.write();
+        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
+            inner.file_size()
+        } else {
+            offset
+        };
         if !is_block_aligned(offset) || !is_block_aligned(write_len) {
             // TODO: Implement a fallback mechanism.
             return_errno_with_message!(Errno::EINVAL, "not block-aligned");
         }
-
-        let fs = self.fs()?;
-        let mut inner = self.inner.write();
         inner.write_direct_at(&fs, offset, reader)
     }
 
@@ -502,14 +514,15 @@ mod test {
         let base_data = vec![0x44u8; BLOCK_SIZE];
 
         let mut reader = VmReader::from(base_data.as_slice()).to_fallible();
-        file.write_direct_at(0, &mut reader).unwrap();
+        file.write_direct_at(0, &mut reader, StatusFlags::empty())
+            .unwrap();
         let free_before_fail = f.ext2.super_block().free_blocks_count();
         assert_eq!(free_before_fail, 1);
 
         let fail_payload = vec![0x66u8; BLOCK_SIZE * 2];
         let mut fail_reader = VmReader::from(fail_payload.as_slice()).to_fallible();
         assert_errno!(
-            file.write_direct_at(BLOCK_SIZE, &mut fail_reader),
+            file.write_direct_at(BLOCK_SIZE, &mut fail_reader, StatusFlags::empty()),
             Errno::ENOSPC
         );
 

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -26,7 +26,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{
                 Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RenameMode,
-                SymbolicLink,
+                SymbolicLink, WriteOffset,
             },
             path::{FsPath, Path},
             registry::{FsCreationCtx, FsProperties, FsType},
@@ -307,7 +307,7 @@ impl OverlayInode {
     /// The corresponding parent directories will be created also if they do not exist.
     pub fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {
@@ -878,7 +878,11 @@ impl OverlayInode {
         let read_len = lower.read_at(0, &mut writer, StatusFlags::empty())?;
 
         let mut reader = data_buf.reader().to_fallible();
-        let _ = upper.write_at(0, reader.limit(read_len), StatusFlags::empty())?;
+        let _ = upper.write_at(
+            WriteOffset::Absolute(0),
+            reader.limit(read_len),
+            StatusFlags::empty(),
+        )?;
         Ok(())
     }
 
@@ -963,7 +967,7 @@ impl FileOps for OverlayInode {
     ) -> Result<usize>;
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize>;
@@ -1281,7 +1285,7 @@ mod tests {
             let f2_inode = f2.inode();
             f2_inode
                 .write_at(
-                    0,
+                    WriteOffset::Absolute(0),
                     &mut VmReader::from([8u8; 4].as_slice()).to_fallible(),
                     StatusFlags::empty(),
                 )

--- a/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/maps.rs
@@ -8,7 +8,7 @@ use crate::{
     fs::{
         file::{AccessMode, PerOpenFileOps, StatusFlags, mkmod},
         procfs::template::{ProcFile, ProcFileOpsByHandle},
-        vfs::inode::{FileOps, Inode},
+        vfs::inode::{FileOps, Inode, WriteOffset},
     },
     prelude::*,
     process::{
@@ -111,7 +111,7 @@ impl FileOps for MapsFileHandle {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mem.rs
@@ -6,7 +6,7 @@ use crate::{
     fs::{
         file::{AccessMode, PerOpenFileOps, StatusFlags, mkmod},
         procfs::template::{ProcFile, ProcFileOpsByHandle},
-        vfs::inode::{FileOps, Inode},
+        vfs::inode::{FileOps, Inode, WriteOffset},
     },
     prelude::*,
     process::{
@@ -99,10 +99,14 @@ impl FileOps for MemFileHandle {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {
+        let WriteOffset::Absolute(offset) = offset else {
+            return_errno_with_message!(Errno::EINVAL, "append write is not supported");
+        };
+
         let Some(process) = self.0.process() else {
             // The process does not exist.
             return Ok(0);

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -17,6 +17,7 @@ use crate::{
             file_system::{FileSystem, SuperBlock},
             inode::{
                 Extension, FileOps, Inode, Metadata, MknodType, RenameMode, RevalidationPolicy,
+                WriteOffset,
             },
             path::{is_dot, is_dotdot},
         },
@@ -105,7 +106,7 @@ impl<D: ProcDirOps + 'static> FileOps for ProcDir<D> {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -11,7 +11,7 @@ use crate::{
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink},
+            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink, WriteOffset},
         },
     },
     prelude::*,
@@ -60,10 +60,14 @@ impl<F: ProcFileOps + 'static> FileOps for ProcFile<F> {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {
+        let WriteOffset::Absolute(offset) = offset else {
+            return_errno_with_message!(Errno::EINVAL, "append write is not supported");
+        };
+
         self.inner.write_at(offset, reader)
     }
 }

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -11,7 +11,7 @@ use crate::{
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink},
+            inode::{Extension, FileOps, Inode, Metadata, SymbolicLink, WriteOffset},
         },
     },
     prelude::*,
@@ -57,7 +57,7 @@ impl<S: ProcSymOps + 'static> FileOps for ProcSym<S> {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -43,7 +43,7 @@ use crate::{
         utils::NAME_MAX,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
-            inode::{Extension, FileOps, Inode, Metadata},
+            inode::{Extension, FileOps, Inode, Metadata, WriteOffset},
         },
     },
     prelude::*,
@@ -251,7 +251,7 @@ impl FileOps for PseudoInode {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -18,7 +18,7 @@ use crate::{
         pseudofs::{NaivePseudoFs, PseudoInode, PseudoInodeType},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata},
+            inode::{Extension, FileOps, Inode, Metadata, WriteOffset},
             path::{Dentry, Mount, Path},
         },
     },
@@ -159,7 +159,7 @@ impl<T: NsCommonOps> FileOps for NsInode<T> {
     ) -> Result<usize>;
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status: StatusFlags,
     ) -> Result<usize>;
@@ -261,7 +261,7 @@ impl<T: NsCommonOps> FileOps for NsFile<T> {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -32,7 +32,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{
                 Extension, FallocMode, FileOps, HardLinkability, Inode, Metadata, MknodType,
-                RenameMode, SymbolicLink,
+                RenameMode, SymbolicLink, WriteOffset,
             },
             path::{is_dot, is_dot_or_dotdot, is_dotdot},
             registry::{FsCreationCtx, FsProperties, FsType},
@@ -696,9 +696,9 @@ impl RamInode {
 
     pub(super) fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
-        status_flags: StatusFlags,
+        _status_flags: StatusFlags,
         seals: Option<FileSeals>,
     ) -> Result<usize> {
         if self.typ != InodeType::File {
@@ -708,11 +708,7 @@ impl RamInode {
         let page_cache = self.inner.as_file().unwrap().lock();
         let mut inode_meta = self.metadata.lock();
         let file_size = inode_meta.size;
-        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
-            file_size
-        } else {
-            offset
-        };
+        let offset = offset.resolve(file_size);
 
         if let Some(seals) = seals {
             if seals.intersects(FileSeals::F_SEAL_WRITE | FileSeals::F_SEAL_FUTURE_WRITE) {
@@ -918,7 +914,7 @@ impl FileOps for RamInode {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -15,7 +15,11 @@ use ostd::{
     sync::{PreemptDisabled, RwLockWriteGuard},
 };
 
-use super::{memfd::MemfdInode, xattr::RamXattr, *};
+use super::{
+    memfd::{FileSeals, MemfdInode},
+    xattr::RamXattr,
+    *,
+};
 use crate::{
     device::{self, DeviceType},
     fs::{
@@ -689,6 +693,200 @@ impl RamInode {
 
         self.inner.as_direntry().unwrap().write().set_parent(parent);
     }
+
+    pub(super) fn write_at(
+        &self,
+        offset: usize,
+        reader: &mut VmReader,
+        status_flags: StatusFlags,
+        seals: Option<FileSeals>,
+    ) -> Result<usize> {
+        if self.typ != InodeType::File {
+            return_errno_with_message!(Errno::EISDIR, "write is not supported");
+        }
+
+        let page_cache = self.inner.as_file().unwrap().lock();
+        let mut inode_meta = self.metadata.lock();
+        let file_size = inode_meta.size;
+        let offset = if status_flags.contains(StatusFlags::O_APPEND) {
+            file_size
+        } else {
+            offset
+        };
+
+        if let Some(seals) = seals {
+            if seals.intersects(FileSeals::F_SEAL_WRITE | FileSeals::F_SEAL_FUTURE_WRITE) {
+                return_errno_with_message!(Errno::EPERM, "the file is sealed against writing");
+            }
+            if seals.contains(FileSeals::F_SEAL_GROW) {
+                let new_size = offset
+                    .checked_add(reader.remain())
+                    .ok_or_else(|| Error::with_message(Errno::EINVAL, "write range overflow"))?;
+                if new_size > file_size {
+                    // For a memfd sealed with `F_SEAL_GROW`, if a write that would grow the file occurs,
+                    // the entire write within the page containing the EOF is rejected. Writes before
+                    // the EOF page are not affected.
+                    //
+                    // For detailed explanation, please see:
+                    // <https://github.com/asterinas/asterinas/pull/2555#discussion_r2509179520>
+                    //
+                    // Reference:
+                    // <https://elixir.bootlin.com/linux/v6.16.5/source/mm/shmem.c#L3309-L3310>
+                    // <https://github.com/google/gvisor/blob/6db745970118635edec4c973f47df2363924d3a7/test/syscalls/linux/memfd.cc#L261-L280>
+                    let eof_page = file_size.align_down(PAGE_SIZE);
+                    if offset >= eof_page {
+                        return_errno_with_message!(
+                            Errno::EPERM,
+                            "the file is sealed against growing"
+                        );
+                    }
+                    reader.limit(eof_page - offset);
+                }
+            }
+        }
+
+        let write_len = reader.remain();
+        let new_size = offset
+            .checked_add(write_len)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "write range overflow"))?;
+        let should_expand_size = new_size > file_size;
+        let new_size_aligned = new_size.align_up(BLOCK_SIZE);
+
+        let now = now();
+        inode_meta.set_mtime(now);
+        inode_meta.set_ctime(now);
+
+        if should_expand_size {
+            inode_meta.size = new_size;
+            inode_meta.blocks = new_size_aligned / BLOCK_SIZE;
+        }
+        drop(inode_meta);
+
+        if should_expand_size {
+            page_cache.resize(new_size_aligned, file_size)?;
+        }
+        page_cache.write(offset, reader)?;
+
+        Ok(write_len)
+    }
+
+    pub(super) fn resize(&self, new_size: usize, seals: Option<FileSeals>) -> Result<()> {
+        if self.typ == InodeType::Dir {
+            return_errno_with_message!(Errno::EISDIR, "the inode is a directory");
+        }
+        if self.typ != InodeType::File {
+            return_errno_with_message!(Errno::EINVAL, "the inode is not a regular file");
+        }
+
+        let page_cache = self.inner.as_file().unwrap().lock();
+        let inode_meta = self.metadata.lock();
+        let file_size = inode_meta.size;
+
+        if let Some(seals) = seals {
+            if seals.contains(FileSeals::F_SEAL_SHRINK) && new_size < file_size {
+                return_errno_with_message!(Errno::EPERM, "the file is sealed against shrinking");
+            }
+            if seals.contains(FileSeals::F_SEAL_GROW) && new_size > file_size {
+                return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
+            }
+        }
+
+        self.resize_file_locked(page_cache, inode_meta, file_size, new_size)
+    }
+
+    pub(super) fn fallocate(
+        &self,
+        mode: FallocMode,
+        offset: usize,
+        len: usize,
+        seals: Option<FileSeals>,
+    ) -> Result<()> {
+        if self.typ == InodeType::Dir {
+            return_errno_with_message!(Errno::EISDIR, "the inode is a directory");
+        }
+        if self.typ != InodeType::File {
+            return_errno_with_message!(Errno::EINVAL, "the inode is not a regular file");
+        }
+
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "fallocate range overflow"))?;
+        let page_cache = self.inner.as_file().unwrap().lock();
+        let inode_meta = self.metadata.lock();
+        let file_size = inode_meta.size;
+
+        match mode {
+            FallocMode::Allocate => {
+                if let Some(seals) = seals
+                    && seals.contains(FileSeals::F_SEAL_GROW)
+                    && end > file_size
+                {
+                    return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
+                }
+                if end <= file_size {
+                    return Ok(());
+                }
+                self.resize_file_locked(page_cache, inode_meta, file_size, end)
+            }
+            FallocMode::AllocateKeepSize => {
+                if let Some(seals) = seals
+                    && seals.contains(FileSeals::F_SEAL_GROW)
+                    && end > file_size
+                {
+                    return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
+                }
+                Ok(())
+            }
+            FallocMode::PunchHoleKeepSize => {
+                if let Some(seals) = seals
+                    && seals.intersects(FileSeals::F_SEAL_WRITE | FileSeals::F_SEAL_FUTURE_WRITE)
+                {
+                    return_errno_with_message!(Errno::EPERM, "the file is sealed against writing");
+                }
+                if offset >= file_size {
+                    return Ok(());
+                }
+                let range = offset..file_size.min(end);
+                drop(inode_meta);
+                page_cache.fill_zeros(range)
+            }
+            _ => {
+                return_errno_with_message!(
+                    Errno::EOPNOTSUPP,
+                    "fallocate with the specified flags is not supported"
+                );
+            }
+        }
+    }
+
+    fn resize_file_locked(
+        &self,
+        page_cache: MutexGuard<'_, PageCache>,
+        mut inode_meta: SpinLockGuard<'_, InodeMeta, PreemptDisabled>,
+        file_size: usize,
+        new_size: usize,
+    ) -> Result<()> {
+        if file_size == new_size {
+            return Ok(());
+        }
+
+        let now = now();
+        inode_meta.set_mtime(now);
+        inode_meta.set_ctime(now);
+
+        if new_size > file_size {
+            inode_meta.resize(new_size);
+            drop(inode_meta);
+            page_cache.resize(new_size, file_size)?;
+        } else {
+            drop(inode_meta);
+            page_cache.resize(new_size, file_size)?;
+            let mut inode_meta = self.metadata.lock();
+            inode_meta.resize(new_size);
+        }
+
+        Ok(())
+    }
 }
 
 impl FileOps for RamInode {
@@ -722,38 +920,9 @@ impl FileOps for RamInode {
         &self,
         offset: usize,
         reader: &mut VmReader,
-        _status_flags: StatusFlags,
+        status_flags: StatusFlags,
     ) -> Result<usize> {
-        let written_len = match self.typ {
-            InodeType::File => {
-                let now = now();
-
-                let page_cache = self.inner.as_file().unwrap().lock();
-
-                let mut inode_meta = self.metadata.lock();
-                let file_size = inode_meta.size;
-                let write_len = reader.remain();
-                let new_size = offset + write_len;
-                let should_expand_size = new_size > file_size;
-                let new_size_aligned = new_size.align_up(BLOCK_SIZE);
-                inode_meta.set_mtime(now);
-                inode_meta.set_ctime(now);
-                if should_expand_size {
-                    inode_meta.size = new_size;
-                    inode_meta.blocks = new_size_aligned / BLOCK_SIZE;
-                }
-                drop(inode_meta);
-
-                if should_expand_size {
-                    page_cache.resize(new_size_aligned, file_size)?;
-                }
-                page_cache.write(offset, reader)?;
-
-                write_len
-            }
-            _ => return_errno_with_message!(Errno::EISDIR, "write is not supported"),
-        };
-        Ok(written_len)
+        self.write_at(offset, reader, status_flags, None)
     }
 
     fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
@@ -786,34 +955,7 @@ impl Inode for RamInode {
     }
 
     fn resize(&self, new_size: usize) -> Result<()> {
-        if self.typ == InodeType::Dir {
-            return_errno_with_message!(Errno::EISDIR, "the inode is a directory");
-        }
-        if self.typ != InodeType::File {
-            return_errno_with_message!(Errno::EINVAL, "the inode is not a regular file");
-        }
-
-        let page_cache = self.inner.as_file().unwrap().lock();
-        let mut inode_meta = self.metadata.lock();
-        let file_size = inode_meta.size;
-        if file_size == new_size {
-            return Ok(());
-        }
-        let now = now();
-        inode_meta.set_mtime(now);
-        inode_meta.set_ctime(now);
-
-        if new_size > file_size {
-            inode_meta.resize(new_size);
-            drop(inode_meta);
-            page_cache.resize(new_size, file_size)?;
-        } else {
-            drop(inode_meta);
-            page_cache.resize(new_size, file_size)?;
-            self.metadata.lock().resize(new_size);
-        }
-
-        Ok(())
+        self.resize(new_size, None)
     }
 
     fn atime(&self) -> Duration {
@@ -1307,35 +1449,7 @@ impl Inode for RamInode {
     }
 
     fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
-        // The support for flags is consistent with Linux
-        match mode {
-            FallocMode::Allocate => {
-                let new_size = offset + len;
-                if new_size > self.size() {
-                    self.resize(new_size)?;
-                }
-                Ok(())
-            }
-            FallocMode::AllocateKeepSize => {
-                // Do nothing
-                Ok(())
-            }
-            FallocMode::PunchHoleKeepSize => {
-                let file_size = self.size();
-                if offset >= file_size {
-                    return Ok(());
-                }
-                let range = offset..file_size.min(offset + len);
-                // TODO: Think of a more light-weight approach
-                self.inner.as_file().unwrap().lock().fill_zeros(range)
-            }
-            _ => {
-                return_errno_with_message!(
-                    Errno::EOPNOTSUPP,
-                    "fallocate with the specified flags is not supported"
-                );
-            }
-        }
+        self.fallocate(mode, offset, len, None)
     }
 
     fn extension(&self) -> &Extension {

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -5,7 +5,6 @@
 use alloc::format;
 use core::time::Duration;
 
-use align_ext::AlignExt;
 use aster_rights::Rights;
 use inherit_methods_macro::inherit_methods;
 use spin::Once;
@@ -115,34 +114,8 @@ impl FileOps for MemfdInode {
         }
 
         let seals = self.seals.lock();
-        if seals.intersects(FileSeals::F_SEAL_WRITE | FileSeals::F_SEAL_FUTURE_WRITE) {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against writing");
-        }
-
-        if seals.contains(FileSeals::F_SEAL_GROW) {
-            // For a memfd sealed with `F_SEAL_GROW`, if a write that would grow the file occurs,
-            // the entire write within the page containing the EOF is rejected. Writes before
-            // the EOF page are not affected.
-            //
-            // For detailed explanation, please see:
-            // <https://github.com/asterinas/asterinas/pull/2555#discussion_r2509179520>
-            //
-            // Reference:
-            // <https://elixir.bootlin.com/linux/v6.16.5/source/mm/shmem.c#L3309-L3310>
-            // <https://github.com/google/gvisor/blob/6db745970118635edec4c973f47df2363924d3a7/test/syscalls/linux/memfd.cc#L261-L280>
-            let old_size = self.inode.size();
-            let new_size = offset.saturating_add(reader.remain());
-            if new_size > old_size {
-                let eof_page = old_size.align_down(PAGE_SIZE);
-                if offset >= eof_page {
-                    return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
-                } else {
-                    reader.limit(eof_page - offset);
-                }
-            }
-        }
-
-        self.inode.write_at(offset, reader, status_flags)
+        self.inode
+            .write_at(offset, reader, status_flags, Some(*seals))
     }
 }
 
@@ -177,15 +150,7 @@ impl Inode for MemfdInode {
 
     fn resize(&self, new_size: usize) -> Result<()> {
         let seals = self.seals.lock();
-        let old_size = self.inode.size();
-        if seals.contains(FileSeals::F_SEAL_SHRINK) && new_size < old_size {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against shrinking");
-        }
-        if seals.contains(FileSeals::F_SEAL_GROW) && new_size > old_size {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
-        }
-
-        self.inode.resize(new_size)
+        self.inode.resize(new_size, Some(*seals))
     }
 
     fn set_mode(&self, mode: InodeMode) -> Result<()> {
@@ -204,16 +169,7 @@ impl Inode for MemfdInode {
 
     fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
         let seals = self.seals.lock();
-        if seals.contains(FileSeals::F_SEAL_GROW) && offset + len > self.inode.size() {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against growing");
-        }
-        if seals.intersects(FileSeals::F_SEAL_WRITE | FileSeals::F_SEAL_FUTURE_WRITE)
-            && mode == FallocMode::PunchHoleKeepSize
-        {
-            return_errno_with_message!(Errno::EPERM, "the file is sealed against writing");
-        }
-
-        self.inode.fallocate(mode, offset, len)
+        self.inode.fallocate(mode, offset, len, Some(*seals))
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -16,7 +16,7 @@ use crate::{
         tmpfs::TmpFs,
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FallocMode, FileOps, Inode, Metadata},
+            inode::{Extension, FallocMode, FileOps, Inode, Metadata, WriteOffset},
             path::{Mount, Path},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
@@ -105,7 +105,7 @@ impl FileOps for MemfdInode {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/sysfs/test.rs
+++ b/kernel/src/fs/fs_impls/sysfs/test.rs
@@ -16,7 +16,7 @@ use crate::{
         file::{InodeType, StatusFlags, mkmod},
         sysfs::{self, fs::SysFs},
         utils::DirentVisitor,
-        vfs::file_system::FileSystem,
+        vfs::{file_system::FileSystem, inode::WriteOffset},
     },
     prelude::*,
     time::clocks::init_for_ktest as time_init_for_ktest,
@@ -391,7 +391,7 @@ fn write_attr() {
     let new_val = "new_value";
     let mut reader = VmReader::from(new_val.as_bytes()).to_fallible();
     let bytes_written = rw_attr_inode
-        .write_at(0, &mut reader, StatusFlags::empty())
+        .write_at(WriteOffset::Absolute(0), &mut reader, StatusFlags::empty())
         .expect("write_at failed");
     assert_eq!(bytes_written, new_val.len());
 
@@ -406,12 +406,13 @@ fn write_attr() {
 
     // Write to r_attr1 (should fail - EIO expected from underlying PermissionDenied)
     let mut reader = VmReader::from("attempt_write".as_bytes()).to_fallible();
-    let result = r_attr_inode.write_at(0, &mut reader, StatusFlags::empty());
+    let result = r_attr_inode.write_at(WriteOffset::Absolute(0), &mut reader, StatusFlags::empty());
     assert!(result.is_err());
 
     // Writing to a directory should fail (expect EINVAL as per inode.rs)
     let mut reader = VmReader::from("attempt_write".as_bytes()).to_fallible();
-    let result = leaf1_dir_inode.write_at(0, &mut reader, StatusFlags::empty());
+    let result =
+        leaf1_dir_inode.write_at(WriteOffset::Absolute(0), &mut reader, StatusFlags::empty());
     assert!(result.is_err());
 }
 

--- a/kernel/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/dir.rs
@@ -10,7 +10,7 @@ use crate::{
     fs::{
         file::{PerOpenFileOps, StatusFlags},
         utils::DirentVisitor,
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -49,7 +49,7 @@ impl FileOps for VirtioFsDir {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/file.rs
@@ -5,15 +5,12 @@
 use aster_fuse::FuseOpenFlags;
 use ostd::warn;
 
-use super::{
-    inode::{VirtioFsInode, WriteOffset},
-    open_handle::VirtioFsOpenHandle,
-};
+use super::{inode::VirtioFsInode, open_handle::VirtioFsOpenHandle};
 use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -103,19 +100,16 @@ impl FileOps for VirtioFsFile {
 
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {
         let fh = self.open_handle.fh();
         let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();
 
-        let write_offset = if status_flags.contains(StatusFlags::O_APPEND) {
+        if offset == WriteOffset::Append {
             self.inode.revalidate_attr(fh)?;
-            WriteOffset::Append
-        } else {
-            WriteOffset::Absolute(offset)
-        };
+        }
 
         // FIXME: Cached writeback currently submits whole-page writes with the
         // original open flags. With `O_APPEND`, the server may append cached
@@ -125,11 +119,9 @@ impl FileOps for VirtioFsFile {
         if self.cache_policy == CachePolicy::Cached
             && !status_flags.intersects(StatusFlags::O_APPEND | StatusFlags::O_DIRECT)
         {
-            self.inode
-                .cached_write_at(write_offset, reader, fh, file_flags)
+            self.inode.cached_write_at(offset, reader, fh, file_flags)
         } else {
-            self.inode
-                .direct_write_at(write_offset, reader, fh, file_flags)
+            self.inode.direct_write_at(offset, reader, fh, file_flags)
         }
     }
 }

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -45,6 +45,7 @@ use crate::{
             file_system::FileSystem,
             inode::{
                 Extension, FileOps, Inode, Metadata, RenameMode, RevalidationPolicy, SymbolicLink,
+                WriteOffset,
             },
         },
     },
@@ -207,15 +208,6 @@ pub(super) enum TimeField {
     Change,
     /// The last content modification timestamp.
     Modify,
-}
-
-/// A write offset resolved while holding the inode inner lock.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum WriteOffset {
-    /// Writes at the caller-provided absolute offset.
-    Absolute(usize),
-    /// Writes at the current end of file.
-    Append,
 }
 
 struct InodeInner {
@@ -566,7 +558,7 @@ impl FileOps for VirtioFsInode {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {

--- a/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -25,13 +25,14 @@ use super::{
         open_handle::VirtioFsOpenHandle,
         valid_until,
     },
-    TimeField, VirtioFsInode, WriteOffset,
+    TimeField, VirtioFsInode,
     metadata::StaleAttrAction,
 };
 use crate::{
     fs::{
         file::{AccessMode, PerOpenFileOps, StatusFlags},
         utils::DirentVisitor,
+        vfs::inode::WriteOffset,
     },
     prelude::*,
     thread::work_queue::{self, WorkPriority},
@@ -221,10 +222,7 @@ impl VirtioFsInode {
     }
 
     fn resolve_write_offset(&self, write_offset: WriteOffset) -> usize {
-        match write_offset {
-            WriteOffset::Absolute(offset) => offset,
-            WriteOffset::Append => self.size(),
-        }
+        write_offset.resolve(self.size())
     }
 
     pub(super) fn open_transient_handle(

--- a/kernel/src/fs/pipe/anon_pipe.rs
+++ b/kernel/src/fs/pipe/anon_pipe.rs
@@ -11,7 +11,7 @@ use crate::{
         pseudofs::{PipeFs, PseudoInode, PseudoInodeType},
         vfs::{
             file_system::FileSystem,
-            inode::{Extension, FileOps, Inode, Metadata},
+            inode::{Extension, FileOps, Inode, Metadata, WriteOffset},
         },
     },
     prelude::*,
@@ -68,7 +68,7 @@ impl FileOps for AnonPipeInode {
     ) -> Result<usize>;
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         _reader: &mut VmReader,
         _status: StatusFlags,
     ) -> Result<usize>;

--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -12,7 +12,7 @@ use crate::{
     fs::{
         file::{AccessMode, PerOpenFileOps, SettableStatusFlags, StatusFlags},
         utils::{Endpoint, EndpointState},
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, WriteOffset},
     },
     prelude::*,
     process::{
@@ -118,7 +118,7 @@ impl FileOps for PipeHandle {
 
     fn write_at(
         &self,
-        _offset: usize,
+        _offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {
@@ -664,7 +664,7 @@ mod test {
 
     fn write(writer: &dyn PerOpenFileOps, buf: &[u8]) -> crate::prelude::Result<usize> {
         writer.write_at(
-            0,
+            WriteOffset::Absolute(0),
             &mut VmReader::from(buf).to_fallible(),
             StatusFlags::empty(),
         )

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -15,7 +15,7 @@ use crate::{
             file_system::{FileSystem, SuperBlock},
             inode::{
                 Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RenameMode,
-                RevalidationPolicy, SymbolicLink,
+                RevalidationPolicy, SymbolicLink, WriteOffset,
             },
         },
     },
@@ -330,7 +330,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> FileOps for KInode {
 
     default fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         buf: &mut VmReader,
         _status_flags: StatusFlags,
     ) -> Result<usize> {
@@ -338,6 +338,9 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> FileOps for KInode {
             return Err(Error::new(Errno::EINVAL));
         };
 
+        let WriteOffset::Absolute(offset) = offset else {
+            return_errno_with_message!(Errno::EINVAL, "append write is not supported");
+        };
         let len = if offset == 0 {
             leaf.write_attr(attr.name(), buf)?
         } else {

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -341,7 +341,7 @@ pub trait FileOps {
     /// Writes data from the given `VmReader` into the file.
     fn write_at(
         &self,
-        offset: usize,
+        offset: WriteOffset,
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize>;
@@ -349,6 +349,25 @@ pub trait FileOps {
     /// Reads directory entries from the given offset.
     fn readdir_at(&self, _offset: usize, _visitor: &mut dyn DirentVisitor) -> Result<usize> {
         return_errno_with_message!(Errno::ENOTDIR, "readdir is not supported");
+    }
+}
+
+/// A write operation's starting offset.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WriteOffset {
+    /// The caller-provided absolute offset.
+    Absolute(usize),
+    /// The current end of file.
+    Append,
+}
+
+impl WriteOffset {
+    /// Resolves the write offset with the supplied append position.
+    pub fn resolve(self, append_offset: usize) -> usize {
+        match self {
+            Self::Absolute(offset) => offset,
+            Self::Append => append_offset,
+        }
     }
 }
 
@@ -642,7 +661,11 @@ impl dyn Inode {
     #[cfg_attr(not(ktest), expect(dead_code))]
     pub fn write_bytes_at(&self, offset: usize, buf: &[u8]) -> Result<usize> {
         let mut reader = VmReader::from(buf).to_fallible();
-        self.write_at(offset, &mut reader, StatusFlags::empty())
+        self.write_at(
+            WriteOffset::Absolute(offset),
+            &mut reader,
+            StatusFlags::empty(),
+        )
     }
 }
 
@@ -657,7 +680,11 @@ impl Write for InodeWriter<'_> {
         let mut reader = VmReader::from(buf).to_fallible();
         let write_len = self
             .inner
-            .write_at(self.offset, &mut reader, StatusFlags::empty())
+            .write_at(
+                WriteOffset::Absolute(self.offset),
+                &mut reader,
+                StatusFlags::empty(),
+            )
             .map_err(|_| IoError::new(IoErrorKind::WriteZero, "failed to write buffer"))?;
         self.offset += write_len;
         Ok(write_len)

--- a/test/initramfs/src/regression/fs/pseudofs/memfd_create.c
+++ b/test/initramfs/src/regression/fs/pseudofs/memfd_create.c
@@ -2,11 +2,20 @@
 
 #define _GNU_SOURCE
 
+#include <fcntl.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
 #include "../../common/test.h"
+
+#ifndef FALLOC_FL_KEEP_SIZE
+#define FALLOC_FL_KEEP_SIZE 0x01
+#endif
+
+#ifndef FALLOC_FL_PUNCH_HOLE
+#define FALLOC_FL_PUNCH_HOLE 0x02
+#endif
 
 FN_TEST(name_too_long)
 {
@@ -20,6 +29,29 @@ FN_TEST(name_too_long)
 
 	name[249] = '\0';
 	fd = TEST_SUCC(memfd_create(name, MFD_CLOEXEC));
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(fallocate_seals)
+{
+	int fd;
+
+	fd = TEST_SUCC(memfd_create("test_memfd", MFD_ALLOW_SEALING));
+	TEST_SUCC(ftruncate(fd, 4096));
+	TEST_SUCC(fcntl(fd, F_ADD_SEALS, F_SEAL_WRITE));
+	TEST_SUCC(fallocate(fd, 0, 0, 4096));
+	TEST_ERRNO(fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, 0,
+			     4096),
+		   EPERM);
+	TEST_SUCC(close(fd));
+
+	fd = TEST_SUCC(memfd_create("test_memfd", MFD_ALLOW_SEALING));
+	TEST_SUCC(ftruncate(fd, 4096));
+	TEST_SUCC(fcntl(fd, F_ADD_SEALS, F_SEAL_GROW));
+	TEST_SUCC(fallocate(fd, 0, 0, 4096));
+	TEST_ERRNO(fallocate(fd, 0, 0, 8192), EPERM);
+	TEST_ERRNO(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 8192), EPERM);
 	TEST_SUCC(close(fd));
 }
 END_TEST()


### PR DESCRIPTION
## Summary

This PR fixes several inode metadata **TOCTOU** issues around `append writes`, `resize`, and `fallocate` which is mainly asociated with `size()`.

The VFS layer no longer resolves `O_APPEND` by reading `path.size()` before entering filesystem-specific write logic. 

Instead, ramfs, ext2, and exfat resolve append offsets while holding their inode/internal locks, so the size check and write operation are serialized by the filesystem implementation.

For ramfs and memfd, this also moves size-dependent seal checks into `RamInode` operations. `MemfdInode` now snapshots seals while holding the memfd seal lock and passes them into the shared ramfs write/resize/fallocate paths. This keeps seal validation and size updates in the same locked inode operation.

 ## Changes

- Resolve `O_APPEND` in filesystem write implementations instead of `InodeHandle`.
- Move ramfs write, resize, and fallocate size checks under inode/page-cache locking.
- Apply memfd seal checks inside the corresponding ramfs operation branches.
- Add regression coverage for memfd fallocate seal behavior.
