### PR TITLE
Support socket timeout options

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/getsockopt_and_setsockopt.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/networking-and-sockets/getsockopt_and_setsockopt.scml
@@ -1,7 +1,9 @@
 socket_options = SO_SNDBUF | SO_RCVBUF | SO_REUSEADDR | SO_REUSEPORT |
                  SO_PRIORITY | SO_LINGER | SO_PASSCRED | SO_KEEPALIVE |
                  SO_SNDBUFFORCE | SO_RCVBUFFORCE | SO_ERROR |
-                 SO_PEERCRED | SO_ACCEPTCONN | SO_PEERGROUPS;
+                 SO_PEERCRED | SO_ACCEPTCONN | SO_PEERGROUPS |
+                 SO_RCVTIMEO_OLD | SO_RCVTIMEO | SO_SNDTIMEO_OLD |
+                 SO_SNDTIMEO;
 
 ip_options = IP_TOS | IP_TTL | IP_HDRINCL;
 

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -20,7 +20,9 @@ use crate::{
             util::{
                 MessageHeader, SendRecvFlags, SocketAddr,
                 datagram_common::{Bound, Inner, select_remote_and_bind},
-                options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
+                options::{
+                    GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet, SocketTimeouts,
+                },
             },
         },
     },
@@ -37,6 +39,7 @@ pub struct DatagramSocket {
     // Lock order: `inner` first, `options` second
     inner: RwMutex<Inner<UnboundDatagram, BoundDatagram>>,
     options: RwLock<OptionSet>,
+    timeouts: SocketTimeouts,
 
     is_nonblocking: AtomicBool,
     pollee: Pollee,
@@ -64,6 +67,7 @@ impl DatagramSocket {
         Arc::new(Self {
             inner: RwMutex::new(Inner::Unbound(unbound_datagram)),
             options: RwLock::new(OptionSet::new()),
+            timeouts: SocketTimeouts::new(),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
             pseudo_path: SockFs::new_path(),
@@ -229,7 +233,9 @@ impl Socket for DatagramSocket {
         }
 
         let (received_bytes, peer_addr) =
-            self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
+            self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
+                self.try_recv(writer, flags)
+            })?;
 
         // TODO: Receive control message
 
@@ -252,7 +258,10 @@ impl Socket for DatagramSocket {
         let options = self.options.read();
 
         // Deal with socket-level options
-        match options.socket.get_option(option, &*inner) {
+        match options
+            .socket
+            .get_option(option, &(&*inner, &self.timeouts))
+        {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
         }
@@ -266,7 +275,10 @@ impl Socket for DatagramSocket {
         let mut options = self.options.write();
 
         // Deal with socket-level options
-        let need_iface_poll = match options.socket.set_option(option, &*inner) {
+        let need_iface_poll = match options
+            .socket
+            .set_option(option, &(&*inner, &self.timeouts))
+        {
             Err(err) if err.error() == Errno::ENOPROTOOPT => {
                 // Deal with IP-level options
                 options.ip.set_option(option, &*inner)?
@@ -297,7 +309,7 @@ impl Socket for DatagramSocket {
     }
 }
 
-impl GetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {
+impl GetSocketLevelOption for (&Inner<UnboundDatagram, BoundDatagram>, &SocketTimeouts) {
     fn socket_type(&self) -> SockType {
         SockType::SOCK_DGRAM
     }
@@ -305,15 +317,23 @@ impl GetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {
     fn is_listening(&self) -> bool {
         false
     }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.1)
+    }
 }
 
-impl SetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {
+impl SetSocketLevelOption for (&Inner<UnboundDatagram, BoundDatagram>, &SocketTimeouts) {
     fn set_reuse_addr(&self, reuse_addr: bool) {
-        let Inner::Bound(bound) = self else {
+        let Inner::Bound(bound) = self.0 else {
             return;
         };
 
         bound.bound_port().set_can_reuse(reuse_addr);
+    }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.1)
     }
 }
 

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -38,7 +38,9 @@ use crate::{
             private::SocketPrivate,
             util::{
                 MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr,
-                options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
+                options::{
+                    GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet, SocketTimeouts,
+                },
             },
         },
     },
@@ -61,6 +63,7 @@ pub struct StreamSocket {
     // and other locks in `aster-bigtcp`), which will break the atomic mode.
     state: RwLock<Takeable<State>>,
     options: RwLock<OptionSet>,
+    timeouts: SocketTimeouts,
 
     is_nonblocking: AtomicBool,
     pollee: Pollee,
@@ -109,13 +112,18 @@ impl StreamSocket {
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Init(init_stream))),
             options: RwLock::new(OptionSet::new()),
+            timeouts: SocketTimeouts::new(),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
             pseudo_path: SockFs::new_path(),
         })
     }
 
-    fn new_accepted(connected_stream: ConnectedStream, listener_options: &OptionSet) -> Arc<Self> {
+    fn new_accepted(
+        connected_stream: ConnectedStream,
+        listener_options: &OptionSet,
+        listener_timeouts: &SocketTimeouts,
+    ) -> Arc<Self> {
         let options = connected_stream.raw_with(|raw_tcp_socket| {
             let mut options = OptionSet::new();
 
@@ -153,6 +161,7 @@ impl StreamSocket {
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
             options: RwLock::new(options),
+            timeouts: listener_timeouts.clone(),
             is_nonblocking: AtomicBool::new(false),
             pollee,
             pseudo_path: SockFs::new_path(),
@@ -322,7 +331,8 @@ impl StreamSocket {
         let accepted = listen_stream.try_accept().map(|connected_stream| {
             let remote_endpoint = connected_stream.remote_endpoint();
             let listener_options = self.options.read();
-            let accepted_socket = Self::new_accepted(connected_stream, &listener_options);
+            let accepted_socket =
+                Self::new_accepted(connected_stream, &listener_options, &self.timeouts);
             (accepted_socket as _, remote_endpoint.into())
         });
         let iface_to_poll = listen_stream.iface().clone();
@@ -466,7 +476,14 @@ impl Socket for StreamSocket {
             return result;
         }
 
-        self.wait_events(IoEvents::OUT, None, || self.check_connect())
+        let send_timeout = self.timeouts.send_timeout();
+        self.wait_events(IoEvents::OUT, send_timeout.as_ref(), || {
+            self.check_connect()
+        })
+        .map_err(|err| match err.error() {
+            Errno::ETIME => Error::with_message(Errno::EINPROGRESS, "the socket timeout expired"),
+            _ => err,
+        })
     }
 
     fn listen(&self, backlog: usize) -> Result<()> {
@@ -509,7 +526,9 @@ impl Socket for StreamSocket {
     }
 
     fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
-        self.block_on(IoEvents::IN, || self.try_accept())
+        self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
+            self.try_accept()
+        })
     }
 
     fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
@@ -581,7 +600,9 @@ impl Socket for StreamSocket {
             warn!("sending control message is not supported");
         }
 
-        self.block_on(IoEvents::OUT, || self.try_send(reader, flags))
+        self.block_on(IoEvents::OUT, self.timeouts.send_timeout(), || {
+            self.try_send(reader, flags)
+        })
 
         // TODO: Trigger `SIGPIPE` if the error code is `EPIPE` and `MSG_NOSIGNAL` is not specified
     }
@@ -596,7 +617,10 @@ impl Socket for StreamSocket {
             warn!("unsupported flags: {:?}", flags);
         }
 
-        let (received_bytes, _) = self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
+        let (received_bytes, _) =
+            self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
+                self.try_recv(writer, flags)
+            })?;
 
         // TODO: Receive control message
 
@@ -620,7 +644,10 @@ impl Socket for StreamSocket {
         let options = self.options.read();
 
         // Deal with socket-level options
-        match options.socket.get_option(option, state.as_ref()) {
+        match options
+            .socket
+            .get_option(option, &(state.as_ref(), &self.timeouts))
+        {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
         }
@@ -707,7 +734,7 @@ impl Socket for StreamSocket {
         // Deal with socket-level options
         let socket_option_result = {
             let OptionSet { socket, tcp, .. } = &mut *options;
-            socket.set_option(option, &(state.as_ref(), &*tcp))
+            socket.set_option(option, &(state.as_ref(), &*tcp, &self.timeouts))
         };
 
         let need_iface_poll = match socket_option_result {
@@ -912,23 +939,31 @@ impl State {
     }
 }
 
-impl GetSocketLevelOption for State {
+impl GetSocketLevelOption for (&State, &SocketTimeouts) {
     fn socket_type(&self) -> SockType {
         SockType::SOCK_STREAM
     }
 
     fn is_listening(&self) -> bool {
-        matches!(self, Self::Listen(_))
+        matches!(self.0, State::Listen(_))
+    }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.1)
     }
 }
 
-impl SetSocketLevelOption for (&State, &TcpOptionSet) {
+impl SetSocketLevelOption for (&State, &TcpOptionSet, &SocketTimeouts) {
     fn set_reuse_addr(&self, reuse_addr: bool) {
         self.0.set_reuse_addr(reuse_addr);
     }
 
     fn set_keep_alive(&self, keep_alive: bool) -> NeedIfacePoll {
         self.0.set_keep_alive(keep_alive, self.1.keep_intvl())
+    }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.2)
     }
 }
 

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -23,6 +23,8 @@ pub mod util;
 pub mod vsock;
 
 mod private {
+    use core::time::Duration;
+
     use crate::{events::IoEvents, prelude::*, process::signal::Pollable};
 
     /// Common methods for sockets, but private to the network module.
@@ -43,7 +45,12 @@ mod private {
         ///
         /// [`EAGAIN`]: crate::error::Errno::EAGAIN
         #[track_caller]
-        fn block_on<F, R>(&self, events: IoEvents, mut try_op: F) -> Result<R>
+        fn block_on<F, R>(
+            &self,
+            events: IoEvents,
+            timeout: Option<Duration>,
+            mut try_op: F,
+        ) -> Result<R>
         where
             Self: Sized,
             F: FnMut() -> Result<R>,
@@ -51,7 +58,13 @@ mod private {
             if self.is_nonblocking() {
                 try_op()
             } else {
-                self.wait_events(events, None, try_op)
+                self.wait_events(events, timeout.as_ref(), try_op)
+                    .map_err(|err| match err.error() {
+                        Errno::ETIME => {
+                            Error::with_message(Errno::EAGAIN, "the socket timeout expired")
+                        }
+                        _ => err,
+                    })
             }
         }
     }

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -20,7 +20,9 @@ use crate::{
         util::{
             MessageHeader, SendRecvFlags, SocketAddr,
             datagram_common::{Bound, Inner, select_remote_and_bind},
-            options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
+            options::{
+                GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet, SocketTimeouts,
+            },
         },
     },
     prelude::*,
@@ -35,6 +37,7 @@ pub struct NetlinkSocket<P: SupportedNetlinkProtocol> {
     inner: RwMutex<Inner<UnboundNetlink<P>, BoundNetlink<P::Message>>>,
     options: RwLock<OptionSet>,
     socket_type: SockType,
+    timeouts: SocketTimeouts,
 
     is_nonblocking: AtomicBool,
     pollee: Pollee,
@@ -66,6 +69,7 @@ where
             inner: RwMutex::new(Inner::Unbound(unbound)),
             options: RwLock::new(OptionSet::new()),
             socket_type,
+            timeouts: SocketTimeouts::new(),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
             pseudo_path: SockFs::new_path(),
@@ -181,7 +185,10 @@ where
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, MessageHeader)> {
-        let (received_len, addr) = self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
+        let (received_len, addr) =
+            self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
+                self.try_recv(writer, flags)
+            })?;
 
         // TODO: Receive control message
 
@@ -206,7 +213,7 @@ where
         // Deal with socket-level options
         options
             .socket
-            .get_option(option, &(&*inner, self.socket_type))
+            .get_option(option, &(&*inner, self.socket_type, &self.timeouts))
 
         // TODO: Deal with netlink-level options
     }
@@ -216,7 +223,10 @@ where
 
         // Deal with socket-level options
         let mut options = self.options.write();
-        match options.socket.set_option(option, &*inner) {
+        match options
+            .socket
+            .set_option(option, &(&*inner, &self.timeouts))
+        {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res.map(|_need_iface_poll| ()),
         }
@@ -259,6 +269,7 @@ impl<P: SupportedNetlinkProtocol> GetSocketLevelOption
     for (
         &Inner<UnboundNetlink<P>, BoundNetlink<P::Message>>,
         SockType,
+        &SocketTimeouts,
     )
 {
     fn socket_type(&self) -> SockType {
@@ -268,11 +279,21 @@ impl<P: SupportedNetlinkProtocol> GetSocketLevelOption
     fn is_listening(&self) -> bool {
         false
     }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.2)
+    }
 }
 
 impl<P: SupportedNetlinkProtocol> SetSocketLevelOption
-    for Inner<UnboundNetlink<P>, BoundNetlink<P::Message>>
+    for (
+        &Inner<UnboundNetlink<P>, BoundNetlink<P::Message>>,
+        &SocketTimeouts,
+    )
 {
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.1)
+    }
 }
 
 impl<P: SupportedNetlinkProtocol> Inner<UnboundNetlink<P>, BoundNetlink<P::Message>> {

--- a/kernel/src/net/socket/options/mod.rs
+++ b/kernel/src/net/socket/options/mod.rs
@@ -2,7 +2,7 @@
 
 use macros::impl_socket_options;
 
-use super::util::LingerOption;
+use super::util::{LingerOption, SocketTimeout};
 use crate::{net::socket::unix::CUserCred, prelude::*, process::Gid, util::net::SockType};
 
 pub(in crate::net) mod macros;
@@ -24,6 +24,8 @@ impl_socket_options!(
     pub struct KeepAlive(bool);
     pub struct Priority(i32);
     pub struct Linger(LingerOption);
+    pub struct RecvTimeout(SocketTimeout);
+    pub struct SendTimeout(SocketTimeout);
     pub struct ReusePort(bool);
     pub struct PassCred(bool);
     pub struct PeerCred(CUserCred);

--- a/kernel/src/net/socket/unix/datagram/message.rs
+++ b/kernel/src/net/socket/unix/datagram/message.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 use ostd::sync::WaitQueue;
 use spin::Once;
@@ -102,14 +105,22 @@ impl MessageQueue {
     }
 
     /// Blocks until the buffer is free and the `try_send` succeeds, or until interrupted.
-    pub(super) fn block_send<F, R>(&self, mut try_send: F) -> Result<R>
+    pub(super) fn block_send<F, R>(&self, timeout: Option<Duration>, mut try_send: F) -> Result<R>
     where
         F: FnMut() -> Result<R>,
     {
-        self.send_wait_queue.pause_until(|| match try_send() {
-            Err(err) if err.error() == Errno::EAGAIN => None,
-            result => Some(result),
-        })?
+        self.send_wait_queue
+            .pause_until_or_timeout(
+                || match try_send() {
+                    Err(err) if err.error() == Errno::EAGAIN => None,
+                    result => Some(result),
+                },
+                timeout.as_ref(),
+            )
+            .map_err(|err| match err.error() {
+                Errno::ETIME => Error::with_message(Errno::EAGAIN, "the socket timeout expired"),
+                _ => err,
+            })?
     }
 }
 

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 use aster_rights::ReadDupOp;
 
@@ -15,7 +18,9 @@ use crate::{
         unix::{CUserCred, UnixSocketAddr, cred::SocketCred, ctrl_msg::AuxiliaryData},
         util::{
             MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr,
-            options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
+            options::{
+                GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet, SocketTimeouts,
+            },
         },
     },
     prelude::*,
@@ -27,6 +32,7 @@ pub struct UnixDatagramSocket {
     local_receiver: MessageReceiver,
     remote_queue: RwLock<Option<Arc<MessageQueue>>>,
     options: RwLock<OptionSet>,
+    timeouts: SocketTimeouts,
     // Since datagram sockets are not connection-oriented, they typically lack well-defined peer
     // credentials. According to the Linux implementation, however, peer credentials are recorded
     // when a socket pair is created using the `socketpair` system call.
@@ -77,6 +83,7 @@ impl UnixDatagramSocket {
             local_receiver: MessageReceiver::new(),
             remote_queue: RwLock::new(None),
             options: RwLock::new(OptionSet::new()),
+            timeouts: SocketTimeouts::new(),
             peer_cred: None,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             is_write_shutdown: AtomicBool::new(false),
@@ -90,6 +97,7 @@ impl UnixDatagramSocket {
         mut aux_data: AuxiliaryData,
         remote: Option<UnixSocketAddr>,
         _flags: SendRecvFlags,
+        timeout: Option<Duration>,
     ) -> Result<usize> {
         if self.is_write_shutdown.load(Ordering::Relaxed) {
             return_errno_with_message!(Errno::EPIPE, "the socket is shut down for writing");
@@ -108,7 +116,9 @@ impl UnixDatagramSocket {
         let res = if self.is_nonblocking() {
             queue.try_send(reader, &mut aux_data, &self.local_receiver)
         } else {
-            queue.block_send(|| queue.try_send(reader, &mut aux_data, &self.local_receiver))
+            queue.block_send(timeout, || {
+                queue.try_send(reader, &mut aux_data, &self.local_receiver)
+            })
         };
 
         // A connected socket will automatically be disconnected if the remote has been closed.
@@ -227,7 +237,10 @@ impl Socket for UnixDatagramSocket {
         let options = self.options.read();
 
         // Deal with socket-level options
-        match options.socket.get_option(option, &self.local_receiver) {
+        match options
+            .socket
+            .get_option(option, &(&self.local_receiver, &self.timeouts))
+        {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
         }
@@ -241,7 +254,10 @@ impl Socket for UnixDatagramSocket {
     fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
         let mut options = self.options.write();
 
-        match options.socket.set_option(option, &self.local_receiver) {
+        match options
+            .socket
+            .set_option(option, &(&self.local_receiver, &self.timeouts))
+        {
             Err(err) if err.error() == Errno::ENOPROTOOPT => {
                 // TODO: Deal with socket options from other levels
                 warn!("only socket-level options are supported");
@@ -277,7 +293,13 @@ impl Socket for UnixDatagramSocket {
 
         let auxiliary_data = AuxiliaryData::from_control(control_messages)?;
 
-        self.do_send(reader, auxiliary_data, remote_addr, flags)
+        self.do_send(
+            reader,
+            auxiliary_data,
+            remote_addr,
+            flags,
+            self.timeouts.send_timeout(),
+        )
     }
 
     fn recvmsg(
@@ -291,7 +313,9 @@ impl Socket for UnixDatagramSocket {
         }
 
         let (received_bytes, control_messages, peer_addr) =
-            self.block_on(IoEvents::IN, || self.local_receiver.try_recv(writer, flags))?;
+            self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
+                self.local_receiver.try_recv(writer, flags)
+            })?;
 
         let message_header = MessageHeader::new(Some(peer_addr.into()), control_messages);
 
@@ -322,7 +346,7 @@ fn do_unix_getsockopt(option: &mut dyn SocketOption, socket: &UnixDatagramSocket
     Ok(())
 }
 
-impl GetSocketLevelOption for MessageReceiver {
+impl GetSocketLevelOption for (&MessageReceiver, &SocketTimeouts) {
     fn socket_type(&self) -> SockType {
         SockType::SOCK_DGRAM
     }
@@ -330,15 +354,23 @@ impl GetSocketLevelOption for MessageReceiver {
     fn is_listening(&self) -> bool {
         false
     }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.1)
+    }
 }
 
-impl SetSocketLevelOption for MessageReceiver {
+impl SetSocketLevelOption for (&MessageReceiver, &SocketTimeouts) {
     fn set_pass_cred(&self, pass_cred: bool) {
         // TODO: According to the Linux man pages, "When this option is set and the socket
         // is not yet connected, a unique name in the abstract namespace will be generated
         // automatically." See <https://man7.org/linux/man-pages/man7/unix.7.html> for
         // details.
 
-        self.set_pass_cred(pass_cred);
+        self.0.set_pass_cred(pass_cred);
+    }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.1)
     }
 }

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use core::{
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    time::Duration,
+};
 
 use aster_rights::ReadDupOp;
 use ostd::sync::WaitQueue;
@@ -323,14 +326,25 @@ impl Backlog {
     }
 
     /// Blocks until the backlogs are free and the `try_connect` succeeds, or until interrupted.
-    pub(super) fn block_connect<F>(&self, mut try_connect: F) -> Result<()>
+    pub(super) fn block_connect<F>(
+        &self,
+        timeout: Option<Duration>,
+        mut try_connect: F,
+    ) -> Result<()>
     where
         F: FnMut() -> Result<()>,
     {
         self.connect_wait_queue
-            .pause_until(|| match try_connect() {
-                Err(err) if err.error() == Errno::EAGAIN => None,
-                result => Some(result),
+            .pause_until_or_timeout(
+                || match try_connect() {
+                    Err(err) if err.error() == Errno::EAGAIN => None,
+                    result => Some(result),
+                },
+                timeout.as_ref(),
+            )
+            .map_err(|err| match err.error() {
+                Errno::ETIME => Error::with_message(Errno::EAGAIN, "the socket timeout expired"),
+                _ => err,
             })?
     }
 }

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -22,7 +22,9 @@ use crate::{
         unix::{CUserCred, UnixSocketAddr, cred::SocketCred, ctrl_msg::AuxiliaryData},
         util::{
             ControlMessage, MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr,
-            options::{GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet},
+            options::{
+                GetSocketLevelOption, SetSocketLevelOption, SocketOptionSet, SocketTimeouts,
+            },
         },
     },
     prelude::*,
@@ -37,6 +39,7 @@ pub struct UnixStreamSocket {
     // Lock order: `state` first, `options` second
     state: RwMutex<Takeable<State>>,
     options: RwLock<OptionSet>,
+    timeouts: SocketTimeouts,
 
     pollee: Pollee,
     is_nonblocking: AtomicBool,
@@ -175,6 +178,7 @@ impl UnixStreamSocket {
         Arc::new(Self {
             state: RwMutex::new(Takeable::new(State::Init(init))),
             options: RwLock::new(OptionSet::new()),
+            timeouts: SocketTimeouts::new(),
             pollee: Pollee::new(),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             socket_type,
@@ -213,6 +217,7 @@ impl UnixStreamSocket {
         Arc::new(Self {
             state: RwMutex::new(Takeable::new(State::Connected(connected))),
             options: RwLock::new(options),
+            timeouts: SocketTimeouts::new(),
             pollee: cloned_pollee,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             socket_type,
@@ -343,7 +348,8 @@ impl Socket for UnixStreamSocket {
         if self.is_nonblocking() {
             self.try_connect(&backlog)
         } else {
-            backlog.block_connect(|| self.try_connect(&backlog))
+            let timeout = self.timeouts.send_timeout();
+            backlog.block_connect(timeout, || self.try_connect(&backlog))
         }
     }
 
@@ -388,7 +394,9 @@ impl Socket for UnixStreamSocket {
     }
 
     fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
-        self.block_on(IoEvents::IN, || self.try_accept())
+        self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
+            self.try_accept()
+        })
     }
 
     fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
@@ -444,7 +452,7 @@ impl Socket for UnixStreamSocket {
         let options = self.options.read();
         match options
             .socket
-            .get_option(option, &(state.as_ref(), self.socket_type))
+            .get_option(option, &(state.as_ref(), self.socket_type, &self.timeouts))
         {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
@@ -459,8 +467,10 @@ impl Socket for UnixStreamSocket {
     fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
         let state = self.state.read();
         let mut options = self.options.write();
-
-        match options.socket.set_option(option, state.as_ref()) {
+        match options
+            .socket
+            .set_option(option, &(state.as_ref(), &self.timeouts))
+        {
             Err(err) if err.error() == Errno::ENOPROTOOPT => {
                 // TODO: Deal with socket options from other levels
                 warn!("only socket-level options are supported");
@@ -506,7 +516,7 @@ impl Socket for UnixStreamSocket {
         }
         let mut auxiliary_data = AuxiliaryData::from_control(control_messages)?;
 
-        self.block_on(IoEvents::OUT, || {
+        self.block_on(IoEvents::OUT, self.timeouts.send_timeout(), || {
             self.try_send(reader, &mut auxiliary_data, flags)
         })
     }
@@ -522,7 +532,9 @@ impl Socket for UnixStreamSocket {
         }
 
         let (received_bytes, control_messages) =
-            self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
+            self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
+                self.try_recv(writer, flags)
+            })?;
 
         let message_header = MessageHeader::new(None, control_messages);
 
@@ -553,7 +565,7 @@ fn do_unix_getsockopt(option: &mut dyn SocketOption, state: &State) -> Result<()
     Ok(())
 }
 
-impl GetSocketLevelOption for (&State, SockType) {
+impl GetSocketLevelOption for (&State, SockType, &SocketTimeouts) {
     fn socket_type(&self) -> SockType {
         self.1
     }
@@ -561,19 +573,27 @@ impl GetSocketLevelOption for (&State, SockType) {
     fn is_listening(&self) -> bool {
         matches!(self.0, State::Listen(_))
     }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.2)
+    }
 }
 
-impl SetSocketLevelOption for State {
+impl SetSocketLevelOption for (&State, &SocketTimeouts) {
     fn set_pass_cred(&self, pass_cred: bool) {
-        match self {
-            Self::Init(_) => {
+        match self.0 {
+            State::Init(_) => {
                 // TODO: According to the Linux man pages, "When this option is set and the socket
                 // is not yet connected, a unique name in the abstract namespace will be generated
                 // automatically." See <https://man7.org/linux/man-pages/man7/unix.7.html> for
                 // details.
             }
-            Self::Listen(listener) => listener.set_pass_cred(pass_cred),
-            Self::Connected(connected) => connected.set_pass_cred(pass_cred),
+            State::Listen(listener) => listener.set_pass_cred(pass_cred),
+            State::Connected(connected) => connected.set_pass_cred(pass_cred),
         }
+    }
+
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        Some(self.1)
     }
 }

--- a/kernel/src/net/socket/util/mod.rs
+++ b/kernel/src/net/socket/util/mod.rs
@@ -8,6 +8,7 @@ mod port_privilege;
 mod send_recv_flags;
 mod shutdown_cmd;
 mod socket_addr;
+mod socket_timeout;
 
 pub use linger_option::LingerOption;
 pub(super) use message_header::CControlHeader;
@@ -16,3 +17,4 @@ pub(super) use port_privilege::check_port_privilege;
 pub use send_recv_flags::SendRecvFlags;
 pub use shutdown_cmd::SockShutdownCmd;
 pub use socket_addr::SocketAddr;
+pub use socket_timeout::SocketTimeout;

--- a/kernel/src/net/socket/util/options.rs
+++ b/kernel/src/net/socket/util/options.rs
@@ -1,19 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::ops::RangeInclusive;
+use core::{
+    ops::RangeInclusive,
+    sync::atomic::{AtomicU32, AtomicU64, Ordering},
+    time::Duration,
+};
 
 use aster_bigtcp::socket::{
     NeedIfacePoll, TCP_RECV_BUF_LEN, TCP_SEND_BUF_LEN, UDP_RECV_PAYLOAD_LEN, UDP_SEND_PAYLOAD_LEN,
 };
 
-use super::LingerOption;
+use super::{LingerOption, SocketTimeout};
 use crate::{
     net::socket::{
         netlink::NETLINK_DEFAULT_BUF_SIZE,
         options::{
             AcceptConn, Broadcast, KeepAlive, Linger, PassCred, PeerCred, PeerGroups, Priority,
-            RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf, SendBufForce, SocketOption,
-            SocketType,
+            RecvBuf, RecvBufForce, RecvTimeout, ReuseAddr, ReusePort, SendBuf, SendBufForce,
+            SendTimeout, SocketOption, SocketType,
             macros::{sock_option_mut, sock_option_ref},
         },
         unix::{CUserCred, UNIX_DATAGRAM_DEFAULT_BUF_SIZE, UNIX_STREAM_DEFAULT_BUF_SIZE},
@@ -142,6 +146,12 @@ impl SocketOptionSet {
                 let linger = self.linger();
                 socket_linger.set(linger);
             }
+            socket_recv_timeout @ RecvTimeout => {
+                socket_recv_timeout.set(SocketTimeout::new(socket.recv_timeout()));
+            }
+            socket_send_timeout @ SendTimeout => {
+                socket_send_timeout.set(SocketTimeout::new(socket.send_timeout()));
+            }
             socket_reuse_port @ ReusePort => {
                 let reuse_port = self.reuse_port();
                 socket_reuse_port.set(reuse_port);
@@ -227,6 +237,14 @@ impl SocketOptionSet {
                 let linger = socket_linger.get().unwrap();
                 self.set_linger(*linger);
             }
+            socket_recv_timeout @ RecvTimeout => {
+                let recv_timeout = socket_recv_timeout.get().unwrap();
+                socket.set_recv_timeout(recv_timeout.duration());
+            }
+            socket_send_timeout @ SendTimeout => {
+                let send_timeout = socket_send_timeout.get().unwrap();
+                socket.set_send_timeout(send_timeout.duration());
+            }
             socket_reuse_port @ ReusePort => {
                 let reuse_port = socket_reuse_port.get().unwrap();
                 self.set_reuse_port(*reuse_port);
@@ -266,6 +284,78 @@ impl SocketOptionSet {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct SocketTimeouts {
+    recv_timeout: DurationCell,
+    send_timeout: DurationCell,
+}
+
+impl Clone for SocketTimeouts {
+    fn clone(&self) -> Self {
+        Self {
+            recv_timeout: DurationCell::new(self.recv_timeout.load()),
+            send_timeout: DurationCell::new(self.send_timeout.load()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DurationCell {
+    seconds: AtomicU64,
+    nanoseconds: AtomicU32,
+}
+
+impl DurationCell {
+    /// Creates a new duration cell.
+    fn new(duration: Duration) -> Self {
+        Self {
+            seconds: AtomicU64::new(duration.as_secs()),
+            nanoseconds: AtomicU32::new(duration.subsec_nanos()),
+        }
+    }
+
+    /// Loads the current duration.
+    ///
+    /// The returned value is not guaranteed to be a snapshot of a single previous `store` call.
+    fn load(&self) -> Duration {
+        Duration::new(
+            self.seconds.load(Ordering::Relaxed),
+            self.nanoseconds.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Stores a new duration.
+    fn store(&self, duration: Duration) {
+        self.seconds.store(duration.as_secs(), Ordering::Relaxed);
+        self.nanoseconds
+            .store(duration.subsec_nanos(), Ordering::Relaxed);
+    }
+}
+
+impl SocketTimeouts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_recv_timeout(&self, recv_timeout: Option<Duration>) {
+        self.recv_timeout.store(recv_timeout.unwrap_or_default());
+    }
+
+    pub fn set_send_timeout(&self, send_timeout: Option<Duration>) {
+        self.send_timeout.store(send_timeout.unwrap_or_default());
+    }
+
+    pub fn recv_timeout(&self) -> Option<Duration> {
+        let timeout = self.recv_timeout.load();
+        (!timeout.is_zero()).then_some(timeout)
+    }
+
+    pub fn send_timeout(&self) -> Option<Duration> {
+        let timeout = self.send_timeout.load();
+        (!timeout.is_zero()).then_some(timeout)
+    }
+}
+
 fn check_current_privileged() -> Result<()> {
     let current = current_thread!();
     let posix_thread = current.as_posix_thread().unwrap();
@@ -296,6 +386,23 @@ pub(in crate::net) trait GetSocketLevelOption {
 
     /// Returns whether the socket is in listening state.
     fn is_listening(&self) -> bool;
+
+    /// Returns timeout values for blocking socket operations.
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        None
+    }
+
+    /// Returns the receive timeout.
+    fn recv_timeout(&self) -> Option<Duration> {
+        self.socket_timeouts()
+            .and_then(SocketTimeouts::recv_timeout)
+    }
+
+    /// Returns the send timeout.
+    fn send_timeout(&self) -> Option<Duration> {
+        self.socket_timeouts()
+            .and_then(SocketTimeouts::send_timeout)
+    }
 }
 
 /// A trait used for setting socket level options on actual sockets.
@@ -309,4 +416,23 @@ pub(in crate::net) trait SetSocketLevelOption {
     }
     /// Sets whether receipt of the credentials of the sending process is enabled.
     fn set_pass_cred(&self, _pass_cred: bool) {}
+
+    /// Returns timeout values for blocking socket operations.
+    fn socket_timeouts(&self) -> Option<&SocketTimeouts> {
+        None
+    }
+
+    /// Sets the receive timeout.
+    fn set_recv_timeout(&self, recv_timeout: Option<Duration>) {
+        if let Some(timeouts) = self.socket_timeouts() {
+            timeouts.set_recv_timeout(recv_timeout);
+        }
+    }
+
+    /// Sets the send timeout.
+    fn set_send_timeout(&self, send_timeout: Option<Duration>) {
+        if let Some(timeouts) = self.socket_timeouts() {
+            timeouts.set_send_timeout(send_timeout);
+        }
+    }
 }

--- a/kernel/src/net/socket/util/socket_timeout.rs
+++ b/kernel/src/net/socket/util/socket_timeout.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::time::Duration;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SocketTimeout(Option<Duration>);
+
+impl SocketTimeout {
+    pub fn new(duration: Option<Duration>) -> Self {
+        Self(duration)
+    }
+
+    pub fn duration(&self) -> Option<Duration> {
+        self.0
+    }
+}

--- a/kernel/src/net/socket/vsock/stream/mod.rs
+++ b/kernel/src/net/socket/vsock/stream/mod.rs
@@ -301,7 +301,7 @@ impl Socket for VsockStreamSocket {
     }
 
     fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
-        self.block_on(IoEvents::IN, || self.try_accept())
+        self.block_on(IoEvents::IN, None, || self.try_accept())
     }
 
     fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {
@@ -399,7 +399,7 @@ impl Socket for VsockStreamSocket {
             warn!("sending control message is not supported");
         }
 
-        self.block_on(IoEvents::OUT, || self.try_send(reader, flags))
+        self.block_on(IoEvents::OUT, None, || self.try_send(reader, flags))
 
         // TODO: Trigger `SIGPIPE` if the error code is `EPIPE` and `MSG_NOSIGNAL` is not specified
     }
@@ -414,7 +414,7 @@ impl Socket for VsockStreamSocket {
             warn!("unsupported flags: {:?}", flags);
         }
 
-        let received_bytes = self.block_on(IoEvents::IN, || self.try_recv(writer, flags))?;
+        let received_bytes = self.block_on(IoEvents::IN, None, || self.try_recv(writer, flags))?;
 
         // TODO: Receive control message
         let message_header = MessageHeader::new(None, Vec::new());

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -118,7 +118,7 @@ impl TryFrom<timeval_t> for Duration {
         if timeval.sec < 0 || timeval.usec < 0 {
             return_errno_with_message!(Errno::EINVAL, "timeval_t cannot be negative");
         }
-        if timeval.usec > USEC_PER_SEC {
+        if timeval.usec >= USEC_PER_SEC {
             // The value of microsecond cannot exceed 10^6,
             // otherwise the value for seconds should be set.
             return_errno_with_message!(Errno::EINVAL, "nsec is not normalized");

--- a/kernel/src/util/net/options/socket.rs
+++ b/kernel/src/util/net/options/socket.rs
@@ -7,8 +7,8 @@ use crate::{
     context::current_userspace,
     net::socket::options::{
         AcceptConn, Broadcast, Error, KeepAlive, Linger, PassCred, PeerCred, PeerGroups, Priority,
-        RecvBuf, RecvBufForce, ReuseAddr, ReusePort, SendBuf, SendBufForce, SocketOption,
-        SocketType,
+        RecvBuf, RecvBufForce, RecvTimeout, ReuseAddr, ReusePort, SendBuf, SendBufForce,
+        SendTimeout, SocketOption, SocketType,
     },
     prelude::*,
     process::Gid,
@@ -39,6 +39,8 @@ enum CSocketOptionName {
     REUSEPORT = 15,
     PASSCRED = 16,
     PEERCRED = 17,
+    RCVTIMEO_OLD = 20,
+    SNDTIMEO_OLD = 21,
     ATTACH_FILTER = 26,
     DETACH_FILTER = 27,
     ACCPETCONN = 30,
@@ -62,6 +64,15 @@ pub fn new_socket_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
         CSocketOptionName::KEEPALIVE => Ok(Box::new(KeepAlive::new())),
         CSocketOptionName::PRIORITY => Ok(Box::new(Priority::new())),
         CSocketOptionName::LINGER => Ok(Box::new(Linger::new())),
+        // On 64-bit systems, the old and new timeout options share the same
+        // `timeval_t` layout and can use the same handlers. A 32-bit userspace
+        // ABI would need separate handlers for the old and new layouts.
+        CSocketOptionName::RCVTIMEO_OLD | CSocketOptionName::RCVTIMEO_NEW => {
+            Ok(Box::new(RecvTimeout::new()))
+        }
+        CSocketOptionName::SNDTIMEO_OLD | CSocketOptionName::SNDTIMEO_NEW => {
+            Ok(Box::new(SendTimeout::new()))
+        }
         CSocketOptionName::REUSEPORT => Ok(Box::new(ReusePort::new())),
         CSocketOptionName::PASSCRED => Ok(Box::new(PassCred::new())),
         CSocketOptionName::PEERCRED => Ok(Box::new(PeerCred::new())),
@@ -82,6 +93,8 @@ impl_raw_socket_option!(RecvBuf);
 impl_raw_socket_option!(KeepAlive);
 impl_raw_socket_option!(Priority);
 impl_raw_socket_option!(Linger);
+impl_raw_socket_option!(RecvTimeout);
+impl_raw_socket_option!(SendTimeout);
 impl_raw_socket_option!(ReusePort);
 impl_raw_socket_option!(PassCred);
 impl_raw_sock_option_get_only!(PeerCred);

--- a/kernel/src/util/net/options/utils.rs
+++ b/kernel/src/util/net/options/utils.rs
@@ -9,9 +9,10 @@ use crate::{
     net::socket::{
         ip::{options::IpTtl, stream_options::CongestionControl},
         unix::CUserCred,
-        util::LingerOption,
+        util::{LingerOption, SocketTimeout},
     },
     prelude::*,
+    time::timeval_t,
     util::net::SockType,
 };
 
@@ -162,6 +163,39 @@ impl WriteToUser for LingerOption {
 
         let linger = CLinger::from(*self);
         current_userspace!().write_val(addr, &linger)?;
+        Ok(write_len)
+    }
+}
+
+impl ReadFromUser for SocketTimeout {
+    fn read_from_user(addr: Vaddr, max_len: u32) -> Result<Self> {
+        if (max_len as usize) < size_of::<timeval_t>() {
+            return_errno_with_message!(Errno::EINVAL, "max_len is too short");
+        }
+
+        let timeval = current_userspace!().read_val::<timeval_t>(addr)?;
+        if timeval.sec < 0 {
+            return Ok(Self::new(None));
+        }
+
+        let duration: Duration = timeval
+            .try_into()
+            .map_err(|_| Error::with_message(Errno::EDOM, "usec is out of range"))?;
+        Ok(Self::new((!duration.is_zero()).then_some(duration)))
+    }
+}
+
+impl WriteToUser for SocketTimeout {
+    fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
+        let write_len = size_of::<timeval_t>();
+
+        if (max_len as usize) < write_len {
+            return_errno_with_message!(Errno::EINVAL, "max_len is too short");
+        }
+
+        let timeval = timeval_t::from(self.duration().unwrap_or_default());
+        current_userspace!().write_val(addr, &timeval)?;
+
         Ok(write_len)
     }
 }

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_dgram_local_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_dgram_local_test
@@ -2,9 +2,6 @@
 DgramUnixSockets/NonStreamSocketPairTest.SplitRecv/*
 DgramUnixSockets/NonStreamSocketPairTest.RecvmsgTruncPeekDontwaitZeroLen/*
 
-# TODO: Support `SO_SNDTIMEO`
-DgramUnixSockets/UnixNonStreamSocketPairTest.SendTimeout/*
-
 # TODO: Support `MSG_TRUNC`
 DgramUnixSockets/NonStreamSocketPairTest.MsgTruncTruncation/*
 DgramUnixSockets/NonStreamSocketPairTest.MsgTruncTruncationRecvmsgMsghdrFlagMsgTrunc/*

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_seqpacket_local_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_seqpacket_local_test
@@ -2,9 +2,6 @@
 SeqpacketUnixSockets/NonStreamSocketPairTest.SplitRecv/*
 SeqpacketUnixSockets/NonStreamSocketPairTest.RecvmsgTruncPeekDontwaitZeroLen/*
 
-# TODO: Support `SO_SNDTIMEO`
-SeqpacketUnixSockets/UnixNonStreamSocketPairTest.SendTimeout/*
-
 # TODO: Support `MSG_TRUNC`
 SeqpacketUnixSockets/NonStreamSocketPairTest.MsgTruncTruncation/*
 SeqpacketUnixSockets/NonStreamSocketPairTest.MsgTruncTruncationRecvmsgMsghdrFlagMsgTrunc/*

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_stream_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_unix_stream_test
@@ -1,6 +1,3 @@
-# TODO: Support the `SO_RCVTIMEO` socket option
-AllUnixDomainSockets/StreamUnixSocketPairTest.RecvmsgOneSideClosed/*
-
 # TODO: Support `ECONNRESET` errors on UNIX sockets
 AllUnixDomainSockets/StreamUnixSocketPairTest.ReadOneSideClosedWithUnreadData/*
 

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
@@ -135,6 +136,110 @@ FN_TEST(socket_type)
 
 	TEST_RES(getsockopt(sk_udp, SOL_SOCKET, SO_TYPE, &type, &type_len),
 		 type == SOCK_DGRAM && type_len == sizeof(type));
+}
+END_TEST()
+
+FN_TEST(socket_timeout)
+{
+	struct timeval timeout;
+	socklen_t timeout_len;
+	char buf;
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 0 &&
+			 timeout_len == sizeof(timeout));
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 200000 };
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 200000 &&
+			 timeout_len == sizeof(timeout));
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 100000 };
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 100000 &&
+			 timeout_len == sizeof(timeout));
+
+	TEST_SUCC(close(sk_connected));
+	TEST_SUCC(close(sk_accepted));
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 500000 };
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 600000 };
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
+
+	sk_connected = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+	TEST_SUCC(connect(sk_connected, (struct sockaddr *)&listen_addr,
+			  sizeof(listen_addr)));
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 700000 };
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 800000 };
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
+
+	sk_accepted = TEST_SUCC(accept(sk_listen, NULL, NULL));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_accepted, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 700000 &&
+			 timeout_len == sizeof(timeout));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_accepted, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 800000 &&
+			 timeout_len == sizeof(timeout));
+
+	timeout = (struct timeval){ .tv_sec = -1, .tv_usec = 0 };
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 0 &&
+			 timeout_len == sizeof(timeout));
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = -1 };
+	TEST_ERRNO(setsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			      sizeof(timeout)),
+		   EDOM);
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 1000000 };
+	TEST_ERRNO(setsockopt(sk_connected, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			      sizeof(timeout)),
+		   EDOM);
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 200000 };
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_ERRNO(recv(sk_connected, &buf, sizeof(buf), 0), EAGAIN);
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 0 };
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/network/sockoption_unix.c
+++ b/test/initramfs/src/regression/network/sockoption_unix.c
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
@@ -57,6 +58,87 @@ FN_TEST(priority)
 	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_PRIORITY, &val, len));
 	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_PRIORITY, &val, &len),
 		 val == 100);
+}
+END_TEST()
+
+FN_TEST(socket_timeout)
+{
+	struct sockaddr_un timeout_addr = {
+		.sun_family = AF_UNIX, .sun_path = "/tmp/sock_timeout_test"
+	};
+	struct timeval timeout;
+	socklen_t timeout_len;
+	char buf;
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 100000 };
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 200000 };
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 100000 &&
+			 timeout_len == sizeof(timeout));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_listen, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 200000 &&
+			 timeout_len == sizeof(timeout));
+
+	int sk_timeout_listen = TEST_SUCC(socket(PF_UNIX, SOCK_STREAM, 0));
+	TEST_SUCC(bind(sk_timeout_listen, (struct sockaddr *)&timeout_addr,
+		       sizeof(timeout_addr)));
+	TEST_SUCC(listen(sk_timeout_listen, 0));
+
+	int sk_queued = TEST_SUCC(socket(PF_UNIX, SOCK_STREAM, 0));
+	TEST_SUCC(connect(sk_queued, (struct sockaddr *)&timeout_addr,
+			  sizeof(timeout_addr)));
+	int sk_blocked = TEST_SUCC(socket(PF_UNIX, SOCK_STREAM, 0));
+	TEST_SUCC(setsockopt(sk_blocked, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_ERRNO(connect(sk_blocked, (struct sockaddr *)&timeout_addr,
+			   sizeof(timeout_addr)),
+		   EAGAIN);
+	TEST_SUCC(close(sk_blocked));
+	TEST_SUCC(close(sk_queued));
+	TEST_SUCC(close(sk_timeout_listen));
+	TEST_SUCC(unlink(timeout_addr.sun_path));
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 100000 };
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_ERRNO(recv(sk_connected, &buf, sizeof(buf), 0), EAGAIN);
+
+	int sk_client = TEST_SUCC(socket(PF_UNIX, SOCK_STREAM, 0));
+	TEST_SUCC(connect(sk_client, (struct sockaddr *)&addr, sizeof(addr)));
+	int sk_server = TEST_SUCC(accept(sk_listen, NULL, NULL));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_server, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 0 &&
+			 timeout_len == sizeof(timeout));
+
+	timeout_len = sizeof(timeout);
+	TEST_RES(getsockopt(sk_server, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			    &timeout_len),
+		 timeout.tv_sec == 0 && timeout.tv_usec == 0 &&
+			 timeout_len == sizeof(timeout));
+
+	TEST_SUCC(close(sk_client));
+	TEST_SUCC(close(sk_server));
+
+	timeout = (struct timeval){ .tv_sec = 0, .tv_usec = 0 };
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_SUCC(setsockopt(sk_listen, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+			     sizeof(timeout)));
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
 }
 END_TEST()
 


### PR DESCRIPTION
Part of #3430.

## Summary

This PR adds `SO_RCVTIMEO` and `SO_SNDTIMEO` support for socket operations.

It includes:

- `getsockopt`/`setsockopt` support for receive and send timeouts.
- Timeout-aware waits for blocking socket operations.
- Correct syscall restart behavior when socket timeouts are configured.
- Regression tests for TCP and Unix socket timeout behavior.