### PR TITLE
Clean symlink02 test in exfat.txt

### DIFF
--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -1536,6 +1536,10 @@ impl Inode for ExfatInode {
             }
         }
 
+        if type_ == InodeType::SymLink {
+            return_errno!(Errno::EPERM)
+        }
+
         let result = self.add_entry(name, type_, mode, &fs_guard)?;
         let _ = fs.insert_inode(result.clone());
 

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -52,9 +52,6 @@ setfsuid04
 setresuid04
 setreuid07
 setuid04
-symlink02
-symlink03
-symlink04
 symlinkat01
 truncate02
 truncate02_64


### PR DESCRIPTION
exFAT is designed not to support symbolic links, so no modification is needed