### PR TITLE
Implement F_SETSIG/F_GETSIG fcntl commands

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/fcntl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/fcntl.scml
@@ -4,9 +4,9 @@ can_change_flags = O_APPEND | O_ASYNC | O_DIRECT | O_NOATIME | O_NONBLOCK;
 // Duplicate a file descriptor
 fcntl(fd, cmd = F_DUPFD | F_DUPFD_CLOEXEC, arg);
 
-// Retrieve file descriptor flags (F_GETFD), file status flags (F_GETFL)
-// or SIGIO/SIGURG owner process (F_GETOWN)
-fcntl(fd, cmd = F_GETFD | F_GETFL | F_GETOWN);
+// Retrieve file descriptor flags (F_GETFD), file status flags (F_GETFL),
+// SIGIO/SIGURG owner process (F_GETOWN), or the async I/O signal number (F_GETSIG)
+fcntl(fd, cmd = F_GETFD | F_GETFL | F_GETOWN | F_GETSIG);
 
 // Set file descriptor flags
 fcntl(fd, cmd = F_SETFD, arg = FD_CLOEXEC);
@@ -19,6 +19,9 @@ fcntl(fd, cmd = F_GETLK | F_SETLK | F_SETLKW, arg);
 
 // Assign SIGIO/SIGURG owner process
 fcntl(fd, cmd = F_SETOWN, arg);
+
+// Set the signal sent when async I/O is possible (0 = default SIGIO)
+fcntl(fd, cmd = F_SETSIG, arg);
 
 // Add seals to the inode referred to
 fcntl(fd, cmd = F_ADD_SEALS, arg = F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_FUTURE_WRITE);

--- a/kernel/src/fs/file/file_common.rs
+++ b/kernel/src/fs/file/file_common.rs
@@ -11,7 +11,7 @@ use crate::{
     prelude::*,
     process::{
         Pid, Process,
-        signal::{PollAdaptor, constants::SIGIO},
+        signal::{PollAdaptor, constants::SIGIO, sig_num::SigNum},
     },
 };
 
