### PR TITLE
Fix `clone_thread` regression test stack reuse race

### DIFF
--- a/test/initramfs/src/regression/process/clone3/clone_parent.c
+++ b/test/initramfs/src/regression/process/clone3/clone_parent.c
@@ -98,7 +98,7 @@ END_TEST()
 int pipefds[2];
 // A stack for the new thread
 #define STACK_SIZE (1024 * 1024) // 1MB stack
-char child_stack[STACK_SIZE];
+char child_stack[2][STACK_SIZE];
 
 int child_function(void *arg)
 {
@@ -113,13 +113,13 @@ FN_TEST(clone_thread)
 	TEST_SUCC((pipe(pipefds)));
 
 	// Clone
-	TEST_SUCC(clone(child_function, child_stack + STACK_SIZE,
+	TEST_SUCC(clone(child_function, child_stack[0] + STACK_SIZE,
 			CLONE_PARENT | CLONE_THREAD | CLONE_VM | CLONE_SIGHAND,
 			NULL));
 	TEST_RES(read(pipefds[0], buf, 1), buf[0] == 'a');
 
 	// Clone
-	TEST_SUCC(clone(child_function, child_stack + STACK_SIZE,
+	TEST_SUCC(clone(child_function, child_stack[1] + STACK_SIZE,
 			CLONE_PARENT | CLONE_THREAD | CLONE_VM | CLONE_SIGHAND |
 				SIGCHLD,
 			NULL));


### PR DESCRIPTION
The failure was observed in CI:

https://github.com/asterinas/asterinas/actions/runs/28461344139/job/84349709936#step:5:2648

The relevant log was:

```text
test_clone_thread: `(pipe(pipefds))` passed [got Success]
test_clone_thread: `clone(child_function, child_stack + (1024 * 1024), 0x00008000 | 0x00010000 | 0x00000100 | 0x00000800, ((void *)0))` passed [got Success]
test_clone_thread: `read(pipefds[0], buf, 1)` passed [got Success]
test_clone_thread: `clone(child_function, child_stack + (1024 * 1024), 0x00008000 | 0x00010000 | 0x00000100 | 0x00000800 | 17, ((void *)0))` passed [got Success]
Segmentation fault
Regression test failed
```

Related code:
https://github.com/asterinas/asterinas/blob/94379b8da3668e17c75180f07799b17a49549a71/test/initramfs/src/regression/process/clone3/clone_parent.c#L110-L126

The code reused the same userspace stack for two consecutive `clone()` calls. The pipe read only proves that the first cloned thread has written one byte; it does not prove that the thread has fully exited and stopped using that stack.

As a result, the second cloned thread may reuse the stack while the first thread is still on its return/exit path, causing a racy `SIGSEGV`.

We can reproduce it locally:
```c
#define _GNU_SOURCE

#include <errno.h>
#include <linux/sched.h>
#include <sched.h>
#include <signal.h>
#include <stdio.h>
#include <string.h>
#include <sys/mman.h>
#include <sys/wait.h>
#include <unistd.h>

#define STACK_SIZE (1024 * 1024)
#define MAX_ITERS 100000

static int pipefds[2];
static char child_stack[STACK_SIZE];
static volatile int *current_iter;

static int child_function(void *arg)
{
        char buf[1] = { 'a' };
        (void)arg;

        if (write(pipefds[1], buf, 1) != 1) {
                _exit(101);
        }

        return 0;
}

static int run_one_iteration(int iter)
{
        char buf[1] = { 0 };
        int flags = CLONE_PARENT | CLONE_THREAD | CLONE_VM | CLONE_SIGHAND;

        if (pipe(pipefds) != 0) {
                perror("pipe");
                return 1;
        }

        if (clone(child_function, child_stack + STACK_SIZE, flags, NULL) < 0) {
                fprintf(stderr, "iter %d: first clone failed: %s\n", iter, strerror(errno));
                return 2;
        }
        if (read(pipefds[0], buf, 1) != 1 || buf[0] != 'a') {
                fprintf(stderr, "iter %d: first read failed\n", iter);
                return 3;
        }

        if (clone(child_function, child_stack + STACK_SIZE, flags | SIGCHLD, NULL) < 0) {
                fprintf(stderr, "iter %d: second clone failed: %s\n", iter, strerror(errno));
                return 4;
        }
        if (read(pipefds[0], buf, 1) != 1 || buf[0] != 'a') {
                fprintf(stderr, "iter %d: second read failed\n", iter);
                return 5;
        }

        close(pipefds[0]);
        close(pipefds[1]);
        return 0;
}

static int run_until_crash(void)
{
        for (int iter = 0; iter < MAX_ITERS; iter++) {
                *current_iter = iter;

                int err = run_one_iteration(iter);
                if (err != 0) {
                        return err;
                }
        }

        return 0;
}

int main(void)
{
        setvbuf(stdout, NULL, _IONBF, 0);

        current_iter = mmap(NULL, sizeof(*current_iter), PROT_READ | PROT_WRITE,
                            MAP_SHARED | MAP_ANONYMOUS, -1, 0);
        if (current_iter == MAP_FAILED) {
                perror("mmap");
                return 1;
        }

        printf("Reusing one child stack for two clone() calls.\n");
        printf("Running up to %d iterations; expecting SIGSEGV if the race is hit.\n", MAX_ITERS);

        pid_t pid = fork();
        if (pid < 0) {
                perror("fork");
                return 1;
        }

        if (pid == 0) {
                _exit(run_until_crash());
        }

        int status = 0;
        if (waitpid(pid, &status, 0) < 0) {
                perror("waitpid");
                return 1;
        }

        if (WIFSIGNALED(status)) {
                printf("Reproduced: child died from signal %d near iter %d.\n",
                       WTERMSIG(status), *current_iter);
                return 128 + WTERMSIG(status);
        }

        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
                printf("Child exited with status %d near iter %d.\n", status, *current_iter);
                return WIFEXITED(status) ? WEXITSTATUS(status) : 1;
        }

        printf("No crash after %d iterations.\n", MAX_ITERS);
        return 0;
}
```

Example output with the buggy single-stack pattern:

```text
Reusing one child stack for two clone() calls.
Running up to 100000 iterations; expecting SIGSEGV if the race is hit.
Reproduced: child died from signal 11 near iter 11.
```

This PR gives the two `clone()` calls separate child stacks.