### PR TITLE
Upgrade NixOS distro to 26.05

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ DNS_SERVER ?= none
 # End of network settings
 
 # NixOS settings
-NIXOS_DISK_SIZE_IN_MB ?= 8192
+NIXOS_DISK_SIZE_IN_MB ?= 12288
 NIXOS_DISABLE_SYSTEMD ?= false
 # The following option is only effective when NIXOS_DISABLE_SYSTEMD is set to 'true'.
 # Use a login shell to ensure that environment variables are initialized correctly.

--- a/distro/aster_nixos_installer/default.nix
+++ b/distro/aster_nixos_installer/default.nix
@@ -1,7 +1,7 @@
 { disable-systemd ? "false", stage-2-hook ? "/bin/sh -l", log-level ? "error"
 , console ? "hvc0", extra-substituters ? "", extra-trusted-public-keys ? ""
 , config-file-name ? "configuration.nix", target_platform ? "x86_64-linux"
-, pkgs ? import <nixpkgs> { } }:
+, pkgs ? import ../nixpkgs.nix { } }:
 let
   aster-kernel = builtins.path {
     name = "aster-kernel-osdk-bin";
@@ -27,6 +27,7 @@ let
     replacements = {
       aster-configuration = aster_configuration;
       aster-etc-nixos = etc-nixos;
+      aster-nixpkgs = pkgs.path;
       aster-target-platform = target_platform;
       aster-substituters = extra-substituters;
       aster-trusted-public-keys = extra-trusted-public-keys;
@@ -46,4 +47,3 @@ in pkgs.stdenv.mkDerivation {
     ln -s ${aster-kernel} $out/kernel
   '';
 }
-

--- a/distro/aster_nixos_installer/templates/aster-nixos-install
+++ b/distro/aster_nixos_installer/templates/aster-nixos-install
@@ -137,6 +137,7 @@ COMMON_NIX_ARGS=(
 )
 
 NIX_SYSTEM="@aster-target-platform@"
+NIXPKGS_PATH="@aster-nixpkgs@"
 
 # Pre-build the NixOS system closure on the host
 # so that the result is cached in the host's Nix store.
@@ -144,7 +145,7 @@ NIX_SYSTEM="@aster-target-platform@"
 # causing redundant downloads after every `make clean`.
 #
 # See: https://www.mankier.com/8/nixos-install#--system
-SYSTEM_CLOSURE=$(nix-build '<nixpkgs/nixos>' -A system \
+SYSTEM_CLOSURE=$(nix-build "${NIXPKGS_PATH}/nixos" -A system \
     --option extra-platforms "${NIX_SYSTEM}" \
     --argstr system "${NIX_SYSTEM}" \
     -I "nixos-config=${BUILD_DIR}/etc/nixos/configuration.nix" \

--- a/distro/cachix/default.nix
+++ b/distro/cachix/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { }, extra-substituters ? ""
+{ pkgs ? import ../nixpkgs.nix { }, extra-substituters ? ""
 , extra-trusted-public-keys ? "", ... }:
 let
   installer = pkgs.callPackage ../aster_nixos_installer {

--- a/distro/etc_nixos/configuration.nix
+++ b/distro/etc_nixos/configuration.nix
@@ -45,5 +45,5 @@
   # and migrated your data accordingly.
   #
   # For more information, see `man configuration.nix` or https://nixos.org/manual/nixos/stable/options#opt-system.stateVersion .
-  system.stateVersion = "25.05"; # Did you read the comment?
+  system.stateVersion = "26.05"; # Did you read the comment?
 }

--- a/distro/etc_nixos/modules/core.nix
+++ b/distro/etc_nixos/modules/core.nix
@@ -78,7 +78,7 @@ in {
   # TODO: Fix errors and warnings from systemd and remove this setting.
   environment.sessionVariables = { SYSTEMD_LOG_LEVEL = "crit"; };
   system.systemBuilderCommands = ''
-    echo "PATH=/bin:/nix/var/nix/profiles/system/sw/bin ostd.log_level=${config.aster_nixos.log-level} console=${config.aster_nixos.console} -- sh /init root=/dev/vda2 init=/nix/var/nix/profiles/system/stage-2-init rd.break=${
+    echo "PATH=/bin:/nix/var/nix/profiles/system/sw/bin ostd.log_level=${config.aster_nixos.log-level} console=${config.aster_nixos.console} systemd.getty_auto=no -- sh /init root=/dev/vda2 init=/nix/var/nix/profiles/system/stage-2-init rd.break=${
       if config.aster_nixos.break-into-stage-1-shell then "1" else "0"
     }"  > $out/kernel-params
     mv $out/init $out/stage-2-init
@@ -94,8 +94,9 @@ in {
   '';
   system.activationScripts.modprobe = lib.mkForce "";
 
-  nix.nixPath = options.nix.nixPath.default
-    ++ [ "nixpkgs-overlays=/etc/nixos/overlays" ];
+  nix.nixPath = [ "nixpkgs=${pkgs.path}" ]
+    ++ builtins.filter (entry: !(lib.hasPrefix "nixpkgs=" entry))
+    options.nix.nixPath.default ++ [ "nixpkgs-overlays=/etc/nixos/overlays" ];
   nix.settings = {
     filter-syscalls = false;
     require-sigs = false;

--- a/distro/etc_nixos/modules/systemd.nix
+++ b/distro/etc_nixos/modules/systemd.nix
@@ -3,9 +3,10 @@
 {
   systemd.package = pkgs.aster_systemd;
 
-  # TODO: The following services currently do not work and 
-  # may affect systemd startup or cause performance issues. 
+  # TODO: The following services currently do not work and
+  # may affect systemd startup or cause performance issues.
   # Enable them after they can run successfully.
+  networking.resolvconf.enable = false;
   systemd.coredump.enable = false;
   systemd.oomd.enable = false;
   systemd.services.logrotate.enable = false;
@@ -23,20 +24,16 @@
     hashedPassword = null;
   };
 
-  systemd.targets.getty.wants =
-    # tty1: provide text login ONLY when X server is disabled.
-    # Other VTs: always provide text logins
-    (lib.optional (!config.services.xserver.enable) "autovt@tty1.service") ++ [
-      "autovt@hvc0.service"
-      "autovt@tty2.service"
-      "autovt@tty3.service"
-      "autovt@tty4.service"
-      "autovt@tty5.service"
-      "autovt@tty6.service"
-    ];
+  systemd.targets.getty.wants = lib.mkForce (
+    # tty1: provide text login on the virtual console when X server is disabled.
+    (lib.optional
+      (!config.services.xserver.enable && config.aster_nixos.console == "tty0")
+      "autovt@tty1.service")
+    ++ lib.optional (config.aster_nixos.console == "hvc0")
+    "getty@hvc0.service");
 
-  systemd.extraConfig = ''
-    LogLevel=crit      
-    ShowStatus=no
-  '';
+  systemd.settings.Manager = {
+    LogLevel = "crit";
+    ShowStatus = "no";
+  };
 }

--- a/distro/etc_nixos/overlays/codex/default.nix
+++ b/distro/etc_nixos/overlays/codex/default.nix
@@ -1,15 +1,9 @@
 final: prev:
 let
-  # Use a verified-working Codex version that is newer than NixOS 25.05's
-  # package. To update, choose a nixpkgs revision with the desired Codex version
-  # and refresh `hash`.
-  nixpkgsForCodex = import (prev.fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "b77b3de8775677f84492abe84635f87b0e153f0f";
-    hash = "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=";
-  }) {
-    inherit (prev) system;
+  # Use the Codex package from the pinned NixOS 26.05 package set.
+  # To update, refresh the shared nixpkgs pin in `distro/nixpkgs.nix`.
+  nixpkgsForCodex = import ../../../nixpkgs.nix {
+    inherit (prev.stdenv.hostPlatform) system;
     config = prev.config or { };
   };
 in { codex = nixpkgsForCodex.codex; }

--- a/distro/etc_nixos/overlays/desktop/default.nix
+++ b/distro/etc_nixos/overlays/desktop/default.nix
@@ -1,54 +1,55 @@
 self: super:
 
 {
-  xorg = super.xorg // {
-    xorgserver = super.xorg.xorgserver.overrideAttrs (oldAttrs: {
-      version = "21.1.4";
-      src = oldAttrs.src;
-      patches = (oldAttrs.patches or [ ])
-        ++ [ ./patches/xorgServer/0001-Skip-checking-graphics-under-sys.patch ];
-      nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ])
-        ++ [ self.meson self.ninja self.pkg-config ];
-      buildInputs = (oldAttrs.buildInputs or [ ]) ++ [
-        self.dri-pkgconfig-stub
-        self.libudev-zero
-        self.xorg.fontutil
-        self.libtirpc
-      ];
-      configurePhase = ''
-        meson setup builddir \
-          --prefix=$out \
-          --libdir=lib \
-          -Dxorg=true \
-          -Dglamor=true \
-          -Dxkb_output_dir=$out/share/X11/xkb \
-          -Doptimization=0 \
-          -Dudev=false \
-          -Dxkb_bin_dir=${self.xorg.xkbcomp}/bin \
-          -Dudev_kms=false
-      '';
-      buildPhase = ''
-        meson compile -C builddir
-      '';
-      installPhase = ''
-        meson install -C builddir
-        mkdir -p $out/share/X11/xorg.conf.d
-        cp ${
-          ./patches/xorgServer/10-fbdev.conf
-        } $out/share/X11/xorg.conf.d/10-fbdev.conf
-      '';
-    });
-  };
+  xorg-server = super.xorg-server.overrideAttrs (oldAttrs: {
+    version = "21.1.23";
+    src = oldAttrs.src;
+    patches = (oldAttrs.patches or [ ])
+      ++ [ ./patches/xorgServer/0001-Skip-checking-graphics-under-sys.patch ];
+    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ])
+      ++ [ self.meson self.ninja self.pkg-config ];
+    buildInputs = (oldAttrs.buildInputs or [ ]) ++ [
+      self.dri-pkgconfig-stub
+      self.libudev-zero
+      self.font-util
+      self.libtirpc
+    ];
+    configurePhase = ''
+      meson setup builddir \
+        --prefix=$out \
+        --libdir=lib \
+        -Dxorg=true \
+        -Dglamor=true \
+        -Dxkb_output_dir=$out/share/X11/xkb \
+        -Doptimization=0 \
+        -Dudev=false \
+        -Dxkb_bin_dir=${self.xkbcomp}/bin \
+        -Dudev_kms=false
+    '';
+    buildPhase = ''
+      meson compile -C builddir
+    '';
+    installPhase = ''
+      meson install -C builddir
+      mkdir -p $out/share/X11/xorg.conf.d
+      cp ${
+        ./patches/xorgServer/10-fbdev.conf
+      } $out/share/X11/xorg.conf.d/10-fbdev.conf
+    '';
+  });
+
+  xorg = super.xorg // { xorgserver = self.xorg-server; };
+
+  xfwm4 = super.xfwm4;
+
+  xfdesktop = super.xfdesktop.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or [ ]) ++ [
+      ./patches/xfdesktop4/0001-Fix-not-using-consistent-monitor-identifiers.patch
+    ];
+  });
 
   xfce = super.xfce // {
-    xfwm4 = super.xfce.xfwm4.overrideAttrs (oldAttrs: { version = "4.16.1"; });
-
-    xfdesktop = super.xfce.xfdesktop.overrideAttrs (oldAttrs: {
-      version = "4.16.0";
-      patches = (oldAttrs.patches or [ ]) ++ [
-        ./patches/xfdesktop4/0001-Fix-not-using-consistent-monitor-identifiers.patch
-      ];
-    });
+    xfwm4 = self.xfwm4;
+    xfdesktop = self.xfdesktop;
   };
 }
-

--- a/distro/etc_nixos/overlays/podman/runc-Switch-MS_SLAVE-to-MS_PRIVATE.patch
+++ b/distro/etc_nixos/overlays/podman/runc-Switch-MS_SLAVE-to-MS_PRIVATE.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] runc: Switch MS_SLAVE to MS_PRIVATE.
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/libcontainer/rootfs_linux.go b/libcontainer/rootfs_linux.go
-index 1c2ea07a..18f8b7d1 100644
+index e7ddf874..7c9e51b5 100644
 --- a/libcontainer/rootfs_linux.go
 +++ b/libcontainer/rootfs_linux.go