@@ -60,7 +60,7 @@ impl FileCommon {
         let mut owner_guard = self.owner.inner.lock();
         if let Some(owner) = owner_guard.as_mut() {
             if update.flags().contains(StatusFlags::O_ASYNC) {
-                owner.register_observer(file);
+                owner.register_observer(file, self.owner.sigio_signum.clone());
             } else {
                 owner.unregister_observer();
             }
@@ -84,6 +84,9 @@ impl FileCommon {
 /// The process that receives asynchronous I/O signals for a file description.
 pub struct FileOwner {
     inner: Mutex<Option<Owner>>,
+    /// The signal number for async I/O notifications.
+    /// `None` means no custom signal has been set; the default signal is used.
+    sigio_signum: Arc<Mutex<Option<SigNum>>>,
 }
 
 impl FileOwner {
@@ -91,12 +94,24 @@ impl FileOwner {
     pub fn new() -> Self {
         Self {
             inner: Mutex::new(None),
+            sigio_signum: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Returns the process ID of the current owner.
     pub fn pid(&self) -> Option<Pid> {
         self.inner.lock().as_ref().map(|owner| owner.pid)
+    }
+
+    /// Returns the custom async I/O signal number, or `None` if not set.
+    pub fn sigio_signum(&self) -> Option<SigNum> {
+        *self.sigio_signum.lock()
+    }
+
+    /// Sets the custom async I/O signal number.
+    /// Passing `None` resets to the default behavior.
+    pub fn set_sigio_signum(&self, signal: Option<SigNum>) {
+        *self.sigio_signum.lock() = signal;
     }
 
     pub(super) fn set(&self, file: &dyn FileLike, owner: Option<&Arc<Process>>) {
@@ -109,7 +124,7 @@ impl FileOwner {
 
         let mut owner = Owner::new(process);
         if file.status_flags().contains(StatusFlags::O_ASYNC) {
-            owner.register_observer(file);
+            owner.register_observer(file, self.sigio_signum.clone());
         }
         *owner_guard = Some(owner);
     }
@@ -136,12 +151,13 @@ impl Owner {
         }
     }
 
-    fn register_observer(&mut self, file: &dyn FileLike) {
+    fn register_observer(&mut self, file: &dyn FileLike, sigio_signum: Arc<Mutex<Option<SigNum>>>) {
         if self.poller.is_some() {
             return;
         }
 
-        let mut poller = PollAdaptor::with_observer(OwnerObserver::new(self.process.clone()));
+        let mut poller =
+            PollAdaptor::with_observer(OwnerObserver::new(self.process.clone(), sigio_signum));
         file.poll(IoEvents::IN | IoEvents::OUT, Some(poller.as_handle_mut()));
         self.poller = Some(poller);
     }
@@ -153,16 +169,21 @@ impl Owner {
 
 struct OwnerObserver {
     owner: Weak<Process>,
+    sigio_signum: Arc<Mutex<Option<SigNum>>>,
 }
 
 impl OwnerObserver {
-    fn new(owner: Weak<Process>) -> Self {
-        Self { owner }
+    fn new(owner: Weak<Process>, sigio_signum: Arc<Mutex<Option<SigNum>>>) -> Self {
+        Self {
+            owner,
+            sigio_signum,
+        }
     }
 }
 
 impl Observer<IoEvents> for OwnerObserver {
     fn on_events(&self, _events: &IoEvents) {
-        crate::process::enqueue_signal_async(self.owner.clone(), SIGIO);
+        let signum = self.sigio_signum.lock().unwrap_or(SIGIO);
+        crate::process::enqueue_signal_async(self.owner.clone(), signum);
     }
 }

--- a/kernel/src/process/signal/constants.rs
+++ b/kernel/src/process/signal/constants.rs
@@ -60,6 +60,8 @@ define_std_signums! {
     SIGSYS    = 31, // Bad system call (SVr4); see also seccomp(2)
 }
 
+pub const SIGRTMAX: SigNum = SigNum::from_u8(MAX_RT_SIG_NUM);
+
 pub const SI_ASYNCNL: i32 = -60;
 pub const SI_TKILL: i32 = -6;
 pub const SI_SIGIO: i32 = -5;

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -13,7 +13,10 @@ use crate::{
         vfs::range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
     },
     prelude::*,
-    process::{Pid, pid_table},
+    process::{
+        Pid, pid_table,
+        signal::{constants::SIGRTMAX, sig_num::SigNum},
+    },
 };
 
 pub fn sys_fcntl(raw_fd: RawFileDesc, cmd: i32, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
@@ -35,6 +38,8 @@ pub fn sys_fcntl(raw_fd: RawFileDesc, cmd: i32, arg: u64, ctx: &Context) -> Resu
         }),
         FcntlCmd::F_GETOWN => handle_getown(fd, ctx),
         FcntlCmd::F_SETOWN => handle_setown(fd, arg, ctx),
+        FcntlCmd::F_GETSIG => handle_getsig(fd, ctx),
+        FcntlCmd::F_SETSIG => handle_setsig(fd, arg, ctx),
         FcntlCmd::F_ADD_SEALS => handle_addseal(fd, arg, ctx),
         FcntlCmd::F_GET_SEALS => handle_getseal(fd, ctx),
     }
@@ -178,6 +183,39 @@ fn handle_getseal(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     Ok(SyscallReturn::Return(file_seals.bits() as _))
 }
 
+fn handle_getsig(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+    let sig = file
+        .common()
+        .owner()
+        .sigio_signum()
+        .map(|s| s.as_u8())
+        .unwrap_or(0);
+    Ok(SyscallReturn::Return(sig as _))
+}
+
+fn handle_setsig(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
+    // 0 resets to default; 1..=SIGRTMAX are valid custom signals.
+    if arg > SIGRTMAX.as_u8() as u64 {
+        // 64 is SIGRTMAX; see signal::constants::SIGRTMAX.
+        return_errno_with_message!(Errno::EINVAL, "signal number must be in 0..=64");
+    }
+    let signal = arg as u8;
+
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+
+    if signal == 0 {
+        file.common().owner().set_sigio_signum(None);
+    } else {
+        file.common()
+            .owner()
+            .set_sigio_signum(Some(SigNum::try_from(signal)?));
+    }
+    Ok(SyscallReturn::Return(0))
+}
+
 #[expect(non_camel_case_types)]
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, TryFromInt)]
@@ -192,6 +230,8 @@ enum FcntlCmd {
     F_SETLKW = 7,
     F_SETOWN = 8,
     F_GETOWN = 9,
+    F_SETSIG = 10,
+    F_GETSIG = 11,
     F_DUPFD_CLOEXEC = 1030,
     F_ADD_SEALS = 1033,
     F_GET_SEALS = 1034,

--- a/test/initramfs/src/conformance/gvisor/blocklists/fcntl_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/fcntl_test
@@ -9,11 +9,6 @@ FcntlTest.SetFileStatusFlagWithOpath
 FcntlTest.SetFlags
 FcntlTest.SetFlO_ASYNC
 FcntlTest.SetFlSetOwnSetSigDoNotRace
-FcntlTest.SetSig
-FcntlTest.SetSigDefaultsToZero
-FcntlTest.SetSigToDefault
-FcntlTest.SetSigInvalid
-FcntlTest.SetSigInvalidDoesNotResetPreviousChoice
 # SetOwnPgrp is verified with F_GETOWN_EX, which is not supported now.
 FcntlTest.SetOwnPgrp
 FcntlTest.SetFlSetOwnDoNotRace


### PR DESCRIPTION
Modify the test FcntlTest.SetSig
Refer to the test code at https://github.com/google/gvisor/blob/df56fdbc6497bc047f3db859a48a67cf37c2e56f/test/syscalls/linux/fcntl.cc#L1431

The main issue addressed here is to add support for F_GETSIG/F_SETSIG.
Save the set signal to FileTableEntry.
SIGRTMAX is defined for calling in other modules, converted using MAX_RT_SIG_NUM.
Add handle_getsig/handle_setsig operations.
The FcntlCmd command adds F_SETSIG/F_GETSIG.

The check has been passed for /aster-code-review