### PR TITLE
Fix FcntlTest.SetFlags

### DIFF
--- a/kernel/src/fs/file/file_attr/status_flags.rs
+++ b/kernel/src/fs/file/file_attr/status_flags.rs
@@ -5,6 +5,25 @@ use core::sync::atomic::AtomicU32;
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 use bitflags::bitflags;
 
+// O_LARGEFILE values from Linux kernel headers:
+// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/include/uapi/asm-generic/fcntl.h#L50>
+// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/arch/arm64/include/uapi/asm/fcntl.h#L26>
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "riscv64",
+    target_arch = "loongarch64"
+))]
+const O_LARGEFILE_VALUE: u32 = 1 << 15;
+#[cfg(target_arch = "aarch64")]
+const O_LARGEFILE_VALUE: u32 = 1 << 17;
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "riscv64",
+    target_arch = "loongarch64",
+    target_arch = "aarch64"
+)))]
+const O_LARGEFILE_VALUE: u32 = 0;
+
 bitflags! {
     pub struct StatusFlags: u32 {
         /// append on each write
@@ -17,7 +36,8 @@ bitflags! {
         const O_ASYNC = 1 << 13;
         /// direct I/O
         const O_DIRECT = 1 << 14;
-        /// on x86_64, O_LARGEFILE is 0
+        /// enable large file support (x86_64/riscv64/loongarch64: 1<<15, arm64: 1<<17)
+        const O_LARGEFILE = O_LARGEFILE_VALUE;
         /// not update st_atime
         const O_NOATIME = 1 << 18;
         /// synchronized I/O, data and metadata

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -75,9 +75,25 @@ fn handle_getfl(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     let file = get_file_fast!(&mut file_table, fd);
     let status_flags = file.status_flags();
     let access_mode = file.access_mode();
-    Ok(SyscallReturn::Return(
-        (status_flags.bits() | access_mode as u32) as _,
-    ))
+
+    // Linux `F_GETFL` returns `status_flags | access_mode`, with `O_LARGEFILE`
+    // conditionally included based on file type:
+    // - O_PATH descriptors: return `status_flags` only (no access mode, no `O_LARGEFILE`).
+    // - Anonymous pipes (pipefs): return `status_flags | access_mode` (no `O_LARGEFILE`).
+    // - All other files: ensure `O_LARGEFILE` is present in the returned flags.
+    //   In Linux, `force_o_largefile()` adds `O_LARGEFILE` automatically on open
+    //   for most architectures; we enforce it here to guarantee consistent behavior.
+    //   Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/open.c#L1458>
+    //   Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/include/linux/fcntl.h#L25>
+    let result = if status_flags.contains(StatusFlags::O_PATH) {
+        status_flags.bits()
+    } else if file.path().inode().fs().name() == "pipefs" {
+        status_flags.bits() | access_mode as u32
+    } else {
+        status_flags.bits() | access_mode as u32 | StatusFlags::O_LARGEFILE.bits()
+    };
+
+    Ok(SyscallReturn::Return(result as _))
 }
 
 fn handle_setfl(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {

--- a/test/initramfs/src/conformance/gvisor/blocklists/fcntl_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/fcntl_test
@@ -6,7 +6,6 @@ FcntlTest.GetO_ASYNC
 FcntlTest.RegularFileOAsync
 FcntlTest.SetFdO_ASYNC
 FcntlTest.SetFileStatusFlagWithOpath
-FcntlTest.SetFlags
 FcntlTest.SetFlO_ASYNC
 FcntlTest.SetFlSetOwnSetSigDoNotRace
 FcntlTest.SetSig


### PR DESCRIPTION
Modify the test `FcntlTest.SetFlags`.

https://github.com/google/gvisor/blob/abf59273b7ba39536ad07ca6579c047f3101f9bb/test/util/fs_util.h#L33
```
// O_LARGEFILE as defined by Linux. glibc tries to be clever by setting it to 0
// because "it isn't needed", even though Linux can return it via F_GETFL.
```

The test code is as follows: if the kernel is a 64-bit system, the `O_LARGEFILE` flag will be automatically added, and the values will differ between x86_64 and aarch64
https://github.com/google/gvisor/blob/df56fdbc6497bc047f3db859a48a67cf37c2e56f/test/syscalls/linux/fcntl.cc#L357 
Definition in kernel
https://elixir.bootlin.com/linux/v6.16.5/source/tools/testing/selftests/openat2/openat2_test.c#L26-L30 
Currently, the modification involves adding the `O_LARGEFILE` definition and returning it in `handle_getfl`.

However, if we directly return the flag, `pipe_test` and `fcntl_test` will fail. Upon further analysis of the reasons for the test failures, we found that different conditions need to be considered for the return values.

Modified `handle_getfl` function in kernel/src/syscall/fcntl.rs to return different flag combinations based on file type:
1. `O_PATH` descriptors: Return only `status_flags`
2. Anonymous pipes (pipefs): Return `status_flags | access_mode` (no O_LARGEFILE )
3. Named pipes and regular files : Return `status_flags | access_mode | O_LARGEFILE`

The check has been passed for /aster-code-review