### PR TITLE
Fix syncfs with O_PATH fd

### DIFF
--- a/kernel/src/syscall/sync.rs
+++ b/kernel/src/syscall/sync.rs
@@ -2,7 +2,10 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        StatusFlags,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
 };
 
@@ -18,6 +21,9 @@ pub fn sys_syncfs(raw_fd: RawFileDesc, ctx: &Context) -> Result<SyscallReturn> {
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
+    if file.status_flags().contains(StatusFlags::O_PATH) {
+        return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
+    }
     file.path().fs().sync()?;
     Ok(SyscallReturn::Return(0))
 }

--- a/test/initramfs/src/conformance/gvisor/blocklists/sync_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/sync_test
@@ -1,4 +1,0 @@
-SyncTest.CannotSyncFileSystemAtOpathFD
-SyncTest.CannotSyncFileSytemAtBadFd
-SyncTest.SyncFileSytem
-SyncTest.SyncFromPipe

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -12,6 +12,7 @@ SUBDIRS := \
 	pseudofs \
 	statx \
 	symlink \
+	sync \
 	tmpfile \
 	utimensat \
 

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -147,6 +147,8 @@ echo "All mount bind file test passed."
 
 ./symlink/symlink
 
+./sync/sync
+
 ./tmpfile/tmpfile
 
 ./utimensat/utimensat

--- a/test/initramfs/src/regression/fs/sync/Makefile
+++ b/test/initramfs/src/regression/fs/sync/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/sync/sync.c
+++ b/test/initramfs/src/regression/fs/sync/sync.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define TEST_FILE "/tmp/syncfs_test_file"
+
+FN_TEST(syncfs_file)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_CREAT | O_RDWR | O_TRUNC, 0600));
+
+	TEST_SUCC(syncfs(fd));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(TEST_FILE));
+}
+END_TEST()
+
+FN_TEST(syncfs_pipe)
+{
+	int fds[2];
+
+	TEST_SUCC(pipe(fds));
+	TEST_SUCC(syncfs(fds[0]));
+	TEST_SUCC(syncfs(fds[1]));
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()
+
+FN_TEST(syncfs_bad_fd)
+{
+	TEST_ERRNO(syncfs(-1), EBADF);
+}
+END_TEST()
+
+FN_TEST(syncfs_opath_fd)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_CREAT | O_RDWR | O_TRUNC, 0600));
+	TEST_SUCC(close(fd));
+
+	fd = TEST_SUCC(open(TEST_FILE, O_PATH));
+	TEST_ERRNO(syncfs(fd), EBADF);
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(TEST_FILE));
+}
+END_TEST()


### PR DESCRIPTION
## Summary

Fix `syncfs()` to return `EBADF` when called with an `O_PATH` file descriptor.

## Changes

- Reject `O_PATH` file descriptors in `syncfs()`.
- Add regression for `syncfs()` on regular files, pipes, bad fds, and `O_PATH` fds.
- Unblock the fixed gVisor `sync_test` cases.

## Testing

- `make check`

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  All conformance tests passed.
  ```