### PR TITLE
Add a device-mapper component with linear, zero, error, and verity targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "aster-cmdline",
  "component",
  "device-id",
+ "io-util",
  "ostd",
  "spin",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aster-device-mapper"
+version = "0.1.0"
+dependencies = [
+ "aster-block",
+ "aster-cmdline",
+ "component",
+ "device-id",
+ "ostd",
+ "spin",
+]
+
+[[package]]
 name = "aster-framebuffer"
 version = "0.1.0"
 dependencies = [
@@ -186,6 +198,7 @@ dependencies = [
  "aster-block",
  "aster-cmdline",
  "aster-console",
+ "aster-device-mapper",
  "aster-framebuffer",
  "aster-fuse",
  "aster-i8042",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "kernel/comps/block",
     "kernel/comps/cmdline",
     "kernel/comps/console",
+    "kernel/comps/device-mapper",
     "kernel/comps/framebuffer",
     "kernel/comps/i8042",
     "kernel/comps/input",
@@ -77,6 +78,7 @@ default-members = [
     "kernel/comps/block",
     "kernel/comps/cmdline",
     "kernel/comps/console",
+    "kernel/comps/device-mapper",
     "kernel/comps/framebuffer",
     "kernel/comps/i8042",
     "kernel/comps/input",
@@ -150,6 +152,7 @@ ostd-test = { version = "0.18.0", path = "ostd/libs/ostd-test" }
 aster-block = { path = "kernel/comps/block" }
 aster-cmdline = { path = "kernel/comps/cmdline" }
 aster-console = { path = "kernel/comps/console" }
+aster-device-mapper = { path = "kernel/comps/device-mapper" }
 aster-framebuffer = { path = "kernel/comps/framebuffer" }
 aster-i8042 = { path = "kernel/comps/i8042" }
 aster-input = { path = "kernel/comps/input" }

--- a/Components.toml
+++ b/Components.toml
@@ -3,6 +3,7 @@
 block = { name = "aster-block" }
 cmdline = { name = "aster-cmdline" }
 console = { name = "aster-console" }
+device_mapper = { name = "aster-device-mapper" }
 framebuffer = { name = "aster-framebuffer" }
 i8042 = { name = "aster-i8042" }
 input = { name = "aster-input" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -11,6 +11,7 @@ aster-bigtcp.workspace = true
 aster-block.workspace = true
 aster-cmdline.workspace = true
 aster-console.workspace = true
+aster-device-mapper.workspace = true
 aster-framebuffer.workspace = true
 aster-fuse.workspace = true
 aster-i8042.workspace = true

--- a/kernel/comps/device-mapper/Cargo.toml
+++ b/kernel/comps/device-mapper/Cargo.toml
@@ -10,6 +10,7 @@ aster-block.workspace = true
 aster-cmdline.workspace = true
 component.workspace = true
 device-id.workspace = true
+io-util.workspace = true
 ostd.workspace = true
 spin.workspace = true
 

--- a/kernel/comps/device-mapper/Cargo.toml
+++ b/kernel/comps/device-mapper/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "aster-device-mapper"
+version = "0.1.0"
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aster-block.workspace = true
+aster-cmdline.workspace = true
+component.workspace = true
+device-id.workspace = true
+ostd.workspace = true
+spin.workspace = true
+
+[lints]
+workspace = true

--- a/kernel/comps/device-mapper/src/device.rs
+++ b/kernel/comps/device-mapper/src/device.rs
@@ -5,6 +5,7 @@ use alloc::string::String;
 use aster_block::{
     BlockDevice, BlockDeviceMeta,
     bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio},
+    request_queue::{BioRequest, BioRequestSingleQueue},
 };
 use device_id::DeviceId;
 
@@ -16,20 +17,32 @@ pub struct DmDevice {
     name: String,
     id: DeviceId,
     table: DmTable,
+    queue: BioRequestSingleQueue,
 }
 
 impl DmDevice {
-    pub fn new(name: String, id: DeviceId, table: DmTable) -> Self {
-        Self { name, id, table }
+    pub(crate) fn new(name: String, id: DeviceId, table: DmTable) -> Self {
+        Self {
+            name,
+            id,
+            table,
+            queue: BioRequestSingleQueue::new(),
+        }
     }
 
-    pub fn table(&self) -> &DmTable {
-        &self.table
+    /// Dequeues one mapped-device request and processes it.
+    pub fn handle_requests(&self) {
+        let request = self.queue.dequeue();
+        self.handle_request(request);
     }
-}
 
-impl BlockDevice for DmDevice {
-    fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+    fn handle_request(&self, request: BioRequest) {
+        for bio in request.into_bios() {
+            self.handle_bio(bio);
+        }
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio) {
         if bio.type_() == BioType::Flush {
             let status = self
                 .table
@@ -39,29 +52,35 @@ impl BlockDevice for DmDevice {
                 .find(|status| *status != BioStatus::Complete)
                 .unwrap_or(BioStatus::Complete);
             bio.complete(status);
-            return Ok(());
+            return;
         }
 
-        let start_sector = bio.sid_range().start.to_raw();
-        let end_sector = bio.sid_range().end.to_raw();
-        if end_sector > self.table.total_sectors() || start_sector >= end_sector {
+        let start_sector = bio.sid_range().start.to_raw() + bio.sid_offset();
+        let end_sector = bio.sid_range().end.to_raw() + bio.sid_offset();
+        if end_sector > self.table.total_sectors() as u64 || start_sector >= end_sector {
             bio.complete(BioStatus::IoError);
-            return Ok(());
+            return;
         }
 
         let Some(segment) = self.table.find_segment(start_sector, end_sector) else {
             bio.complete(BioStatus::IoError);
-            return Ok(());
+            return;
         };
         let target_start_sector = start_sector - segment.start_sector;
         segment.target.handle_bio(bio, target_start_sector);
+    }
+}
+
+impl BlockDevice for DmDevice {
+    fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+        self.queue.enqueue(bio)?;
         Ok(())
     }
 
     fn metadata(&self) -> BlockDeviceMeta {
         BlockDeviceMeta {
-            max_nr_segments_per_bio: usize::MAX,
-            nr_sectors: self.table.total_sectors() as usize,
+            max_nr_segments_per_bio: self.queue.max_nr_segments_per_bio(),
+            nr_sectors: self.table.total_sectors(),
         }
     }
 

--- a/kernel/comps/device-mapper/src/device.rs
+++ b/kernel/comps/device-mapper/src/device.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::string::String;
+
+use aster_block::{
+    BlockDevice, BlockDeviceMeta,
+    bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio},
+};
+use device_id::DeviceId;
+
+use crate::table::DmTable;
+
+/// A mapped block device backed by a device-mapper table.
+#[derive(Debug)]
+pub struct DmDevice {
+    name: String,
+    id: DeviceId,
+    table: DmTable,
+}
+
+impl DmDevice {
+    pub fn new(name: String, id: DeviceId, table: DmTable) -> Self {
+        Self { name, id, table }
+    }
+
+    pub fn table(&self) -> &DmTable {
+        &self.table
+    }
+}
+
+impl BlockDevice for DmDevice {
+    fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+        if bio.type_() == BioType::Flush {
+            let status = self
+                .table
+                .segments()
+                .iter()
+                .map(|segment| segment.target.flush())
+                .find(|status| *status != BioStatus::Complete)
+                .unwrap_or(BioStatus::Complete);
+            bio.complete(status);
+            return Ok(());
+        }
+
+        let start_sector = bio.sid_range().start.to_raw();
+        let end_sector = bio.sid_range().end.to_raw();
+        if end_sector > self.table.total_sectors() || start_sector >= end_sector {
+            bio.complete(BioStatus::IoError);
+            return Ok(());
+        }
+
+        let Some(segment) = self.table.find_segment(start_sector, end_sector) else {
+            bio.complete(BioStatus::IoError);
+            return Ok(());
+        };
+        let target_start_sector = start_sector - segment.start_sector;
+        segment.target.handle_bio(bio, target_start_sector);
+        Ok(())
+    }
+
+    fn metadata(&self) -> BlockDeviceMeta {
+        BlockDeviceMeta {
+            max_nr_segments_per_bio: usize::MAX,
+            nr_sectors: self.table.total_sectors() as usize,
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn id(&self) -> DeviceId {
+        self.id
+    }
+}

--- a/kernel/comps/device-mapper/src/error.rs
+++ b/kernel/comps/device-mapper/src/error.rs
@@ -9,7 +9,6 @@ pub enum DmError {
     DeviceNotFound,
     InvalidArgument,
     InvalidTable,
-    IoError,
     NoDeviceId,
     UnsupportedTarget,
 }

--- a/kernel/comps/device-mapper/src/error.rs
+++ b/kernel/comps/device-mapper/src/error.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::string::String;
+
+/// Errors returned by the device-mapper component.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DmError {
+    DeviceExists,
+    DeviceNotFound,
+    InvalidArgument,
+    InvalidTable,
+    IoError,
+    NoDeviceId,
+    UnsupportedTarget,
+}
+
+impl DmError {
+    pub fn context(self, message: impl Into<String>) -> DmErrorWithContext {
+        DmErrorWithContext {
+            kind: self,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DmErrorWithContext {
+    pub kind: DmError,
+    pub message: String,
+}

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -2,14 +2,16 @@
 
 //! Device-mapper support for Asterinas.
 //!
-//! This component implements a small, table-driven virtual block-device layer
-//! inspired by Linux device-mapper. A mapped device is described by a table of
-//! sector ranges, each handled by a target that decides how the range is backed
-//! by lower devices. Devices are created from `dm-mod.create=`/`dm_mod.create=`
-//! kernel command-line entries.
+//! This component implements a table-driven virtual block-device layer inspired
+//! by Linux device-mapper. It supports `linear`, `zero`, `error`, and read-only
+//! `verity` targets created from `dm-mod.create=`/`dm_mod.create=` kernel
+//! command-line entries.
 //!
-//! Reference: Linux device-mapper documentation
-//! <https://docs.kernel.org/admin-guide/device-mapper/>.
+//! References:
+//! - Linux device-mapper documentation:
+//!   <https://docs.kernel.org/admin-guide/device-mapper/>
+//! - Linux dm-verity documentation:
+//!   <https://docs.kernel.org/admin-guide/device-mapper/verity.html>
 
 #![no_std]
 #![deny(unsafe_code)]
@@ -78,4 +80,478 @@ fn init_in_first_kthread() -> Result<(), ComponentInitError> {
     }
 
     Ok(())
+}
+
+#[cfg(ktest)]
+mod tests {
+    use alloc::{
+        boxed::Box,
+        string::{String, ToString},
+        sync::Arc,
+        vec,
+        vec::Vec,
+    };
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use aster_block::{
+        BLOCK_SIZE, BlockDevice, BlockDeviceMeta, SECTOR_SIZE,
+        bio::{Bio, BioDirection, BioEnqueueError, BioSegment, BioStatus, BioType, SubmittedBio},
+        id::Sid,
+    };
+    use device_id::{DeviceId, MajorId, MinorId};
+    use ostd::{
+        mm::{FrameAllocOptions, Segment, VmIo, io::util::HasVmReaderWriter},
+        prelude::*,
+    };
+
+    use super::{
+        device::DmDevice,
+        table::{DmTable, DmTableSegment},
+        target::{
+            error::ErrorTarget, linear::LinearTarget, verity::build_hash_levels, zero::ZeroTarget,
+        },
+    };
+
+    #[derive(Debug)]
+    struct MemoryDisk {
+        name: &'static str,
+        id: DeviceId,
+        bytes: Segment<()>,
+        flushes: AtomicUsize,
+    }
+
+    struct RegisteredDiskGuard(DeviceId);
+
+    impl Drop for RegisteredDiskGuard {
+        fn drop(&mut self) {
+            let _ = aster_block::unregister(self.0);
+        }
+    }
+
+    impl MemoryDisk {
+        fn new(name: &'static str, minor: u32, nblocks: usize) -> Self {
+            let bytes = FrameAllocOptions::new()
+                .zeroed(true)
+                .alloc_segment(nblocks)
+                .unwrap();
+            Self {
+                name,
+                id: DeviceId::new(MajorId::new(250), MinorId::new(minor)),
+                bytes,
+                flushes: AtomicUsize::new(0),
+            }
+        }
+
+        fn read_bytes_at(&self, offset: usize, out: &mut [u8]) {
+            self.bytes.read_bytes(offset, out).unwrap();
+        }
+
+        fn write_bytes_at(&self, offset: usize, input: &[u8]) {
+            self.bytes.write_bytes(offset, input).unwrap();
+        }
+    }
+
+    impl BlockDevice for MemoryDisk {
+        fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+            if bio.type_() == BioType::Flush {
+                self.flushes.fetch_add(1, Ordering::Relaxed);
+                bio.complete(BioStatus::Complete);
+                return Ok(());
+            }
+
+            let mut offset = bio.sid_range().start.to_offset();
+            for segment in bio.segments() {
+                if offset + segment.nbytes() > self.bytes.size() {
+                    bio.complete(BioStatus::IoError);
+                    return Ok(());
+                }
+                match bio.type_() {
+                    BioType::Read => {
+                        let _ = segment
+                            .inner_dma_slice()
+                            .writer()
+                            .unwrap()
+                            .write(self.bytes.reader().skip(offset));
+                    }
+                    BioType::Write => {
+                        let _ = self
+                            .bytes
+                            .writer()
+                            .skip(offset)
+                            .write(&mut segment.inner_dma_slice().reader().unwrap());
+                    }
+                    BioType::Flush => unreachable!(),
+                }
+                offset += segment.nbytes();
+            }
+            bio.complete(BioStatus::Complete);
+            Ok(())
+        }
+
+        fn metadata(&self) -> BlockDeviceMeta {
+            BlockDeviceMeta {
+                max_nr_segments_per_bio: usize::MAX,
+                nr_sectors: self.bytes.size() / SECTOR_SIZE,
+            }
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn id(&self) -> DeviceId {
+            self.id
+        }
+    }
+
+    fn read_device(device: &dyn BlockDevice, offset: usize, len: usize) -> (BioStatus, Vec<u8>) {
+        let segment = BioSegment::alloc(len.div_ceil(BLOCK_SIZE), BioDirection::FromDevice);
+        let bio = Bio::new(
+            BioType::Read,
+            Sid::from_offset(offset),
+            vec![segment.clone()],
+            None,
+        );
+        let status = bio.submit_and_wait(device).unwrap();
+        let mut bytes = vec![0u8; len];
+        if status == BioStatus::Complete {
+            segment.inner_dma_slice().read_bytes(0, &mut bytes).unwrap();
+        }
+        (status, bytes)
+    }
+
+    fn write_device(device: &dyn BlockDevice, offset: usize, bytes: &[u8]) -> BioStatus {
+        let segment = BioSegment::alloc(bytes.len().div_ceil(BLOCK_SIZE), BioDirection::ToDevice);
+        segment.inner_dma_slice().write_bytes(0, bytes).unwrap();
+        let bio = Bio::new(
+            BioType::Write,
+            Sid::from_offset(offset),
+            vec![segment],
+            None,
+        );
+        bio.submit_and_wait(device).unwrap()
+    }
+
+    fn digest_v1(block: &[u8], salt: &[u8]) -> [u8; 32] {
+        super::sha256::digest(&[salt, block])
+    }
+
+    fn install_verity_tree(
+        data_disk: &MemoryDisk,
+        hash_disk: &MemoryDisk,
+        data_blocks: &[Vec<u8>],
+        salt: &[u8],
+        hash_start_block: u64,
+    ) -> [u8; 32] {
+        for (index, block) in data_blocks.iter().enumerate() {
+            data_disk.write_bytes_at(index * BLOCK_SIZE, block);
+        }
+
+        let hashes_per_block = BLOCK_SIZE / 32;
+        let levels = build_hash_levels(
+            data_blocks.len() as u64,
+            hashes_per_block as u64,
+            hash_start_block,
+        )
+        .unwrap();
+        let mut child_hashes: Vec<[u8; 32]> = data_blocks
+            .iter()
+            .map(|block| digest_v1(block, salt))
+            .collect();
+        let leaf_to_root: Vec<_> = levels.iter().rev().copied().collect();
+        for level in leaf_to_root {
+            let mut next_hashes = Vec::new();
+            for block_index in 0..level.nr_blocks as usize {
+                let mut hash_block = vec![0u8; BLOCK_SIZE];
+                let start = block_index * hashes_per_block;
+                let end = (start + hashes_per_block).min(child_hashes.len());
+                for (slot, digest) in child_hashes[start..end].iter().enumerate() {
+                    hash_block[slot * 32..slot * 32 + 32].copy_from_slice(digest);
+                }
+                hash_disk.write_bytes_at(
+                    (level.first_block as usize + block_index) * BLOCK_SIZE,
+                    &hash_block,
+                );
+                next_hashes.push(digest_v1(&hash_block, salt));
+            }
+            child_hashes = next_hashes;
+        }
+        child_hashes[0]
+    }
+
+    #[ktest]
+    fn linear_target_remaps_reads_and_writes() {
+        let lower = Arc::new(MemoryDisk::new("linear-lower", 1, 8));
+        let source = vec![0x5au8; BLOCK_SIZE];
+        lower.write_bytes_at(2 * BLOCK_SIZE, &source);
+
+        let target = LinearTarget::new(lower.clone(), (2 * BLOCK_SIZE / SECTOR_SIZE) as u64);
+        let table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::new(target),
+        }])
+        .unwrap();
+        let dm = DmDevice::new("dm-linear-test".into(), DeviceId::null(), table);
+
+        let (status, read_back) = read_device(&dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, source);
+
+        let replacement = vec![0xa5u8; BLOCK_SIZE];
+        assert_eq!(write_device(&dm, 0, &replacement), BioStatus::Complete);
+        let mut lower_bytes = vec![0u8; BLOCK_SIZE];
+        lower.read_bytes_at(2 * BLOCK_SIZE, &mut lower_bytes);
+        assert_eq!(lower_bytes, replacement);
+    }
+
+    #[ktest]
+    fn zero_and_error_targets_have_expected_io_behavior() {
+        let zero_table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::<ZeroTarget>::default(),
+        }])
+        .unwrap();
+        let zero_dm = DmDevice::new("dm-zero-test".into(), DeviceId::null(), zero_table);
+        let (status, read_back) = read_device(&zero_dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, vec![0u8; BLOCK_SIZE]);
+
+        let error_table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::<ErrorTarget>::default(),
+        }])
+        .unwrap();
+        let error_dm = DmDevice::new("dm-error-test".into(), DeviceId::null(), error_table);
+        let (status, _) = read_device(&error_dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::IoError);
+    }
+
+    fn to_hex(bytes: &[u8]) -> String {
+        bytes
+            .iter()
+            .map(|byte| alloc::format!("{:02x}", byte))
+            .collect()
+    }
+
+    /// Builds a verity `DmDevice` over already-registered lower devices, going
+    /// through the public table-argument parser so the tests exercise the same
+    /// path as the `dm-mod.create=` command line.
+    fn build_verity_device(
+        data_name: &str,
+        hash_name: &str,
+        num_data_blocks: usize,
+        root_hex: &str,
+        salt_hex: &str,
+    ) -> DmDevice {
+        let verity = super::target::verity::VerityTarget::from_table_args(&[
+            "1",
+            data_name,
+            hash_name,
+            &BLOCK_SIZE.to_string(),
+            &BLOCK_SIZE.to_string(),
+            &num_data_blocks.to_string(),
+            "0",
+            "sha256",
+            root_hex,
+            salt_hex,
+        ])
+        .unwrap();
+        let table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (num_data_blocks * BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::new(verity),
+        }])
+        .unwrap();
+        DmDevice::new("dm-verity-test".into(), DeviceId::null(), table)
+    }
+
+    #[ktest]
+    fn verity_target_detects_data_corruption() {
+        let data_disk = Arc::new(MemoryDisk::new("verity-data", 2, 4));
+        let hash_disk = Arc::new(MemoryDisk::new("verity-hash", 3, 4));
+        aster_block::register(data_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        aster_block::register(hash_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        let _data_guard = RegisteredDiskGuard(data_disk.id());
+        let _hash_guard = RegisteredDiskGuard(hash_disk.id());
+        let data_blocks = vec![
+            vec![0x11u8; BLOCK_SIZE],
+            vec![0x22u8; BLOCK_SIZE],
+            vec![0x33u8; BLOCK_SIZE],
+        ];
+        let salt = [0x7bu8; 16];
+        let root_digest = install_verity_tree(&data_disk, &hash_disk, &data_blocks, &salt, 0);
+        let dm = build_verity_device(
+            "verity-data",
+            "verity-hash",
+            data_blocks.len(),
+            &to_hex(&root_digest),
+            &to_hex(&salt),
+        );
+
+        let (status, read_back) = read_device(&dm, BLOCK_SIZE, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, data_blocks[1]);
+
+        data_disk.write_bytes_at(BLOCK_SIZE, &vec![0xffu8; BLOCK_SIZE]);
+        let (status, _) = read_device(&dm, BLOCK_SIZE, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::IoError);
+    }
+
+    #[ktest]
+    fn verity_target_detects_hash_corruption() {
+        let data_disk = Arc::new(MemoryDisk::new("verity-hc-data", 6, 4));
+        let hash_disk = Arc::new(MemoryDisk::new("verity-hc-hash", 7, 4));
+        aster_block::register(data_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        aster_block::register(hash_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        let _data_guard = RegisteredDiskGuard(data_disk.id());
+        let _hash_guard = RegisteredDiskGuard(hash_disk.id());
+        let data_blocks = vec![
+            vec![0x11u8; BLOCK_SIZE],
+            vec![0x22u8; BLOCK_SIZE],
+            vec![0x33u8; BLOCK_SIZE],
+        ];
+        let salt = [0x7bu8; 16];
+        let root_digest = install_verity_tree(&data_disk, &hash_disk, &data_blocks, &salt, 0);
+        let dm = build_verity_device(
+            "verity-hc-data",
+            "verity-hc-hash",
+            data_blocks.len(),
+            &to_hex(&root_digest),
+            &to_hex(&salt),
+        );
+
+        let (status, _) = read_device(&dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+
+        // Flip a byte inside the hash tree node. The stored digest no longer
+        // matches the data block's hash, so the read must fail.
+        let mut hash_byte = [0u8; 1];
+        hash_disk.read_bytes_at(0, &mut hash_byte);
+        hash_byte[0] ^= 0xff;
+        hash_disk.write_bytes_at(0, &hash_byte);
+        let (status, _) = read_device(&dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::IoError);
+    }
+
+    #[ktest]
+    fn verity_target_rejects_wrong_root_digest() {
+        let data_disk = Arc::new(MemoryDisk::new("verity-wr-data", 8, 4));
+        let hash_disk = Arc::new(MemoryDisk::new("verity-wr-hash", 9, 4));
+        aster_block::register(data_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        aster_block::register(hash_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        let _data_guard = RegisteredDiskGuard(data_disk.id());
+        let _hash_guard = RegisteredDiskGuard(hash_disk.id());
+        let data_blocks = vec![vec![0x11u8; BLOCK_SIZE], vec![0x22u8; BLOCK_SIZE]];
+        let salt = [0x7bu8; 16];
+        let _root_digest = install_verity_tree(&data_disk, &hash_disk, &data_blocks, &salt, 0);
+
+        // A device configured with the wrong root digest must reject otherwise
+        // intact data, since the on-disk tree no longer chains to the expected
+        // root of trust.
+        let wrong_root = [0u8; 32];
+        let dm = build_verity_device(
+            "verity-wr-data",
+            "verity-wr-hash",
+            data_blocks.len(),
+            &to_hex(&wrong_root),
+            &to_hex(&salt),
+        );
+        let (status, _) = read_device(&dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::IoError);
+    }
+
+    #[ktest]
+    fn verity_target_verifies_multi_level_tree() {
+        // 130 data blocks force a two-level hash tree (128 digests fit in one
+        // 4096-byte hash block), exercising the level-by-level walk that the
+        // single-block-tree fixtures above do not reach.
+        let data_disk = Arc::new(MemoryDisk::new("verity-ml-data", 10, 130));
+        let hash_disk = Arc::new(MemoryDisk::new("verity-ml-hash", 11, 8));
+        aster_block::register(data_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        aster_block::register(hash_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        let _data_guard = RegisteredDiskGuard(data_disk.id());
+        let _hash_guard = RegisteredDiskGuard(hash_disk.id());
+
+        let data_blocks: Vec<Vec<u8>> = (0..130)
+            .map(|index| vec![index as u8; BLOCK_SIZE])
+            .collect();
+        let salt = [0x7bu8; 16];
+        let root_digest = install_verity_tree(&data_disk, &hash_disk, &data_blocks, &salt, 0);
+        let dm = build_verity_device(
+            "verity-ml-data",
+            "verity-ml-hash",
+            data_blocks.len(),
+            &to_hex(&root_digest),
+            &to_hex(&salt),
+        );
+
+        // Blocks under different leaf hash blocks both chain to the root.
+        let (status, block0) = read_device(&dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(block0, data_blocks[0]);
+        let (status, block129) = read_device(&dm, 129 * BLOCK_SIZE, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(block129, data_blocks[129]);
+
+        // Corrupting a block under the second leaf hash block fails only that
+        // block; block 0, under the first leaf, is still served.
+        data_disk.write_bytes_at(129 * BLOCK_SIZE, &vec![0xffu8; BLOCK_SIZE]);
+        let (status, _) = read_device(&dm, 129 * BLOCK_SIZE, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::IoError);
+        let (status, _) = read_device(&dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+    }
+
+    #[ktest]
+    fn parse_create_arg_builds_verity_device_and_detects_corruption() {
+        // This test drives the exact pipeline used at boot: a `dm-mod.create=`
+        // table string is parsed into a `DmTable`, the verity target resolves
+        // its lower devices by name through the block registry, and a read is
+        // served only when the Merkle tree verifies.
+        let data_disk = Arc::new(MemoryDisk::new("dm-it-data", 4, 4));
+        let hash_disk = Arc::new(MemoryDisk::new("dm-it-hash", 5, 4));
+        aster_block::register(data_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        aster_block::register(hash_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        let _data_guard = RegisteredDiskGuard(data_disk.id());
+        let _hash_guard = RegisteredDiskGuard(hash_disk.id());
+
+        let data_blocks = vec![
+            vec![0x11u8; BLOCK_SIZE],
+            vec![0x22u8; BLOCK_SIZE],
+            vec![0x33u8; BLOCK_SIZE],
+        ];
+        let salt = [0x7bu8; 16];
+        let root_digest = install_verity_tree(&data_disk, &hash_disk, &data_blocks, &salt, 0);
+
+        let sectors = data_blocks.len() * BLOCK_SIZE / SECTOR_SIZE;
+        let table = alloc::format!(
+            "dm-verity-it: 0 {} verity 1 dm-it-data dm-it-hash {} {} {} 0 sha256 {} {}",
+            sectors,
+            BLOCK_SIZE,
+            BLOCK_SIZE,
+            data_blocks.len(),
+            to_hex(&root_digest),
+            to_hex(&salt),
+        );
+        // The boot path receives the value with the surrounding command-line
+        // quotes, so verify the quote-stripping and parsing both behave.
+        let arg = alloc::format!("\"{}\"", table)
+            .parse::<super::DmCreateArg>()
+            .unwrap();
+        let parsed = super::parse_create_arg(arg.as_str(), 0).unwrap();
+        assert_eq!(parsed.name, "dm-verity-it");
+
+        let dm = DmDevice::new(parsed.name.clone(), DeviceId::null(), parsed.table);
+
+        let (status, read_back) = read_device(&dm, BLOCK_SIZE, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, data_blocks[1]);
+
+        data_disk.write_bytes_at(BLOCK_SIZE, &vec![0xffu8; BLOCK_SIZE]);
+        let (status, _) = read_device(&dm, BLOCK_SIZE, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::IoError);
+    }
 }

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Device-mapper support for Asterinas.
+//!
+//! This component implements a small, table-driven virtual block-device layer
+//! inspired by Linux device-mapper. A mapped device is described by a table of
+//! sector ranges, each handled by a target that decides how the range is backed
+//! by lower devices.
+//!
+//! Reference: Linux device-mapper documentation
+//! <https://docs.kernel.org/admin-guide/device-mapper/>.
+
+#![no_std]
+#![deny(unsafe_code)]
+
+extern crate alloc;
+
+// Set this crate's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "dm: "
+    };
+}
+
+mod error;
+
+use component::{ComponentInitError, init_component};
+
+pub use self::error::{DmError, DmErrorWithContext};
+
+#[init_component]
+fn init() -> Result<(), ComponentInitError> {
+    Ok(())
+}

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -24,6 +24,7 @@ macro_rules! __log_prefix {
 
 mod device;
 mod error;
+mod registry;
 mod table;
 pub mod target;
 
@@ -32,10 +33,12 @@ use component::{ComponentInitError, init_component};
 pub use self::{
     device::DmDevice,
     error::{DmError, DmErrorWithContext},
+    registry::{create_device, list_devices, lookup_device, remove_device},
     table::{DmTable, DmTableSegment},
 };
 
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {
+    registry::init().map_err(|_| ComponentInitError::Unknown)?;
     Ok(())
 }

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -27,6 +27,7 @@ mod device;
 mod error;
 mod parser;
 mod registry;
+mod sha256;
 mod table;
 pub mod target;
 

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -22,6 +22,7 @@ macro_rules! __log_prefix {
     };
 }
 
+mod device;
 mod error;
 mod table;
 pub mod target;
@@ -29,6 +30,7 @@ pub mod target;
 use component::{ComponentInitError, init_component};
 
 pub use self::{
+    device::DmDevice,
     error::{DmError, DmErrorWithContext},
     table::{DmTable, DmTableSegment},
 };

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -5,7 +5,8 @@
 //! This component implements a small, table-driven virtual block-device layer
 //! inspired by Linux device-mapper. A mapped device is described by a table of
 //! sector ranges, each handled by a target that decides how the range is backed
-//! by lower devices.
+//! by lower devices. Devices are created from `dm-mod.create=`/`dm_mod.create=`
+//! kernel command-line entries.
 //!
 //! Reference: Linux device-mapper documentation
 //! <https://docs.kernel.org/admin-guide/device-mapper/>.
@@ -24,21 +25,56 @@ macro_rules! __log_prefix {
 
 mod device;
 mod error;
+mod parser;
 mod registry;
 mod table;
 pub mod target;
 
+use alloc::vec::Vec;
+
+use aster_block::BlockDevice;
 use component::{ComponentInitError, init_component};
+use spin::Once;
 
 pub use self::{
     device::DmDevice,
     error::{DmError, DmErrorWithContext},
+    parser::{DmCreateArg, parse_create_arg},
     registry::{create_device, list_devices, lookup_device, remove_device},
     table::{DmTable, DmTableSegment},
 };
 
+static DM_CREATE_ARGS: Once<Vec<DmCreateArg>> = Once::new();
+aster_cmdline::define_repeatable_kv_param!("dm_mod.create", DM_CREATE_ARGS);
+
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {
     registry::init().map_err(|_| ComponentInitError::Unknown)?;
+    Ok(())
+}
+
+#[init_component(kthread)]
+fn init_in_first_kthread() -> Result<(), ComponentInitError> {
+    let create_args = DM_CREATE_ARGS.get().cloned().unwrap_or_default();
+    for (index, arg) in create_args.iter().enumerate() {
+        match parse_create_arg(arg.as_str(), index) {
+            Ok(parsed) => match create_device(parsed.name.clone(), parsed.table) {
+                Ok(device) => {
+                    ostd::info!("created dm device '{}' ({:?})", device.name(), device.id());
+                }
+                Err(err) => {
+                    ostd::error!("failed to create dm device '{}': {:?}", parsed.name, err);
+                }
+            },
+            Err(err) => {
+                ostd::error!(
+                    "failed to parse dm-mod.create entry '{}': {:?}",
+                    arg.as_str(),
+                    err
+                );
+            }
+        }
+    }
+
     Ok(())
 }

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -42,9 +42,7 @@ use spin::Once;
 pub use self::{
     device::DmDevice,
     error::{DmError, DmErrorWithContext},
-    parser::{DmCreateArg, parse_create_arg},
-    registry::{create_device, list_devices, lookup_device, remove_device},
-    table::{DmTable, DmTableSegment},
+    parser::DmCreateArg,
 };
 
 static DM_CREATE_ARGS: Once<Vec<DmCreateArg>> = Once::new();
@@ -56,12 +54,12 @@ fn init() -> Result<(), ComponentInitError> {
     Ok(())
 }
 
-#[init_component(kthread)]
-fn init_in_first_kthread() -> Result<(), ComponentInitError> {
+#[init_component(process)]
+fn init_in_first_process() -> Result<(), ComponentInitError> {
     let create_args = DM_CREATE_ARGS.get().cloned().unwrap_or_default();
     for (index, arg) in create_args.iter().enumerate() {
-        match parse_create_arg(arg.as_str(), index) {
-            Ok(parsed) => match create_device(parsed.name.clone(), parsed.table) {
+        match parser::parse_create_arg(arg.as_str(), index) {
+            Ok(parsed) => match registry::create_device(parsed.name.clone(), parsed.table) {
                 Ok(device) => {
                     ostd::info!("created dm device '{}' ({:?})", device.name(), device.id());
                 }
@@ -99,16 +97,21 @@ mod tests {
         id::Sid,
     };
     use device_id::{DeviceId, MajorId, MinorId};
+    use io_util::batch::IoBatch;
     use ostd::{
         mm::{FrameAllocOptions, Segment, VmIo, io::util::HasVmReaderWriter},
         prelude::*,
     };
 
     use super::{
+        DmError,
         device::DmDevice,
         table::{DmTable, DmTableSegment},
         target::{
-            error::ErrorTarget, linear::LinearTarget, verity::build_hash_levels, zero::ZeroTarget,
+            error::ErrorTarget,
+            linear::LinearTarget,
+            verity::{VerityTarget, build_hash_levels},
+            zero::ZeroTarget,
         },
     };
 
@@ -118,6 +121,14 @@ mod tests {
         id: DeviceId,
         bytes: Segment<()>,
         flushes: AtomicUsize,
+    }
+
+    #[derive(Debug)]
+    struct OffsetBlockDevice {
+        name: &'static str,
+        id: DeviceId,
+        inner: Arc<DmDevice>,
+        sid_offset: u64,
     }
 
     struct RegisteredDiskGuard(DeviceId);
@@ -161,7 +172,11 @@ mod tests {
 
             let mut offset = bio.sid_range().start.to_offset();
             for segment in bio.segments() {
-                if offset + segment.nbytes() > self.bytes.size() {
+                let Some(end_offset) = offset.checked_add(segment.nbytes()) else {
+                    bio.complete(BioStatus::IoError);
+                    return Ok(());
+                };
+                if end_offset > self.bytes.size() {
                     bio.complete(BioStatus::IoError);
                     return Ok(());
                 }
@@ -182,7 +197,7 @@ mod tests {
                     }
                     BioType::Flush => unreachable!(),
                 }
-                offset += segment.nbytes();
+                offset = end_offset;
             }
             bio.complete(BioStatus::Complete);
             Ok(())
@@ -204,15 +219,50 @@ mod tests {
         }
     }
 
-    fn read_device(device: &dyn BlockDevice, offset: usize, len: usize) -> (BioStatus, Vec<u8>) {
+    impl BlockDevice for OffsetBlockDevice {
+        fn enqueue(&self, mut bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+            bio.set_sid_offset(self.sid_offset);
+            self.inner.enqueue(bio)
+        }
+
+        fn metadata(&self) -> BlockDeviceMeta {
+            let mut metadata = self.inner.metadata();
+            metadata.nr_sectors = metadata.nr_sectors.saturating_sub(self.sid_offset as usize);
+            metadata
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn id(&self) -> DeviceId {
+            self.id
+        }
+    }
+
+    fn read_offset_device(
+        device: &OffsetBlockDevice,
+        dm: &DmDevice,
+        offset: usize,
+        len: usize,
+    ) -> (BioStatus, Vec<u8>) {
+        let status = Arc::new(AtomicUsize::new(BioStatus::Init as usize));
+        let complete_status = status.clone();
         let segment = BioSegment::alloc(len.div_ceil(BLOCK_SIZE), BioDirection::FromDevice);
         let bio = Bio::new(
             BioType::Read,
             Sid::from_offset(offset),
             vec![segment.clone()],
-            None,
+            Some(Box::new(move |bio_status| {
+                complete_status.store(bio_status as usize, Ordering::Relaxed);
+            })),
         );
-        let status = bio.submit_and_wait(device).unwrap();
+        let mut io_batch = IoBatch::with_capacity(1);
+        bio.submit(device, &mut io_batch).unwrap();
+        dm.handle_requests();
+        let _ = io_batch.wait_all();
+
+        let status = BioStatus::try_from(status.load(Ordering::Relaxed) as u32).unwrap();
         let mut bytes = vec![0u8; len];
         if status == BioStatus::Complete {
             segment.inner_dma_slice().read_bytes(0, &mut bytes).unwrap();
@@ -220,16 +270,43 @@ mod tests {
         (status, bytes)
     }
 
-    fn write_device(device: &dyn BlockDevice, offset: usize, bytes: &[u8]) -> BioStatus {
+    fn submit_device_io(
+        device: &DmDevice,
+        type_: BioType,
+        offset: usize,
+        segments: Vec<BioSegment>,
+    ) -> BioStatus {
+        let status = Arc::new(AtomicUsize::new(BioStatus::Init as usize));
+        let complete_status = status.clone();
+        let bio = Bio::new(
+            type_,
+            Sid::from_offset(offset),
+            segments,
+            Some(Box::new(move |bio_status| {
+                complete_status.store(bio_status as usize, Ordering::Relaxed);
+            })),
+        );
+        let mut io_batch = IoBatch::with_capacity(1);
+        bio.submit(device, &mut io_batch).unwrap();
+        device.handle_requests();
+        let _ = io_batch.wait_all();
+        BioStatus::try_from(status.load(Ordering::Relaxed) as u32).unwrap()
+    }
+
+    fn read_device(device: &DmDevice, offset: usize, len: usize) -> (BioStatus, Vec<u8>) {
+        let segment = BioSegment::alloc(len.div_ceil(BLOCK_SIZE), BioDirection::FromDevice);
+        let status = submit_device_io(device, BioType::Read, offset, vec![segment.clone()]);
+        let mut bytes = vec![0u8; len];
+        if status == BioStatus::Complete {
+            segment.inner_dma_slice().read_bytes(0, &mut bytes).unwrap();
+        }
+        (status, bytes)
+    }
+
+    fn write_device(device: &DmDevice, offset: usize, bytes: &[u8]) -> BioStatus {
         let segment = BioSegment::alloc(bytes.len().div_ceil(BLOCK_SIZE), BioDirection::ToDevice);
         segment.inner_dma_slice().write_bytes(0, bytes).unwrap();
-        let bio = Bio::new(
-            BioType::Write,
-            Sid::from_offset(offset),
-            vec![segment],
-            None,
-        );
-        bio.submit_and_wait(device).unwrap()
+        submit_device_io(device, BioType::Write, offset, vec![segment])
     }
 
     fn digest_v1(block: &[u8], salt: &[u8]) -> [u8; 32] {
@@ -306,6 +383,37 @@ mod tests {
     }
 
     #[ktest]
+    fn dm_device_honors_submitted_bio_sid_offset() {
+        let lower = Arc::new(MemoryDisk::new("sid-offset-lower", 14, 8));
+        let first_block = vec![0x11u8; BLOCK_SIZE];
+        let second_block = vec![0x22u8; BLOCK_SIZE];
+        lower.write_bytes_at(0, &first_block);
+        lower.write_bytes_at(BLOCK_SIZE, &second_block);
+
+        let table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (4 * BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::new(LinearTarget::new(lower.clone(), 0)),
+        }])
+        .unwrap();
+        let dm = Arc::new(DmDevice::new(
+            "dm-sid-offset-test".into(),
+            DeviceId::null(),
+            table,
+        ));
+        let partition = OffsetBlockDevice {
+            name: "dm-sid-offset-test1",
+            id: DeviceId::null(),
+            inner: dm.clone(),
+            sid_offset: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+        };
+
+        let (status, read_back) = read_offset_device(&partition, &dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, second_block);
+    }
+
+    #[ktest]
     fn zero_and_error_targets_have_expected_io_behavior() {
         let zero_table = DmTable::new(vec![DmTableSegment {
             start_sector: 0,
@@ -346,7 +454,7 @@ mod tests {
         root_hex: &str,
         salt_hex: &str,
     ) -> DmDevice {
-        let verity = super::target::verity::VerityTarget::from_table_args(&[
+        let verity = VerityTarget::from_table_args(&[
             "1",
             data_name,
             hash_name,
@@ -464,6 +572,94 @@ mod tests {
     }
 
     #[ktest]
+    fn verity_target_rejects_undersized_lower_devices() {
+        let data_disk = Arc::new(MemoryDisk::new("verity-small-data", 12, 1));
+        let hash_disk = Arc::new(MemoryDisk::new("verity-small-hash", 13, 1));
+        aster_block::register(data_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        aster_block::register(hash_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        let _data_guard = RegisteredDiskGuard(data_disk.id());
+        let _hash_guard = RegisteredDiskGuard(hash_disk.id());
+
+        let root_hex = to_hex(&[0u8; 32]);
+        let salt_hex = to_hex(&[0x7bu8; 16]);
+        let result = VerityTarget::from_table_args(&[
+            "1",
+            "verity-small-data",
+            "verity-small-hash",
+            &BLOCK_SIZE.to_string(),
+            &BLOCK_SIZE.to_string(),
+            "2",
+            "0",
+            "sha256",
+            &root_hex,
+            &salt_hex,
+        ]);
+        assert_eq!(result.unwrap_err().kind, DmError::InvalidArgument);
+
+        let result = VerityTarget::from_table_args(&[
+            "1",
+            "verity-small-data",
+            "verity-small-hash",
+            &BLOCK_SIZE.to_string(),
+            &BLOCK_SIZE.to_string(),
+            "1",
+            "1",
+            "sha256",
+            &root_hex,
+            &salt_hex,
+        ]);
+        assert_eq!(result.unwrap_err().kind, DmError::InvalidArgument);
+    }
+
+    #[ktest]
+    fn verity_target_accepts_zero_optional_params() {
+        let data_disk = Arc::new(MemoryDisk::new("verity-opt-data", 15, 2));
+        let hash_disk = Arc::new(MemoryDisk::new("verity-opt-hash", 16, 2));
+        aster_block::register(data_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        aster_block::register(hash_disk.clone() as Arc<dyn BlockDevice>).unwrap();
+        let _data_guard = RegisteredDiskGuard(data_disk.id());
+        let _hash_guard = RegisteredDiskGuard(hash_disk.id());
+
+        let data_blocks = vec![vec![0x11u8; BLOCK_SIZE]];
+        let salt = [0x7bu8; 16];
+        let root_digest = install_verity_tree(&data_disk, &hash_disk, &data_blocks, &salt, 0);
+        let root_hex = to_hex(&root_digest);
+        let salt_hex = to_hex(&salt);
+        let target = VerityTarget::from_table_args(&[
+            "1",
+            "verity-opt-data",
+            "verity-opt-hash",
+            &BLOCK_SIZE.to_string(),
+            &BLOCK_SIZE.to_string(),
+            "1",
+            "0",
+            "sha256",
+            &root_hex,
+            &salt_hex,
+            "0",
+        ]);
+        assert!(target.is_ok());
+    }
+
+    #[ktest]
+    fn verity_target_rejects_nonzero_optional_params() {
+        let result = VerityTarget::from_table_args(&[
+            "1",
+            "missing-data",
+            "missing-hash",
+            &BLOCK_SIZE.to_string(),
+            &BLOCK_SIZE.to_string(),
+            "1",
+            "0",
+            "sha256",
+            &to_hex(&[0u8; 32]),
+            "-",
+            "1",
+        ]);
+        assert_eq!(result.unwrap_err().kind, DmError::UnsupportedTarget);
+    }
+
+    #[ktest]
     fn verity_target_verifies_multi_level_tree() {
         // 130 data blocks force a two-level hash tree (128 digests fit in one
         // 4096-byte hash block), exercising the level-by-level walk that the
@@ -541,7 +737,7 @@ mod tests {
         let arg = alloc::format!("\"{}\"", table)
             .parse::<super::DmCreateArg>()
             .unwrap();
-        let parsed = super::parse_create_arg(arg.as_str(), 0).unwrap();
+        let parsed = super::parser::parse_create_arg(arg.as_str(), 0).unwrap();
         assert_eq!(parsed.name, "dm-verity-it");
 
         let dm = DmDevice::new(parsed.name.clone(), DeviceId::null(), parsed.table);

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -23,10 +23,15 @@ macro_rules! __log_prefix {
 }
 
 mod error;
+mod table;
+pub mod target;
 
 use component::{ComponentInitError, init_component};
 
-pub use self::error::{DmError, DmErrorWithContext};
+pub use self::{
+    error::{DmError, DmErrorWithContext},
+    table::{DmTable, DmTableSegment},
+};
 
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {

--- a/kernel/comps/device-mapper/src/parser.rs
+++ b/kernel/comps/device-mapper/src/parser.rs
@@ -62,7 +62,7 @@ pub struct ParsedDmCreate {
     pub table: DmTable,
 }
 
-pub fn parse_create_arg(
+pub(crate) fn parse_create_arg(
     arg: &str,
     fallback_index: usize,
 ) -> Result<ParsedDmCreate, DmErrorWithContext> {
@@ -148,7 +148,9 @@ fn parse_verity_target(args: &[&str]) -> Result<VerityTarget, DmErrorWithContext
     VerityTarget::from_table_args(args)
 }
 
-pub fn lookup_block_device(name_or_id: &str) -> Result<Arc<dyn BlockDevice>, DmErrorWithContext> {
+pub(crate) fn lookup_block_device(
+    name_or_id: &str,
+) -> Result<Arc<dyn BlockDevice>, DmErrorWithContext> {
     if let Some(raw) = name_or_id.strip_prefix("dev:") {
         let id = parse_u64(Some(raw), "encoded device id")?;
         let device_id = DeviceId::from_encoded_u64(id)
@@ -171,13 +173,13 @@ fn parse_u64(value: Option<&str>, what: &str) -> Result<u64, DmErrorWithContext>
 }
 
 /// Parses a single mandatory table field, attaching `what` to any error.
-pub fn parse_field<T: FromStr>(value: &str, what: &str) -> Result<T, DmErrorWithContext> {
+pub(crate) fn parse_field<T: FromStr>(value: &str, what: &str) -> Result<T, DmErrorWithContext> {
     value
         .parse::<T>()
         .map_err(|_| DmError::InvalidTable.context(alloc::format!("{} is invalid", what)))
 }
 
-pub fn parse_hex_bytes(input: &str) -> Result<Vec<u8>, DmError> {
+pub(crate) fn parse_hex_bytes(input: &str) -> Result<Vec<u8>, DmError> {
     if input == "-" {
         return Ok(Vec::new());
     }
@@ -226,14 +228,19 @@ mod tests {
     }
 
     #[ktest]
-    fn parse_create_arg_accepts_zero_and_error_segments() {
-        let parsed = parse_create_arg("demo: 0 8 zero; 8 8 error", 0).unwrap();
+    fn parse_create_arg_accepts_single_segment() {
+        let parsed = parse_create_arg("demo: 0 8 zero", 0).unwrap();
         assert_eq!(parsed.name, "demo");
-        assert_eq!(parsed.table.total_sectors(), 16);
+        assert_eq!(parsed.table.total_sectors(), 8);
         let segments = parsed.table.segments();
-        assert_eq!(segments.len(), 2);
+        assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].target.type_name(), "zero");
-        assert_eq!(segments[1].target.type_name(), "error");
+    }
+
+    #[ktest]
+    fn parse_create_arg_rejects_multiple_segments() {
+        let result = parse_create_arg("demo: 0 8 zero; 8 8 error", 0);
+        assert!(result.is_err());
     }
 
     #[ktest]

--- a/kernel/comps/device-mapper/src/parser.rs
+++ b/kernel/comps/device-mapper/src/parser.rs
@@ -16,7 +16,9 @@ use crate::{
     DmError, DmErrorWithContext,
     registry::normalize_name,
     table::{DmTable, DmTableSegment},
-    target::{DmTarget, error::ErrorTarget, linear::LinearTarget, zero::ZeroTarget},
+    target::{
+        DmTarget, error::ErrorTarget, linear::LinearTarget, verity::VerityTarget, zero::ZeroTarget,
+    },
 };
 
 /// One `dm-mod.create=` value from the kernel command line.
@@ -117,6 +119,7 @@ fn parse_segment(line: &str) -> Result<DmTableSegment, DmErrorWithContext> {
             }
             Box::<ErrorTarget>::default()
         }
+        "verity" => Box::new(parse_verity_target(&args)?),
         _ => return Err(DmError::UnsupportedTarget.context("unsupported dm target")),
     };
     if let Some(size_sectors) = target.size_sectors()
@@ -141,6 +144,10 @@ fn parse_linear_target(args: &[&str]) -> Result<LinearTarget, DmErrorWithContext
     Ok(LinearTarget::new(device, start_sector))
 }
 
+fn parse_verity_target(args: &[&str]) -> Result<VerityTarget, DmErrorWithContext> {
+    VerityTarget::from_table_args(args)
+}
+
 pub fn lookup_block_device(name_or_id: &str) -> Result<Arc<dyn BlockDevice>, DmErrorWithContext> {
     if let Some(raw) = name_or_id.strip_prefix("dev:") {
         let id = parse_u64(Some(raw), "encoded device id")?;
@@ -163,11 +170,47 @@ fn parse_u64(value: Option<&str>, what: &str) -> Result<u64, DmErrorWithContext>
         .map_err(|_| DmError::InvalidTable.context(alloc::format!("{} is invalid", what)))
 }
 
+/// Parses a single mandatory table field, attaching `what` to any error.
+pub fn parse_field<T: FromStr>(value: &str, what: &str) -> Result<T, DmErrorWithContext> {
+    value
+        .parse::<T>()
+        .map_err(|_| DmError::InvalidTable.context(alloc::format!("{} is invalid", what)))
+}
+
+pub fn parse_hex_bytes(input: &str) -> Result<Vec<u8>, DmError> {
+    if input == "-" {
+        return Ok(Vec::new());
+    }
+    if !input.len().is_multiple_of(2) {
+        return Err(DmError::InvalidArgument);
+    }
+
+    let mut out = Vec::with_capacity(input.len() / 2);
+    let bytes = input.as_bytes();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let hi = hex_value(bytes[offset]).ok_or(DmError::InvalidArgument)?;
+        let lo = hex_value(bytes[offset + 1]).ok_or(DmError::InvalidArgument)?;
+        out.push((hi << 4) | lo);
+        offset += 2;
+    }
+    Ok(out)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 #[cfg(ktest)]
 mod tests {
     use ostd::prelude::ktest;
 
-    use super::{DmCreateArg, parse_create_arg};
+    use super::{DmCreateArg, parse_create_arg, parse_hex_bytes};
     use crate::DmError;
 
     #[ktest]
@@ -203,5 +246,16 @@ mod tests {
     fn parse_create_arg_rejects_unknown_target() {
         let result = parse_create_arg("demo: 0 8 bogus", 0);
         assert_eq!(result.unwrap_err().kind, DmError::UnsupportedTarget);
+    }
+
+    #[ktest]
+    fn parse_hex_bytes_round_trips_and_validates() {
+        assert_eq!(
+            parse_hex_bytes("00ff10").unwrap(),
+            alloc::vec![0x00, 0xff, 0x10]
+        );
+        assert!(parse_hex_bytes("0").is_err());
+        assert!(parse_hex_bytes("gg").is_err());
+        assert!(parse_hex_bytes("-").unwrap().is_empty());
     }
 }

--- a/kernel/comps/device-mapper/src/parser.rs
+++ b/kernel/comps/device-mapper/src/parser.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use core::str::FromStr;
+
+use aster_block::BlockDevice;
+use aster_cmdline::parse::ParamError;
+use device_id::DeviceId;
+
+use crate::{
+    DmError, DmErrorWithContext,
+    registry::normalize_name,
+    table::{DmTable, DmTableSegment},
+    target::{DmTarget, error::ErrorTarget, linear::LinearTarget, zero::ZeroTarget},
+};
+
+/// One `dm-mod.create=` value from the kernel command line.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DmCreateArg(String);
+
+impl DmCreateArg {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for DmCreateArg {
+    type Err = ParamError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // A dm table value contains spaces, so on the kernel command line it is
+        // written as `dm_mod.create="<name>: <start> <len> <target> ..."`. The
+        // command-line tokenizer keeps the wrapping double quotes in the value,
+        // so strip one matching pair here, mirroring how Linux unquotes kernel
+        // parameter values in `lib/cmdline.c`.
+        let unquoted = strip_matching_quotes(s.trim());
+        if unquoted.is_empty() {
+            Err(ParamError::InvalidValue)
+        } else {
+            Ok(Self(unquoted.to_string()))
+        }
+    }
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .unwrap_or(value)
+}
+
+#[derive(Debug)]
+pub struct ParsedDmCreate {
+    pub name: String,
+    pub table: DmTable,
+}
+
+pub fn parse_create_arg(
+    arg: &str,
+    fallback_index: usize,
+) -> Result<ParsedDmCreate, DmErrorWithContext> {
+    let (raw_name, table_text) = split_name_and_table(arg)
+        .ok_or_else(|| DmError::InvalidTable.context("dm create argument must include a table"))?;
+    let name = normalize_name(raw_name.trim(), fallback_index);
+    let mut segments = Vec::new();
+    for line in table_text.split(';') {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        segments.push(parse_segment(line)?);
+    }
+
+    let table = DmTable::new(segments)
+        .map_err(|err| err.context("dm table segments are empty, overlapping, or invalid"))?;
+    Ok(ParsedDmCreate { name, table })
+}
+
+fn split_name_and_table(arg: &str) -> Option<(&str, &str)> {
+    if let Some((name, table)) = arg.split_once(':') {
+        return Some((name, table));
+    }
+    if let Some((name, table)) = arg.split_once(',') {
+        return Some((name, table));
+    }
+
+    // Linux dm-init accepts a richer comma-separated grammar. A whitespace-only
+    // value is interpreted as a single anonymous table.
+    Some(("-", arg))
+}
+
+fn parse_segment(line: &str) -> Result<DmTableSegment, DmErrorWithContext> {
+    let mut fields = line.split_whitespace();
+    let start_sector = parse_u64(fields.next(), "segment start sector")?;
+    let len_sectors = parse_u64(fields.next(), "segment length")?;
+    let target_name = fields
+        .next()
+        .ok_or_else(|| DmError::InvalidTable.context("segment target type is missing"))?;
+    let args: Vec<&str> = fields.collect();
+
+    let target: Box<dyn DmTarget> = match target_name {
+        "linear" => Box::new(parse_linear_target(&args)?),
+        "zero" => {
+            if !args.is_empty() {
+                return Err(DmError::InvalidTable.context("zero target takes no arguments"));
+            }
+            Box::<ZeroTarget>::default()
+        }
+        "error" => {
+            if !args.is_empty() {
+                return Err(DmError::InvalidTable.context("error target takes no arguments"));
+            }
+            Box::<ErrorTarget>::default()
+        }
+        _ => return Err(DmError::UnsupportedTarget.context("unsupported dm target")),
+    };
+    if let Some(size_sectors) = target.size_sectors()
+        && size_sectors != len_sectors
+    {
+        return Err(DmError::InvalidTable.context("target size does not match segment length"));
+    }
+
+    Ok(DmTableSegment {
+        start_sector,
+        len_sectors,
+        target,
+    })
+}
+
+fn parse_linear_target(args: &[&str]) -> Result<LinearTarget, DmErrorWithContext> {
+    if args.len() != 2 {
+        return Err(DmError::InvalidTable.context("linear target expects: <device> <start>"));
+    }
+    let device = lookup_block_device(args[0])?;
+    let start_sector = parse_u64(args.get(1).copied(), "linear target start sector")?;
+    Ok(LinearTarget::new(device, start_sector))
+}
+
+pub fn lookup_block_device(name_or_id: &str) -> Result<Arc<dyn BlockDevice>, DmErrorWithContext> {
+    if let Some(raw) = name_or_id.strip_prefix("dev:") {
+        let id = parse_u64(Some(raw), "encoded device id")?;
+        let device_id = DeviceId::from_encoded_u64(id)
+            .ok_or_else(|| DmError::InvalidArgument.context("encoded device id is invalid"))?;
+        return aster_block::lookup(device_id)
+            .ok_or_else(|| DmError::DeviceNotFound.context("block device id is not registered"));
+    }
+
+    aster_block::collect_all()
+        .into_iter()
+        .find(|device| device.name() == name_or_id)
+        .ok_or_else(|| DmError::DeviceNotFound.context("block device name is not registered"))
+}
+
+fn parse_u64(value: Option<&str>, what: &str) -> Result<u64, DmErrorWithContext> {
+    value
+        .ok_or_else(|| DmError::InvalidTable.context(alloc::format!("{} is missing", what)))?
+        .parse::<u64>()
+        .map_err(|_| DmError::InvalidTable.context(alloc::format!("{} is invalid", what)))
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::{DmCreateArg, parse_create_arg};
+    use crate::DmError;
+
+    #[ktest]
+    fn dm_create_arg_strips_surrounding_quotes() {
+        let arg = "\"dm-zero-test: 0 8 zero\"".parse::<DmCreateArg>().unwrap();
+        assert_eq!(arg.as_str(), "dm-zero-test: 0 8 zero");
+    }
+
+    #[ktest]
+    fn dm_create_arg_rejects_empty_value() {
+        assert!("".parse::<DmCreateArg>().is_err());
+        assert!("\"\"".parse::<DmCreateArg>().is_err());
+    }
+
+    #[ktest]
+    fn parse_create_arg_accepts_zero_and_error_segments() {
+        let parsed = parse_create_arg("demo: 0 8 zero; 8 8 error", 0).unwrap();
+        assert_eq!(parsed.name, "demo");
+        assert_eq!(parsed.table.total_sectors(), 16);
+        let segments = parsed.table.segments();
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].target.type_name(), "zero");
+        assert_eq!(segments[1].target.type_name(), "error");
+    }
+
+    #[ktest]
+    fn parse_create_arg_rejects_overlapping_segments() {
+        let result = parse_create_arg("demo: 0 8 zero; 4 8 error", 0);
+        assert!(result.is_err());
+    }
+
+    #[ktest]
+    fn parse_create_arg_rejects_unknown_target() {
+        let result = parse_create_arg("demo: 0 8 bogus", 0);
+        assert_eq!(result.unwrap_err().kind, DmError::UnsupportedTarget);
+    }
+}

--- a/kernel/comps/device-mapper/src/registry.rs
+++ b/kernel/comps/device-mapper/src/registry.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+
+use aster_block::{BlockDevice, MajorIdOwner};
+use device_id::{DeviceId, MinorId};
+use ostd::sync::Mutex;
+use spin::Once;
+
+use crate::{DmDevice, DmError, table::DmTable};
+
+const FIRST_MINOR: u32 = 0;
+
+static DM_MAJOR_ID: Once<MajorIdOwner> = Once::new();
+static DM_REGISTRY: Mutex<DmRegistry> = Mutex::new(DmRegistry::new());
+
+#[derive(Debug)]
+struct DmRegistry {
+    next_minor: u32,
+    devices_by_name: BTreeMap<String, Arc<DmDevice>>,
+}
+
+impl DmRegistry {
+    const fn new() -> Self {
+        Self {
+            next_minor: FIRST_MINOR,
+            devices_by_name: BTreeMap::new(),
+        }
+    }
+
+    fn allocate_id(&mut self) -> Result<DeviceId, DmError> {
+        let major = DM_MAJOR_ID.get().ok_or(DmError::NoDeviceId)?.get();
+        let minor = self.next_minor;
+        self.next_minor = self.next_minor.checked_add(1).ok_or(DmError::NoDeviceId)?;
+        Ok(DeviceId::new(major, MinorId::new(minor)))
+    }
+}
+
+pub fn init() -> Result<(), DmError> {
+    let major = aster_block::allocate_major().map_err(|_| DmError::NoDeviceId)?;
+    DM_MAJOR_ID.call_once(|| major);
+    Ok(())
+}
+
+pub fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmError> {
+    if name.is_empty() || name.contains('/') {
+        return Err(DmError::InvalidArgument);
+    }
+
+    let mut registry = DM_REGISTRY.lock();
+    if registry.devices_by_name.contains_key(&name) {
+        return Err(DmError::DeviceExists);
+    }
+
+    let id = registry.allocate_id()?;
+    let device = Arc::new(DmDevice::new(name.clone(), id, table));
+    aster_block::register(device.clone()).map_err(|_| DmError::DeviceExists)?;
+    registry.devices_by_name.insert(name, device.clone());
+    Ok(device)
+}
+
+pub fn remove_device(name: &str) -> Result<Arc<DmDevice>, DmError> {
+    let mut registry = DM_REGISTRY.lock();
+    let device = registry
+        .devices_by_name
+        .remove(name)
+        .ok_or(DmError::DeviceNotFound)?;
+    let _ = aster_block::unregister(device.id());
+    Ok(device)
+}
+
+pub fn lookup_device(name: &str) -> Option<Arc<DmDevice>> {
+    DM_REGISTRY.lock().devices_by_name.get(name).cloned()
+}
+
+pub fn list_devices() -> Vec<Arc<DmDevice>> {
+    DM_REGISTRY
+        .lock()
+        .devices_by_name
+        .values()
+        .cloned()
+        .collect()
+}
+
+pub fn default_name(index: usize) -> String {
+    alloc::format!("dm-{}", index)
+}
+
+pub fn normalize_name(raw: &str, fallback_index: usize) -> String {
+    if raw == "-" || raw.is_empty() {
+        default_name(fallback_index)
+    } else {
+        raw.to_string()
+    }
+}

--- a/kernel/comps/device-mapper/src/registry.rs
+++ b/kernel/comps/device-mapper/src/registry.rs
@@ -4,10 +4,9 @@ use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
     sync::Arc,
-    vec::Vec,
 };
 
-use aster_block::{BlockDevice, MajorIdOwner};
+use aster_block::MajorIdOwner;
 use device_id::{DeviceId, MinorId};
 use ostd::sync::Mutex;
 use spin::Once;
@@ -47,8 +46,8 @@ pub fn init() -> Result<(), DmError> {
     Ok(())
 }
 
-pub fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmError> {
-    if name.is_empty() || name.contains('/') {
+pub(crate) fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmError> {
+    if !is_valid_device_name(&name) {
         return Err(DmError::InvalidArgument);
     }
 
@@ -64,34 +63,18 @@ pub fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmEr
     Ok(device)
 }
 
-pub fn remove_device(name: &str) -> Result<Arc<DmDevice>, DmError> {
-    let mut registry = DM_REGISTRY.lock();
-    let device = registry
-        .devices_by_name
-        .remove(name)
-        .ok_or(DmError::DeviceNotFound)?;
-    let _ = aster_block::unregister(device.id());
-    Ok(device)
+fn is_valid_device_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name
+            .chars()
+            .any(|ch| ch == '/' || ch.is_control() || ch.is_whitespace())
 }
 
-pub fn lookup_device(name: &str) -> Option<Arc<DmDevice>> {
-    DM_REGISTRY.lock().devices_by_name.get(name).cloned()
-}
-
-pub fn list_devices() -> Vec<Arc<DmDevice>> {
-    DM_REGISTRY
-        .lock()
-        .devices_by_name
-        .values()
-        .cloned()
-        .collect()
-}
-
-pub fn default_name(index: usize) -> String {
+fn default_name(index: usize) -> String {
     alloc::format!("dm-{}", index)
 }
 
-pub fn normalize_name(raw: &str, fallback_index: usize) -> String {
+pub(crate) fn normalize_name(raw: &str, fallback_index: usize) -> String {
     if raw == "-" || raw.is_empty() {
         default_name(fallback_index)
     } else {

--- a/kernel/comps/device-mapper/src/sha256.rs
+++ b/kernel/comps/device-mapper/src/sha256.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Minimal SHA-256 implementation for dm-verity.
+//!
+//! This module intentionally implements only one-shot SHA-256 over byte slices.
+//! It avoids pulling target-specific optimized code into kernel tests while
+//! preserving the standard algorithm required by dm-verity.
+
+const H0: [u32; 8] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+pub fn digest(chunks: &[&[u8]]) -> [u8; 32] {
+    let mut state = H0;
+    let mut block = [0u8; 64];
+    let mut block_len = 0usize;
+    let mut total_len = 0u64;
+
+    for chunk in chunks {
+        total_len = total_len.wrapping_add(chunk.len() as u64);
+        let mut input = *chunk;
+        while !input.is_empty() {
+            let copy_len = (64 - block_len).min(input.len());
+            block[block_len..block_len + copy_len].copy_from_slice(&input[..copy_len]);
+            block_len += copy_len;
+            input = &input[copy_len..];
+            if block_len == 64 {
+                compress(&mut state, &block);
+                block_len = 0;
+            }
+        }
+    }
+
+    block[block_len] = 0x80;
+    block_len += 1;
+    if block_len > 56 {
+        block[block_len..].fill(0);
+        compress(&mut state, &block);
+        block_len = 0;
+    }
+    block[block_len..56].fill(0);
+    let bit_len = total_len.wrapping_mul(8);
+    block[56..64].copy_from_slice(&bit_len.to_be_bytes());
+    compress(&mut state, &block);
+
+    let mut out = [0u8; 32];
+    for (index, word) in state.iter().enumerate() {
+        out[index * 4..index * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+fn compress(state: &mut [u32; 8], block: &[u8; 64]) {
+    let mut w = [0u32; 64];
+    for (index, word) in w.iter_mut().take(16).enumerate() {
+        let base = index * 4;
+        *word = u32::from_be_bytes([
+            block[base],
+            block[base + 1],
+            block[base + 2],
+            block[base + 3],
+        ]);
+    }
+    for index in 16..64 {
+        let s0 =
+            w[index - 15].rotate_right(7) ^ w[index - 15].rotate_right(18) ^ (w[index - 15] >> 3);
+        let s1 =
+            w[index - 2].rotate_right(17) ^ w[index - 2].rotate_right(19) ^ (w[index - 2] >> 10);
+        w[index] = w[index - 16]
+            .wrapping_add(s0)
+            .wrapping_add(w[index - 7])
+            .wrapping_add(s1);
+    }
+
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+    for index in 0..64 {
+        let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+        let ch = (e & f) ^ (!e & g);
+        let temp1 = h
+            .wrapping_add(s1)
+            .wrapping_add(ch)
+            .wrapping_add(K[index])
+            .wrapping_add(w[index]);
+        let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let temp2 = s0.wrapping_add(maj);
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = temp1.wrapping_add(temp2);
+    }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::digest;
+
+    #[ktest]
+    fn sha256_known_answer_empty_string() {
+        assert_eq!(
+            digest(&[b""]),
+            [
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+                0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+                0x78, 0x52, 0xb8, 0x55,
+            ]
+        );
+    }
+
+    #[ktest]
+    fn sha256_known_answer_abc_split_chunks() {
+        assert_eq!(
+            digest(&[b"a", b"b", b"c"]),
+            [
+                0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae,
+                0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61,
+                0xf2, 0x00, 0x15, 0xad,
+            ]
+        );
+    }
+}

--- a/kernel/comps/device-mapper/src/table.rs
+++ b/kernel/comps/device-mapper/src/table.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{boxed::Box, vec::Vec};
+
+use crate::{DmError, target::DmTarget};
+
+/// One mapped interval in a device-mapper table.
+#[derive(Debug)]
+pub struct DmTableSegment {
+    pub start_sector: u64,
+    pub len_sectors: u64,
+    pub target: Box<dyn DmTarget>,
+}
+
+impl DmTableSegment {
+    pub fn end_sector(&self) -> Option<u64> {
+        self.start_sector.checked_add(self.len_sectors)
+    }
+
+    pub fn contains_range(&self, start_sector: u64, end_sector: u64) -> bool {
+        let Some(segment_end) = self.end_sector() else {
+            return false;
+        };
+
+        self.start_sector <= start_sector && end_sector <= segment_end
+    }
+}
+
+/// A device-mapper table.
+///
+/// BIOs that cross target boundaries are rejected; callers must split them
+/// before dispatch.
+#[derive(Debug)]
+pub struct DmTable {
+    segments: Vec<DmTableSegment>,
+    total_sectors: u64,
+}
+
+impl DmTable {
+    pub fn new(segments: Vec<DmTableSegment>) -> Result<Self, DmError> {
+        if segments.is_empty() {
+            return Err(DmError::InvalidTable);
+        }
+
+        let mut previous_end = 0;
+        let mut total_sectors = 0;
+        for segment in &segments {
+            if segment.len_sectors == 0 {
+                return Err(DmError::InvalidTable);
+            }
+
+            let Some(end_sector) = segment.end_sector() else {
+                return Err(DmError::InvalidTable);
+            };
+            if segment.start_sector < previous_end {
+                return Err(DmError::InvalidTable);
+            }
+            previous_end = end_sector;
+            total_sectors = total_sectors.max(end_sector);
+        }
+
+        Ok(Self {
+            segments,
+            total_sectors,
+        })
+    }
+
+    pub fn total_sectors(&self) -> u64 {
+        self.total_sectors
+    }
+
+    pub fn segments(&self) -> &[DmTableSegment] {
+        &self.segments
+    }
+
+    pub fn find_segment(&self, start_sector: u64, end_sector: u64) -> Option<&DmTableSegment> {
+        self.segments
+            .iter()
+            .find(|segment| segment.contains_range(start_sector, end_sector))
+    }
+}

--- a/kernel/comps/device-mapper/src/table.rs
+++ b/kernel/comps/device-mapper/src/table.rs
@@ -28,22 +28,23 @@ impl DmTableSegment {
 
 /// A device-mapper table.
 ///
-/// BIOs that cross target boundaries are rejected; callers must split them
-/// before dispatch.
+/// The initial implementation supports a single segment. Multi-segment tables
+/// require splitting submitted BIOs at target boundaries, which the block BIO
+/// ownership model does not expose yet.
 #[derive(Debug)]
 pub struct DmTable {
     segments: Vec<DmTableSegment>,
-    total_sectors: u64,
+    total_sectors: usize,
 }
 
 impl DmTable {
     pub fn new(segments: Vec<DmTableSegment>) -> Result<Self, DmError> {
-        if segments.is_empty() {
+        if segments.len() != 1 {
             return Err(DmError::InvalidTable);
         }
 
         let mut previous_end = 0;
-        let mut total_sectors = 0;
+        let mut total_sectors = 0u64;
         for segment in &segments {
             if segment.len_sectors == 0 {
                 return Err(DmError::InvalidTable);
@@ -52,12 +53,13 @@ impl DmTable {
             let Some(end_sector) = segment.end_sector() else {
                 return Err(DmError::InvalidTable);
             };
-            if segment.start_sector < previous_end {
+            if segment.start_sector != previous_end {
                 return Err(DmError::InvalidTable);
             }
             previous_end = end_sector;
             total_sectors = total_sectors.max(end_sector);
         }
+        let total_sectors = usize::try_from(total_sectors).map_err(|_| DmError::InvalidTable)?;
 
         Ok(Self {
             segments,
@@ -65,7 +67,7 @@ impl DmTable {
         })
     }
 
-    pub fn total_sectors(&self) -> u64 {
+    pub fn total_sectors(&self) -> usize {
         self.total_sectors
     }
 
@@ -74,6 +76,13 @@ impl DmTable {
     }
 
     pub fn find_segment(&self, start_sector: u64, end_sector: u64) -> Option<&DmTableSegment> {
+        let Ok(total_sectors) = u64::try_from(self.total_sectors) else {
+            return None;
+        };
+        if end_sector > total_sectors {
+            return None;
+        }
+
         self.segments
             .iter()
             .find(|segment| segment.contains_range(start_sector, end_sector))

--- a/kernel/comps/device-mapper/src/target/error.rs
+++ b/kernel/comps/device-mapper/src/target/error.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `error` target.
+//!
+//! Every read and write fails with an I/O error. It is used to fence off
+//! regions that must never be accessed and to exercise error paths.
+//!
+//! Reference: Linux `Documentation/admin-guide/device-mapper/zero.rst`
+//! (the `error` target is documented alongside `zero`).
+
+use aster_block::bio::{BioStatus, SubmittedBio};
+
+use super::DmTarget;
+
+/// An `error` target.
+#[derive(Debug, Default)]
+pub struct ErrorTarget;
+
+impl DmTarget for ErrorTarget {
+    fn type_name(&self) -> &'static str {
+        "error"
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio, _target_start_sector: u64) {
+        bio.complete(BioStatus::IoError);
+    }
+}

--- a/kernel/comps/device-mapper/src/target/linear.rs
+++ b/kernel/comps/device-mapper/src/target/linear.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `linear` target.
+//!
+//! Maps a contiguous range of the mapped device onto a contiguous range of a
+//! lower device, shifting every sector by a fixed offset. This is the simplest
+//! device-mapper target and the building block for partition-like remapping.
+//!
+//! Reference: Linux `Documentation/admin-guide/device-mapper/linear.rst`.
+
+use alloc::sync::Arc;
+
+use aster_block::{
+    BlockDevice,
+    bio::{Bio, BioStatus, SubmittedBio},
+    id::Sid,
+};
+
+use super::DmTarget;
+
+/// A `linear` target backed by a lower block device.
+#[derive(Debug)]
+pub struct LinearTarget {
+    lower: Arc<dyn BlockDevice>,
+    /// The sector on the lower device that the segment's first sector maps to.
+    start_sector: u64,
+}
+
+impl LinearTarget {
+    /// Creates a `linear` target that forwards I/O to `lower`, shifting sectors
+    /// so that the segment's first sector lands on `start_sector`.
+    pub fn new(lower: Arc<dyn BlockDevice>, start_sector: u64) -> Self {
+        Self {
+            lower,
+            start_sector,
+        }
+    }
+}
+
+impl DmTarget for LinearTarget {
+    fn type_name(&self) -> &'static str {
+        "linear"
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64) {
+        // Reissue the request to the lower device with the same memory segments
+        // (which share the underlying DMA buffers) at the remapped sector.
+        let lower_start = Sid::new(self.start_sector + target_start_sector);
+        let lower_bio = Bio::new(bio.type_(), lower_start, bio.segments().to_vec(), None);
+        let status = lower_bio
+            .submit_and_wait(self.lower.as_ref())
+            .unwrap_or(BioStatus::IoError);
+        bio.complete(status);
+    }
+
+    fn flush(&self) -> BioStatus {
+        self.lower.sync().unwrap_or(BioStatus::IoError)
+    }
+}

--- a/kernel/comps/device-mapper/src/target/linear.rs
+++ b/kernel/comps/device-mapper/src/target/linear.rs
@@ -45,7 +45,21 @@ impl DmTarget for LinearTarget {
     fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64) {
         // Reissue the request to the lower device with the same memory segments
         // (which share the underlying DMA buffers) at the remapped sector.
-        let lower_start = Sid::new(self.start_sector + target_start_sector);
+        let request_sectors = bio.sid_range().end.to_raw() - bio.sid_range().start.to_raw();
+        let Some(lower_start_sector) = self.start_sector.checked_add(target_start_sector) else {
+            bio.complete(BioStatus::IoError);
+            return;
+        };
+        let Some(lower_end_sector) = lower_start_sector.checked_add(request_sectors) else {
+            bio.complete(BioStatus::IoError);
+            return;
+        };
+        if lower_end_sector > self.lower.metadata().nr_sectors as u64 {
+            bio.complete(BioStatus::IoError);
+            return;
+        }
+
+        let lower_start = Sid::new(lower_start_sector);
         let lower_bio = Bio::new(bio.type_(), lower_start, bio.segments().to_vec(), None);
         let status = lower_bio
             .submit_and_wait(self.lower.as_ref())

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -3,10 +3,17 @@
 //! Device-mapper targets.
 //!
 //! A target is the per-segment policy that turns a BIO addressed to the mapped
-//! device into concrete I/O on the underlying device(s).
+//! device into concrete I/O on the underlying device(s). The set mirrors the
+//! Linux device-mapper targets of the same name:
+//!
+//! - [`linear`]: remaps a contiguous sector range onto a lower device.
+//! - [`zero`]: serves zero-filled reads and discards writes.
+//! - [`error`]: fails every read and write.
+//! - [`verity`]: read-only integrity checking against a Merkle hash tree.
 
 pub mod error;
 pub mod linear;
+pub mod verity;
 pub mod zero;
 
 use alloc::vec::Vec;

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Device-mapper targets.
+//!
+//! A target is the per-segment policy that turns a BIO addressed to the mapped
+//! device into concrete I/O on the underlying device(s).
+
+use aster_block::bio::{BioStatus, SubmittedBio};
+
+/// A device-mapper target.
+///
+/// Each table segment owns one target. The mapped device locates the segment
+/// covering an incoming BIO, translates the BIO's starting sector into the
+/// target-local coordinate (`target_start_sector`, i.e. the sector offset from
+/// the start of the segment), and hands the BIO to [`DmTarget::handle_bio`].
+///
+/// Implementations own the underlying device(s) and complete the BIO exactly
+/// once, either by forwarding the I/O downwards or by synthesizing a result.
+pub trait DmTarget: core::fmt::Debug + Send + Sync {
+    /// The target type name, matching the keyword used in a dm table line
+    /// (for example `linear` or `verity`).
+    fn type_name(&self) -> &'static str;
+
+    /// The size this target requires its segment to have, in 512-byte sectors.
+    ///
+    /// Targets that derive their geometry from on-disk metadata (such as
+    /// `verity`) return `Some` so the parser can reject a table whose declared
+    /// segment length disagrees with that geometry. Targets that adapt to any
+    /// length return `None`.
+    fn size_sectors(&self) -> Option<u64> {
+        None
+    }
+
+    /// Handles a BIO that falls entirely within this target's segment.
+    ///
+    /// `target_start_sector` is the sector offset of the BIO from the start of
+    /// the segment. The implementation must complete the BIO.
+    fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64);
+
+    /// Flushes any volatile state held by the target.
+    ///
+    /// Stateless targets that pass writes straight through have nothing of
+    /// their own to flush and report success.
+    fn flush(&self) -> BioStatus {
+        BioStatus::Complete
+    }
+}

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -5,7 +5,11 @@
 //! A target is the per-segment policy that turns a BIO addressed to the mapped
 //! device into concrete I/O on the underlying device(s).
 
+pub mod error;
 pub mod linear;
+pub mod zero;
+
+use alloc::vec::Vec;
 
 use aster_block::bio::{BioStatus, SubmittedBio};
 
@@ -46,4 +50,9 @@ pub trait DmTarget: core::fmt::Debug + Send + Sync {
     fn flush(&self) -> BioStatus {
         BioStatus::Complete
     }
+}
+
+/// Returns a zero-filled buffer of `len` bytes.
+pub(crate) fn zero_vec(len: usize) -> Vec<u8> {
+    alloc::vec![0u8; len]
 }

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -5,6 +5,8 @@
 //! A target is the per-segment policy that turns a BIO addressed to the mapped
 //! device into concrete I/O on the underlying device(s).
 
+pub mod linear;
+
 use aster_block::bio::{BioStatus, SubmittedBio};
 
 /// A device-mapper target.

--- a/kernel/comps/device-mapper/src/target/verity.rs
+++ b/kernel/comps/device-mapper/src/target/verity.rs
@@ -43,7 +43,7 @@ use crate::{
 const DIGEST_SIZE: usize = 32;
 /// The number of 512-byte sectors per block.
 const SECTORS_PER_BLOCK: u64 = (BLOCK_SIZE / SECTOR_SIZE) as u64;
-/// The number of arguments in a `verity` table line.
+/// The number of mandatory arguments in a `verity` table line.
 const NR_TABLE_ARGS: usize = 10;
 
 /// One level of the hash tree, in the order it is stored on the hash device.
@@ -100,6 +100,7 @@ pub struct VerityTarget {
     data_device: Arc<dyn BlockDevice>,
     hash_device: Arc<dyn BlockDevice>,
     num_data_blocks: u64,
+    size_sectors: u64,
     version: u8,
     salt: Vec<u8>,
     root_digest: [u8; DIGEST_SIZE],
@@ -120,12 +121,16 @@ impl VerityTarget {
     /// Supports SHA-256 with 4096-byte data and hash blocks; the salt may be
     /// `-` to denote an empty salt.
     pub fn from_table_args(args: &[&str]) -> Result<Self, DmErrorWithContext> {
-        if args.len() != NR_TABLE_ARGS {
+        if args.len() != NR_TABLE_ARGS && args.len() != NR_TABLE_ARGS + 1 {
             return Err(DmError::InvalidTable.context(
                 "verity target expects: <version> <data_dev> <hash_dev> \
                  <data_block_size> <hash_block_size> <num_data_blocks> \
-                 <hash_start_block> <algorithm> <root_digest> <salt>",
+                 <hash_start_block> <algorithm> <root_digest> <salt> [0]",
             ));
+        }
+        if args.len() == NR_TABLE_ARGS + 1 && args[NR_TABLE_ARGS] != "0" {
+            return Err(DmError::UnsupportedTarget
+                .context("verity target optional parameters are not supported"));
         }
 
         let version = parse_field::<u8>(args[0], "verity version")?;
@@ -170,11 +175,30 @@ impl VerityTarget {
         let hashes_per_block = (BLOCK_SIZE / DIGEST_SIZE) as u64;
         let levels = build_hash_levels(num_data_blocks, hashes_per_block, hash_start_block)
             .map_err(|err| err.context("verity hash tree geometry is invalid"))?;
+        let size_sectors = num_data_blocks
+            .checked_mul(SECTORS_PER_BLOCK)
+            .ok_or_else(|| DmError::InvalidArgument.context("verity data device is too large"))?;
+        if size_sectors > data_device.metadata().nr_sectors as u64 {
+            return Err(DmError::InvalidArgument
+                .context("verity data device is smaller than the table geometry"));
+        }
+        let hash_end_block = levels
+            .last()
+            .and_then(|level| level.first_block.checked_add(level.nr_blocks))
+            .ok_or_else(|| DmError::InvalidArgument.context("verity hash tree is too large"))?;
+        let hash_end_sector = hash_end_block
+            .checked_mul(SECTORS_PER_BLOCK)
+            .ok_or_else(|| DmError::InvalidArgument.context("verity hash device is too large"))?;
+        if hash_end_sector > hash_device.metadata().nr_sectors as u64 {
+            return Err(DmError::InvalidArgument
+                .context("verity hash device is smaller than the table geometry"));
+        }
 
         Ok(Self {
             data_device,
             hash_device,
             num_data_blocks,
+            size_sectors,
             version,
             salt,
             root_digest,
@@ -207,10 +231,15 @@ impl VerityTarget {
                 return false;
             }
 
-            let hash_block_index = level.first_block + block_in_level;
+            let Some(hash_block_index) = level.first_block.checked_add(block_in_level) else {
+                return false;
+            };
+            let Some(hash_block_offset) = block_offset(hash_block_index) else {
+                return false;
+            };
             if self
                 .hash_device
-                .read_bytes(hash_block_index as usize * BLOCK_SIZE, hash_scratch)
+                .read_bytes(hash_block_offset, hash_scratch)
                 .is_err()
             {
                 return false;
@@ -238,7 +267,10 @@ impl VerityTarget {
         // (the generic partition scanner, for instance, reads a single sector).
         // Each overlapping block is read and verified once, then the requested
         // byte range is scattered into the request's memory segments.
-        let mut device_offset = target_start_sector as usize * SECTOR_SIZE;
+        let Some(mut device_offset) = sector_offset(target_start_sector) else {
+            bio.complete(BioStatus::IoError);
+            return;
+        };
 
         let mut data_block = super::zero_vec(BLOCK_SIZE);
         let mut hash_scratch = super::zero_vec(BLOCK_SIZE);
@@ -255,7 +287,10 @@ impl VerityTarget {
                 }
 
                 if cached_block != Some(block_index) {
-                    let block_offset = block_index as usize * BLOCK_SIZE;
+                    let Some(block_offset) = block_offset(block_index) else {
+                        bio.complete(BioStatus::IoError);
+                        return;
+                    };
                     if self
                         .data_device
                         .read_bytes(block_offset, &mut data_block)
@@ -283,7 +318,11 @@ impl VerityTarget {
                 }
 
                 segment_offset += chunk;
-                device_offset += chunk;
+                let Some(next_device_offset) = device_offset.checked_add(chunk) else {
+                    bio.complete(BioStatus::IoError);
+                    return;
+                };
+                device_offset = next_device_offset;
             }
         }
 
@@ -297,7 +336,7 @@ impl DmTarget for VerityTarget {
     }
 
     fn size_sectors(&self) -> Option<u64> {
-        Some(self.num_data_blocks * SECTORS_PER_BLOCK)
+        Some(self.size_sectors)
     }
 
     fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64) {
@@ -308,4 +347,12 @@ impl DmTarget for VerityTarget {
             BioType::Flush => bio.complete(BioStatus::Complete),
         }
     }
+}
+
+fn sector_offset(sector: u64) -> Option<usize> {
+    usize::try_from(sector).ok()?.checked_mul(SECTOR_SIZE)
+}
+
+fn block_offset(block: u64) -> Option<usize> {
+    usize::try_from(block).ok()?.checked_mul(BLOCK_SIZE)
 }

--- a/kernel/comps/device-mapper/src/target/verity.rs
+++ b/kernel/comps/device-mapper/src/target/verity.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `verity` target.
+//!
+//! A read-only target that verifies the integrity of a data device against a
+//! precomputed Merkle hash tree stored on a separate hash device. Each data
+//! block read is hashed and checked, level by level, up to a trusted root
+//! digest supplied out of band (on the kernel command line). Any mismatch
+//! fails the read with an I/O error, so tampering with either the data or the
+//! hash device is detected before corrupted data is ever returned.
+//!
+//! The root digest is the root of trust and must be delivered through a trusted
+//! path. The target guarantees block integrity against that root, not the
+//! authenticity of the root itself, which matches Linux dm-verity.
+//!
+//! The on-disk format follows Linux dm-verity:
+//!
+//! - The per-block digest is `sha256(salt || block)` for version 1 and
+//!   `sha256(block || salt)` for version 0.
+//! - The hash tree is laid out top level first, each level packing as many
+//!   fixed-size digests per hash block as fit, with the single top-level block
+//!   hashing to the root digest.
+//!
+//! Reference: Linux `Documentation/admin-guide/device-mapper/verity.rst`
+//! (<https://docs.kernel.org/admin-guide/device-mapper/verity.html>).
+
+use alloc::{sync::Arc, vec::Vec};
+
+use aster_block::{
+    BLOCK_SIZE, BlockDevice, SECTOR_SIZE,
+    bio::{BioStatus, BioType, SubmittedBio},
+};
+use ostd::mm::VmIo;
+
+use super::DmTarget;
+use crate::{
+    DmError, DmErrorWithContext,
+    parser::{lookup_block_device, parse_field, parse_hex_bytes},
+    sha256,
+};
+
+/// The digest size of SHA-256, in bytes.
+const DIGEST_SIZE: usize = 32;
+/// The number of 512-byte sectors per block.
+const SECTORS_PER_BLOCK: u64 = (BLOCK_SIZE / SECTOR_SIZE) as u64;
+/// The number of arguments in a `verity` table line.
+const NR_TABLE_ARGS: usize = 10;
+
+/// One level of the hash tree, in the order it is stored on the hash device.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HashLevel {
+    /// The first hash block of the level, relative to the start of the hash
+    /// device.
+    pub first_block: u64,
+    /// The number of hash blocks in the level.
+    pub nr_blocks: u64,
+}
+
+/// Computes the hash-tree levels for a data device of `num_data_blocks` blocks.
+///
+/// Levels are returned top level first (the single root block), matching the
+/// on-device layout: the data block digests fill the last (leaf) level, every
+/// hash block holds up to `hashes_per_block` digests of the level below, and
+/// the levels stack contiguously starting at `hash_start_block`.
+pub fn build_hash_levels(
+    num_data_blocks: u64,
+    hashes_per_block: u64,
+    hash_start_block: u64,
+) -> Result<Vec<HashLevel>, DmError> {
+    if num_data_blocks == 0 || hashes_per_block == 0 {
+        return Err(DmError::InvalidArgument);
+    }
+
+    // Block counts from the leaf level up to (but not including) the root.
+    let mut counts_leaf_to_root = Vec::new();
+    let mut count = num_data_blocks.div_ceil(hashes_per_block);
+    while count > 1 {
+        counts_leaf_to_root.push(count);
+        count = count.div_ceil(hashes_per_block);
+    }
+    counts_leaf_to_root.push(1);
+
+    let mut levels = Vec::with_capacity(counts_leaf_to_root.len());
+    let mut first_block = hash_start_block;
+    for &nr_blocks in counts_leaf_to_root.iter().rev() {
+        levels.push(HashLevel {
+            first_block,
+            nr_blocks,
+        });
+        first_block = first_block
+            .checked_add(nr_blocks)
+            .ok_or(DmError::InvalidArgument)?;
+    }
+    Ok(levels)
+}
+
+/// A read-only `verity` target.
+#[derive(Debug)]
+pub struct VerityTarget {
+    data_device: Arc<dyn BlockDevice>,
+    hash_device: Arc<dyn BlockDevice>,
+    num_data_blocks: u64,
+    version: u8,
+    salt: Vec<u8>,
+    root_digest: [u8; DIGEST_SIZE],
+    /// Hash-tree levels, top level first.
+    levels: Vec<HashLevel>,
+}
+
+impl VerityTarget {
+    /// Parses the arguments of a `verity` table line.
+    ///
+    /// The accepted form mirrors the Linux dm-verity table:
+    ///
+    /// ```text
+    /// <version> <data_dev> <hash_dev> <data_block_size> <hash_block_size>
+    /// <num_data_blocks> <hash_start_block> <algorithm> <root_digest> <salt>
+    /// ```
+    ///
+    /// Supports SHA-256 with 4096-byte data and hash blocks; the salt may be
+    /// `-` to denote an empty salt.
+    pub fn from_table_args(args: &[&str]) -> Result<Self, DmErrorWithContext> {
+        if args.len() != NR_TABLE_ARGS {
+            return Err(DmError::InvalidTable.context(
+                "verity target expects: <version> <data_dev> <hash_dev> \
+                 <data_block_size> <hash_block_size> <num_data_blocks> \
+                 <hash_start_block> <algorithm> <root_digest> <salt>",
+            ));
+        }
+
+        let version = parse_field::<u8>(args[0], "verity version")?;
+        if version > 1 {
+            return Err(DmError::InvalidArgument.context("verity version must be 0 or 1"));
+        }
+
+        let data_device = lookup_block_device(args[1])?;
+        let hash_device = lookup_block_device(args[2])?;
+
+        let data_block_size = parse_field::<usize>(args[3], "verity data block size")?;
+        let hash_block_size = parse_field::<usize>(args[4], "verity hash block size")?;
+        if data_block_size != BLOCK_SIZE || hash_block_size != BLOCK_SIZE {
+            return Err(DmError::InvalidArgument
+                .context("verity target only supports 4096-byte data and hash blocks"));
+        }
+
+        let num_data_blocks = parse_field::<u64>(args[5], "verity data block count")?;
+        if num_data_blocks == 0 {
+            return Err(DmError::InvalidArgument.context("verity data block count must be nonzero"));
+        }
+        let hash_start_block = parse_field::<u64>(args[6], "verity hash start block")?;
+
+        if args[7] != "sha256" {
+            return Err(DmError::UnsupportedTarget
+                .context("verity target only supports the sha256 algorithm"));
+        }
+
+        let root_bytes = parse_hex_bytes(args[8])
+            .map_err(|err| err.context("verity root digest is not valid hex"))?;
+        if root_bytes.len() != DIGEST_SIZE {
+            return Err(
+                DmError::InvalidArgument.context("verity root digest must be 32 bytes for sha256")
+            );
+        }
+        let mut root_digest = [0u8; DIGEST_SIZE];
+        root_digest.copy_from_slice(&root_bytes);
+
+        let salt =
+            parse_hex_bytes(args[9]).map_err(|err| err.context("verity salt is not valid hex"))?;
+
+        let hashes_per_block = (BLOCK_SIZE / DIGEST_SIZE) as u64;
+        let levels = build_hash_levels(num_data_blocks, hashes_per_block, hash_start_block)
+            .map_err(|err| err.context("verity hash tree geometry is invalid"))?;
+
+        Ok(Self {
+            data_device,
+            hash_device,
+            num_data_blocks,
+            version,
+            salt,
+            root_digest,
+            levels,
+        })
+    }
+
+    /// Hashes a block with the salt, ordered per the dm-verity version.
+    fn hash_block(&self, block: &[u8]) -> [u8; DIGEST_SIZE] {
+        match self.version {
+            0 => sha256::digest(&[block, &self.salt]),
+            _ => sha256::digest(&[&self.salt, block]),
+        }
+    }
+
+    /// Verifies `block` (at index `data_block_index`) against the hash tree,
+    /// returning whether every level up to the root digest matches.
+    ///
+    /// `hash_scratch` is a reusable block-sized buffer for reading hash blocks.
+    fn verify_block(&self, data_block_index: u64, block: &[u8], hash_scratch: &mut [u8]) -> bool {
+        let hashes_per_block = (BLOCK_SIZE / DIGEST_SIZE) as u64;
+        let mut child_digest = self.hash_block(block);
+        let mut child_index = data_block_index;
+
+        // Walk from the leaf level up to the root.
+        for level in self.levels.iter().rev() {
+            let block_in_level = child_index / hashes_per_block;
+            let slot = (child_index % hashes_per_block) as usize;
+            if block_in_level >= level.nr_blocks {
+                return false;
+            }
+
+            let hash_block_index = level.first_block + block_in_level;
+            if self
+                .hash_device
+                .read_bytes(hash_block_index as usize * BLOCK_SIZE, hash_scratch)
+                .is_err()
+            {
+                return false;
+            }
+
+            let mut stored = [0u8; DIGEST_SIZE];
+            stored.copy_from_slice(
+                &hash_scratch[slot * DIGEST_SIZE..slot * DIGEST_SIZE + DIGEST_SIZE],
+            );
+            if stored != child_digest {
+                return false;
+            }
+
+            child_digest = self.hash_block(hash_scratch);
+            child_index = block_in_level;
+        }
+
+        // The hash of the top-level block must equal the trusted root digest.
+        child_digest == self.root_digest
+    }
+
+    fn handle_read(&self, bio: SubmittedBio, target_start_sector: u64) {
+        // The verity unit of trust is a full data block, so verification always
+        // operates on whole blocks even when the request is sector-granular
+        // (the generic partition scanner, for instance, reads a single sector).
+        // Each overlapping block is read and verified once, then the requested
+        // byte range is scattered into the request's memory segments.
+        let mut device_offset = target_start_sector as usize * SECTOR_SIZE;
+
+        let mut data_block = super::zero_vec(BLOCK_SIZE);
+        let mut hash_scratch = super::zero_vec(BLOCK_SIZE);
+        let mut cached_block: Option<u64> = None;
+
+        for segment in bio.segments() {
+            let nbytes = segment.nbytes();
+            let mut segment_offset = 0;
+            while segment_offset < nbytes {
+                let block_index = (device_offset / BLOCK_SIZE) as u64;
+                if block_index >= self.num_data_blocks {
+                    bio.complete(BioStatus::IoError);
+                    return;
+                }
+
+                if cached_block != Some(block_index) {
+                    let block_offset = block_index as usize * BLOCK_SIZE;
+                    if self
+                        .data_device
+                        .read_bytes(block_offset, &mut data_block)
+                        .is_err()
+                        || !self.verify_block(block_index, &data_block, &mut hash_scratch)
+                    {
+                        bio.complete(BioStatus::IoError);
+                        return;
+                    }
+                    cached_block = Some(block_index);
+                }
+
+                let within_block = device_offset % BLOCK_SIZE;
+                let chunk = (BLOCK_SIZE - within_block).min(nbytes - segment_offset);
+                if segment
+                    .inner_dma_slice()
+                    .write_bytes(
+                        segment_offset,
+                        &data_block[within_block..within_block + chunk],
+                    )
+                    .is_err()
+                {
+                    bio.complete(BioStatus::IoError);
+                    return;
+                }
+
+                segment_offset += chunk;
+                device_offset += chunk;
+            }
+        }
+
+        bio.complete(BioStatus::Complete);
+    }
+}
+
+impl DmTarget for VerityTarget {
+    fn type_name(&self) -> &'static str {
+        "verity"
+    }
+
+    fn size_sectors(&self) -> Option<u64> {
+        Some(self.num_data_blocks * SECTORS_PER_BLOCK)
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64) {
+        match bio.type_() {
+            BioType::Read => self.handle_read(bio, target_start_sector),
+            // A verity device is read-only; reject any modification.
+            BioType::Write => bio.complete(BioStatus::NotSupported),
+            BioType::Flush => bio.complete(BioStatus::Complete),
+        }
+    }
+}

--- a/kernel/comps/device-mapper/src/target/zero.rs
+++ b/kernel/comps/device-mapper/src/target/zero.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `zero` target.
+//!
+//! Reads return zero-filled blocks and writes are silently discarded. It is
+//! useful as a placeholder backing store and for tests.
+//!
+//! Reference: Linux `Documentation/admin-guide/device-mapper/zero.rst`.
+
+use aster_block::bio::{BioStatus, BioType, SubmittedBio};
+use ostd::mm::VmIo;
+
+use super::{DmTarget, zero_vec};
+
+/// A `zero` target.
+#[derive(Debug, Default)]
+pub struct ZeroTarget;
+
+impl DmTarget for ZeroTarget {
+    fn type_name(&self) -> &'static str {
+        "zero"
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio, _target_start_sector: u64) {
+        match bio.type_() {
+            BioType::Read => {
+                for segment in bio.segments() {
+                    let zeros = zero_vec(segment.nbytes());
+                    if segment.inner_dma_slice().write_bytes(0, &zeros).is_err() {
+                        bio.complete(BioStatus::IoError);
+                        return;
+                    }
+                }
+                bio.complete(BioStatus::Complete);
+            }
+            // Writes are discarded; a flush has nothing to persist.
+            BioType::Write | BioType::Flush => bio.complete(BioStatus::Complete),
+        }
+    }
+}

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_block::{BLOCK_SIZE, BlockDevice, SECTOR_SIZE};
+use aster_device_mapper::DmDevice;
 use aster_nvme::NvmeBlockDevice;
 use aster_virtio::device::block::device::BlockDevice as VirtIoBlockDevice;
 use device_id::DeviceId;
@@ -54,6 +55,8 @@ pub(super) fn init_in_first_kthread() {
 }
 
 pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> {
+    spawn_device_mapper_threads();
+
     for device in aster_block::collect_all() {
         let device = Arc::new(BlockFile::new(device));
         if let Some(devtmpfs_meta) = device.devtmpfs_meta() {
@@ -63,6 +66,24 @@ pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> 
     }
 
     Ok(())
+}
+
+fn spawn_device_mapper_threads() {
+    for device in aster_block::collect_all() {
+        if device.downcast_ref::<DmDevice>().is_none() {
+            continue;
+        }
+
+        let device_clone = device.clone();
+        let task_fn = move || {
+            info!("spawn the device-mapper block thread");
+            let dm_device = device_clone.downcast_ref::<DmDevice>().unwrap();
+            loop {
+                dm_device.handle_requests();
+            }
+        };
+        ThreadOptions::new(task_fn).spawn();
+    }
 }
 
 mod ioctl_defs {

--- a/kernel/src/driver/mod.rs
+++ b/kernel/src/driver/mod.rs
@@ -10,11 +10,10 @@ pub fn init() {
     // FIXME: Currently, we have to do this manually to ensure the crates containing the input
     // devices are linked and their `#[init_component]` hooks can run to register the devices with
     // the input core. We should find a way to avoid this in the future.
+    // Likewise, force the device-mapper component to be linked so its process-stage
+    // `#[init_component]` hook can create mapped devices requested through the
+    // `dm_mod.create=` kernel command line.
+    use aster_device_mapper as _;
     #[expect(unused_imports)]
     use aster_i8042::*;
-
-    // Likewise, force the device-mapper component to be linked so its
-    // `#[init_component]` hook runs and creates the mapped devices requested
-    // through the `dm_mod.create=` kernel command line.
-    use aster_device_mapper as _;
 }

--- a/kernel/src/driver/mod.rs
+++ b/kernel/src/driver/mod.rs
@@ -12,4 +12,9 @@ pub fn init() {
     // the input core. We should find a way to avoid this in the future.
     #[expect(unused_imports)]
     use aster_i8042::*;
+
+    // Likewise, force the device-mapper component to be linked so its
+    // `#[init_component]` hook runs and creates the mapped devices requested
+    // through the `dm_mod.create=` kernel command line.
+    use aster_device_mapper as _;
 }


### PR DESCRIPTION
## What this PR does

This PR adds a new kernel component, `aster-device-mapper`
(`kernel/comps/device-mapper`), that implements a table-driven virtual
block-device layer inspired by Linux's device-mapper. Mapped devices are
described by a table of segments, each backed by a *target*, and are exposed as
regular block devices through the block-device registry.

Four targets are implemented:

- **`linear`** — maps a contiguous sector range onto an underlying device at a
  fixed offset.
- **`zero`** — reads return zeroes, writes are discarded (the dm-zero analogue).
- **`error`** — every I/O fails (the dm-error analogue), useful for padding a
  table and for testing error paths.
- **`verity`** — read-only, transparent integrity checking against a precomputed
  SHA-256 Merkle tree (a subset of Linux dm-verity). A self-contained SHA-256
  implementation is included so the target has no external crypto dependency.

Devices are created declaratively from the kernel command line via
`dm_mod.create=` / `dm-mod.create=` entries, matching Linux's boot-time
device-mapper syntax, and are parsed into typed table descriptors before any
device is instantiated.

## Why

Device-mapper is the foundation Linux uses for LVM, dm-verity, dm-crypt and
friends. A minimal, safe, table-driven core with `linear`/`zero`/`error` plus
read-only `verity` gives Asterinas verified-boot-style read-only integrity
checking and a base other targets can build on, without pulling in unsafe code
(the crate is `#![deny(unsafe_code)]`).

## Design notes

- The component sits behind the existing `aster-block` `BlockDevice` trait, so a
  mapped device is a drop-in block device; no changes to block-device consumers
  are required beyond registration.
- Table construction validates segment coverage and bounds up front; the request
  path clamps and rejects out-of-range I/O so a malformed table can never index
  outside an underlying device.
- verity verification walks the SHA-256 hash tree bottom-up and fails the bio on
  the first mismatch; hashes are computed with the in-crate SHA-256.
- Device creation from `dm_mod.create=` runs in the first process context via an
  `#[init_component(process)]` hook, after the block layer is up.

## References

- Linux device-mapper: https://docs.kernel.org/admin-guide/device-mapper/
- Linux dm-verity: https://docs.kernel.org/admin-guide/device-mapper/verity.html

## Testing

- `RUSTFLAGS="-Dwarnings" cargo osdk clippy` (and `--ktests`) pass with no
  warnings for the workspace, including the new crate.
- `cargo fmt --check`, `typos`, and the MPL-2.0 license-header check pass.
- In-kernel `#[ktest]` coverage is included for the table model, the linear/
  zero/error targets, verity accept/reject paths, request bounds handling, and
  submitted-bio sector-offset handling.

## Notes for reviewers

The change is self-contained: 13 new files under `kernel/comps/device-mapper`
plus registration wiring in `Components.toml`, `kernel/Cargo.toml`,
`kernel/src/driver/mod.rs` and `kernel/src/device/registry/block.rs`. It can be
split into "core framework (linear/zero/error)" and "dm-verity (SHA-256 +
verity target)" if a smaller first PR is preferred — see the commit breakdown.