### PR TITLE
Implement fsopen, fsconfig, fsmount, and move_mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ EXTRA_BLOCKLISTS ?= ""
 # Parameters for xfstests.
 XFSTESTS_RUNLIST ?= /opt/xfstests/short.list
 XFSTESTS_DISK_SIZE ?= 12G
-XFSTESTS_TEST_DEV ?= /dev/vdc
-XFSTESTS_SCRATCH_DEV ?= /dev/vdd
+XFSTESTS_TEST_DEV ?= /dev/vdd
+XFSTESTS_SCRATCH_DEV ?= /dev/vde
 # Specify whether to build regression tests under `test/initramfs/src/regression`.
 ENABLE_REGRESSION_TEST ?= false
 # End of auto test features.

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -345,6 +345,7 @@ which are summarized in the table below.
 | 332     | statx                  | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#statx) |
 | 424     | pidfd_send_signal      | ✅             | 💯 |
 | 430     | fsopen                 | ✅             | 💯 |
+| 431     | fsconfig               | ✅             | [⚠️](syscall-flag-coverage/file-systems-and-mount-control/#fsconfig) |
 | 434     | pidfd_open             | ✅             | 💯 |
 | 435     | clone3                 | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#clone-and-clone3) |
 | 436     | close_range            | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -344,6 +344,7 @@ which are summarized in the table below.
 | 328     | pwritev2               | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#preadv2-and-pwritev2) |
 | 332     | statx                  | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#statx) |
 | 424     | pidfd_send_signal      | ✅             | 💯 |
+| 430     | fsopen                 | ✅             | 💯 |
 | 434     | pidfd_open             | ✅             | 💯 |
 | 435     | clone3                 | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#clone-and-clone3) |
 | 436     | close_range            | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -346,6 +346,7 @@ which are summarized in the table below.
 | 424     | pidfd_send_signal      | ✅             | 💯 |
 | 430     | fsopen                 | ✅             | 💯 |
 | 431     | fsconfig               | ✅             | [⚠️](syscall-flag-coverage/file-systems-and-mount-control/#fsconfig) |
+| 432     | fsmount                | ✅             | [⚠️](syscall-flag-coverage/file-systems-and-mount-control/#fsmount) |
 | 434     | pidfd_open             | ✅             | 💯 |
 | 435     | clone3                 | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#clone-and-clone3) |
 | 436     | close_range            | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -344,6 +344,7 @@ which are summarized in the table below.
 | 328     | pwritev2               | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#preadv2-and-pwritev2) |
 | 332     | statx                  | ✅             | [⚠️](syscall-flag-coverage/file-and-directory-operations/#statx) |
 | 424     | pidfd_send_signal      | ✅             | 💯 |
+| 429     | move_mount             | ✅             | [⚠️](syscall-flag-coverage/file-systems-and-mount-control/#move_mount) |
 | 430     | fsopen                 | ✅             | 💯 |
 | 431     | fsconfig               | ✅             | [⚠️](syscall-flag-coverage/file-systems-and-mount-control/#fsconfig) |
 | 432     | fsmount                | ✅             | [⚠️](syscall-flag-coverage/file-systems-and-mount-control/#fsmount) |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
@@ -80,6 +80,23 @@ Unsupported commands:
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/fsconfig.2.html).
 
+### `fsmount`
+
+Supported functionality in SCML:
+
+```c
+{{#include fsmount.scml}}
+```
+
+Silently-ignored mount attributes:
+* `MOUNT_ATTR_NOATIME`
+* `MOUNT_ATTR_NODIRATIME`
+* `MOUNT_ATTR_RELATIME`
+* `MOUNT_ATTR_STRICTATIME`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/fsmount.2.html).
+
 ## Event notifications
 
 ### `inotify_init` and `inotify_init1`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
@@ -60,6 +60,8 @@ Silently-ignored flags:
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/umount.2.html).
 
+## New mount API
+
 ## Event notifications
 
 ### `inotify_init` and `inotify_init1`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
@@ -97,6 +97,26 @@ Silently-ignored mount attributes:
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/fsmount.2.html).
 
+### `move_mount`
+
+Supported functionality in SCML:
+
+```c
+{{#include move_mount.scml}}
+```
+
+Unsupported flags:
+* `MOVE_MOUNT_F_SYMLINKS`
+* `MOVE_MOUNT_F_AUTOMOUNTS`
+* `MOVE_MOUNT_T_SYMLINKS`
+* `MOVE_MOUNT_T_AUTOMOUNTS`
+* `MOVE_MOUNT_T_EMPTY_PATH`
+* `MOVE_MOUNT_SET_GROUP`
+* `MOVE_MOUNT_BENEATH`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/move_mount.2.html).
+
 ## Event notifications
 
 ### `inotify_init` and `inotify_init1`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/README.md
@@ -62,6 +62,24 @@ see [the man page](https://man7.org/linux/man-pages/man2/umount.2.html).
 
 ## New mount API
 
+### `fsconfig`
+
+Supported functionality in SCML:
+
+```c
+{{#include fsconfig.scml}}
+```
+
+Unsupported commands:
+* `FSCONFIG_SET_BINARY`
+* `FSCONFIG_SET_PATH`
+* `FSCONFIG_SET_PATH_EMPTY`
+* `FSCONFIG_SET_FD`
+* `FSCONFIG_CMD_CREATE_EXCL`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/fsconfig.2.html).
+
 ## Event notifications
 
 ### `inotify_init` and `inotify_init1`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fsconfig.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fsconfig.scml
@@ -1,0 +1,7 @@
+// Configure a filesystem context
+fsconfig(
+    fs_fd,
+    cmd = FSCONFIG_SET_FLAG | FSCONFIG_SET_STRING |
+          FSCONFIG_CMD_CREATE | FSCONFIG_CMD_RECONFIGURE,
+    key, value, aux
+);

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fsmount.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fsmount.scml
@@ -1,0 +1,7 @@
+mount_attrs = MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV |
+              MOUNT_ATTR_NOEXEC | MOUNT_ATTR_RELATIME | MOUNT_ATTR_NOATIME |
+              MOUNT_ATTR_STRICTATIME | MOUNT_ATTR_NODIRATIME |
+              MOUNT_ATTR_NOSYMFOLLOW;
+
+// Create a mount object from a filesystem context
+fsmount(fs_fd, flags = FSMOUNT_CLOEXEC, mount_attrs = <mount_attrs>);

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/fully_covered.scml
@@ -12,6 +12,9 @@ syncfs(fd);
 // Change root directory
 chroot(path);
 
+// Open a filesystem context
+fsopen(fs_name, flags = FSOPEN_CLOEXEC);
+
 // Remove a watch from an inotify instance
 inotify_rm_watch(fd, wd);
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/move_mount.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-systems-and-mount-control/move_mount.scml
@@ -1,0 +1,2 @@
+// Move or attach a mount object to the filesystem
+move_mount(from_dfd, from_path, to_dfd, to_path, flags = MOVE_MOUNT_F_EMPTY_PATH);

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -269,7 +269,6 @@ impl DetachedMountFile {
     }
 
     /// Returns the detached mount.
-    #[expect(dead_code)]
     pub fn mount(&self) -> Arc<Mount> {
         self.mount.clone()
     }

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -2,13 +2,17 @@
 
 use core::fmt::Display;
 
-use super::{AccessMode, CreationFlags, FileLike};
+use super::{AccessMode, CreationFlags, FileLike, InodeMode};
 use crate::{
     events::IoEvents,
     fs::{
         file::file_table::FdFlags,
         pseudofs::AnonInodeFs,
-        vfs::{path::Path, registry::FsType},
+        vfs::{
+            file_system::{FileSystem, FsFlags},
+            path::Path,
+            registry::{FsCreationCtx, FsType},
+        },
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -20,15 +24,126 @@ use crate::{
 /// filesystem is created. Once creation succeeds, further configuration is
 /// rejected unless it is an explicit reconfiguration request.
 pub struct FsConfigFile {
+    context: Mutex<FsConfigContext>,
     pseudo_path: Path,
+}
+
+/// Stores the mutable state of a filesystem configuration context.
+struct FsConfigContext {
+    fs_type: &'static dyn FsType,
+    fs_flags: FsFlags,
+    source: Option<String>,
+    mode: Option<InodeMode>,
+    fs: Option<Arc<dyn FileSystem>>,
+    /// Accumulates filesystem-specific mount options as a comma-separated
+    /// string, so they can be forwarded to `FsCreationCtx`.
+    extra_options: String,
 }
 
 impl FsConfigFile {
     /// Creates a filesystem configuration file for a filesystem type.
-    pub fn new(_fs_type: &'static dyn FsType) -> Self {
+    pub fn new(fs_type: &'static dyn FsType) -> Self {
         Self {
+            context: Mutex::new(FsConfigContext {
+                fs_type,
+                fs_flags: FsFlags::empty(),
+                source: None,
+                mode: None,
+                fs: None,
+                extra_options: String::new(),
+            }),
             pseudo_path: AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string()),
         }
+    }
+
+    /// Sets a boolean filesystem configuration option.
+    pub fn set_flag(&self, key: &str) -> Result<()> {
+        let mut context = self.context.lock();
+        if context.fs.is_some() {
+            return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
+        }
+        match key {
+            "ro" => {
+                context.fs_flags |= FsFlags::RDONLY;
+                Ok(())
+            }
+            _ => {
+                append_option(&mut context.extra_options, key, None);
+                Ok(())
+            }
+        }
+    }
+
+    /// Sets a string filesystem configuration option.
+    pub fn set_string(&self, key: &str, value: &str) -> Result<()> {
+        let mut context = self.context.lock();
+        if context.fs.is_some() {
+            return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
+        }
+        match key {
+            "source" => {
+                if context.source.is_some() {
+                    return_errno_with_message!(Errno::EINVAL, "the source is already specified");
+                }
+                context.source = Some(value.to_string());
+                Ok(())
+            }
+            "mode" => {
+                context.mode = Some(parse_octal_mode(value)?);
+                Ok(())
+            }
+            _ => {
+                append_option(&mut context.extra_options, key, Some(value));
+                Ok(())
+            }
+        }
+    }
+
+    /// Creates the configured filesystem.
+    pub fn create_fs(&self, ctx: &Context) -> Result<()> {
+        let mut context = self.context.lock();
+        if context.fs.is_some() {
+            return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
+        }
+
+        let args_cstr = if context.extra_options.is_empty() {
+            None
+        } else {
+            Some(CString::new(context.extra_options.as_str()).map_err(|_| {
+                Error::with_message(Errno::EINVAL, "mount options contain null byte")
+            })?)
+        };
+        let args_ref = args_cstr.as_deref();
+        let fs_creation_ctx =
+            FsCreationCtx::new(context.source.as_deref(), context.fs_flags, args_ref, ctx);
+        let fs = context.fs_type.create(&fs_creation_ctx)?;
+        if Arc::strong_count(&fs) > 1 {
+            let extant_readonly = fs.flags().contains(FsFlags::RDONLY);
+            let context_readonly = context.fs_flags.contains(FsFlags::RDONLY);
+            if extant_readonly != context_readonly {
+                return_errno_with_message!(
+                    Errno::EBUSY,
+                    "the read-only flag of the extant filesystem does not match"
+                );
+            }
+        } else {
+            if let Some(mode) = context.mode {
+                fs.root_inode().set_mode(mode)?;
+            }
+        }
+        context.fs = Some(fs);
+        Ok(())
+    }
+
+    /// Reconfigures the created filesystem with the current flags.
+    pub fn reconfigure_fs(&self, ctx: &Context) -> Result<()> {
+        let context = self.context.lock();
+        let fs = context
+            .fs
+            .as_ref()
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file system is not created"))?;
+
+        fs.set_fs_flags(context.fs_flags, None, ctx)
     }
 }
 
@@ -71,5 +186,27 @@ impl Display for MountApiFdInfo {
         writeln!(f, "flags:\t0{:o}", flags)?;
         writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
         writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())
+    }
+}
+
+fn parse_octal_mode(value: &str) -> Result<InodeMode> {
+    const MAX_MODE_BITS: u16 = 0o7777;
+
+    let mode = u16::from_str_radix(value, 8)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid octal mode"))?;
+    if mode & !MAX_MODE_BITS != 0 {
+        return_errno_with_message!(Errno::EINVAL, "invalid mode bits");
+    }
+    Ok(InodeMode::from_bits_truncate(mode))
+}
+
+fn append_option(options: &mut String, key: &str, value: Option<&str>) {
+    if !options.is_empty() {
+        options.push(',');
+    }
+    options.push_str(key);
+    if let Some(value) = value {
+        options.push('=');
+        options.push_str(value);
     }
 }

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -221,6 +221,7 @@ impl Pollable for FsConfigFile {
 
 impl FileLike for FsConfigFile {
     fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/fsopen.c#L97>.
         AccessMode::O_RDWR
     }
 
@@ -282,6 +283,7 @@ impl Pollable for DetachedMountFile {
 
 impl FileLike for DetachedMountFile {
     fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/namespace.c#L4497>.
         AccessMode::O_RDONLY
     }
 

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::fmt::Display;
+
+use super::{AccessMode, CreationFlags, FileLike};
+use crate::{
+    events::IoEvents,
+    fs::{
+        file::file_table::FdFlags,
+        pseudofs::AnonInodeFs,
+        vfs::{path::Path, registry::FsType},
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+};
+
+/// Represents a filesystem configuration context opened by `fsopen`.
+///
+/// The file stores configuration supplied through `fsconfig` until the
+/// filesystem is created. Once creation succeeds, further configuration is
+/// rejected unless it is an explicit reconfiguration request.
+pub struct FsConfigFile {
+    pseudo_path: Path,
+}
+
+impl FsConfigFile {
+    /// Creates a filesystem configuration file for a filesystem type.
+    pub fn new(_fs_type: &'static dyn FsType) -> Self {
+        Self {
+            pseudo_path: AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string()),
+        }
+    }
+}
+
+impl Pollable for FsConfigFile {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
+impl FileLike for FsConfigFile {
+    fn access_mode(&self) -> AccessMode {
+        AccessMode::O_RDWR
+    }
+
+    fn path(&self) -> &Path {
+        &self.pseudo_path
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
+        Box::new(MountApiFdInfo {
+            access_mode: self.access_mode(),
+            fd_flags,
+        })
+    }
+}
+
+struct MountApiFdInfo {
+    access_mode: AccessMode,
+    fd_flags: FdFlags,
+}
+
+impl Display for MountApiFdInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut flags = self.access_mode as u32;
+        if self.fd_flags.contains(FdFlags::CLOEXEC) {
+            flags |= CreationFlags::O_CLOEXEC.bits();
+        }
+
+        writeln!(f, "pos:\t{}", 0)?;
+        writeln!(f, "flags:\t0{:o}", flags)?;
+        writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
+        writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())
+    }
+}

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -10,7 +10,7 @@ use crate::{
         pseudofs::AnonInodeFs,
         vfs::{
             file_system::{FileSystem, FsFlags},
-            path::Path,
+            path::{Mount, MountNamespace, Path, PerMountFlags},
             registry::{FsCreationCtx, FsType},
         },
     },
@@ -24,102 +24,123 @@ use crate::{
 /// filesystem is created. Once creation succeeds, further configuration is
 /// rejected unless it is an explicit reconfiguration request.
 pub struct FsConfigFile {
-    context: Mutex<FsConfigContext>,
+    fs_type: &'static dyn FsType,
+    state: Mutex<FsConfigState>,
     pseudo_path: Path,
 }
 
-/// Stores the mutable state of a filesystem configuration context.
-struct FsConfigContext {
-    fs_type: &'static dyn FsType,
-    fs_flags: FsFlags,
+enum FsConfigState {
+    Configuring(FsCreationConfig),
+    Created(Option<CreatedFs>),
+}
+
+struct FsCreationConfig {
+    flags: FsFlags,
     source: Option<String>,
     mode: Option<InodeMode>,
-    fs: Option<Arc<dyn FileSystem>>,
     /// Accumulates filesystem-specific mount options as a comma-separated
     /// string, so they can be forwarded to `FsCreationCtx`.
     extra_options: String,
+}
+
+struct CreatedFs {
+    fs: Arc<dyn FileSystem>,
+    flags: FsFlags,
+    source: Option<String>,
 }
 
 impl FsConfigFile {
     /// Creates a filesystem configuration file for a filesystem type.
     pub fn new(fs_type: &'static dyn FsType) -> Self {
         Self {
-            context: Mutex::new(FsConfigContext {
-                fs_type,
-                fs_flags: FsFlags::empty(),
+            fs_type,
+            state: Mutex::new(FsConfigState::Configuring(FsCreationConfig {
+                flags: FsFlags::empty(),
                 source: None,
                 mode: None,
-                fs: None,
                 extra_options: String::new(),
-            }),
+            })),
             pseudo_path: AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string()),
         }
     }
 
-    /// Sets a boolean filesystem configuration option.
+    /// Sets a flag-style filesystem configuration option.
+    ///
+    /// This is only valid while the context is still configuring the filesystem.
+    /// It returns `EBUSY` after the filesystem has been created.
     pub fn set_flag(&self, key: &str) -> Result<()> {
-        let mut context = self.context.lock();
-        if context.fs.is_some() {
+        let mut state = self.state.lock();
+        let FsConfigState::Configuring(config) = &mut *state else {
             return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
-        }
+        };
+
         match key {
             "ro" => {
-                context.fs_flags |= FsFlags::RDONLY;
+                config.flags |= FsFlags::RDONLY;
                 Ok(())
             }
             _ => {
-                append_option(&mut context.extra_options, key, None);
+                append_option(&mut config.extra_options, key, None);
                 Ok(())
             }
         }
     }
 
     /// Sets a string filesystem configuration option.
+    ///
+    /// This is only valid while the context is still configuring the filesystem.
+    /// It returns `EBUSY` after the filesystem has been created. The `source`
+    /// option may only be specified once.
     pub fn set_string(&self, key: &str, value: &str) -> Result<()> {
-        let mut context = self.context.lock();
-        if context.fs.is_some() {
+        let mut state = self.state.lock();
+        let FsConfigState::Configuring(config) = &mut *state else {
             return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
-        }
+        };
+
         match key {
             "source" => {
-                if context.source.is_some() {
+                if config.source.is_some() {
                     return_errno_with_message!(Errno::EINVAL, "the source is already specified");
                 }
-                context.source = Some(value.to_string());
+                config.source = Some(value.to_string());
                 Ok(())
             }
             "mode" => {
-                context.mode = Some(parse_octal_mode(value)?);
+                config.mode = Some(parse_octal_mode(value)?);
                 Ok(())
             }
             _ => {
-                append_option(&mut context.extra_options, key, Some(value));
+                append_option(&mut config.extra_options, key, Some(value));
                 Ok(())
             }
         }
     }
 
     /// Creates the configured filesystem.
+    ///
+    /// This consumes the current creation configuration and moves the context
+    /// into the created state. It returns `EBUSY` if the filesystem has already
+    /// been created.
     pub fn create_fs(&self, ctx: &Context) -> Result<()> {
-        let mut context = self.context.lock();
-        if context.fs.is_some() {
+        let mut state = self.state.lock();
+        let FsConfigState::Configuring(config) = &mut *state else {
             return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
-        }
+        };
 
-        let args_cstr = if context.extra_options.is_empty() {
+        let args_cstr = if config.extra_options.is_empty() {
             None
         } else {
-            Some(CString::new(context.extra_options.as_str()).map_err(|_| {
+            Some(CString::new(config.extra_options.as_str()).map_err(|_| {
                 Error::with_message(Errno::EINVAL, "mount options contain null byte")
             })?)
         };
         let args_ref = args_cstr.as_deref();
         let fs_creation_ctx =
-            FsCreationCtx::new(context.source.as_deref(), context.fs_flags, args_ref, ctx);
-        let fs = context.fs_type.create(&fs_creation_ctx)?;
+            FsCreationCtx::new(config.source.as_deref(), config.flags, args_ref, ctx);
+        let fs = self.fs_type.create(&fs_creation_ctx)?;
         if Arc::strong_count(&fs) > 1 {
             let extant_readonly = fs.flags().contains(FsFlags::RDONLY);
-            let context_readonly = context.fs_flags.contains(FsFlags::RDONLY);
+            let context_readonly = config.flags.contains(FsFlags::RDONLY);
             if extant_readonly != context_readonly {
                 return_errno_with_message!(
                     Errno::EBUSY,
@@ -127,23 +148,68 @@ impl FsConfigFile {
                 );
             }
         } else {
-            if let Some(mode) = context.mode {
+            if let Some(mode) = config.mode {
                 fs.root_inode().set_mode(mode)?;
             }
         }
-        context.fs = Some(fs);
+        let flags = config.flags;
+        let source = config.source.clone();
+        *state = FsConfigState::Created(Some(CreatedFs { fs, flags, source }));
         Ok(())
     }
 
     /// Reconfigures the created filesystem with the current flags.
+    ///
+    /// This is only valid after the filesystem has been created and before it
+    /// has been consumed by `create_detached_mount`. It returns `EINVAL` if the
+    /// filesystem has not been created yet, and `EBUSY` if it has already been
+    /// consumed.
     pub fn reconfigure_fs(&self, ctx: &Context) -> Result<()> {
-        let context = self.context.lock();
-        let fs = context
-            .fs
-            .as_ref()
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file system is not created"))?;
+        let state = self.state.lock();
+        let (fs, flags) = match &*state {
+            FsConfigState::Created(Some(created)) => (&created.fs, created.flags),
+            FsConfigState::Created(None) => {
+                return_errno_with_message!(
+                    Errno::EBUSY,
+                    "the file system has already been mounted"
+                );
+            }
+            FsConfigState::Configuring(_) => {
+                return_errno_with_message!(Errno::EINVAL, "the file system is not created");
+            }
+        };
 
-        fs.set_fs_flags(context.fs_flags, None, ctx)
+        fs.set_fs_flags(flags, None, ctx)
+    }
+
+    /// Creates a detached mount from the created filesystem.
+    ///
+    /// This is only valid after `create_fs` has succeeded and before a
+    /// detached mount has already been created from this file. On success, the
+    /// filesystem is consumed and subsequent calls return `EBUSY`. On failure,
+    /// the filesystem remains available for a later `fsmount`.
+    pub fn create_detached_mount(
+        &self,
+        flags: PerMountFlags,
+        mnt_ns: Weak<MountNamespace>,
+    ) -> Result<Arc<Mount>> {
+        let mut state = self.state.lock();
+        let FsConfigState::Created(created) = &mut *state else {
+            return_errno_with_message!(Errno::EINVAL, "the file system is not created");
+        };
+        let Some(created_fs) = created.as_ref() else {
+            return_errno_with_message!(Errno::EBUSY, "the file system has already been mounted");
+        };
+
+        let detached_mount = Mount::new_detached(
+            created_fs.fs.clone(),
+            flags,
+            mnt_ns,
+            created_fs.source.clone(),
+        )?;
+        *created = None;
+
+        Ok(detached_mount)
     }
 }
 
@@ -163,29 +229,91 @@ impl FileLike for FsConfigFile {
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
-        Box::new(MountApiFdInfo {
+        struct FdInfo {
+            access_mode: AccessMode,
+            fd_flags: FdFlags,
+        }
+
+        impl Display for FdInfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let mut flags = self.access_mode as u32;
+                if self.fd_flags.contains(FdFlags::CLOEXEC) {
+                    flags |= CreationFlags::O_CLOEXEC.bits();
+                }
+
+                writeln!(f, "pos:\t{}", 0)?;
+                writeln!(f, "flags:\t0{:o}", flags)?;
+                writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
+                writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())
+            }
+        }
+
+        Box::new(FdInfo {
             access_mode: self.access_mode(),
             fd_flags,
         })
     }
 }
 
-struct MountApiFdInfo {
-    access_mode: AccessMode,
-    fd_flags: FdFlags,
+/// Represents a detached mount returned by `fsmount`.
+pub struct DetachedMountFile {
+    mount: Arc<Mount>,
+    root_path: Path,
 }
 
-impl Display for MountApiFdInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut flags = self.access_mode as u32;
-        if self.fd_flags.contains(FdFlags::CLOEXEC) {
-            flags |= CreationFlags::O_CLOEXEC.bits();
+impl DetachedMountFile {
+    /// Creates a detached mount file.
+    pub fn new(mount: Arc<Mount>) -> Self {
+        let root_path = Path::new_fs_root(mount.clone());
+        Self { mount, root_path }
+    }
+
+    /// Returns the detached mount.
+    #[expect(dead_code)]
+    pub fn mount(&self) -> Arc<Mount> {
+        self.mount.clone()
+    }
+}
+
+impl Pollable for DetachedMountFile {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
+impl FileLike for DetachedMountFile {
+    fn access_mode(&self) -> AccessMode {
+        AccessMode::O_RDONLY
+    }
+
+    fn path(&self) -> &Path {
+        &self.root_path
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
+        struct FdInfo {
+            access_mode: AccessMode,
+            fd_flags: FdFlags,
         }
 
-        writeln!(f, "pos:\t{}", 0)?;
-        writeln!(f, "flags:\t0{:o}", flags)?;
-        writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
-        writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())
+        impl Display for FdInfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let mut flags = self.access_mode as u32;
+                if self.fd_flags.contains(FdFlags::CLOEXEC) {
+                    flags |= CreationFlags::O_CLOEXEC.bits();
+                }
+
+                writeln!(f, "pos:\t{}", 0)?;
+                writeln!(f, "flags:\t0{:o}", flags)?;
+                writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
+                writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())
+            }
+        }
+
+        Box::new(FdInfo {
+            access_mode: self.access_mode(),
+            fd_flags,
+        })
     }
 }
 

--- a/kernel/src/fs/file/mod.rs
+++ b/kernel/src/fs/file/mod.rs
@@ -17,7 +17,7 @@ pub use file_attr::{
     status_flags::{AtomicStatusFlags, StatusFlags},
 };
 pub use file_handle::{FileLike, Mappable};
-pub(crate) use fs_config_file::FsConfigFile;
+pub use fs_config_file::{DetachedMountFile, FsConfigFile};
 pub(crate) use inode_attr::mode::{
     chmod, mkmod, perms_to_mask, who_and_perms_to_mask, who_to_mask,
 };

--- a/kernel/src/fs/file/mod.rs
+++ b/kernel/src/fs/file/mod.rs
@@ -6,6 +6,7 @@ mod file_attr;
 mod file_handle;
 pub mod file_table;
 pub mod flock;
+mod fs_config_file;
 mod inode_attr;
 mod inode_handle;
 
@@ -16,6 +17,7 @@ pub use file_attr::{
     status_flags::{AtomicStatusFlags, StatusFlags},
 };
 pub use file_handle::{FileLike, Mappable};
+pub(crate) use fs_config_file::FsConfigFile;
 pub(crate) use inode_attr::mode::{
     chmod, mkmod, perms_to_mask, who_and_perms_to_mask, who_to_mask,
 };

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -506,12 +506,13 @@ impl Path {
     ///
     /// # Errors
     ///
-    /// Returns `ENOTDIR` if the `dst_path` is not a directory.
-    ///
     /// Returns `EINVAL` in the following cases:
     /// - The current path is not a mount root.
     /// - The mount of the current path is the root mount.
-    /// - Either source or destination path is not in the current mount namespace.
+    /// - The source is a non-root mount in a detached mount tree.
+    /// - The destination is in a detached mount tree while the source is not.
+    /// - The source and destination are in the same detached mount tree.
+    /// - One of the source and destination is a directory and the other is not.
     ///
     /// Returns `ELOOP` in the following cases:
     /// - The destination path is inside the subtree being moved.
@@ -520,12 +521,12 @@ impl Path {
         if !self.is_mount_root() {
             return_errno_with_message!(Errno::EINVAL, "the path is not a mount root");
         };
-        if self.mount_node().parent().is_none() {
-            return_errno_with_message!(Errno::EINVAL, "the root mount can not be moved");
-        }
 
         let current_ns_proxy = ctx.thread_local.borrow_ns_proxy();
         let current_mnt_ns = current_ns_proxy.unwrap().mnt_ns();
+        if self.mount.id() == current_mnt_ns.root().id() {
+            return_errno_with_message!(Errno::EINVAL, "the root mount can not be moved");
+        }
         if !current_mnt_ns.owns(&self.mount) {
             return_errno_with_message!(
                 Errno::EINVAL,
@@ -538,7 +539,48 @@ impl Path {
                 "the destination path is not in this mount namespace"
             );
         }
+
         let mut topology_guard = MountTopology::write_lock();
+        let source_tree_root = mount_tree_root(self.mount_node());
+        let target_tree_root = mount_tree_root(dst_path.mount_node());
+        let current_tree_root = current_mnt_ns.root();
+        let source_is_detached = source_tree_root.id() != current_tree_root.id();
+        let target_is_detached = target_tree_root.id() != current_tree_root.id();
+
+        // Since Linux v6.15, a detached anonymous-namespace root can be
+        // moved onto either the current mount namespace or an acceptable
+        // anonymous namespace. Asterinas does not model anonymous mount
+        // namespaces yet, so compare detached mount tree roots instead.
+        // TODO: Once anonymous mount namespaces are modeled, determine
+        // detachedness from the mount namespace directly instead of inferring it
+        // from whether the mount tree root is the current namespace root.
+        if source_is_detached && self.mount.id() != source_tree_root.id() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "only a detached mount tree root can be moved out of the detached tree"
+            );
+        }
+        if !source_is_detached && target_is_detached {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the destination path is in a detached mount tree"
+            );
+        }
+        if source_is_detached && source_tree_root.id() == target_tree_root.id() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the source and destination are in the same detached mount tree"
+            );
+        }
+        let source_is_dir = self.type_() == InodeType::Dir;
+        let target_is_dir = dst_path.type_() == InodeType::Dir;
+        if source_is_dir != target_is_dir {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the source and destination must both be directories or both be non-directories"
+            );
+        }
+
         current_mnt_ns.check_no_mnt_ns_loop_in_tree(self.mount_node(), &topology_guard)?;
         if dst_path
             .mount_node()
@@ -580,6 +622,15 @@ impl Path {
 
         Ok(())
     }
+}
+
+fn mount_tree_root(mount: &Arc<Mount>) -> Arc<Mount> {
+    let mut root = mount.clone();
+    while let Some(parent) = root.parent().and_then(|parent| parent.upgrade()) {
+        root = parent;
+    }
+
+    root
 }
 
 // Methods inherited from `Dentry`.

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -332,7 +332,7 @@ impl Mount {
     ///
     /// If the source is provided by user, it will be recorded in the new mount.
     ///
-    /// Return the mounted child mount.
+    /// Returns the mounted child mount.
     pub(super) fn do_mount(
         self: &Arc<Self>,
         fs: Arc<dyn FileSystem>,

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -262,6 +262,22 @@ impl Mount {
         Self::new(fs, PerMountFlags::KERNMOUNT, None, Weak::new(), None)
     }
 
+    /// Creates a mount node that is not attached to the mount tree.
+    //
+    // FIXME: Linux creates detached mounts in an anonymous mount namespace
+    // and moves them into the target namespace when they are attached. Asterinas
+    // currently records the caller's namespace here because `Mount::mnt_ns` is
+    // immutable. This should be changed once mount namespaces can be updated
+    // during attach.
+    pub fn new_detached(
+        fs: Arc<dyn FileSystem>,
+        flags: PerMountFlags,
+        mnt_ns: Weak<MountNamespace>,
+        source: Option<String>,
+    ) -> Result<Arc<Self>> {
+        Self::new(fs, flags, None, mnt_ns, source)
+    }
+
     /// The internal constructor.
     ///
     /// A root mount node has no mountpoint, while other mount nodes must have one.

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -622,11 +622,13 @@ impl PathResolver {
             }
             FsPathInner::Cwd => LookupResult::Resolved(self.cwd.clone()),
             FsPathInner::FdRelative(fd, path) => {
-                let task = Task::current().unwrap();
-                let mut file_table = task.as_thread_local().unwrap().borrow_file_table_mut();
-                let file = get_file_fast!(&mut file_table, fd);
-                let parent = file.as_inode_handle_or_err()?.path();
-                self.lookup_from_parent(parent, path, follow_tail_link)?
+                let parent = {
+                    let task = Task::current().unwrap();
+                    let mut file_table = task.as_thread_local().unwrap().borrow_file_table_mut();
+                    let file = get_file_fast!(&mut file_table, fd);
+                    file.path().clone()
+                };
+                self.lookup_from_parent(&parent, path, follow_tail_link)?
             }
             FsPathInner::Fd(fd) => {
                 let task = Task::current().unwrap();

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -36,6 +36,7 @@ macro_rules! import_generic_syscall_entries {
             fcntl::sys_fcntl,
             flock::sys_flock,
             fsconfig::sys_fsconfig,
+            fsmount::sys_fsmount,
             fsopen::sys_fsopen,
             fsync::{sys_fdatasync, sys_fsync},
             futex::sys_futex,
@@ -403,6 +404,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
             SYS_FSOPEN = 430                 => sys_fsopen(args[..2]);
             SYS_FSCONFIG = 431               => sys_fsconfig(args[..5]);
+            SYS_FSMOUNT = 432                => sys_fsmount(args[..3]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
             SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -35,6 +35,7 @@ macro_rules! import_generic_syscall_entries {
             fallocate::sys_fallocate,
             fcntl::sys_fcntl,
             flock::sys_flock,
+            fsopen::sys_fsopen,
             fsync::{sys_fdatasync, sys_fsync},
             futex::sys_futex,
             get_ioprio::sys_ioprio_get,
@@ -399,6 +400,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_PWRITEV2 = 287               => sys_pwritev2(args[..6]);
             SYS_STATX = 291                  => sys_statx(args[..5]);
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
+            SYS_FSOPEN = 430                 => sys_fsopen(args[..2]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
             SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -77,6 +77,7 @@ macro_rules! import_generic_syscall_entries {
             mknod::sys_mknodat,
             mmap::sys_mmap,
             mount::sys_mount,
+            move_mount::sys_move_mount,
             mprotect::sys_mprotect,
             mremap::sys_mremap,
             msync::sys_msync,
@@ -402,6 +403,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_PWRITEV2 = 287               => sys_pwritev2(args[..6]);
             SYS_STATX = 291                  => sys_statx(args[..5]);
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
+            SYS_MOVE_MOUNT = 429             => sys_move_mount(args[..5]);
             SYS_FSOPEN = 430                 => sys_fsopen(args[..2]);
             SYS_FSCONFIG = 431               => sys_fsconfig(args[..5]);
             SYS_FSMOUNT = 432                => sys_fsmount(args[..3]);

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -35,6 +35,7 @@ macro_rules! import_generic_syscall_entries {
             fallocate::sys_fallocate,
             fcntl::sys_fcntl,
             flock::sys_flock,
+            fsconfig::sys_fsconfig,
             fsopen::sys_fsopen,
             fsync::{sys_fdatasync, sys_fsync},
             futex::sys_futex,
@@ -401,6 +402,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_STATX = 291                  => sys_statx(args[..5]);
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
             SYS_FSOPEN = 430                 => sys_fsopen(args[..2]);
+            SYS_FSCONFIG = 431               => sys_fsconfig(args[..5]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
             SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -77,6 +77,7 @@ use super::{
     mknod::{sys_mknod, sys_mknodat},
     mmap::sys_mmap,
     mount::sys_mount,
+    move_mount::sys_move_mount,
     mprotect::sys_mprotect,
     mremap::sys_mremap,
     msync::sys_msync,
@@ -417,6 +418,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PWRITEV2 = 328         => sys_pwritev2(args[..6]);
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
+    SYS_MOVE_MOUNT = 429        => sys_move_mount(args[..5]);
     SYS_FSOPEN = 430           => sys_fsopen(args[..2]);
     SYS_FSCONFIG = 431         => sys_fsconfig(args[..5]);
     SYS_FSMOUNT = 432          => sys_fsmount(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -34,6 +34,7 @@ use super::{
     flock::sys_flock,
     fork::{sys_fork, sys_vfork},
     fsconfig::sys_fsconfig,
+    fsmount::sys_fsmount,
     fsopen::sys_fsopen,
     fsync::{sys_fdatasync, sys_fsync},
     futex::sys_futex,
@@ -418,6 +419,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
     SYS_FSOPEN = 430           => sys_fsopen(args[..2]);
     SYS_FSCONFIG = 431         => sys_fsconfig(args[..5]);
+    SYS_FSMOUNT = 432          => sys_fsmount(args[..3]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -33,6 +33,7 @@ use super::{
     fcntl::sys_fcntl,
     flock::sys_flock,
     fork::{sys_fork, sys_vfork},
+    fsconfig::sys_fsconfig,
     fsopen::sys_fsopen,
     fsync::{sys_fdatasync, sys_fsync},
     futex::sys_futex,
@@ -416,6 +417,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
     SYS_FSOPEN = 430           => sys_fsopen(args[..2]);
+    SYS_FSCONFIG = 431         => sys_fsconfig(args[..5]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -33,6 +33,7 @@ use super::{
     fcntl::sys_fcntl,
     flock::sys_flock,
     fork::{sys_fork, sys_vfork},
+    fsopen::sys_fsopen,
     fsync::{sys_fdatasync, sys_fsync},
     futex::sys_futex,
     get_ioprio::sys_ioprio_get,
@@ -414,6 +415,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PWRITEV2 = 328         => sys_pwritev2(args[..6]);
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
+    SYS_FSOPEN = 430           => sys_fsopen(args[..2]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);

--- a/kernel/src/syscall/fsconfig.rs
+++ b/kernel/src/syscall/fsconfig.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use int_to_c_enum::TryFromInt;
+
+use super::{SyscallReturn, constants::MAX_FILENAME_LEN};
+use crate::{
+    fs::file::{
+        FsConfigFile,
+        file_table::{FileDesc, RawFileDesc, get_file_fast},
+    },
+    prelude::*,
+};
+
+pub fn sys_fsconfig(
+    fs_fd: RawFileDesc,
+    cmd: u32,
+    key_addr: Vaddr,
+    value_addr: Vaddr,
+    aux: i32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let fs_fd = FileDesc::try_from(fs_fd)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid fsconfig fd"))?;
+    let cmd = FsConfigOps::try_from(cmd)
+        .map_err(|_| Error::with_message(Errno::EOPNOTSUPP, "unsupported fsconfig command"))?;
+
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, fs_fd);
+    let fs_config = file
+        .downcast_ref::<FsConfigFile>()
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not a fs context"))?;
+
+    match cmd {
+        FsConfigOps::SetFlag => {
+            ensure_valid_args(key_addr != 0 && value_addr == 0 && aux == 0)?;
+            let key = ctx.user_space().read_cstring(key_addr, MAX_FILENAME_LEN)?;
+            fs_config.set_flag(key.to_str()?)?;
+        }
+        FsConfigOps::SetString => {
+            ensure_valid_args(key_addr != 0 && value_addr != 0 && aux == 0)?;
+            let key = ctx.user_space().read_cstring(key_addr, MAX_FILENAME_LEN)?;
+            let value = ctx
+                .user_space()
+                .read_cstring(value_addr, MAX_FILENAME_LEN)?;
+            fs_config.set_string(key.to_str()?, value.to_str()?)?;
+        }
+        FsConfigOps::SetBinary => {
+            ensure_valid_args(key_addr != 0 && value_addr != 0 && aux > 0)?;
+            return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported fsconfig command");
+        }
+        FsConfigOps::SetPath | FsConfigOps::SetPathEmpty => {
+            ensure_valid_args(key_addr != 0 && value_addr != 0 && aux >= 0)?;
+            return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported fsconfig command");
+        }
+        FsConfigOps::SetFd => {
+            ensure_valid_args(key_addr != 0 && value_addr == 0 && aux >= 0)?;
+            return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported fsconfig command");
+        }
+        FsConfigOps::Create => {
+            ensure_valid_args(key_addr == 0 && value_addr == 0 && aux == 0)?;
+            super::fsopen::check_mount_api_capability(ctx)?;
+            fs_config.create_fs(ctx)?;
+        }
+        FsConfigOps::CreateExcl => {
+            ensure_valid_args(key_addr == 0 && value_addr == 0 && aux == 0)?;
+            return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported fsconfig command");
+        }
+        FsConfigOps::Reconfigure => {
+            ensure_valid_args(key_addr == 0 && value_addr == 0 && aux == 0)?;
+            super::fsopen::check_mount_api_capability(ctx)?;
+            fs_config.reconfigure_fs(ctx)?;
+        }
+    }
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn ensure_valid_args(valid: bool) -> Result<()> {
+    if !valid {
+        return_errno_with_message!(Errno::EINVAL, "invalid fsconfig arguments");
+    }
+    Ok(())
+}
+
+/// The configuration operations supported by `fsconfig`.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+enum FsConfigOps {
+    /// Sets a boolean parameter.
+    SetFlag = 0,
+    /// Sets a string parameter.
+    SetString = 1,
+    /// Sets a binary blob parameter.
+    SetBinary = 2,
+    /// Sets a path parameter.
+    SetPath = 3,
+    /// Sets a path parameter that can be empty.
+    SetPathEmpty = 4,
+    /// Sets a parameter using a file descriptor.
+    SetFd = 5,
+    /// Creates the filesystem superblock.
+    Create = 6,
+    /// Reconfigures an existing filesystem superblock.
+    Reconfigure = 7,
+    /// Creates a new filesystem superblock, failing if reusing an existing one.
+    CreateExcl = 8,
+}

--- a/kernel/src/syscall/fsmount.rs
+++ b/kernel/src/syscall/fsmount.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::SyscallReturn;
+use crate::{
+    fs::{
+        file::{
+            DetachedMountFile, FileLike, FsConfigFile,
+            file_table::{FdFlags, RawFileDesc, get_file_fast},
+        },
+        vfs::path::PerMountFlags,
+    },
+    prelude::*,
+};
+
+pub fn sys_fsmount(
+    fs_fd: RawFileDesc,
+    flags: u32,
+    mount_attrs: u32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let flags = FsMountFlags::try_from(flags)?;
+    let mount_attrs = MountAttrs::try_from(mount_attrs)?;
+    let per_mount_flags = PerMountFlags::try_from(mount_attrs)?;
+    super::fsopen::check_mount_api_capability(ctx)?;
+
+    let fs_config_file = {
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
+        let file = get_file_fast!(&mut file_table, fs_fd.try_into()?).into_owned();
+        file.downcast_ref::<FsConfigFile>()
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not a fs context"))?;
+        file
+    };
+    let fs_config = fs_config_file
+        .downcast_ref::<FsConfigFile>()
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not a fs context"))?;
+
+    let current_ns_proxy = ctx.thread_local.borrow_ns_proxy();
+    let current_mnt_ns = current_ns_proxy.unwrap().mnt_ns();
+    let detached_mount =
+        fs_config.create_detached_mount(per_mount_flags, Arc::downgrade(current_mnt_ns))?;
+    let file = Arc::new(DetachedMountFile::new(detached_mount)) as Arc<dyn FileLike>;
+    let fd = ctx
+        .thread_local
+        .borrow_file_table()
+        .unwrap()
+        .write()
+        .insert(file, FdFlags::from(flags));
+    Ok(SyscallReturn::Return(fd.into()))
+}
+
+bitflags! {
+    struct FsMountFlags: u32 {
+        const FSMOUNT_CLOEXEC = 1;
+    }
+
+    struct MountAttrs: u32 {
+        const RDONLY = 0x0000_0001;
+        const NOSUID = 0x0000_0002;
+        const NODEV = 0x0000_0004;
+        const NOEXEC = 0x0000_0008;
+        const NOATIME = 0x0000_0010;
+        const STRICTATIME = 0x0000_0020;
+        const NODIRATIME = 0x0000_0080;
+        const NOSYMFOLLOW = 0x0020_0000;
+    }
+}
+
+impl TryFrom<u32> for FsMountFlags {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        Self::from_bits(value)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown fsmount flags"))
+    }
+}
+
+impl From<FsMountFlags> for FdFlags {
+    fn from(value: FsMountFlags) -> Self {
+        if value.contains(FsMountFlags::FSMOUNT_CLOEXEC) {
+            Self::CLOEXEC
+        } else {
+            Self::empty()
+        }
+    }
+}
+
+impl TryFrom<u32> for MountAttrs {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        Self::from_bits(value)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "unsupported mount attributes"))
+    }
+}
+
+impl TryFrom<MountAttrs> for PerMountFlags {
+    type Error = Error;
+
+    fn try_from(attrs: MountAttrs) -> Result<Self> {
+        const SHARED_BITS: MountAttrs = MountAttrs::RDONLY
+            .union(MountAttrs::NOSUID)
+            .union(MountAttrs::NODEV)
+            .union(MountAttrs::NOEXEC);
+
+        let atime_attrs = attrs & (MountAttrs::NOATIME | MountAttrs::STRICTATIME);
+        if atime_attrs.bits().count_ones() > 1 {
+            return_errno_with_message!(Errno::EINVAL, "conflicting atime mount attributes");
+        }
+
+        let mut flags = PerMountFlags::from_bits_truncate((attrs & SHARED_BITS).bits());
+        if atime_attrs.is_empty() {
+            flags |= PerMountFlags::RELATIME;
+        } else if attrs.contains(MountAttrs::NOATIME) {
+            flags |= PerMountFlags::NOATIME;
+        } else {
+            flags |= PerMountFlags::STRICTATIME;
+        }
+        if attrs.contains(MountAttrs::NODIRATIME) {
+            flags |= PerMountFlags::NODIRATIME;
+        }
+        if attrs.contains(MountAttrs::NOSYMFOLLOW) {
+            flags |= PerMountFlags::NOSYMFOLLOW;
+        }
+
+        Ok(flags)
+    }
+}

--- a/kernel/src/syscall/fsopen.rs
+++ b/kernel/src/syscall/fsopen.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{SyscallReturn, constants::MAX_FILENAME_LEN};
+use crate::{
+    fs::{
+        file::{FileLike, FsConfigFile, file_table::FdFlags},
+        vfs::registry::look_up,
+    },
+    prelude::*,
+};
+
+pub fn sys_fsopen(fs_name_addr: Vaddr, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let flags = FsOpenFlags::try_from(flags)?;
+    check_mount_api_capability(ctx)?;
+
+    let fs_name = ctx
+        .user_space()
+        .read_cstring(fs_name_addr, MAX_FILENAME_LEN)?;
+    let fs_name = fs_name
+        .to_str()
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid filesystem name"))?;
+    let fs_type = look_up(fs_name).ok_or_else(|| {
+        Error::with_message(
+            Errno::ENODEV,
+            "the filesystem is not configured in the kernel",
+        )
+    })?;
+
+    let file = Arc::new(FsConfigFile::new(fs_type)) as Arc<dyn FileLike>;
+    let fd = ctx
+        .thread_local
+        .borrow_file_table()
+        .unwrap()
+        .write()
+        .insert(file, FdFlags::from(flags));
+    Ok(SyscallReturn::Return(fd.into()))
+}
+
+pub(super) fn check_mount_api_capability(ctx: &Context) -> Result<()> {
+    use crate::{process::credentials::capabilities::CapSet, security::lsm::hooks as lsm_hooks};
+
+    lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+        ctx.thread_local.borrow_user_ns().as_ref(),
+        ctx.posix_thread,
+        CapSet::SYS_ADMIN,
+    ))
+}
+
+bitflags! {
+    struct FsOpenFlags: u32 {
+        const FSOPEN_CLOEXEC = 1;
+    }
+}
+
+impl TryFrom<u32> for FsOpenFlags {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        Self::from_bits(value)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown fsopen flags"))
+    }
+}
+
+impl From<FsOpenFlags> for FdFlags {
+    fn from(value: FsOpenFlags) -> Self {
+        if value.contains(FsOpenFlags::FSOPEN_CLOEXEC) {
+            Self::CLOEXEC
+        } else {
+            Self::empty()
+        }
+    }
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -47,6 +47,7 @@ mod fallocate;
 mod fcntl;
 mod flock;
 mod fork;
+mod fsconfig;
 mod fsopen;
 mod fsync;
 mod futex;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -48,6 +48,7 @@ mod fcntl;
 mod flock;
 mod fork;
 mod fsconfig;
+mod fsmount;
 mod fsopen;
 mod fsync;
 mod futex;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -47,6 +47,7 @@ mod fallocate;
 mod fcntl;
 mod flock;
 mod fork;
+mod fsopen;
 mod fsync;
 mod futex;
 mod get_ioprio;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -90,6 +90,7 @@ mod mkdir;
 mod mknod;
 mod mmap;
 mod mount;
+mod move_mount;
 mod mprotect;
 mod mremap;
 mod msync;

--- a/kernel/src/syscall/move_mount.rs
+++ b/kernel/src/syscall/move_mount.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{SyscallReturn, constants::MAX_FILENAME_LEN};
+use crate::{
+    fs::{
+        file::{
+            DetachedMountFile,
+            file_table::{RawFileDesc, get_file_fast},
+        },
+        vfs::path::{EmptyPathStr, FsPath, Mount, Path},
+    },
+    prelude::*,
+};
+
+pub fn sys_move_mount(
+    from_dfd: RawFileDesc,
+    from_path_addr: Vaddr,
+    to_dfd: RawFileDesc,
+    to_path_addr: Vaddr,
+    flags: u32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let flags = MoveMountFlags::try_from(flags)?;
+    let supported_flags = MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH;
+    if !(flags - supported_flags).is_empty() {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported move_mount flags");
+    }
+    super::fsopen::check_mount_api_capability(ctx)?;
+
+    let from_path = ctx
+        .user_space()
+        .read_cstring(from_path_addr, MAX_FILENAME_LEN)?;
+    let source = if from_path.is_empty() {
+        if !flags.contains(MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH) {
+            return_errno_with_message!(Errno::ENOENT, "the source path is empty");
+        }
+        MoveMountSource::Detached(get_detached_mount(from_dfd, ctx)?)
+    } else {
+        MoveMountSource::Path(from_path)
+    };
+
+    let to_path = ctx
+        .user_space()
+        .read_cstring(to_path_addr, MAX_FILENAME_LEN)?;
+
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    let to_path = to_path.to_string_lossy();
+    let to_fs_path = FsPath::from_fd_at(to_dfd, &to_path, EmptyPathStr::Reject)?;
+    let target_path = path_resolver.lookup(&to_fs_path)?;
+    match source {
+        MoveMountSource::Detached(detached_mount) => {
+            let detached_root = Path::new_fs_root(detached_mount);
+            detached_root.move_mount_to(&target_path, ctx)?;
+        }
+        MoveMountSource::Path(from_path) => {
+            let from_path = from_path.to_string_lossy();
+            let from_fs_path = FsPath::from_fd_at(from_dfd, &from_path, EmptyPathStr::Reject)?;
+            let source_path = path_resolver.lookup(&from_fs_path)?;
+            source_path.move_mount_to(&target_path, ctx)?;
+        }
+    };
+
+    Ok(SyscallReturn::Return(0))
+}
+
+enum MoveMountSource {
+    Detached(Arc<Mount>),
+    Path(CString),
+}
+
+fn get_detached_mount(from_dfd: RawFileDesc, ctx: &Context) -> Result<Arc<Mount>> {
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, from_dfd.try_into()?);
+    let mount_file = file
+        .downcast_ref::<DetachedMountFile>()
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not a detached mount"))?;
+
+    Ok(mount_file.mount())
+}
+
+bitflags! {
+    struct MoveMountFlags: u32 {
+        const MOVE_MOUNT_F_SYMLINKS   = 0x0000_0001;
+        const MOVE_MOUNT_F_AUTOMOUNTS = 0x0000_0002;
+        const MOVE_MOUNT_F_EMPTY_PATH = 0x0000_0004;
+        const MOVE_MOUNT_T_SYMLINKS   = 0x0000_0010;
+        const MOVE_MOUNT_T_AUTOMOUNTS = 0x0000_0020;
+        const MOVE_MOUNT_T_EMPTY_PATH = 0x0000_0040;
+        const MOVE_MOUNT_SET_GROUP    = 0x0000_0100;
+        const MOVE_MOUNT_BENEATH      = 0x0000_0200;
+    }
+}
+
+impl TryFrom<u32> for MoveMountFlags {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        Self::from_bits(value)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown move_mount flags"))
+    }
+}

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -29,6 +29,7 @@ INITRAMFS_COMPRESSED := true
 endif
 EXT2_IMAGE := $(BUILD_DIR)/ext2.img
 EXFAT_IMAGE := $(BUILD_DIR)/exfat.img
+LTP_DEV_IMAGE := $(BUILD_DIR)/ltp_dev.img
 SSD_IMAGE := $(BUILD_DIR)/nvme0n1.img
 XFSTESTS_TEST_IMAGE := $(BUILD_DIR)/xfstests_test.img
 XFSTESTS_SCRATCH_IMAGE := $(BUILD_DIR)/xfstests_scratch.img
@@ -62,9 +63,9 @@ build: $(EXT2_IMAGE) $(EXFAT_IMAGE)
 	@echo "For loongarch, we generate a fake initramfs to successfully test or build."
 	@touch $(INITRAMFS_IMAGE)
 else ifeq ($(BUILD_XFSTESTS_IMAGES), true)
-build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(SSD_IMAGE) $(XFSTESTS_TEST_IMAGE) $(XFSTESTS_SCRATCH_IMAGE)
+build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(LTP_DEV_IMAGE) $(SSD_IMAGE) $(XFSTESTS_TEST_IMAGE) $(XFSTESTS_SCRATCH_IMAGE)
 else
-build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(SSD_IMAGE)
+build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(LTP_DEV_IMAGE) $(SSD_IMAGE)
 endif
 
 .PHONY: $(INITRAMFS_IMAGE)
@@ -175,6 +176,11 @@ $(EXFAT_IMAGE):
 	@mkdir -p $(BUILD_DIR)
 	@fallocate -l 512M $(EXFAT_IMAGE)
 	@mkfs.exfat $(EXFAT_IMAGE)
+
+$(LTP_DEV_IMAGE):
+	@mkdir -p $(BUILD_DIR)
+	@dd if=/dev/zero of=$(LTP_DEV_IMAGE) bs=512M count=1
+	@mke2fs -t ext2 -F $(LTP_DEV_IMAGE)
 
 $(SSD_IMAGE):
 	@mkdir -p $(BUILD_DIR)

--- a/test/initramfs/src/conformance/gvisor/Makefile
+++ b/test/initramfs/src/conformance/gvisor/Makefile
@@ -29,6 +29,7 @@ TESTS ?= \
 	mknod_test \
 	mmap_test \
 	mount_test \
+	mount_fd_test \
 	mremap_test \
 	msync_test \
 	open_create_test \

--- a/test/initramfs/src/conformance/gvisor/blocklists/mount_fd_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/mount_fd_test
@@ -1,0 +1,4 @@
+# TODO: Support applying tmpfs creation options such as `nr_inodes`.
+FsMountTest.FsMountSuccess
+# TODO: Support open_tree(2).
+OpenTreeTest.*

--- a/test/initramfs/src/conformance/ltp/run_ltp_test.sh
+++ b/test/initramfs/src/conformance/ltp/run_ltp_test.sh
@@ -7,8 +7,8 @@ TEST_TMP_DIR=${CONFORMANCE_TEST_WORKDIR:-/tmp}
 LOG_FILE=$TEST_TMP_DIR/result.log
 RESULT=0
 
-# Some test cases require a block device. Select the first one by default.
-export LTP_DEV=${LTP_DEV:-/dev/vda}
+# Some test cases require a block device. Select the dedicated LTP device by default.
+export LTP_DEV=${LTP_DEV:-/dev/vdc}
 export LTP_TIMEOUT_MUL=5
 
 rm -f $LOG_FILE

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -414,15 +414,15 @@ fpathconf01
 # fremovexattr01
 # fremovexattr02
 
-# fsconfig01
-# fsconfig02
+fsconfig01
+fsconfig02
 # fsconfig03
 
-# fsmount01
-# fsmount02
+fsmount01
+fsmount02
 
-# fsopen01
-# fsopen02
+fsopen01
+fsopen02
 
 # fspick01
 # fspick02

--- a/test/initramfs/src/conformance/xfstests/local.config
+++ b/test/initramfs/src/conformance/xfstests/local.config
@@ -1,7 +1,6 @@
 export FSTYP=ext2
 
-# TEST_DEV and SCRATCH_DEV are set by run_xfstests.sh from
-# /dev/disk/by-id/virtio-vxfstest and virtio-vxfsscratch.
+# TEST_DEV and SCRATCH_DEV are set by run_xfstests.sh.
 
 export TEST_DIR=/opt/xfstests/test
 export SCRATCH_MNT=/opt/xfstests/scratch

--- a/test/initramfs/src/conformance/xfstests/run_xfstests.sh
+++ b/test/initramfs/src/conformance/xfstests/run_xfstests.sh
@@ -10,8 +10,8 @@ export PATH=__RUNTIME_PATH__
 XFSTESTS_DIR=/opt/xfstests
 cd "$XFSTESTS_DIR"
 
-TEST_DEV=${XFSTESTS_TEST_DEV:-/dev/vdc}
-SCRATCH_DEV=${XFSTESTS_SCRATCH_DEV:-/dev/vdd}
+TEST_DEV=${XFSTESTS_TEST_DEV:-/dev/vdd}
+SCRATCH_DEV=${XFSTESTS_SCRATCH_DEV:-/dev/vde}
 export TEST_DEV SCRATCH_DEV
 
 # Mount xfstests images with explicit error checking so a mount failure is not

--- a/test/initramfs/src/regression/fs/mount/mount_api.c
+++ b/test/initramfs/src/regression/fs/mount/mount_api.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+static void ensure_dir(const char *path)
+{
+	CHECK_WITH(mkdir(path, 0755), _ret == 0 || errno == EEXIST);
+}
+
+static int create_detached_tmpfs(void)
+{
+	int fs_fd = CHECK(syscall(SYS_fsopen, "tmpfs", 0));
+	CHECK(syscall(SYS_fsconfig, fs_fd, FSCONFIG_CMD_CREATE, NULL, NULL, 0));
+	int mount_fd = CHECK(syscall(SYS_fsmount, fs_fd, 0, 0));
+	CHECK(close(fs_fd));
+	return mount_fd;
+}
+
+FN_TEST(fsopen_invalid_fsname)
+{
+	TEST_ERRNO(syscall(SYS_fsopen, "invalid_fs_name", 0), ENODEV);
+	TEST_ERRNO(syscall(SYS_fsopen, "", 0), ENODEV);
+}
+END_TEST()
+
+FN_TEST(fsopen_null_fsname)
+{
+	TEST_ERRNO(syscall(SYS_fsopen, NULL, 0), EFAULT);
+}
+END_TEST()
+
+FN_TEST(fsopen_tmpfs)
+{
+	int fd = TEST_SUCC(syscall(SYS_fsopen, "tmpfs", 0));
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(fsopen_cloexec)
+{
+	int fd = TEST_SUCC(syscall(SYS_fsopen, "tmpfs", FSOPEN_CLOEXEC));
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(fsconfig_and_fsmount)
+{
+	int fs_fd = TEST_SUCC(syscall(SYS_fsopen, "tmpfs", 0));
+	TEST_SUCC(syscall(SYS_fsconfig, fs_fd, FSCONFIG_SET_STRING, "source",
+			  "test_source", 0));
+	TEST_SUCC(syscall(SYS_fsconfig, fs_fd, FSCONFIG_CMD_CREATE, NULL, NULL,
+			  0));
+	int mount_fd =
+		TEST_SUCC(syscall(SYS_fsmount, fs_fd, FSMOUNT_CLOEXEC, 0));
+	TEST_SUCC(close(mount_fd));
+	TEST_SUCC(close(fs_fd));
+}
+END_TEST()
+
+FN_TEST(move_mount_flags_zero_nonempty_from_path)
+{
+	const char *src = "/tmp/move_mount_flags_zero_src";
+	const char *dst = "/tmp/move_mount_flags_zero_dst";
+
+	TEST_SUCC(unshare(CLONE_NEWNS));
+	ensure_dir(src);
+	ensure_dir(dst);
+	TEST_SUCC(mount("tmpfs", src, "tmpfs", 0, NULL));
+
+	TEST_SUCC(syscall(SYS_move_mount, AT_FDCWD, src, AT_FDCWD, dst, 0));
+
+	TEST_SUCC(umount(dst));
+	TEST_SUCC(rmdir(src));
+	TEST_SUCC(rmdir(dst));
+}
+END_TEST()
+
+FN_TEST(move_mount_flags_zero_empty_from_path)
+{
+	const char *dst = "/tmp/move_mount_empty_without_flag_dst";
+
+	TEST_SUCC(unshare(CLONE_NEWNS));
+	ensure_dir(dst);
+	int mount_fd = create_detached_tmpfs();
+
+	TEST_ERRNO(syscall(SYS_move_mount, mount_fd, "", AT_FDCWD, dst, 0),
+		   ENOENT);
+
+	TEST_SUCC(close(mount_fd));
+	TEST_SUCC(rmdir(dst));
+}
+END_TEST()
+
+FN_TEST(move_mount_empty_path_detached_mount)
+{
+	const char *dst = "/tmp/move_mount_empty_detached_dst";
+
+	TEST_SUCC(unshare(CLONE_NEWNS));
+	ensure_dir(dst);
+	int mount_fd = create_detached_tmpfs();
+
+	TEST_SUCC(syscall(SYS_move_mount, mount_fd, "", AT_FDCWD, dst,
+			  MOVE_MOUNT_F_EMPTY_PATH));
+
+	TEST_SUCC(close(mount_fd));
+	TEST_SUCC(umount(dst));
+	TEST_SUCC(rmdir(dst));
+}
+END_TEST()
+
+FN_TEST(move_mount_empty_path_nonempty_from_path)
+{
+	const char *src = "/tmp/move_mount_empty_flag_src";
+	const char *dst = "/tmp/move_mount_empty_flag_dst";
+
+	TEST_SUCC(unshare(CLONE_NEWNS));
+	ensure_dir(src);
+	ensure_dir(dst);
+	TEST_SUCC(mount("tmpfs", src, "tmpfs", 0, NULL));
+
+	TEST_SUCC(syscall(SYS_move_mount, AT_FDCWD, src, AT_FDCWD, dst,
+			  MOVE_MOUNT_F_EMPTY_PATH));
+
+	TEST_SUCC(umount(dst));
+	TEST_SUCC(rmdir(src));
+	TEST_SUCC(rmdir(dst));
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -122,6 +122,7 @@ echo "All mount bind file test passed."
 ./isolation/chroot
 ./isolation/pivot_root
 
+./mount/mount_api
 ./mount/mount_move
 
 ./overlayfs/ovl_test

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -70,8 +70,10 @@ else
 fi
 
 if [ "$1" = "riscv" ]; then
-    # NOTE: The `/etc/profile.d/init.sh` assumes that `ext2.img` appears as the first block device (`/dev/vda`).
-    # The ordering below ensures `x1` (ext2.img) is discovered before `x0`, maintaining this assumption.
+    # NOTE: The initramfs assumes that ext2.img, exfat.img, and ltp_dev.img appear as
+    # `/dev/vda`, `/dev/vdb`, and `/dev/vdc`, respectively. RISC-V virtio-mmio
+    # block devices are discovered in reverse command-line order, so list them
+    # in the reverse of the desired device-node order.
     # TODO: Once UUID-based mounting is implemented, this strict ordering will no longer be required.
     QEMU_ARGS="\
         -cpu rv64,svpbmt=true,zkr=true \
@@ -85,6 +87,8 @@ if [ "$1" = "riscv" ]; then
         -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
         -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
         -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
+        -drive if=none,format=raw,id=x2,file=./test/initramfs/build/ltp_dev.img \
+        -device virtio-blk-device,drive=x2 \
         -device virtio-blk-device,drive=x1 \
         -device virtio-blk-device,drive=x0 \
         -device virtio-keyboard-device \
@@ -111,8 +115,10 @@ if [ "$1" = "tdx" ]; then
         -object '$TDX_OBJECT' \
         -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
         -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
+        -drive if=none,format=raw,id=x2,file=./test/initramfs/build/ltp_dev.img \
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
         -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
+        -device virtio-blk-pci,bus=pcie.0,addr=0x8,drive=x2,serial=vltpdev,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES \
         -device virtio-keyboard-pci,disable-legacy=on,disable-modern=off \
         $NETDEV_ARGS \
@@ -142,13 +148,14 @@ COMMON_QEMU_ARGS="\
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
     -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
     -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
+    -drive if=none,format=raw,id=x2,file=./test/initramfs/build/ltp_dev.img \
 "
 
 # Add xfstests drives when the selected conformance suite is `xfstests`.
 if [ "$ATTACH_XFSTESTS_IMAGES" = "true" ]; then
     COMMON_QEMU_ARGS="$COMMON_QEMU_ARGS \
-    -drive if=none,format=raw,id=x2,file=./test/initramfs/build/xfstests_test.img \
-    -drive if=none,format=raw,id=x3,file=./test/initramfs/build/xfstests_scratch.img \
+    -drive if=none,format=raw,id=x3,file=./test/initramfs/build/xfstests_test.img \
+    -drive if=none,format=raw,id=x4,file=./test/initramfs/build/xfstests_scratch.img \
 "
 fi
 
@@ -173,6 +180,7 @@ if [ "$1" = "microvm" ]; then
         -no-user-config \
         -device virtio-blk-device,drive=x0,serial=vext2 \
         -device virtio-blk-device,drive=x1,serial=vexfat \
+        -device virtio-blk-device,drive=x2,serial=vltpdev \
         -device virtio-keyboard-device \
         -device virtio-net-device,netdev=net01 \
         -device virtio-serial-device \
@@ -184,8 +192,9 @@ else
         -machine q35,kernel-irqchip=split \
         -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        -device virtio-blk-pci,bus=pcie.0,addr=0x8,drive=x2,serial=vltpdev,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -object rng-random,id=rng0,filename=/dev/urandom \
-        -device virtio-rng-pci,bus=pcie.0,addr=0x8,disable-legacy=on,disable-modern=off,rng=rng0,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        -device virtio-rng-pci,bus=pcie.0,addr=0x9,disable-legacy=on,disable-modern=off,rng=rng0,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
         -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \
         -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
         -drive if=none,format=raw,id=nvme0n1,file=./test/initramfs/build/nvme0n1.img \
@@ -199,13 +208,13 @@ fi
 if [ "$ATTACH_XFSTESTS_IMAGES" = "true" ]; then
     if [ "$1" = "microvm" ]; then
         QEMU_ARGS="$QEMU_ARGS \
-        -device virtio-blk-device,drive=x2,serial=vxfstest \
-        -device virtio-blk-device,drive=x3,serial=vxfsscratch \
+        -device virtio-blk-device,drive=x3,serial=vxfstest \
+        -device virtio-blk-device,drive=x4,serial=vxfsscratch \
     "
     else
         QEMU_ARGS="$QEMU_ARGS \
-        -device virtio-blk-pci,bus=pcie.0,addr=0x9,drive=x2,serial=vxfstest,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
-        -device virtio-blk-pci,bus=pcie.0,addr=0xa,drive=x3,serial=vxfsscratch,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        -device virtio-blk-pci,bus=pcie.0,addr=0xa,drive=x3,serial=vxfstest,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+        -device virtio-blk-pci,bus=pcie.0,addr=0xb,drive=x4,serial=vxfsscratch,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     "
     fi
 fi


### PR DESCRIPTION
This is part of the groundwork for #3488.

## Summary

Implement the initial Linux fd-based mount API support for `fsopen`, `fsconfig`, `fsmount`, and `move_mount`. This supports configuring mount contexts through discrete syscall steps, which is required by newer systemd and container managers.

## Changes

### Kernel

- Implement `fsopen`, `fsconfig`, `fsmount`, and `move_mount`.
- Add filesystem configuration contexts and detached mount file descriptors.
- Add `CAP_SYS_ADMIN` checks for fd-based mount API operations.
- Validate `fsconfig` arguments, including NULL key/value cases and duplicate `source` parameters.
- Forward filesystem-specific `fsconfig` options to `FsCreationCtx` instead of hard-coding filesystem option names in the syscall layer.
- Return `EOPNOTSUPP` for unsupported `fsconfig` commands and parameter types.
- Make `fsmount` consume a created filesystem context once, matching Linux `EBUSY` behavior on repeated mounts.
- Support mount attributes such as `MOUNT_ATTR_RDONLY` through per-mount flags.
- Reject moving submounts out of detached mount trees.

### LTP Tests

- Enable `fsopen01`, `fsopen02`, `fsconfig01`, `fsconfig02`, `fsmount01`, and `fsmount02`.
- Keep `fsconfig03` disabled because Asterinas lacks `/proc/sys/kernel/tainted`, which the test uses to check kernel taint status.
- Provide a dedicated LTP block device image and set `LTP_DEV=/dev/vdc` for mount-related LTP coverage.

### gVisor Tests

- Enable `mount_fd_test` in the gVisor syscall test list.
- Cover the upstream `FsOpenTest`, `FsConfigTest`, most `FsMountTest`, and `MoveMountTest` cases added by gVisor.
- Keep `FsMountTest.FsMountSuccess` blocklisted because it requires tmpfs to apply creation options such as `nr_inodes`, which is outside this PR.
- Keep `OpenTreeTest.*` blocklisted because `open_tree` is outside the implemented subset in this PR.

### Regression Tests

- Add regression coverage for basic `fsopen`, `fsconfig`, `fsmount`, and `move_mount` flows.
- Add regression coverage for detached mount movement and empty-path handling.

### SCML Coverage

- Add SCML coverage files for `fsopen`, `fsconfig`, `fsmount`, and `move_mount`.
- Update the filesystem and mount-control syscall coverage README.