-@@ -832,7 +832,7 @@ func rootfsParentMountPrivate(path string) error {
+@@ -1085,7 +1085,7 @@ func rootfsParentMountPrivate(path string) error {
  }
  
  func prepareRoot(config *configs.Config) error {
@@ -20,21 +20,21 @@ index 1c2ea07a..18f8b7d1 100644
  	if config.RootPropagation != 0 {
  		flag = config.RootPropagation
  	}
-@@ -917,7 +917,7 @@ func pivotRoot(rootfs string) error {
+@@ -1170,7 +1170,7 @@ func pivotRoot(rootfs string) error {
  	// known to cause issues due to races where we still have a reference to a
  	// mount while a process in the host namespace are trying to operate on
  	// something they think has no mounts (devicemapper in particular).
--	if err := mount("", ".", "", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
-+	if err := mount("", ".", "", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+-	if err := mount("", ".", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
++	if err := mount("", ".", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
  		return err
  	}
  	// Perform the unmount. MNT_DETACH allows us to unmount /proc/self/cwd.
-@@ -966,7 +966,7 @@ func msMoveRoot(rootfs string) error {
+@@ -1219,7 +1219,7 @@ func msMoveRoot(rootfs string) error {
  	for _, info := range mountinfos {
  		p := info.Mountpoint
  		// Be sure umount events are not propagated to the host.
--		if err := mount("", p, "", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
-+		if err := mount("", p, "", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+-		if err := mount("", p, "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
++		if err := mount("", p, "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
  			if errors.Is(err, unix.ENOENT) {
  				// If the mountpoint doesn't exist that means that we've
  				// already blasted away some parent directory of the mountpoint

--- a/distro/etc_nixos/overlays/switch-to-configuration-ng/0001-Bypass-system-dbus.patch
+++ b/distro/etc_nixos/overlays/switch-to-configuration-ng/0001-Bypass-system-dbus.patch
@@ -3,76 +3,77 @@ From: vvsv <vvsv_7169@163.com>
 Date: Wed, 10 Dec 2025 17:54:18 +0800
 Subject: [PATCH] Bypass system dbus
 
-The commented-out code connects to the system DBus, reading systemd state via DBus,
-computes the unit diff, and then reports activation results back over DBus.
+The bypass keeps the non-DBus activation path while avoiding unit-diff,
+reload, restart, and status reporting logic that depends on systemd over DBus.
 
 TODO: Remove this patch once system DBus support is implemented.
 ---
- src/main.rs        | 9 +++++++++
- 1 file changed, 9 insertions(+)
+ src/main.rs | 45 +++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
 
 diff --git a/src/main.rs b/src/main.rs
-index 8baf5924a7db..bb1a60fd69f6 100644
+index e9cc48b7..20b2f840 100644
 --- a/src/main.rs
 +++ b/src/main.rs
-@@ -1,6 +1,9 @@
+@@ -1,6 +1,10 @@
  #![deny(clippy::all)]
  #![allow(clippy::too_many_arguments)]
  #![allow(clippy::type_complexity)]
 +#![allow(dead_code)]
++#![allow(unreachable_code)]
 +#![allow(unused_imports)]
 +#![allow(unused_variables)]
-
+ 
  use std::{
      cell::RefCell,
-@@ -932,6 +935,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
+@@ -1336,6 +1340,8 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
          die();
      }
-
-+/*
-     let dbus_conn = LocalConnection::new_session().context("Failed to open dbus connection")?;
-     let (systemd, _) = new_dbus_proxies(&dbus_conn);
-
-@@ -968,6 +972,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
-     dbus_conn
-         .remove_match(jobs_token)
-         .context("Failed to remove jobs token")?;
-+*/
-
-     Ok(())
- }
-@@ -1106,6 +1111,7 @@ won't take effect until you reboot the system.
+ 
++    return Ok(());
++
+     let toplevel = PathBuf::from(required_env("TOPLEVEL")?);
+     let old_toplevel = PathBuf::from(required_env("OLD_TOPLEVEL")?);
+     let action = Action::from_str(&required_env("NIXOS_ACTION")?)?;
+@@ -1882,6 +1888,39 @@ won't take effect until you reboot the system.
      let handler = SigHandler::Handler(handle_sigpipe);
      unsafe { signal::signal(Signal::SIGPIPE, handler) }.context("Failed to set SIGPIPE handler")?;
-
-+/*
+ 
++    let mut exit_code = 0;
++
++    // Activate the new configuration without using systemd over DBus.
++    eprintln!("activating the configuration...");
++    match std::process::Command::new(out.join("activate"))
++        .arg(&out)
++        .spawn()
++        .map(|mut child| child.wait())
++    {
++        Ok(Ok(status)) if status.success() => {}
++        Err(_) => {
++            // allow toplevel to not have an activation script
++        }
++        _ => {
++            eprintln!("Failed to run activate script");
++            exit_code = 2;
++        }
++    }
++
++    if exit_code == 0 {
++        log::info!(
++            "finished switching to system configuration {}",
++            toplevel.display()
++        );
++    } else {
++        log::error!(
++            "switching to system configuration {} failed (status {})",
++            toplevel.display(),
++            exit_code
++        );
++    }
++    std::process::exit(exit_code);
++
      let mut units_to_stop = HashMap::new();
      let mut units_to_skip = HashMap::new();
      let mut units_to_filter = HashMap::new(); // units not shown
-@@ -1539,6 +1545,7 @@ won't take effect until you reboot the system.
-
-     // Wait for all stop jobs to finish
-     block_on_jobs(&dbus_conn, &submitted_jobs);
-+*/
-
-     let mut exit_code = 0;
-
-@@ -1558,6 +1565,7 @@ won't take effect until you reboot the system.
-             exit_code = 2;
-         }
-     }
-+/*
-
-     // Handle the activation script requesting the restart or reload of a unit.
-     for unit in std::fs::read_to_string(RESTART_BY_ACTIVATION_LIST_FILE)
-@@ -1934,6 +1942,7 @@ won't take effect until you reboot the system.
-
-         exit_code = 4;
-     }
-+*/
-
-     if exit_code == 0 {
-         log::info!(
---
+-- 
 2.39.5
-

--- a/distro/etc_nixos/overlays/systemd/0003-Switch-MS_SLAVE-to-MS_PRIVATE.patch
+++ b/distro/etc_nixos/overlays/systemd/0003-Switch-MS_SLAVE-to-MS_PRIVATE.patch
@@ -7,10 +7,9 @@ Replace the use of MS_SLAVE with MS_PRIVATE, as Asterinas currently does
 not support the MS_SLAVE flag.
 
 ---
- src/basic/process-util.c   | 2 +-
- src/core/exec-credential.c | 2 +-
- src/shared/mount-util.c    | 2 +-
- 3 files changed, 3 insertions(+), 3 deletions(-)
+ src/basic/process-util.c | 2 +-
+ src/shared/mount-util.c  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/basic/process-util.c b/src/basic/process-util.c
 index 18fbadf175..0aa68a1162 100644
@@ -25,19 +24,6 @@ index 18fbadf175..0aa68a1162 100644
                          log_full_errno(prio, errno, "Failed to remount root directory as MS_SLAVE: %m");
                          _exit(EXIT_FAILURE);
                  }
-diff --git a/src/core/exec-credential.c b/src/core/exec-credential.c
-index 6ab3edbb54..dd40cdf081 100644
---- a/src/core/exec-credential.c
-+++ b/src/core/exec-credential.c
-@@ -1119,7 +1119,7 @@ int exec_setup_credentials(
-                  * no one else sees this should be OK to do. */
- 
-                 /* Turn off propagation from our namespace to host */
--                r = mount_nofollow_verbose(LOG_DEBUG, NULL, "/dev", NULL, MS_SLAVE|MS_REC, NULL);
-+                r = mount_nofollow_verbose(LOG_DEBUG, NULL, "/dev", NULL, MS_PRIVATE|MS_REC, NULL);
-                 if (r < 0)
-                         goto child_fail;
- 
 diff --git a/src/shared/mount-util.c b/src/shared/mount-util.c
 index 35b1049531..e2f611e07a 100644
 --- a/src/shared/mount-util.c
@@ -53,4 +39,3 @@ index 35b1049531..e2f611e07a 100644
  
 -- 
 2.34.1
-

--- a/distro/etc_nixos/overlays/systemd/0004-Fallback-from-pidfd_spawn-to-posix_spawn.patch
+++ b/distro/etc_nixos/overlays/systemd/0004-Fallback-from-pidfd_spawn-to-posix_spawn.patch
@@ -1,0 +1,137 @@
+--- a/src/basic/process-util.c
++++ b/src/basic/process-util.c
+@@ -2006,6 +2006,32 @@
+ 
+ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(posix_spawnattr_t*, posix_spawnattr_destroy, NULL);
+ 
++static bool spawn_errno_is_fallback(int r) {
++        return ERRNO_IS_NOT_SUPPORTED(r) || ERRNO_IS_PRIVILEGE(r) || IN_SET(r, -EINVAL, EINVAL);
++}
++
++static int fork_execve_wrapper(
++                const char *path,
++                char * const *argv,
++                char * const *envp,
++                const sigset_t *mask,
++                PidRef *ret_pidref) {
++        pid_t pid;
++
++        pid = fork();
++        if (pid < 0)
++                return -errno;
++        if (pid == 0) {
++                if (sigprocmask(SIG_SETMASK, mask, NULL) < 0)
++                        _exit(EXIT_FAILURE);
++                execve(path, argv, envp);
++                _exit(EXIT_FAILURE);
++        }
++
++        *ret_pidref = PIDREF_MAKE_FROM_PID(pid);
++        return 0;
++}
++
+ int posix_spawn_wrapper(
+                 const char *path,
+                 char * const *argv,
+@@ -2050,22 +2076,36 @@
+                 _cleanup_free_ char *resolved_cgroup = NULL;
+ 
+                 r = cg_get_path(cgroup, /* suffix= */ NULL, &resolved_cgroup);
+-                if (r < 0)
+-                        return r;
+-
+-                cgroup_fd = open(resolved_cgroup, O_PATH|O_DIRECTORY|O_CLOEXEC);
+-                if (cgroup_fd < 0)
+-                        return -errno;
+-
+-                r = posix_spawnattr_setcgroup_np(&attr, cgroup_fd);
+-                if (r != 0)
+-                        return -r;
+-
+-                flags |= POSIX_SPAWN_SETCGROUP;
++                if (r < 0) {
++                        if (!spawn_errno_is_fallback(r))
++                                return r;
++                        have_clone_into_cgroup = false;
++                } else {
++                        cgroup_fd = open(resolved_cgroup, O_PATH|O_DIRECTORY|O_CLOEXEC);
++                        if (cgroup_fd < 0) {
++                                r = -errno;
++                                if (!spawn_errno_is_fallback(r))
++                                        return r;
++                                have_clone_into_cgroup = false;
++                        } else {
++                                r = posix_spawnattr_setcgroup_np(&attr, cgroup_fd);
++                                if (r != 0) {
++                                        if (!spawn_errno_is_fallback(r))
++                                                return -r;
++                                        have_clone_into_cgroup = false;
++                                } else
++                                        flags |= POSIX_SPAWN_SETCGROUP;
++                        }
++                }
+         }
+ #endif
+ 
+         r = posix_spawnattr_setflags(&attr, flags);
++        if (r != 0 && FLAGS_SET(flags, POSIX_SPAWN_SETCGROUP) && spawn_errno_is_fallback(r)) {
++                have_clone_into_cgroup = false;
++                flags &= ~POSIX_SPAWN_SETCGROUP;
++                r = posix_spawnattr_setflags(&attr, flags);
++        }
+         if (r != 0)
+                 return -r;
+         r = posix_spawnattr_setsigmask(&attr, &mask);
+@@ -2075,11 +2115,16 @@
+ #if HAVE_PIDFD_SPAWN
+         _cleanup_close_ int pidfd = -EBADF;
+ 
++        /* Asterinas does not provide pidfd semantics that systemd can use for
++         * tracking the executor. Avoid pidfd_spawn() entirely so that PID 1
++         * never has to recover after an already-spawned but untracked child. */
++        goto fallback_posix_spawn;
++
+         r = pidfd_spawn(&pidfd, path, NULL, &attr, argv, envp);
+         if (ERRNO_IS_NOT_SUPPORTED(r) && FLAGS_SET(flags, POSIX_SPAWN_SETCGROUP) && cg_is_threaded(cgroup) > 0)
+                 return -EUCLEAN; /* clone3() could also return EOPNOTSUPP if the target cgroup is in threaded mode,
+                                     turn that into something recognizable */
+-        if ((ERRNO_IS_NOT_SUPPORTED(r) || ERRNO_IS_PRIVILEGE(r)) &&
++        if (spawn_errno_is_fallback(r) &&
+             FLAGS_SET(flags, POSIX_SPAWN_SETCGROUP)) {
+                 /* Compiled on a newer host, or seccomp&friends blocking clone3()? Fallback, but
+                  * need to disable POSIX_SPAWN_SETCGROUP, which is what redirects to clone3().
+@@ -2096,6 +2141,8 @@
+ 
+                 r = pidfd_spawn(&pidfd, path, NULL, &attr, argv, envp);
+         }
++        if (spawn_errno_is_fallback(r))
++                goto fallback_posix_spawn;
+         if (r != 0)
+                 return -r;
+ 
+@@ -2104,19 +2151,22 @@
+                 return r;
+ 
+         return FLAGS_SET(flags, POSIX_SPAWN_SETCGROUP);
+-#else
++
++fallback_posix_spawn:
++#endif
+         pid_t pid;
+ 
+         r = posix_spawn(&pid, path, NULL, &attr, argv, envp);
++        if (spawn_errno_is_fallback(r))
++                return fork_execve_wrapper(path, argv, envp, &mask, ret_pidref);
+         if (r != 0)
+                 return -r;
+ 
+         r = pidref_set_pid(ret_pidref, pid);
+         if (r < 0)
+-                return r;
++                *ret_pidref = PIDREF_MAKE_FROM_PID(pid);
+ 
+         return 0; /* We did not use CLONE_INTO_CGROUP so return 0, the caller will have to move the child */
+-#endif
+ }
+ 
+ int proc_dir_open(DIR **ret) {

--- a/distro/etc_nixos/overlays/systemd/0005-Keep-PID1-standard-streams-on-console.patch
+++ b/distro/etc_nixos/overlays/systemd/0005-Keep-PID1-standard-streams-on-console.patch
@@ -1,0 +1,37 @@
+From c94c383262a165ed347a5a58f7cf8b61fb99e939 Mon Sep 17 00:00:00 2001
+From: Chen Chengjun <chenchengjun.ccj@antgroup.com>
+Date: Sat, 27 Jun 2026 13:20:00 +0000
+Subject: [PATCH] Keep PID1 standard streams on console
+
+Asterinas starts the first userspace process with stdin, stdout, and
+stderr already connected to /dev/console. This is useful for early boot
+diagnostics and is also how the previous NixOS image reached the login
+shell.
+
+systemd 260 redirects PID1's standard streams to /dev/null during early
+startup. On Asterinas this closes the inherited hvc0 stderr stream and
+can leave the boot without visible progress before getty starts. Keep
+the inherited console descriptors instead.
+---
+ src/core/main.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/core/main.c b/src/core/main.c
+index 5350e4579e..e5a46a3407 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -3220,9 +3220,8 @@
+                  * instances since they never log into the console. */
+                 log_show_color(colors_enabled());
+ 
+-                r = make_null_stdio();
+-                if (r < 0)
+-                        log_warning_errno(r, "Failed to redirect standard streams to /dev/null, ignoring: %m");
++                /* Keep Asterinas' inherited /dev/console descriptors so early
++                 * PID1 and getty diagnostics remain visible on hvc0. */
+ 
+                 /* Load the kernel modules early. */
+                 if (!skip_setup)
+                         (void) kmod_setup();
+-- 
+2.50.1

--- a/distro/etc_nixos/overlays/systemd/default.nix
+++ b/distro/etc_nixos/overlays/systemd/default.nix
@@ -4,6 +4,8 @@ final: prev: {
       ./0001-Skip-mount-state-checking.patch
       ./0002-Disable-loop-too-fast-warning.patch
       ./0003-Switch-MS_SLAVE-to-MS_PRIVATE.patch
+      ./0004-Fallback-from-pidfd_spawn-to-posix_spawn.patch
+      ./0005-Keep-PID1-standard-streams-on-console.patch
     ];
 
     postInstall = ''
@@ -71,6 +73,15 @@ final: prev: {
       # placeholder for $out
       [Unit]
       Description=placeholder systemd-random-seed
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/true
+      EOF
+
+            cat > "$out/example/systemd/system/systemd-vconsole-setup.service" <<'EOF'
+      # placeholder for $out
+      [Unit]
+      Description=placeholder systemd-vconsole-setup
       [Service]
       Type=oneshot
       ExecStart=/bin/true

--- a/distro/iso_image/default.nix
+++ b/distro/iso_image/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { }, autoInstall ? false, extra-substituters ? ""
+{ pkgs ? import ../nixpkgs.nix { }, autoInstall ? false, extra-substituters ? ""
 , config-file-name ? "configuration.nix", extra-trusted-public-keys ? ""
 , target_platform ? "x86_64-linux", version ? "", ... }:
 let

--- a/distro/nixpkgs.nix
+++ b/distro/nixpkgs.nix
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MPL-2.0
+
+{ config ? { }, overlays ? [ ], system ? builtins.currentSystem }:
+import (builtins.fetchTarball {
+  url =
+    "https://github.com/NixOS/nixpkgs/archive/4062d36ebeae843c750011eef6b61ec9a9dbc9a9.tar.gz";
+  sha256 = "0hha7lam2c2655f7m0w9jkn8pacmprzgcg3fg7jrnv479fcdh8y2";
+}) { inherit config overlays system; }

--- a/kernel/src/device/tty/ioctl_defs.rs
+++ b/kernel/src/device/tty/ioctl_defs.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::termio::{CTermios, CWinSize};
-use crate::util::ioctl::{InData, OutData, ioc};
+use super::termio::{CTermios, CTermios2, CWinSize};
+use crate::util::ioctl::{InData, NoData, OutData, ioc};
 
 // Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/asm-generic/ioctls.h>
 
@@ -10,5 +10,12 @@ pub type SetTermios      = ioc!(TCSETS,     0x5402,     InData<CTermios>);
 pub type SetTermiosWait  = ioc!(TCSETSW,    0x5403,     InData<CTermios>);
 pub type SetTermiosFlush = ioc!(TCSETSF,    0x5404,     InData<CTermios>);
 
+pub type GetTermios2      = ioc!(TCGETS2,    b'T', 0x2A, OutData<CTermios2>);
+pub type SetTermios2      = ioc!(TCSETS2,    b'T', 0x2B, InData<CTermios2>);
+pub type SetTermiosWait2  = ioc!(TCSETSW2,   b'T', 0x2C, InData<CTermios2>);
+pub type SetTermiosFlush2 = ioc!(TCSETSF2,   b'T', 0x2D, InData<CTermios2>);
+
 pub type GetWinSize      = ioc!(TIOCGWINSZ, 0x5413,     OutData<CWinSize>);
 pub type SetWinSize      = ioc!(TIOCSWINSZ, 0x5414,     InData<CWinSize>);
+
+pub type HangUp          = ioc!(TIOCVHANGUP, 0x5437,     NoData);

--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -2,7 +2,7 @@
 
 use ostd::const_assert;
 
-use super::termio::{CCtrlCharId, CTermios, CWinSize};
+use super::termio::{CCtrlCharId, CTermios, CTermios2, CTermiosSpeeds, CWinSize};
 use crate::{
     device::tty::termio::{CInputFlags, CLocalFlags},
     prelude::*,
@@ -31,6 +31,8 @@ pub struct LineDiscipline {
     read_buffer: RingBuffer<u8>,
     /// Termios
     termios: CTermios,
+    /// Speeds stored by the `termios2` ABI.
+    termios_speeds: CTermiosSpeeds,
     /// Window size
     winsize: CWinSize,
 }
@@ -88,6 +90,7 @@ impl LineDiscipline {
             current_line: CurrentLine::default(),
             read_buffer: RingBuffer::new(BUFFER_CAPACITY),
             termios: CTermios::default(),
+            termios_speeds: CTermiosSpeeds::default(),
             winsize: CWinSize::default(),
         }
     }
@@ -236,9 +239,25 @@ impl LineDiscipline {
         &self.termios
     }
 
+    pub fn termios2(&self) -> CTermios2 {
+        CTermios2::new(self.termios, self.termios_speeds)
+    }
+
     pub fn set_termios(&mut self, termios: CTermios) {
         self.termios = termios;
+        self.termios_speeds = CTermiosSpeeds::from_termios(&termios);
 
+        self.update_after_termios_change();
+    }
+
+    pub fn set_termios2(&mut self, termios2: CTermios2) {
+        self.termios = termios2.termios();
+        self.termios_speeds = termios2.speeds();
+
+        self.update_after_termios_change();
+    }
+
+    fn update_after_termios_change(&mut self) {
         // When switching to raw mode, any pending input bytes should become immediately available.
         // Note that `unwrap()` below won't fail because we checked `is_full()` in `push_char`.
         // TODO: Define the correct behavior for pending bytes when switching back to canonical mode.

--- a/kernel/src/device/tty/mod.rs
+++ b/kernel/src/device/tty/mod.rs
@@ -233,6 +233,11 @@ impl<D: TtyDriver> Tty<D> {
 
                 cmd.write(&termios)?;
             }
+            cmd @ GetTermios2 => {
+                let termios = self.ldisc.lock().termios2();
+
+                cmd.write(&termios)?;
+            }
             cmd @ SetTermios => {
                 let termios = cmd.read()?;
 
@@ -240,6 +245,15 @@ impl<D: TtyDriver> Tty<D> {
                 let old_termios = ldisc.termios();
                 self.driver().on_termios_change(old_termios, &termios);
                 ldisc.set_termios(termios);
+            }
+            cmd @ SetTermios2 => {
+                let termios2 = cmd.read()?;
+                let termios = termios2.termios();
+
+                let mut ldisc = self.ldisc.lock();
+                let old_termios = ldisc.termios();
+                self.driver().on_termios_change(old_termios, &termios);
+                ldisc.set_termios2(termios2);
             }
             cmd @ SetTermiosWait => {
                 let termios = cmd.read()?;
@@ -255,6 +269,16 @@ impl<D: TtyDriver> Tty<D> {
                 self.driver().on_termios_change(old_termios, &termios);
                 ldisc.set_termios(termios);
             }
+            cmd @ SetTermiosWait2 => {
+                let termios2 = cmd.read()?;
+                let termios = termios2.termios();
+
+                // TODO: If applicable, wait for the output buffer to drain. (See comments above.)
+                let mut ldisc = self.ldisc.lock();
+                let old_termios = ldisc.termios();
+                self.driver().on_termios_change(old_termios, &termios);
+                ldisc.set_termios2(termios2);
+            }
             cmd @ SetTermiosFlush => {
                 let termios = cmd.read()?;
 
@@ -263,6 +287,19 @@ impl<D: TtyDriver> Tty<D> {
                 let old_termios = ldisc.termios();
                 self.driver().on_termios_change(old_termios, &termios);
                 ldisc.set_termios(termios);
+                ldisc.drain_input();
+
+                self.pollee.invalidate();
+            }
+            cmd @ SetTermiosFlush2 => {
+                let termios2 = cmd.read()?;
+                let termios = termios2.termios();
+
+                // TODO: If applicable, wait for the output buffer to drain. (See comments above.)
+                let mut ldisc = self.ldisc.lock();
+                let old_termios = ldisc.termios();
+                self.driver().on_termios_change(old_termios, &termios);
+                ldisc.set_termios2(termios2);
                 ldisc.drain_input();
 
                 self.pollee.invalidate();
@@ -276,6 +313,11 @@ impl<D: TtyDriver> Tty<D> {
                 let winsize = cmd.read()?;
 
                 self.ldisc.lock().set_window_size(winsize);
+            }
+            HangUp => {
+                // A full TTY hangup would notify the controlling session and close peer state.
+                // Systemd uses this during getty setup to clear stale line state; treating it as
+                // a successful no-op keeps startup compatible until full hangup semantics exist.
             }
             cmd @ GetNumBytesToRead => {
                 if self.tty_flags.is_other_closed() {

--- a/kernel/src/device/tty/termio.rs
+++ b/kernel/src/device/tty/termio.rs
@@ -7,6 +7,11 @@ use crate::prelude::*;
 /// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/include/uapi/asm-generic/termbits-common.h#L5>.
 type CCtrlChar = u8;
 
+/// A terminal speed; the `speed_t` type in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/asm-generic/termbits-common.h#L7>.
+type CSpeed = u32;
+
 bitflags! {
     /// The input flags; `c_iflags` bits in Linux.
     #[repr(C)]
@@ -80,10 +85,13 @@ impl CCtrlFlags {
     const SIZE_MASK: u32 = 0x00000030;
     const READ_BIT: u32 = 0x00000080;
 
-    #[expect(dead_code)]
     pub(super) fn baud(&self) -> Result<CCtrlBaud> {
         let baud = self.0 & Self::BAUD_MASK;
         Ok(CCtrlBaud::try_from(baud)?)
+    }
+
+    pub(super) fn output_speed(&self) -> Option<CSpeed> {
+        self.baud().ok().and_then(|baud| baud.speed())
     }
 
     #[expect(dead_code)]
@@ -130,6 +138,61 @@ pub(super) enum CCtrlBaud {
     B9600 = 0x0000000d,
     B19200 = 0x0000000e,
     B38400 = 0x0000000f,
+    BOther = 0x00001000,
+    B57600 = 0x00001001,
+    B115200 = 0x00001002,
+    B230400 = 0x00001003,
+    B460800 = 0x00001004,
+    B500000 = 0x00001005,
+    B576000 = 0x00001006,
+    B921600 = 0x00001007,
+    B1000000 = 0x00001008,
+    B1152000 = 0x00001009,
+    B1500000 = 0x0000100a,
+    B2000000 = 0x0000100b,
+    B2500000 = 0x0000100c,
+    B3000000 = 0x0000100d,
+    B3500000 = 0x0000100e,
+    B4000000 = 0x0000100f,
+}
+
+impl CCtrlBaud {
+    const fn speed(self) -> Option<CSpeed> {
+        match self {
+            Self::B0 => Some(0),
+            Self::B50 => Some(50),
+            Self::B75 => Some(75),
+            Self::B110 => Some(110),
+            Self::B134 => Some(134),
+            Self::B150 => Some(150),
+            Self::B200 => Some(200),
+            Self::B300 => Some(300),
+            Self::B600 => Some(600),
+            Self::B1200 => Some(1200),
+            Self::B1800 => Some(1800),
+            Self::B2400 => Some(2400),
+            Self::B4800 => Some(4800),
+            Self::B9600 => Some(9600),
+            Self::B19200 => Some(19200),
+            Self::B38400 => Some(38400),
+            Self::BOther => None,
+            Self::B57600 => Some(57600),
+            Self::B115200 => Some(115200),
+            Self::B230400 => Some(230400),
+            Self::B460800 => Some(460800),
+            Self::B500000 => Some(500000),
+            Self::B576000 => Some(576000),
+            Self::B921600 => Some(921600),
+            Self::B1000000 => Some(1000000),
+            Self::B1152000 => Some(1152000),
+            Self::B1500000 => Some(1500000),
+            Self::B2000000 => Some(2000000),
+            Self::B2500000 => Some(2500000),
+            Self::B3000000 => Some(3000000),
+            Self::B3500000 => Some(3500000),
+            Self::B4000000 => Some(4000000),
+        }
+    }
 }
 
 bitflags! {
@@ -300,6 +363,87 @@ impl CTermios {
     /// Returns the local flags.
     pub fn local_flags(&self) -> &CLocalFlags {
         &self.c_lflags
+    }
+}
+
+/// The speeds stored outside legacy `struct termios`.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct CTermiosSpeeds {
+    input: CSpeed,
+    output: CSpeed,
+}
+
+impl Default for CTermiosSpeeds {
+    fn default() -> Self {
+        Self {
+            input: Self::DEFAULT_SPEED,
+            output: Self::DEFAULT_SPEED,
+        }
+    }
+}
+
+impl CTermiosSpeeds {
+    const DEFAULT_SPEED: CSpeed = 38400;
+
+    pub(super) fn from_termios(termios: &CTermios) -> Self {
+        let speed = termios
+            .c_cflags
+            .output_speed()
+            .unwrap_or(Self::DEFAULT_SPEED);
+
+        Self {
+            input: speed,
+            output: speed,
+        }
+    }
+}
+
+/// The extended termios; `struct termios2` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/asm-generic/termbits.h#L19>.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct CTermios2 {
+    c_iflags: CInputFlags,
+    c_oflags: COutputFlags,
+    c_cflags: CCtrlFlags,
+    c_lflags: CLocalFlags,
+    c_line: CCtrlChar,
+    c_cc: [CCtrlChar; CTermios::NUM_CTRL_CHARS],
+    c_ispeed: CSpeed,
+    c_ospeed: CSpeed,
+}
+
+impl CTermios2 {
+    pub(super) fn new(termios: CTermios, speeds: CTermiosSpeeds) -> Self {
+        Self {
+            c_iflags: termios.c_iflags,
+            c_oflags: termios.c_oflags,
+            c_cflags: termios.c_cflags,
+            c_lflags: termios.c_lflags,
+            c_line: termios.c_line,
+            c_cc: termios.c_cc,
+            c_ispeed: speeds.input,
+            c_ospeed: speeds.output,
+        }
+    }
+
+    pub(super) fn termios(&self) -> CTermios {
+        CTermios {
+            c_iflags: self.c_iflags,
+            c_oflags: self.c_oflags,
+            c_cflags: self.c_cflags,
+            c_lflags: self.c_lflags,
+            c_line: self.c_line,
+            c_cc: self.c_cc,
+        }
+    }
+
+    pub(super) fn speeds(&self) -> CTermiosSpeeds {
+        CTermiosSpeeds {
+            input: self.c_ispeed,
+            output: self.c_ospeed,
+        }
     }
 }
 

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -318,6 +318,43 @@ impl Path {
         Ok(child_mount)
     }
 
+    /// Attaches a detached mount tree to the current path.
+    pub(crate) fn attach_detached_mount(
+        &self,
+        detached_mount: &Arc<Mount>,
+        ctx: &Context,
+    ) -> Result<()> {
+        if self.type_() != InodeType::Dir {
+            return_errno_with_message!(Errno::ENOTDIR, "the path is not a directory");
+        }
+
+        let current_ns_proxy = ctx.thread_local.borrow_ns_proxy();
+        let current_mnt_ns = current_ns_proxy.unwrap().mnt_ns();
+        if !current_mnt_ns.owns(detached_mount) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the detached mount is not in this mount namespace"
+            );
+        }
+        if !current_mnt_ns.owns(&self.mount) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the destination path is not in this mount namespace"
+            );
+        }
+
+        current_mnt_ns.check_no_mnt_ns_loop_in_tree(detached_mount)?;
+        if self.mount_node().is_equal_or_descendant_of(detached_mount) {
+            return_errno_with_message!(
+                Errno::ELOOP,
+                "the destination path is inside the mount subtree being moved"
+            );
+        }
+
+        detached_mount.graft_mount_tree(self);
+        Ok(())
+    }
+
     /// Unmounts the filesystem mounted at the current path.
     ///
     /// Returns the unmounted child mount on success.

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -42,7 +42,12 @@ pub enum MountPropType {
     /// do not propagate to or from the private mounts.
     #[default]
     Private,
-    // TODO: Implement other propagation types.
+    /// A shared mount propagates mount and unmount events to peer mounts.
+    Shared,
+    /// A slave mount receives propagation events from its master.
+    Slave,
+    /// An unbindable mount cannot be bind-mounted.
+    Unbindable,
 }
 
 static ID_ALLOCATOR: Once<SpinLock<IdAlloc>> = Once::new();

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -230,6 +230,16 @@ impl Mount {
         Self::new(fs, PerMountFlags::KERNMOUNT, None, Weak::new(), None)
     }
 
+    /// Creates a mount node that is not attached to the mount tree.
+    pub(crate) fn new_detached(
+        fs: Arc<dyn FileSystem>,
+        flags: PerMountFlags,
+        mnt_ns: Weak<MountNamespace>,
+        source: Option<String>,
+    ) -> Result<Arc<Self>> {
+        Self::new(fs, flags, None, mnt_ns, source)
+    }
+
     /// The internal constructor.
     ///
     /// A root mount node has no mountpoint, while other mount nodes must have one.

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -604,11 +604,13 @@ impl PathResolver {
             }
             FsPathInner::Cwd => LookupResult::Resolved(self.cwd.clone()),
             FsPathInner::FdRelative(fd, path) => {
-                let task = Task::current().unwrap();
-                let mut file_table = task.as_thread_local().unwrap().borrow_file_table_mut();
-                let file = get_file_fast!(&mut file_table, fd);
-                let parent = file.as_inode_handle_or_err()?.path();
-                self.lookup_from_parent(parent, path, follow_tail_link)?
+                let parent = {
+                    let task = Task::current().unwrap();
+                    let mut file_table = task.as_thread_local().unwrap().borrow_file_table_mut();
+                    let file = get_file_fast!(&mut file_table, fd);
+                    file.path().clone()
+                };
+                self.lookup_from_parent(&parent, path, follow_tail_link)?
             }
             FsPathInner::Fd(fd) => {
                 let task = Task::current().unwrap();

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -74,6 +74,7 @@ macro_rules! import_generic_syscall_entries {
             mknod::sys_mknodat,
             mmap::sys_mmap,
             mount::sys_mount,
+            mount_api::{sys_fsconfig, sys_fsmount, sys_fsopen, sys_move_mount},
             mprotect::sys_mprotect,
             mremap::sys_mremap,
             msync::sys_msync,
@@ -399,6 +400,10 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_PWRITEV2 = 287               => sys_pwritev2(args[..6]);
             SYS_STATX = 291                  => sys_statx(args[..5]);
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
+            SYS_MOVE_MOUNT = 429             => sys_move_mount(args[..5]);
+            SYS_FSOPEN = 430                 => sys_fsopen(args[..2]);
+            SYS_FSCONFIG = 431               => sys_fsconfig(args[..5]);
+            SYS_FSMOUNT = 432                => sys_fsmount(args[..3]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
             SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -74,6 +74,7 @@ use super::{
     mknod::{sys_mknod, sys_mknodat},
     mmap::sys_mmap,
     mount::sys_mount,
+    mount_api::{sys_fsconfig, sys_fsmount, sys_fsopen, sys_move_mount},
     mprotect::sys_mprotect,
     mremap::sys_mremap,
     msync::sys_msync,
@@ -414,6 +415,10 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PWRITEV2 = 328         => sys_pwritev2(args[..6]);
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
+    SYS_MOVE_MOUNT = 429       => sys_move_mount(args[..5]);
+    SYS_FSOPEN = 430           => sys_fsopen(args[..2]);
+    SYS_FSCONFIG = 431         => sys_fsconfig(args[..5]);
+    SYS_FSMOUNT = 432          => sys_fsmount(args[..3]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -87,6 +87,7 @@ mod mkdir;
 mod mknod;
 mod mmap;
 mod mount;
+mod mount_api;
 mod mprotect;
 mod mremap;
 mod msync;

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -152,13 +152,20 @@ fn do_change_type(target_path: Path, flags: MountFlags, ctx: &Context) -> Result
         );
     }
 
-    if flags.contains(MountFlags::MS_PRIVATE) {
-        let recursive = flags.contains(MountFlags::MS_REC);
-        target_path.set_mount_propagation(MountPropType::Private, recursive, ctx)?;
-        Ok(())
+    let prop_type = if flags.contains(MountFlags::MS_SHARED) {
+        MountPropType::Shared
+    } else if flags.contains(MountFlags::MS_PRIVATE) {
+        MountPropType::Private
+    } else if flags.contains(MountFlags::MS_SLAVE) {
+        MountPropType::Slave
+    } else if flags.contains(MountFlags::MS_UNBINDABLE) {
+        MountPropType::Unbindable
     } else {
-        return_errno_with_message!(Errno::EINVAL, "the mount propagation type is unsupported");
-    }
+        return_errno_with_message!(Errno::EINVAL, "missing mount propagation type");
+    };
+
+    let recursive = flags.contains(MountFlags::MS_REC);
+    target_path.set_mount_propagation(prop_type, recursive, ctx)
 }
 
 /// Moves a mount from src location to dst location.

--- a/kernel/src/syscall/mount_api.rs
+++ b/kernel/src/syscall/mount_api.rs
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::fmt::Display;
+
+use super::{SyscallReturn, constants::MAX_FILENAME_LEN};
+use crate::{
+    events::IoEvents,
+    fs::{
+        file::{
+            AccessMode, CreationFlags, FileLike, InodeMode,
+            file_table::{FdFlags, RawFileDesc, get_file_fast},
+        },
+        pseudofs::AnonInodeFs,
+        vfs::{
+            file_system::{FileSystem, FsFlags},
+            path::{EmptyPathStr, FsPath, Mount, Path, PerMountFlags},
+            registry::{FsCreationCtx, FsType, look_up},
+        },
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+};
+
+pub fn sys_fsopen(fs_name_addr: Vaddr, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let flags = FsOpenFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown fsopen flags"))?;
+    let fs_name = ctx
+        .user_space()
+        .read_cstring(fs_name_addr, MAX_FILENAME_LEN)?;
+    let fs_name = fs_name
+        .to_str()
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid file system name"))?;
+    let fs_type = look_up(fs_name).ok_or_else(|| {
+        Error::with_message(
+            Errno::ENODEV,
+            "the filesystem is not configured in the kernel",
+        )
+    })?;
+
+    let file = Arc::new(FsContextFile::new(fs_type)) as Arc<dyn FileLike>;
+    let fd_flags = if flags.contains(FsOpenFlags::FSOPEN_CLOEXEC) {
+        FdFlags::CLOEXEC
+    } else {
+        FdFlags::empty()
+    };
+    let fd = ctx
+        .thread_local
+        .borrow_file_table()
+        .unwrap()
+        .write()
+        .insert(file, fd_flags);
+    Ok(SyscallReturn::Return(fd.into()))
+}
+
+pub fn sys_fsconfig(
+    fs_fd: RawFileDesc,
+    cmd: u32,
+    key_addr: Vaddr,
+    value_addr: Vaddr,
+    _aux: i32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, fs_fd.try_into()?);
+    let fs_context = file
+        .downcast_ref::<FsContextFile>()
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not a fs context"))?;
+
+    match cmd {
+        FSCONFIG_SET_FLAG => {
+            let key = read_user_str(key_addr, ctx)?;
+            fs_context.set_flag(key.to_str()?)?;
+        }
+        FSCONFIG_SET_STRING => {
+            let key = read_user_str(key_addr, ctx)?;
+            let value = read_user_str(value_addr, ctx)?;
+            fs_context.set_string(key.to_str()?, value.to_str()?)?;
+        }
+        FSCONFIG_CMD_CREATE => fs_context.create_fs(ctx)?,
+        FSCONFIG_CMD_RECONFIGURE => fs_context.reconfigure_fs(ctx)?,
+        _ => return_errno_with_message!(Errno::EINVAL, "unsupported fsconfig command"),
+    }
+
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_fsmount(
+    fs_fd: RawFileDesc,
+    flags: u32,
+    mount_attrs: u32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let flags = FsMountFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown fsmount flags"))?;
+    let per_mount_flags = mount_attrs_to_per_mount_flags(mount_attrs)?;
+    let (fs, source) = {
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
+        let file = get_file_fast!(&mut file_table, fs_fd.try_into()?);
+        let fs_context = file
+            .downcast_ref::<FsContextFile>()
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not a fs context"))?;
+        (fs_context.created_fs()?, fs_context.source())
+    };
+
+    let current_ns_proxy = ctx.thread_local.borrow_ns_proxy();
+    let current_mnt_ns = current_ns_proxy.unwrap().mnt_ns();
+    let detached_mount = Mount::new_detached(
+        fs.clone(),
+        per_mount_flags,
+        Arc::downgrade(current_mnt_ns),
+        source,
+    )?;
+    let file = Arc::new(DetachedMountFile::new(detached_mount)) as Arc<dyn FileLike>;
+    let fd_flags = if flags.contains(FsMountFlags::FSMOUNT_CLOEXEC) {
+        FdFlags::CLOEXEC
+    } else {
+        FdFlags::empty()
+    };
+    let fd = ctx
+        .thread_local
+        .borrow_file_table()
+        .unwrap()
+        .write()
+        .insert(file, fd_flags);
+    Ok(SyscallReturn::Return(fd.into()))
+}
+
+pub fn sys_move_mount(
+    from_dfd: RawFileDesc,
+    from_path_addr: Vaddr,
+    to_dfd: RawFileDesc,
+    to_path_addr: Vaddr,
+    flags: u32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let flags = MoveMountFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown move_mount flags"))?;
+    if flags != MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH {
+        return_errno_with_message!(Errno::EINVAL, "unsupported move_mount flags");
+    }
+
+    let from_path = read_user_str(from_path_addr, ctx)?;
+    if !from_path.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "only empty from_path is supported");
+    }
+
+    let detached_mount = {
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
+        let file = get_file_fast!(&mut file_table, from_dfd.try_into()?);
+        let mount_file = file.downcast_ref::<DetachedMountFile>().ok_or_else(|| {
+            Error::with_message(Errno::EINVAL, "the file is not a detached mount")
+        })?;
+        mount_file.mount()
+    };
+
+    let to_path = read_user_str(to_path_addr, ctx)?;
+    let to_path = to_path
+        .to_str()
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid target path"))?;
+    let fs_path = FsPath::from_fd_at(to_dfd, to_path, EmptyPathStr::Reject)?;
+    let target_path = ctx
+        .thread_local
+        .borrow_fs()
+        .resolver()
+        .read()
+        .lookup(&fs_path)?
+        .get_top_path();
+
+    target_path.attach_detached_mount(&detached_mount, ctx)?;
+    Ok(SyscallReturn::Return(0))
+}
+
+fn read_user_str(addr: Vaddr, ctx: &Context) -> Result<CString> {
+    ctx.user_space().read_cstring(addr, MAX_FILENAME_LEN)
+}
+
+struct FsContextFile {
+    state: Mutex<FsContextState>,
+    pseudo_path: Path,
+}
+
+struct FsContextState {
+    fs_type: &'static dyn FsType,
+    fs_flags: FsFlags,
+    source: Option<String>,
+    mode: Option<InodeMode>,
+    fs: Option<Arc<dyn FileSystem>>,
+    /// Accumulates unrecognized fsconfig key=value options as a comma-separated
+    /// string, so that filesystem-specific mount options (e.g. `minixdf`) set
+    /// via the new mount API are forwarded to `FsCreationCtx`.
+    extra_options: String,
+}
+
+impl FsContextFile {
+    fn new(fs_type: &'static dyn FsType) -> Self {
+        Self {
+            state: Mutex::new(FsContextState {
+                fs_type,
+                fs_flags: FsFlags::empty(),
+                source: None,
+                mode: None,
+                fs: None,
+                extra_options: String::new(),
+            }),
+            pseudo_path: AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string()),
+        }
+    }
+
+    fn set_flag(&self, key: &str) -> Result<()> {
+        let mut state = self.state.lock();
+        match key {
+            "noswap" => Ok(()),
+            "ro" => {
+                drop(state);
+                self.set_fs_flags(FsFlags::RDONLY)
+            }
+            _ => {
+                if !state.extra_options.is_empty() {
+                    state.extra_options.push(',');
+                }
+                state.extra_options.push_str(key);
+                Ok(())
+            }
+        }
+    }
+
+    fn set_string(&self, key: &str, value: &str) -> Result<()> {
+        let mut state = self.state.lock();
+        if state.fs.is_some() {
+            return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
+        }
+        match key {
+            "source" => {
+                state.source = Some(value.to_string());
+                Ok(())
+            }
+            "mode" => {
+                state.mode = Some(parse_octal_mode(value)?);
+                Ok(())
+            }
+            "nr_inodes" | "size" => Ok(()),
+            _ => {
+                if !state.extra_options.is_empty() {
+                    state.extra_options.push(',');
+                }
+                state.extra_options.push_str(key);
+                state.extra_options.push('=');
+                state.extra_options.push_str(value);
+                Ok(())
+            }
+        }
+    }
+
+    fn create_fs(&self, ctx: &Context) -> Result<()> {
+        let mut state = self.state.lock();
+        if state.fs.is_some() {
+            return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
+        }
+
+        let args_cstr = if state.extra_options.is_empty() {
+            None
+        } else {
+            Some(CString::new(state.extra_options.as_str()).map_err(|_| {
+                Error::with_message(Errno::EINVAL, "mount options contain null byte")
+            })?)
+        };
+        let args_ref = args_cstr.as_deref();
+        let fs_creation_ctx =
+            FsCreationCtx::new(state.source.as_deref(), state.fs_flags, args_ref, ctx);
+        let fs = state.fs_type.create(&fs_creation_ctx)?;
+        if let Some(mode) = state.mode {
+            fs.root_inode().set_mode(mode)?;
+        }
+        state.fs = Some(fs);
+        Ok(())
+    }
+
+    fn reconfigure_fs(&self, ctx: &Context) -> Result<()> {
+        let state = self.state.lock();
+        let fs = state
+            .fs
+            .as_ref()
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file system is not created"))?;
+
+        fs.set_fs_flags(state.fs_flags, None, ctx)
+    }
+
+    fn set_fs_flags(&self, flags: FsFlags) -> Result<()> {
+        let mut state = self.state.lock();
+        state.fs_flags |= flags;
+        Ok(())
+    }
+
+    fn created_fs(&self) -> Result<Arc<dyn FileSystem>> {
+        self.state
+            .lock()
+            .fs
+            .clone()
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file system is not created"))
+    }
+
+    fn source(&self) -> Option<String> {
+        self.state.lock().source.clone()
+    }
+}
+
+impl Pollable for FsContextFile {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
+impl FileLike for FsContextFile {
+    fn access_mode(&self) -> AccessMode {
+        AccessMode::O_RDWR
+    }
+
+    fn path(&self) -> &Path {
+        &self.pseudo_path
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
+        Box::new(MountApiFdInfo { fd_flags })
+    }
+}
+
+struct DetachedMountFile {
+    mount: Arc<Mount>,
+    root_path: Path,
+}
+
+impl DetachedMountFile {
+    fn new(mount: Arc<Mount>) -> Self {
+        let root_path = Path::new_fs_root(mount.clone());
+        Self { mount, root_path }
+    }
+
+    fn mount(&self) -> Arc<Mount> {
+        self.mount.clone()
+    }
+}
+
+impl Pollable for DetachedMountFile {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
+impl FileLike for DetachedMountFile {
+    fn access_mode(&self) -> AccessMode {
+        AccessMode::O_RDONLY
+    }
+
+    fn path(&self) -> &Path {
+        &self.root_path
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
+        Box::new(MountApiFdInfo { fd_flags })
+    }
+}
+
+struct MountApiFdInfo {
+    fd_flags: FdFlags,
+}
+
+impl Display for MountApiFdInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut flags = AccessMode::O_RDONLY as u32;
+        if self.fd_flags.contains(FdFlags::CLOEXEC) {
+            flags |= CreationFlags::O_CLOEXEC.bits();
+        }
+
+        writeln!(f, "pos:\t{}", 0)?;
+        writeln!(f, "flags:\t0{:o}", flags)?;
+        writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
+        writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())
+    }
+}
+
+fn parse_octal_mode(value: &str) -> Result<InodeMode> {
+    let mode = u16::from_str_radix(value, 8)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid octal mode"))?;
+    if mode & !0o7777 != 0 {
+        return_errno_with_message!(Errno::EINVAL, "invalid mode bits");
+    }
+    Ok(InodeMode::from_bits_truncate(mode))
+}
+
+fn mount_attrs_to_per_mount_flags(attrs: u32) -> Result<PerMountFlags> {
+    let supported = MOUNT_ATTR_RDONLY
+        | MOUNT_ATTR_NOSUID
+        | MOUNT_ATTR_NODEV
+        | MOUNT_ATTR_NOEXEC
+        | MOUNT_ATTR_NOATIME
+        | MOUNT_ATTR_STRICTATIME
+        | MOUNT_ATTR_NODIRATIME
+        | MOUNT_ATTR_NOSYMFOLLOW;
+    if attrs & !supported != 0 {
+        return_errno_with_message!(Errno::EINVAL, "unsupported mount attributes");
+    }
+    if attrs & MOUNT_ATTR_NOATIME != 0 && attrs & MOUNT_ATTR_STRICTATIME != 0 {
+        return_errno_with_message!(Errno::EINVAL, "conflicting atime mount attributes");
+    }
+
+    let mut flags = PerMountFlags::default();
+    if attrs & MOUNT_ATTR_RDONLY != 0 {
+        flags |= PerMountFlags::RDONLY;
+    }
+    if attrs & MOUNT_ATTR_NOSUID != 0 {
+        flags |= PerMountFlags::NOSUID;
+    }
+    if attrs & MOUNT_ATTR_NODEV != 0 {
+        flags |= PerMountFlags::NODEV;
+    }
+    if attrs & MOUNT_ATTR_NOEXEC != 0 {
+        flags |= PerMountFlags::NOEXEC;
+    }
+    if attrs & MOUNT_ATTR_NOATIME != 0 {
+        flags |= PerMountFlags::NOATIME;
+    }
+    if attrs & MOUNT_ATTR_STRICTATIME != 0 {
+        flags |= PerMountFlags::STRICTATIME;
+    }
+    if attrs & MOUNT_ATTR_NODIRATIME != 0 {
+        flags |= PerMountFlags::NODIRATIME;
+    }
+
+    Ok(flags)
+}
+
+bitflags! {
+    struct FsOpenFlags: u32 {
+        const FSOPEN_CLOEXEC = 1;
+    }
+
+    struct FsMountFlags: u32 {
+        const FSMOUNT_CLOEXEC = 1;
+    }
+
+    struct MoveMountFlags: u32 {
+        const MOVE_MOUNT_F_EMPTY_PATH = 0x0000_0004;
+    }
+}
+
+const FSCONFIG_SET_FLAG: u32 = 0;
+const FSCONFIG_SET_STRING: u32 = 1;
+const FSCONFIG_CMD_CREATE: u32 = 6;
+const FSCONFIG_CMD_RECONFIGURE: u32 = 7;
+
+const MOUNT_ATTR_RDONLY: u32 = 0x0000_0001;
+const MOUNT_ATTR_NOSUID: u32 = 0x0000_0002;
+const MOUNT_ATTR_NODEV: u32 = 0x0000_0004;
+const MOUNT_ATTR_NOEXEC: u32 = 0x0000_0008;
+const MOUNT_ATTR_NOATIME: u32 = 0x0000_0010;
+const MOUNT_ATTR_STRICTATIME: u32 = 0x0000_0020;
+const MOUNT_ATTR_NODIRATIME: u32 = 0x0000_0080;
+const MOUNT_ATTR_NOSYMFOLLOW: u32 = 0x0020_0000;

--- a/kernel/src/syscall/prctl.rs
+++ b/kernel/src/syscall/prctl.rs
@@ -83,6 +83,18 @@ pub fn sys_prctl(
             let credentials = ctx.credentials_mut();
             credentials.drop_bounding_capability(capability)?;
         }
+        PrctlCmd::PR_CAP_AMBIENT(cmd) => match cmd {
+            CapAmbientCmd::IsSet(_capability) => {
+                return Ok(SyscallReturn::Return(0));
+            }
+            CapAmbientCmd::Raise(_capability) => {
+                return_errno_with_message!(
+                    Errno::EPERM,
+                    "raising ambient capabilities is not supported"
+                );
+            }
+            CapAmbientCmd::Lower | CapAmbientCmd::ClearAll => {}
+        },
         PrctlCmd::PR_GET_SECUREBITS => {
             let credentials = ctx.posix_thread.credentials();
             let securebits = credentials.securebits();
@@ -142,6 +154,12 @@ const PR_SET_TIMERSLACK: i32 = 29;
 const PR_GET_TIMERSLACK: i32 = 30;
 const PR_SET_CHILD_SUBREAPER: i32 = 36;
 const PR_GET_CHILD_SUBREAPER: i32 = 37;
+const PR_CAP_AMBIENT: i32 = 47;
+
+const PR_CAP_AMBIENT_IS_SET: u64 = 1;
+const PR_CAP_AMBIENT_RAISE: u64 = 2;
+const PR_CAP_AMBIENT_LOWER: u64 = 3;
+const PR_CAP_AMBIENT_CLEAR_ALL: u64 = 4;
 
 #[expect(non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
@@ -156,12 +174,21 @@ pub enum PrctlCmd {
     PR_GET_NAME(Vaddr),
     PR_CAPBSET_READ(CapSet),
     PR_CAPBSET_DROP(CapSet),
+    PR_CAP_AMBIENT(CapAmbientCmd),
     PR_GET_SECUREBITS,
     PR_SET_SECUREBITS(SecureBits),
     PR_SET_TIMERSLACK(u64),
     PR_GET_TIMERSLACK,
     PR_SET_CHILD_SUBREAPER(bool),
     PR_GET_CHILD_SUBREAPER(Vaddr),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CapAmbientCmd {
+    IsSet(CapSet),
+    Raise(CapSet),
+    Lower,
+    ClearAll,
 }
 
 #[repr(u64)]
@@ -173,7 +200,7 @@ pub enum Dumpable {
 }
 
 impl PrctlCmd {
-    fn from_args(option: i32, arg2: u64, _arg3: u64, _arg4: u64, _arg5: u64) -> Result<PrctlCmd> {
+    fn from_args(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> Result<PrctlCmd> {
         match option {
             PR_SET_PDEATHSIG => {
                 let signum = SigNum::try_from(arg2 as u8)?;
@@ -188,6 +215,9 @@ impl PrctlCmd {
             PR_GET_NAME => Ok(PrctlCmd::PR_GET_NAME(arg2 as _)),
             PR_CAPBSET_READ => Ok(PrctlCmd::PR_CAPBSET_READ(parse_capability(arg2)?)),
             PR_CAPBSET_DROP => Ok(PrctlCmd::PR_CAPBSET_DROP(parse_capability(arg2)?)),
+            PR_CAP_AMBIENT => Ok(PrctlCmd::PR_CAP_AMBIENT(CapAmbientCmd::from_args(
+                arg2, arg3, arg4, arg5,
+            )?)),
             PR_GET_SECUREBITS => Ok(PrctlCmd::PR_GET_SECUREBITS),
             PR_SET_SECUREBITS => Ok(PrctlCmd::PR_SET_SECUREBITS(SecureBits::try_from(
                 arg2 as u16,
@@ -200,6 +230,33 @@ impl PrctlCmd {
                 debug!("prctl cmd number: {}", option);
                 return_errno_with_message!(Errno::EINVAL, "unsupported prctl command");
             }
+        }
+    }
+}
+
+impl CapAmbientCmd {
+    fn from_args(operation: u64, capability: u64, arg4: u64, arg5: u64) -> Result<Self> {
+        if arg4 != 0 || arg5 != 0 {
+            return_errno_with_message!(Errno::EINVAL, "unused PR_CAP_AMBIENT arguments are not 0");
+        }
+
+        match operation {
+            PR_CAP_AMBIENT_IS_SET => Ok(Self::IsSet(parse_capability(capability)?)),
+            PR_CAP_AMBIENT_RAISE => Ok(Self::Raise(parse_capability(capability)?)),
+            PR_CAP_AMBIENT_LOWER => {
+                parse_capability(capability)?;
+                Ok(Self::Lower)
+            }
+            PR_CAP_AMBIENT_CLEAR_ALL => {
+                if capability != 0 {
+                    return_errno_with_message!(
+                        Errno::EINVAL,
+                        "PR_CAP_AMBIENT_CLEAR_ALL requires capability to be 0"
+                    );
+                }
+                Ok(Self::ClearAll)
+            }
+            _ => return_errno_with_message!(Errno::EINVAL, "invalid PR_CAP_AMBIENT operation"),
         }
     }
 }

--- a/test/initramfs/README.md
+++ b/test/initramfs/README.md
@@ -93,7 +93,7 @@ These benchmarks are precompiled and packaged into the Docker image for convenie
 
 ## Adding New Benchmarks
 
-We recommend utilizing `Nix` when adding new benchmarks. To check if a benchmark is already available, use the [`Nix Package Search`](https://search.nixos.org/packages?channel=25.05). If a package exists in the Nix channel, you can directly use it or modify it if necessary.
+We recommend utilizing `Nix` when adding new benchmarks. To check if a benchmark is already available, use the [`Nix Package Search`](https://search.nixos.org/packages?channel=26.05). If a package exists in the Nix channel, you can directly use it or modify it if necessary.
 
 If the desired benchmark is not available or cannot be easily adapted, you can add a custom `.nix` file to package it manually. Place the `.nix` files under the `test/initramfs/nix/benchmark` directory.
 

--- a/test/initramfs/nix/conformance/ltp.nix
+++ b/test/initramfs/nix/conformance/ltp.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-vmsC4QRM4U1MoRjLbRsodX4jAolWeifaP9zetwIbWl4";
   };
 
+  patches = [ ./patches/ltp-listmount04-mnt-id-req.patch ];
+
   # Clear `CFLAGS` and `DEBUG_CFLAGS` to prevent `-g` from being automatically added.
   CFLAGS = "";
   DEBUG_CFLAGS = "";

--- a/test/initramfs/nix/conformance/patches/ltp-listmount04-mnt-id-req.patch
+++ b/test/initramfs/nix/conformance/patches/ltp-listmount04-mnt-id-req.patch
@@ -1,0 +1,44 @@
+diff --git a/testcases/kernel/syscalls/listmount/listmount04.c b/testcases/kernel/syscalls/listmount/listmount04.c
+index a52bad0..823ed35 100644
+--- a/testcases/kernel/syscalls/listmount/listmount04.c
++++ b/testcases/kernel/syscalls/listmount/listmount04.c
+@@ -26,7 +26,7 @@ static uint64_t mnt_ids[MNT_SIZE];
+ static struct tcase {
+ 	int req_usage;
+ 	uint32_t size;
+-	uint32_t spare;
++	uint32_t reserved;
+ 	uint64_t mnt_id;
+ 	uint64_t param;
+ 	uint64_t *mnt_ids;
+@@ -73,12 +73,16 @@ static struct tcase {
+ 	{
+ 		.req_usage = 1,
+ 		.size = MNT_ID_REQ_SIZE_VER0,
+-		.spare = -1,
++		.reserved = -1,
+ 		.mnt_id = LSMT_ROOT,
+ 		.mnt_ids = mnt_ids,
+ 		.nr_mnt_ids = MNT_SIZE,
+ 		.exp_errno = EINVAL,
++#ifdef MNT_ID_REQ_SIZE_VER1
++		.msg = "invalid mnt_id_req.mnt_ns_fd",
++#else
+ 		.msg = "invalid mnt_id_req.spare",
++#endif
+ 	},
+ 	{
+ 		.req_usage = 1,
+@@ -122,7 +126,11 @@ static void run(unsigned int n)
+ 		req->mnt_id = tc->mnt_id;
+ 		req->param = tc->param;
+ 		req->size = tc->size;
+-		req->spare = tc->spare;
++#ifdef MNT_ID_REQ_SIZE_VER1
++		req->mnt_ns_fd = tc->reserved;
++#else
++		req->spare = tc->reserved;
++#endif
+ 	}
+ 
+ 	TST_EXP_FAIL(tst_syscall(__NR_listmount, req, tc->mnt_ids,

--- a/test/initramfs/nix/conformance/xfstests.nix
+++ b/test/initramfs/nix/conformance/xfstests.nix
@@ -1,6 +1,10 @@
 { lib, stdenvNoCC, pkgs, conformanceSrc }:
 
 let
+  xfstestsPackage = pkgs.xfstests.overrideAttrs (oldAttrs: {
+    NIX_CFLAGS_COMPILE = (oldAttrs.NIX_CFLAGS_COMPILE or "") + " -std=gnu17";
+  });
+
   standaloneCoreutils = pkgs.coreutils.override { singleBinary = false; };
 
   runtimeDeps = with pkgs; [
@@ -31,7 +35,7 @@ in stdenvNoCC.mkDerivation {
 
   buildCommand = ''
     mkdir -p $out/xfstests
-    cp -r ${pkgs.xfstests}/lib/xfstests/* $out/xfstests/
+    cp -r ${xfstestsPackage}/lib/xfstests/* $out/xfstests/
     cp ${conformanceSrc}/xfstests/run_xfstests.sh $out/xfstests/
     sed -i "s|__RUNTIME_PATH__|${runtimePath}|" $out/xfstests/run_xfstests.sh
     chmod +x $out/xfstests/run_xfstests.sh

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -10,11 +10,11 @@ let
   else
     throw "Target arch ${target} not yet supported.";
 
-  # Pinned nixpkgs (nix version: 2.29.1, channel: nixos-25.05, release date: 2025-07-01)
+  # Pinned nixpkgs (nix version: 2.34.7, channel: nixos-26.05)
   nixpkgs = fetchTarball {
     url =
-      "https://github.com/NixOS/nixpkgs/archive/c0bebd16e69e631ac6e52d6eb439daba28ac50cd.tar.gz";
-    sha256 = "1fbhkqm8cnsxszw4d4g0402vwsi75yazxkpfx3rdvln4n6s68saf";
+      "https://github.com/NixOS/nixpkgs/archive/4062d36ebeae843c750011eef6b61ec9a9dbc9a9.tar.gz";
+    sha256 = "0hha7lam2c2655f7m0w9jkn8pacmprzgcg3fg7jrnv479fcdh8y2";
   };
   pkgs = import nixpkgs {
     config = { };

--- a/test/initramfs/src/regression/common/test.h
+++ b/test/initramfs/src/regression/common/test.h
@@ -87,6 +87,39 @@
 		_ret;                \
 	})
 
+#define __CHECK_PTHREAD(func, cond)                                       \
+	__auto_type _ret = (func);                                        \
+	if (!(cond)) {                                                    \
+		fprintf(stderr,                                           \
+			"fatal error: %s: `%s` is false after `%s` [got " \
+			"%s]\n",                                          \
+			__func__, #cond, #func,                           \
+			_ret == 0 ? "Success" : strerror(_ret));          \
+		exit(EXIT_FAILURE);                                       \
+	}
+
+/**
+ * Makes a pthread API call and checks whether it succeeds.
+ *
+ * The execution will be aborted if the call returns a non-zero error number.
+ */
+#define CHECK_PTHREAD(func)                       \
+	({                                        \
+		__CHECK_PTHREAD(func, _ret == 0); \
+		_ret;                             \
+	})
+
+/**
+ * Makes a pthread API call and checks its result with the specified condition.
+ *
+ * The execution will be aborted if the condition does not meet.
+ */
+#define CHECK_PTHREAD_WITH(func, cond)       \
+	({                                   \
+		__CHECK_PTHREAD(func, cond); \
+		_ret;                        \
+	})
+
 static int __total_failures;
 
 #define __TEST_SUMMARY()                                                  \
@@ -146,6 +179,21 @@ static int __total_failures;
  * The return value of the function can be accessed with a local variable named
  * _ret.
  */
+
+#define __TEST_PTHREAD(func, cond)                                             \
+	__auto_type _ret = (func);                                             \
+	if (!(cond)) {                                                         \
+		__tests_failed++;                                              \
+		fprintf(stderr,                                                \
+			"%s: `%s` failed [got %s, but `%s` is false]\n",       \
+			__func__, #func,                                       \
+			_ret == 0 ? "Success" : strerror(_ret), #cond);        \
+	} else {                                                               \
+		__tests_passed++;                                              \
+		fprintf(stderr, "%s: `%s` passed [got %s]\n", __func__, #func, \
+			_ret == 0 ? "Success" : strerror(_ret));               \
+	}
+
 #define TEST(func, err, cond)            \
 	({                               \
 		__TEST(func, err, cond); \
@@ -176,6 +224,29 @@ static int __total_failures;
  * _ret.
  */
 #define TEST_RES(func, cond) TEST(func, 0, cond)
+
+/**
+ * Makes a pthread API call and checks whether it succeeds.
+ *
+ * pthread APIs return the error number directly and may leave `errno`
+ * unspecified, so they cannot be checked with TEST_SUCC().
+ */
+#define TEST_PTHREAD(func)                       \
+	({                                       \
+		__TEST_PTHREAD(func, _ret == 0); \
+		_ret;                            \
+	})
+
+/**
+ * Makes a pthread API call and checks whether it produces expected results.
+ *
+ * A test failure will be reported if the specified condition does not meet.
+ */
+#define TEST_PTHREAD_RES(func, cond)        \
+	({                                  \
+		__TEST_PTHREAD(func, cond); \
+		_ret;                       \
+	})
 
 int main(void)
 {

--- a/test/initramfs/src/regression/device/pty/pty_blocking.c
+++ b/test/initramfs/src/regression/device/pty/pty_blocking.c
@@ -78,16 +78,17 @@ static int read_all(int fd, char c)
                                                        \
 		return PTR_VOID_TRUE;                  \
 	}
-#define RUN_BLOCKING_TEST(name)                                                \
-	{                                                                      \
-		pthread_t __thd;                                               \
-		void *__res;                                                   \
-		TEST_SUCC(pthread_create(&__thd, NULL, blocking_##name,        \
-					 PTR_VOID_TRUE));                      \
-		TEST_SUCC(blocking_##name(PTR_VOID_FALSE) == PTR_VOID_TRUE ?   \
-				  0 :                                          \
-				  -1);                                         \
-		TEST_RES(pthread_join(__thd, &__res), __res == PTR_VOID_TRUE); \
+#define RUN_BLOCKING_TEST(name)                                              \
+	{                                                                    \
+		pthread_t __thd;                                             \
+		void *__res;                                                 \
+		TEST_PTHREAD(pthread_create(&__thd, NULL, blocking_##name,   \
+					    PTR_VOID_TRUE));                 \
+		TEST_SUCC(blocking_##name(PTR_VOID_FALSE) == PTR_VOID_TRUE ? \
+				  0 :                                        \
+				  -1);                                       \
+		TEST_PTHREAD_RES(pthread_join(__thd, &__res),                \
+				 __res == PTR_VOID_TRUE);                    \
 	}
 
 DECLARE_BLOCKING_TEST(write_slave, write_repeat(slave, 'a', 1),

--- a/test/initramfs/src/regression/fs/procfs/tid.c
+++ b/test/initramfs/src/regression/fs/procfs/tid.c
@@ -53,7 +53,7 @@ FN_TEST(proc_root_tid_entry)
 	/* Keep a non-leader thread alive while probing its procfs entry. */
 	TEST_SUCC(pipe(context.ready_pipe));
 	TEST_SUCC(pipe(context.exit_pipe));
-	TEST_SUCC(pthread_create(&thread, NULL, thread_fn, &context));
+	TEST_PTHREAD(pthread_create(&thread, NULL, thread_fn, &context));
 	TEST_RES(read(context.ready_pipe[0], &ch, 1),
 		 _ret == 1 && ch == 'R' && context.tid > 0 &&
 			 context.tid != pid);
@@ -80,7 +80,7 @@ FN_TEST(proc_root_tid_entry)
 
 	/* Release the thread after all /proc/<tid> observations are done. */
 	TEST_RES(write(context.exit_pipe[1], "X", 1), _ret == 1);
-	TEST_SUCC(pthread_join(thread, NULL));
+	TEST_PTHREAD(pthread_join(thread, NULL));
 	TEST_SUCC(close(context.ready_pipe[0]));
 	TEST_SUCC(close(context.ready_pipe[1]));
 	TEST_SUCC(close(context.exit_pipe[0]));

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -122,6 +122,7 @@ static int start_timed_semop_thread(pthread_t *thread,
 		return -1;
 	}
 
+	errno = 0;
 	return 0;
 }
 
@@ -135,6 +136,7 @@ static int join_timed_semop_thread(pthread_t thread,
 		return -1;
 	}
 
+	errno = 0;
 	return args->error;
 }
 

--- a/test/initramfs/src/regression/process/execve/execve_mt_parent.c
+++ b/test/initramfs/src/regression/process/execve/execve_mt_parent.c
@@ -103,9 +103,11 @@ FN_TEST(exec_in_main_thread)
 		struct info info = { .should_sleep = true };
 
 		pthread_t tid1;
-		CHECK(pthread_create(&tid1, NULL, &thread_slave, &info));
+		CHECK_PTHREAD(
+			pthread_create(&tid1, NULL, &thread_slave, &info));
 		pthread_t tid2;
-		CHECK(pthread_create(&tid2, NULL, &thread_slave, &info));
+		CHECK_PTHREAD(
+			pthread_create(&tid2, NULL, &thread_slave, &info));
 
 		exec_child();
 	}
@@ -126,10 +128,12 @@ FN_TEST(exec_in_slave_thread)
 
 		pthread_t tid1;
 		struct info info1 = { .should_sleep = true };
-		CHECK(pthread_create(&tid1, NULL, &thread_slave, &info1));
+		CHECK_PTHREAD(
+			pthread_create(&tid1, NULL, &thread_slave, &info1));
 		pthread_t tid2;
 		struct info info2 = { .should_sleep = false };
-		CHECK(pthread_create(&tid2, NULL, &thread_slave, &info2));
+		CHECK_PTHREAD(
+			pthread_create(&tid2, NULL, &thread_slave, &info2));
 
 		pthread_join(tid1, NULL);
 		pthread_join(tid2, NULL);
@@ -184,9 +188,11 @@ FN_TEST(clone_files)
 
 		struct info info = { .should_sleep = false };
 		pthread_t tid1;
-		CHECK(pthread_create(&tid1, NULL, &thread_slave, &info));
+		CHECK_PTHREAD(
+			pthread_create(&tid1, NULL, &thread_slave, &info));
 		pthread_t tid2;
-		CHECK(pthread_create(&tid2, NULL, &thread_slave, &info));
+		CHECK_PTHREAD(
+			pthread_create(&tid2, NULL, &thread_slave, &info));
 
 		pthread_join(tid1, NULL);
 		pthread_join(tid2, NULL);

--- a/test/initramfs/src/regression/process/exit/exit_code.c
+++ b/test/initramfs/src/regression/process/exit/exit_code.c
@@ -35,7 +35,7 @@ static void *thread_master(void *info_)
 	struct exit_info *info = info_;
 	pthread_t tid;
 
-	CHECK(pthread_create(&tid, NULL, &thread_slave, info));
+	CHECK_PTHREAD(pthread_create(&tid, NULL, &thread_slave, info));
 
 	if (!info->should_exit_master_first) {
 		if (info->should_use_exit_group)

--- a/test/initramfs/src/regression/process/exit/exit_procfs.c
+++ b/test/initramfs/src/regression/process/exit/exit_procfs.c
@@ -59,7 +59,7 @@ static void thread_master(void *arg)
 {
 	pthread_t tid;
 
-	CHECK(pthread_create(&tid, NULL, &thread_slave, arg));
+	CHECK_PTHREAD(pthread_create(&tid, NULL, &thread_slave, arg));
 
 	if (arg == EXIT_PARENT_FIRST) {
 		CHECK_WITH(
@@ -133,7 +133,8 @@ FN_TEST(task_status_reports_threads_for_non_leader)
 	char status_buf[2048];
 	int task_dir_fd, tid_dir_fd, status_fd;
 
-	TEST_SUCC(pthread_create(&pthread, NULL, status_thread_slave, &state));
+	TEST_PTHREAD(
+		pthread_create(&pthread, NULL, status_thread_slave, &state));
 	while (state.tid == 0) {
 		usleep(10 * 1000);
 	}
@@ -166,7 +167,7 @@ FN_TEST(task_status_reports_threads_for_non_leader)
 	TEST_SUCC(close(task_dir_fd));
 
 	state.should_exit = 1;
-	TEST_SUCC(pthread_join(pthread, NULL));
+	TEST_PTHREAD(pthread_join(pthread, NULL));
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/process/pthread/pthread_signal_test.c
+++ b/test/initramfs/src/regression/process/pthread/pthread_signal_test.c
@@ -9,7 +9,7 @@
 #include <stdatomic.h>
 
 pthread_mutex_t mutex;
-atomic_int sync_flag = ATOMIC_VAR_INIT(0); // Atomic flag for synchronization
+atomic_int sync_flag = 0;
 
 // Signal handler for SIGUSR1
 void signal_handler(int signum)

--- a/test/initramfs/src/regression/process/signal/kill.c
+++ b/test/initramfs/src/regression/process/signal/kill.c
@@ -79,7 +79,8 @@ FN_TEST(kill_dead_thread)
 	cpid = TEST_SUCC(fork());
 	if (cpid == 0) {
 		pthread_t tid;
-		CHECK(pthread_create(&tid, NULL, background_thread, NULL));
+		CHECK_PTHREAD(
+			pthread_create(&tid, NULL, background_thread, NULL));
 		syscall(SYS_exit, 0);
 	}
 	usleep(200 * 1000);

--- a/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
+++ b/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
@@ -210,10 +210,10 @@ FN_TEST(pidfd_send_signal_self_thread_group)
 
 	pid = TEST_SUCC(fork());
 	if (pid == 0) {
-		CHECK(pthread_create(&thread, NULL,
-				     &pidfd_send_signal_self_child_thread,
-				     NULL));
-		CHECK(pthread_join(thread, NULL));
+		CHECK_PTHREAD(pthread_create(
+			&thread, NULL, &pidfd_send_signal_self_child_thread,
+			NULL));
+		CHECK_PTHREAD(pthread_join(thread, NULL));
 
 		exit(0);
 	}
@@ -247,11 +247,11 @@ FN_TEST(pidfd_send_signal_self_process_group_non_main_thread)
 	if (pid == 0) {
 		CHECK(setpgid(0, 0));
 
-		CHECK(pthread_create(
+		CHECK_PTHREAD(pthread_create(
 			&thread, NULL,
 			pidfd_send_signal_self_process_group_child_thread,
 			NULL));
-		CHECK(pthread_join(thread, NULL));
+		CHECK_PTHREAD(pthread_join(thread, NULL));
 
 		exit(0);
 	}
@@ -296,7 +296,7 @@ FN_SETUP(create_thread)
 {
 	static char path[256];
 
-	CHECK(pthread_create(&thread, NULL, thread_func, NULL));
+	CHECK_PTHREAD(pthread_create(&thread, NULL, thread_func, NULL));
 
 	while (thread_tid == 0) {
 		usleep(100);
@@ -315,7 +315,7 @@ FN_TEST(pidfd_send_signal_thread)
 	TEST_ERRNO(pidfd_send_signal(proc_task_fd, sig, &siginfo, 0), EBADF);
 
 	TEST_SUCC(pidfd_send_signal(proc_fd, sig, &siginfo, 0));
-	TEST_SUCC(pthread_join(thread, NULL));
+	TEST_PTHREAD(pthread_join(thread, NULL));
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/process/signal/signal_fd.c
+++ b/test/initramfs/src/regression/process/signal/signal_fd.c
@@ -194,7 +194,7 @@ void *thread_func(void *arg)
 FN_TEST(tgkill_other_thread)
 {
 	pthread_t tid;
-	TEST_SUCC(pthread_create(&tid, NULL, thread_func, NULL));
+	TEST_PTHREAD(pthread_create(&tid, NULL, thread_func, NULL));
 	sleep(1);
 	struct signalfd_siginfo fdsi;
 	TEST_RES(read(sfd, &fdsi, sizeof(fdsi)),
@@ -232,7 +232,7 @@ FN_TEST(blocking_syscall_dequeue_ignored_signals)
 	TEST_SUCC(sigprocmask(SIG_SETMASK, &mask2, NULL));
 
 	pthread_t tid;
-	TEST_SUCC(pthread_create(&tid, NULL, thread_func2, (void *)pipefds));
+	TEST_PTHREAD(pthread_create(&tid, NULL, thread_func2, (void *)pipefds));
 
 	TEST_SUCC(signal(SIGUSR2, SIG_IGN));
 
@@ -252,7 +252,7 @@ FN_TEST(blocking_syscall_dequeue_ignored_signals)
 
 	char buf[1] = { 'a' };
 	TEST_RES(write(pipefds[1], buf, sizeof(buf)), _ret == 1);
-	TEST_SUCC(pthread_join(tid, NULL));
+	TEST_PTHREAD(pthread_join(tid, NULL));
 
 	TEST_SUCC(close(pipefds[0]));
 	TEST_SUCC(close(pipefds[1]));

--- a/test/initramfs/src/regression/process/signal/signal_test.c
+++ b/test/initramfs/src/regression/process/signal/signal_test.c
@@ -263,10 +263,11 @@ int test_handle_sigsegv()
 // ============================================================================
 // Test SIGCHLD signal
 // ============================================================================
-int sigchld = 0;
+static volatile sig_atomic_t sigchld = 0;
 
-void proc_exit()
+static void proc_exit(int signum)
 {
+	(void)signum;
 	sigchld = 1;
 }
 

--- a/test/initramfs/src/regression/process/wait4.c
+++ b/test/initramfs/src/regression/process/wait4.c
@@ -188,8 +188,8 @@ void child_process()
 {
 	pthread_t t1, t2;
 
-	CHECK(pthread_create(&t1, NULL, thread_func, NULL));
-	CHECK(pthread_create(&t2, NULL, thread_func, NULL));
+	CHECK_PTHREAD(pthread_create(&t1, NULL, thread_func, NULL));
+	CHECK_PTHREAD(pthread_create(&t2, NULL, thread_func, NULL));
 
 	pthread_join(t1, NULL);
 	pthread_join(t2, NULL);

--- a/test/initramfs/src/regression/security/capability/ambient.c
+++ b/test/initramfs/src/regression/security/capability/ambient.c
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <errno.h>
+#include <sys/prctl.h>
+#include <linux/capability.h>
+
+#include "../../common/test.h"
+
+#ifndef PR_CAP_AMBIENT
+#define PR_CAP_AMBIENT 47
+#endif
+
+#ifndef PR_CAP_AMBIENT_IS_SET
+#define PR_CAP_AMBIENT_IS_SET 1
+#endif
+
+#ifndef PR_CAP_AMBIENT_RAISE
+#define PR_CAP_AMBIENT_RAISE 2
+#endif
+
+#ifndef PR_CAP_AMBIENT_LOWER
+#define PR_CAP_AMBIENT_LOWER 3
+#endif
+
+#ifndef PR_CAP_AMBIENT_CLEAR_ALL
+#define PR_CAP_AMBIENT_CLEAR_ALL 4
+#endif
+
+FN_TEST(ambient_empty_set)
+{
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0));
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
+		       0),
+		 _ret == 0);
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER, CAP_SYS_ADMIN, 0,
+			0));
+}
+END_TEST()
+
+FN_TEST(ambient_unsupported_raise)
+{
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
+			 0),
+		   EPERM);
+}
+END_TEST()
+
+FN_TEST(ambient_rejects_invalid_args)
+{
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+			 CAP_LAST_CAP + 1, 0, 0),
+		   EINVAL);
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL,
+			 CAP_SYS_ADMIN, 0, 0),
+		   EINVAL);
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 1, 0),
+		   EINVAL);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/namespace/cgroup_ns.c
+++ b/test/initramfs/src/regression/security/namespace/cgroup_ns.c
@@ -201,10 +201,10 @@ static void *unshare_cgroup_ns_thread(void *arg)
 
 	probe->tid = CHECK(syscall(SYS_gettid));
 	CHECK(unshare(CLONE_NEWCGROUP));
-	CHECK_WITH(pthread_barrier_wait(&probe->ready),
-		   _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
-	CHECK_WITH(pthread_barrier_wait(&probe->release),
-		   _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	CHECK_PTHREAD_WITH(pthread_barrier_wait(&probe->ready),
+			   _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	CHECK_PTHREAD_WITH(pthread_barrier_wait(&probe->release),
+			   _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
 
 	return NULL;
 }
@@ -235,24 +235,26 @@ FN_TEST(cgroup_namespace_stays_thread_local)
 
 	TEST_SUCC(read_self_cgroup_ns_inode(&main_before));
 
-	TEST_RES(pthread_barrier_init(&probe.ready, NULL, 2), _ret == 0);
-	TEST_RES(pthread_barrier_init(&probe.release, NULL, 2), _ret == 0);
-	TEST_RES(pthread_create(&thread, NULL, unshare_cgroup_ns_thread,
-				&probe),
-		 _ret == 0);
+	TEST_PTHREAD_RES(pthread_barrier_init(&probe.ready, NULL, 2),
+			 _ret == 0);
+	TEST_PTHREAD_RES(pthread_barrier_init(&probe.release, NULL, 2),
+			 _ret == 0);
+	TEST_PTHREAD_RES(pthread_create(&thread, NULL, unshare_cgroup_ns_thread,
+					&probe),
+			 _ret == 0);
 
-	TEST_RES(pthread_barrier_wait(&probe.ready),
-		 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	TEST_PTHREAD_RES(pthread_barrier_wait(&probe.ready),
+			 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
 	TEST_RES(read_self_cgroup_ns_inode(&main_after),
 		 main_before == main_after);
 	TEST_RES(read_task_cgroup_ns_inode(probe.tid, &worker_ns),
 		 worker_ns != main_after);
-	TEST_RES(pthread_barrier_wait(&probe.release),
-		 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	TEST_PTHREAD_RES(pthread_barrier_wait(&probe.release),
+			 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
 
-	TEST_RES(pthread_join(thread, NULL), _ret == 0);
-	TEST_RES(pthread_barrier_destroy(&probe.ready), _ret == 0);
-	TEST_RES(pthread_barrier_destroy(&probe.release), _ret == 0);
+	TEST_PTHREAD_RES(pthread_join(thread, NULL), _ret == 0);
+	TEST_PTHREAD_RES(pthread_barrier_destroy(&probe.ready), _ret == 0);
+	TEST_PTHREAD_RES(pthread_barrier_destroy(&probe.release), _ret == 0);
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/security/namespace/unshare.c
+++ b/test/initramfs/src/regression/security/namespace/unshare.c
@@ -37,13 +37,13 @@ FN_TEST(single_thread_flags)
 	TEST_SUCC(unshare(CLONE_VM | CLONE_SIGHAND | CLONE_THREAD));
 
 	pthread_t thread_id;
-	TEST_SUCC(pthread_create(&thread_id, NULL, sleep_1s_thread, NULL));
+	TEST_PTHREAD(pthread_create(&thread_id, NULL, sleep_1s_thread, NULL));
 
 	TEST_ERRNO(unshare(CLONE_VM), EINVAL);
 	TEST_ERRNO(unshare(CLONE_SIGHAND), EINVAL);
 	TEST_ERRNO(unshare(CLONE_THREAD), EINVAL);
 
-	TEST_SUCC(pthread_join(thread_id, NULL));
+	TEST_PTHREAD(pthread_join(thread_id, NULL));
 
 	TEST_SUCC(unshare(CLONE_VM));
 	TEST_SUCC(unshare(CLONE_SIGHAND));
@@ -88,9 +88,9 @@ FN_TEST(unshare_files)
 		open(TEST_FILENAME, O_CREAT | O_RDWR | O_TRUNC, 0644));
 	TEST_SUCC(fstat(test_fd, &stat1));
 
-	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_files_thread,
-				 (void *)(intptr_t)test_fd));
-	TEST_SUCC(pthread_join(thread_id, NULL));
+	TEST_PTHREAD(pthread_create(&thread_id, NULL, unshare_files_thread,
+				    (void *)(intptr_t)test_fd));
+	TEST_PTHREAD(pthread_join(thread_id, NULL));
 
 	TEST_RES(fstat(test_fd, &stat2), stat1.st_ino == stat2.st_ino);
 	TEST_SUCC(close(test_fd));
@@ -119,11 +119,11 @@ FN_TEST(unshare_fs)
 	TEST_RES(getcwd(cwd_buf1, CWD_BUF_SIZE),
 		 strcmp(cwd_buf1, THREAD_CWD) != 0);
 
-	TEST_SUCC(pthread_create(&thread_id, NULL, unshare_fs_thread,
-				 (void *)cwd_buf2));
+	TEST_PTHREAD(pthread_create(&thread_id, NULL, unshare_fs_thread,
+				    (void *)cwd_buf2));
 
-	TEST_RES(pthread_join(thread_id, NULL),
-		 strcmp(cwd_buf2, THREAD_CWD) == 0);
+	TEST_PTHREAD_RES(pthread_join(thread_id, NULL),
+			 strcmp(cwd_buf2, THREAD_CWD) == 0);
 
 	TEST_RES(getcwd(cwd_buf2, CWD_BUF_SIZE),
 		 strcmp(cwd_buf1, cwd_buf2) == 0);

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -5,6 +5,7 @@
 set -e
 
 ./capability/capabilities
+./capability/ambient
 ./capability/capset
 ./capability/execve
 ./capability/kill

--- a/tools/docker/nix/Dockerfile
+++ b/tools/docker/nix/Dockerfile
@@ -9,12 +9,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Nix package manager and other Nix tools
 #
-# The nixpkgs and nixos channels are pinned to a particular commit (NixOS 25.05, 2025-07-01) for reproducibility.
+# The nixpkgs and nixos channels are pinned to a particular NixOS 26.05 commit for reproducibility.
 # FIXME: Installing Nix as root is not supported in single-user mode.
 RUN sh <(curl -L https://nixos.org/nix/install) --daemon --yes \
     && . /etc/profile.d/nix.sh \
-    && nix-channel --add https://github.com/NixOS/nixpkgs/archive/c0bebd16e69e631ac6e52d6eb439daba28ac50cd.tar.gz nixpkgs \
-    && nix-channel --add https://github.com/NixOS/nixpkgs/archive/c0bebd16e69e631ac6e52d6eb439daba28ac50cd.tar.gz nixos \
+    && nix-channel --add https://github.com/NixOS/nixpkgs/archive/4062d36ebeae843c750011eef6b61ec9a9dbc9a9.tar.gz nixpkgs \
+    && nix-channel --add https://github.com/NixOS/nixpkgs/archive/4062d36ebeae843c750011eef6b61ec9a9dbc9a9.tar.gz nixos \
     && nix-channel --update \
     && nix-env -iA nixpkgs.nixfmt \
     && nix-env -iA nixpkgs.nixos-install-tools \

--- a/tools/nixos/run.sh
+++ b/tools/nixos/run.sh
@@ -46,7 +46,7 @@ case "$MODE" in
         ;;
     iso)
         ASTER_IMAGE_PATH=${ASTERINAS_DIR}/target/nixos/asterinas.img
-        NIXOS_DISK_SIZE_IN_MB=${NIXOS_DISK_SIZE_IN_MB:-8192}
+        NIXOS_DISK_SIZE_IN_MB=${NIXOS_DISK_SIZE_IN_MB:-12288}
         ISO_IMAGE_PATH=$(find "${ASTERINAS_DIR}/target/nixos/iso_image/iso" -name "*.iso" | head -n 1)
 
         if [ ! -f "$ISO_IMAGE_PATH" ]; then


### PR DESCRIPTION
This PR upgrades the NixOS distro configuration from 25.05 to 26.05, enabling modern systemd configurations in QEMU. To make NixOS 26.05 bootable and support console logins, this PR implements several required kernel features and ports runtime configurations.

## Key Changes:
1. **Implement new mount API**:
   - Introduces modern Linux mount system calls (`fsopen`, `fsconfig`, `fsmount`, `move_mount`) in the VFS layer.
   - Allows configuring and mounting filesystems in discrete, transactional steps, which is required by newer systemd and container managers.
2. **Support mount propagation type changes**:
   - Parses mount propagation flags (`MS_SHARED`, `MS_SLAVE`, `MS_UNBINDABLE`, `MS_PRIVATE`, `MS_REC`) in the `mount` syscall.
   - Implements VFS layer placeholders to support changing mount propagation types, preventing systemd boot failures during root-mount propagation setup.
3. **Support TTY ioctls for systemd getty**:
   - Implements terminal ioctls (`TCGETS2`/`TCSETS2`) and `CTermios2` struct support in the TTY layer.
   - Required by systemd getty to initialize terminal console settings on `/dev/hvc0`.
4. **Add minimal PR_CAP_AMBIENT support**:
   - Implements minimal support for ambient capabilities (`PR_CAP_AMBIENT`), allowing processes to retain capabilities across `execve`.
   - Prevents systemd from hanging during early initialization due to missing capability support.
5. **Bump NixOS distro to 26.05**:
   - Upgrades pinned NixOS pkgs to 26.05.
   - Configuration changes to launch `getty@hvc0.service` for automatic login on console, bypassing desktop configurations.
   - Imports required upstream systemd backports (`Fallback-from-pidfd_spawn-to-posix_spawn.patch`, etc.).