### PR TITLE
Add a device-mapper component with linear, zero, and error targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "aster-cmdline",
  "component",
  "device-id",
+ "io-util",
  "ostd",
  "spin",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aster-device-mapper"
+version = "0.1.0"
+dependencies = [
+ "aster-block",
+ "aster-cmdline",
+ "component",
+ "device-id",
+ "ostd",
+ "spin",
+]
+
+[[package]]
 name = "aster-framebuffer"
 version = "0.1.0"
 dependencies = [
@@ -186,6 +198,7 @@ dependencies = [
  "aster-block",
  "aster-cmdline",
  "aster-console",
+ "aster-device-mapper",
  "aster-framebuffer",
  "aster-fuse",
  "aster-i8042",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "kernel/comps/block",
     "kernel/comps/cmdline",
     "kernel/comps/console",
+    "kernel/comps/device-mapper",
     "kernel/comps/framebuffer",
     "kernel/comps/i8042",
     "kernel/comps/input",
@@ -77,6 +78,7 @@ default-members = [
     "kernel/comps/block",
     "kernel/comps/cmdline",
     "kernel/comps/console",
+    "kernel/comps/device-mapper",
     "kernel/comps/framebuffer",
     "kernel/comps/i8042",
     "kernel/comps/input",
@@ -150,6 +152,7 @@ ostd-test = { version = "0.18.0", path = "ostd/libs/ostd-test" }
 aster-block = { path = "kernel/comps/block" }
 aster-cmdline = { path = "kernel/comps/cmdline" }
 aster-console = { path = "kernel/comps/console" }
+aster-device-mapper = { path = "kernel/comps/device-mapper" }
 aster-framebuffer = { path = "kernel/comps/framebuffer" }
 aster-i8042 = { path = "kernel/comps/i8042" }
 aster-input = { path = "kernel/comps/input" }

--- a/Components.toml
+++ b/Components.toml
@@ -3,6 +3,7 @@
 block = { name = "aster-block" }
 cmdline = { name = "aster-cmdline" }
 console = { name = "aster-console" }
+device_mapper = { name = "aster-device-mapper" }
 framebuffer = { name = "aster-framebuffer" }
 i8042 = { name = "aster-i8042" }
 input = { name = "aster-input" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -11,6 +11,7 @@ aster-bigtcp.workspace = true
 aster-block.workspace = true
 aster-cmdline.workspace = true
 aster-console.workspace = true
+aster-device-mapper.workspace = true
 aster-framebuffer.workspace = true
 aster-fuse.workspace = true
 aster-i8042.workspace = true

--- a/kernel/comps/device-mapper/Cargo.toml
+++ b/kernel/comps/device-mapper/Cargo.toml
@@ -10,6 +10,7 @@ aster-block.workspace = true
 aster-cmdline.workspace = true
 component.workspace = true
 device-id.workspace = true
+io-util.workspace = true
 ostd.workspace = true
 spin.workspace = true
 

--- a/kernel/comps/device-mapper/Cargo.toml
+++ b/kernel/comps/device-mapper/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "aster-device-mapper"
+version = "0.1.0"
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aster-block.workspace = true
+aster-cmdline.workspace = true
+component.workspace = true
+device-id.workspace = true
+ostd.workspace = true
+spin.workspace = true
+
+[lints]
+workspace = true

--- a/kernel/comps/device-mapper/src/device.rs
+++ b/kernel/comps/device-mapper/src/device.rs
@@ -5,6 +5,7 @@ use alloc::string::String;
 use aster_block::{
     BlockDevice, BlockDeviceMeta,
     bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio},
+    request_queue::{BioRequest, BioRequestSingleQueue},
 };
 use device_id::DeviceId;
 
@@ -16,20 +17,32 @@ pub struct DmDevice {
     name: String,
     id: DeviceId,
     table: DmTable,
+    queue: BioRequestSingleQueue,
 }
 
 impl DmDevice {
-    pub fn new(name: String, id: DeviceId, table: DmTable) -> Self {
-        Self { name, id, table }
+    pub(crate) fn new(name: String, id: DeviceId, table: DmTable) -> Self {
+        Self {
+            name,
+            id,
+            table,
+            queue: BioRequestSingleQueue::new(),
+        }
     }
 
-    pub fn table(&self) -> &DmTable {
-        &self.table
+    /// Dequeues one mapped-device request and processes it.
+    pub fn handle_requests(&self) {
+        let request = self.queue.dequeue();
+        self.handle_request(request);
     }
-}
 
-impl BlockDevice for DmDevice {
-    fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+    fn handle_request(&self, request: BioRequest) {
+        for bio in request.into_bios() {
+            self.handle_bio(bio);
+        }
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio) {
         if bio.type_() == BioType::Flush {
             let status = self
                 .table
@@ -39,29 +52,35 @@ impl BlockDevice for DmDevice {
                 .find(|status| *status != BioStatus::Complete)
                 .unwrap_or(BioStatus::Complete);
             bio.complete(status);
-            return Ok(());
+            return;
         }
 
-        let start_sector = bio.sid_range().start.to_raw();
-        let end_sector = bio.sid_range().end.to_raw();
-        if end_sector > self.table.total_sectors() || start_sector >= end_sector {
+        let start_sector = bio.sid_range().start.to_raw() + bio.sid_offset();
+        let end_sector = bio.sid_range().end.to_raw() + bio.sid_offset();
+        if end_sector > self.table.total_sectors() as u64 || start_sector >= end_sector {
             bio.complete(BioStatus::IoError);
-            return Ok(());
+            return;
         }
 
         let Some(segment) = self.table.find_segment(start_sector, end_sector) else {
             bio.complete(BioStatus::IoError);
-            return Ok(());
+            return;
         };
         let target_start_sector = start_sector - segment.start_sector;
         segment.target.handle_bio(bio, target_start_sector);
+    }
+}
+
+impl BlockDevice for DmDevice {
+    fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+        self.queue.enqueue(bio)?;
         Ok(())
     }
 
     fn metadata(&self) -> BlockDeviceMeta {
         BlockDeviceMeta {
-            max_nr_segments_per_bio: usize::MAX,
-            nr_sectors: self.table.total_sectors() as usize,
+            max_nr_segments_per_bio: self.queue.max_nr_segments_per_bio(),
+            nr_sectors: self.table.total_sectors(),
         }
     }
 

--- a/kernel/comps/device-mapper/src/device.rs
+++ b/kernel/comps/device-mapper/src/device.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::string::String;
+
+use aster_block::{
+    BlockDevice, BlockDeviceMeta,
+    bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio},
+};
+use device_id::DeviceId;
+
+use crate::table::DmTable;
+
+/// A mapped block device backed by a device-mapper table.
+#[derive(Debug)]
+pub struct DmDevice {
+    name: String,
+    id: DeviceId,
+    table: DmTable,
+}
+
+impl DmDevice {
+    pub fn new(name: String, id: DeviceId, table: DmTable) -> Self {
+        Self { name, id, table }
+    }
+
+    pub fn table(&self) -> &DmTable {
+        &self.table
+    }
+}
+
+impl BlockDevice for DmDevice {
+    fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+        if bio.type_() == BioType::Flush {
+            let status = self
+                .table
+                .segments()
+                .iter()
+                .map(|segment| segment.target.flush())
+                .find(|status| *status != BioStatus::Complete)
+                .unwrap_or(BioStatus::Complete);
+            bio.complete(status);
+            return Ok(());
+        }
+
+        let start_sector = bio.sid_range().start.to_raw();
+        let end_sector = bio.sid_range().end.to_raw();
+        if end_sector > self.table.total_sectors() || start_sector >= end_sector {
+            bio.complete(BioStatus::IoError);
+            return Ok(());
+        }
+
+        let Some(segment) = self.table.find_segment(start_sector, end_sector) else {
+            bio.complete(BioStatus::IoError);
+            return Ok(());
+        };
+        let target_start_sector = start_sector - segment.start_sector;
+        segment.target.handle_bio(bio, target_start_sector);
+        Ok(())
+    }
+
+    fn metadata(&self) -> BlockDeviceMeta {
+        BlockDeviceMeta {
+            max_nr_segments_per_bio: usize::MAX,
+            nr_sectors: self.table.total_sectors() as usize,
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn id(&self) -> DeviceId {
+        self.id
+    }
+}

--- a/kernel/comps/device-mapper/src/error.rs
+++ b/kernel/comps/device-mapper/src/error.rs
@@ -9,7 +9,6 @@ pub enum DmError {
     DeviceNotFound,
     InvalidArgument,
     InvalidTable,
-    IoError,
     NoDeviceId,
     UnsupportedTarget,
 }

--- a/kernel/comps/device-mapper/src/error.rs
+++ b/kernel/comps/device-mapper/src/error.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::string::String;
+
+/// Errors returned by the device-mapper component.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DmError {
+    DeviceExists,
+    DeviceNotFound,
+    InvalidArgument,
+    InvalidTable,
+    IoError,
+    NoDeviceId,
+    UnsupportedTarget,
+}
+
+impl DmError {
+    pub fn context(self, message: impl Into<String>) -> DmErrorWithContext {
+        DmErrorWithContext {
+            kind: self,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DmErrorWithContext {
+    pub kind: DmError,
+    pub message: String,
+}

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Device-mapper support for Asterinas.
+//!
+//! This component implements a small, table-driven virtual block-device layer
+//! inspired by Linux device-mapper. A mapped device is described by a table of
+//! sector ranges, each handled by a target that decides how the range is backed
+//! by lower devices.
+//!
+//! Reference: Linux device-mapper documentation
+//! <https://docs.kernel.org/admin-guide/device-mapper/>.
+
+#![no_std]
+#![deny(unsafe_code)]
+
+extern crate alloc;
+
+// Set this crate's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "dm: "
+    };
+}
+
+mod error;
+
+use component::{ComponentInitError, init_component};
+
+pub use self::error::{DmError, DmErrorWithContext};
+
+#[init_component]
+fn init() -> Result<(), ComponentInitError> {
+    Ok(())
+}

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -24,6 +24,7 @@ macro_rules! __log_prefix {
 
 mod device;
 mod error;
+mod registry;
 mod table;
 pub mod target;
 
@@ -32,10 +33,12 @@ use component::{ComponentInitError, init_component};
 pub use self::{
     device::DmDevice,
     error::{DmError, DmErrorWithContext},
+    registry::{create_device, list_devices, lookup_device, remove_device},
     table::{DmTable, DmTableSegment},
 };
 
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {
+    registry::init().map_err(|_| ComponentInitError::Unknown)?;
     Ok(())
 }

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -2,14 +2,13 @@
 
 //! Device-mapper support for Asterinas.
 //!
-//! This component implements a small, table-driven virtual block-device layer
-//! inspired by Linux device-mapper. A mapped device is described by a table of
-//! sector ranges, each handled by a target that decides how the range is backed
-//! by lower devices. Devices are created from `dm-mod.create=`/`dm_mod.create=`
-//! kernel command-line entries.
+//! This component implements a table-driven virtual block-device layer inspired
+//! by Linux device-mapper. It supports `linear`, `zero`, and `error` targets
+//! created from `dm-mod.create=`/`dm_mod.create=` kernel command-line entries.
 //!
-//! Reference: Linux device-mapper documentation
-//! <https://docs.kernel.org/admin-guide/device-mapper/>.
+//! References:
+//! - Linux device-mapper documentation:
+//!   <https://docs.kernel.org/admin-guide/device-mapper/>
 
 #![no_std]
 #![deny(unsafe_code)]
@@ -39,9 +38,7 @@ use spin::Once;
 pub use self::{
     device::DmDevice,
     error::{DmError, DmErrorWithContext},
-    parser::{DmCreateArg, parse_create_arg},
-    registry::{create_device, list_devices, lookup_device, remove_device},
-    table::{DmTable, DmTableSegment},
+    parser::DmCreateArg,
 };
 
 static DM_CREATE_ARGS: Once<Vec<DmCreateArg>> = Once::new();
@@ -53,12 +50,12 @@ fn init() -> Result<(), ComponentInitError> {
     Ok(())
 }
 
-#[init_component(kthread)]
-fn init_in_first_kthread() -> Result<(), ComponentInitError> {
+#[init_component(process)]
+fn init_in_first_process() -> Result<(), ComponentInitError> {
     let create_args = DM_CREATE_ARGS.get().cloned().unwrap_or_default();
     for (index, arg) in create_args.iter().enumerate() {
-        match parse_create_arg(arg.as_str(), index) {
-            Ok(parsed) => match create_device(parsed.name.clone(), parsed.table) {
+        match parser::parse_create_arg(arg.as_str(), index) {
+            Ok(parsed) => match registry::create_device(parsed.name.clone(), parsed.table) {
                 Ok(device) => {
                     ostd::info!("created dm device '{}' ({:?})", device.name(), device.id());
                 }
@@ -77,4 +74,295 @@ fn init_in_first_kthread() -> Result<(), ComponentInitError> {
     }
 
     Ok(())
+}
+
+#[cfg(ktest)]
+mod tests {
+    use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use aster_block::{
+        BLOCK_SIZE, BlockDevice, BlockDeviceMeta, SECTOR_SIZE,
+        bio::{Bio, BioDirection, BioEnqueueError, BioSegment, BioStatus, BioType, SubmittedBio},
+        id::Sid,
+    };
+    use device_id::{DeviceId, MajorId, MinorId};
+    use io_util::batch::IoBatch;
+    use ostd::{
+        mm::{FrameAllocOptions, Segment, VmIo, io::util::HasVmReaderWriter},
+        prelude::*,
+    };
+
+    use super::{
+        device::DmDevice,
+        table::{DmTable, DmTableSegment},
+        target::{error::ErrorTarget, linear::LinearTarget, zero::ZeroTarget},
+    };
+
+    #[derive(Debug)]
+    struct MemoryDisk {
+        name: &'static str,
+        id: DeviceId,
+        bytes: Segment<()>,
+        flushes: AtomicUsize,
+    }
+
+    #[derive(Debug)]
+    struct OffsetBlockDevice {
+        name: &'static str,
+        id: DeviceId,
+        inner: Arc<DmDevice>,
+        sid_offset: u64,
+    }
+
+    impl MemoryDisk {
+        fn new(name: &'static str, minor: u32, nblocks: usize) -> Self {
+            let bytes = FrameAllocOptions::new()
+                .zeroed(true)
+                .alloc_segment(nblocks)
+                .unwrap();
+            Self {
+                name,
+                id: DeviceId::new(MajorId::new(250), MinorId::new(minor)),
+                bytes,
+                flushes: AtomicUsize::new(0),
+            }
+        }
+
+        fn read_bytes_at(&self, offset: usize, out: &mut [u8]) {
+            self.bytes.read_bytes(offset, out).unwrap();
+        }
+
+        fn write_bytes_at(&self, offset: usize, input: &[u8]) {
+            self.bytes.write_bytes(offset, input).unwrap();
+        }
+    }
+
+    impl BlockDevice for MemoryDisk {
+        fn enqueue(&self, bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+            if bio.type_() == BioType::Flush {
+                self.flushes.fetch_add(1, Ordering::Relaxed);
+                bio.complete(BioStatus::Complete);
+                return Ok(());
+            }
+
+            let mut offset = bio.sid_range().start.to_offset();
+            for segment in bio.segments() {
+                let Some(end_offset) = offset.checked_add(segment.nbytes()) else {
+                    bio.complete(BioStatus::IoError);
+                    return Ok(());
+                };
+                if end_offset > self.bytes.size() {
+                    bio.complete(BioStatus::IoError);
+                    return Ok(());
+                }
+                match bio.type_() {
+                    BioType::Read => {
+                        let _ = segment
+                            .inner_dma_slice()
+                            .writer()
+                            .unwrap()
+                            .write(self.bytes.reader().skip(offset));
+                    }
+                    BioType::Write => {
+                        let _ = self
+                            .bytes
+                            .writer()
+                            .skip(offset)
+                            .write(&mut segment.inner_dma_slice().reader().unwrap());
+                    }
+                    BioType::Flush => unreachable!(),
+                }
+                offset = end_offset;
+            }
+            bio.complete(BioStatus::Complete);
+            Ok(())
+        }
+
+        fn metadata(&self) -> BlockDeviceMeta {
+            BlockDeviceMeta {
+                max_nr_segments_per_bio: usize::MAX,
+                nr_sectors: self.bytes.size() / SECTOR_SIZE,
+            }
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn id(&self) -> DeviceId {
+            self.id
+        }
+    }
+
+    impl BlockDevice for OffsetBlockDevice {
+        fn enqueue(&self, mut bio: SubmittedBio) -> Result<(), BioEnqueueError> {
+            bio.set_sid_offset(self.sid_offset);
+            self.inner.enqueue(bio)
+        }
+
+        fn metadata(&self) -> BlockDeviceMeta {
+            let mut metadata = self.inner.metadata();
+            metadata.nr_sectors = metadata.nr_sectors.saturating_sub(self.sid_offset as usize);
+            metadata
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn id(&self) -> DeviceId {
+            self.id
+        }
+    }
+
+    fn read_offset_device(
+        device: &OffsetBlockDevice,
+        dm: &DmDevice,
+        offset: usize,
+        len: usize,
+    ) -> (BioStatus, Vec<u8>) {
+        let status = Arc::new(AtomicUsize::new(BioStatus::Init as usize));
+        let complete_status = status.clone();
+        let segment = BioSegment::alloc(len.div_ceil(BLOCK_SIZE), BioDirection::FromDevice);
+        let bio = Bio::new(
+            BioType::Read,
+            Sid::from_offset(offset),
+            vec![segment.clone()],
+            Some(Box::new(move |bio_status| {
+                complete_status.store(bio_status as usize, Ordering::Relaxed);
+            })),
+        );
+        let mut io_batch = IoBatch::with_capacity(1);
+        bio.submit(device, &mut io_batch).unwrap();
+        dm.handle_requests();
+        let _ = io_batch.wait_all();
+
+        let status = BioStatus::try_from(status.load(Ordering::Relaxed) as u32).unwrap();
+        let mut bytes = vec![0u8; len];
+        if status == BioStatus::Complete {
+            segment.inner_dma_slice().read_bytes(0, &mut bytes).unwrap();
+        }
+        (status, bytes)
+    }
+
+    fn submit_device_io(
+        device: &DmDevice,
+        type_: BioType,
+        offset: usize,
+        segments: Vec<BioSegment>,
+    ) -> BioStatus {
+        let status = Arc::new(AtomicUsize::new(BioStatus::Init as usize));
+        let complete_status = status.clone();
+        let bio = Bio::new(
+            type_,
+            Sid::from_offset(offset),
+            segments,
+            Some(Box::new(move |bio_status| {
+                complete_status.store(bio_status as usize, Ordering::Relaxed);
+            })),
+        );
+        let mut io_batch = IoBatch::with_capacity(1);
+        bio.submit(device, &mut io_batch).unwrap();
+        device.handle_requests();
+        let _ = io_batch.wait_all();
+        BioStatus::try_from(status.load(Ordering::Relaxed) as u32).unwrap()
+    }
+
+    fn read_device(device: &DmDevice, offset: usize, len: usize) -> (BioStatus, Vec<u8>) {
+        let segment = BioSegment::alloc(len.div_ceil(BLOCK_SIZE), BioDirection::FromDevice);
+        let status = submit_device_io(device, BioType::Read, offset, vec![segment.clone()]);
+        let mut bytes = vec![0u8; len];
+        if status == BioStatus::Complete {
+            segment.inner_dma_slice().read_bytes(0, &mut bytes).unwrap();
+        }
+        (status, bytes)
+    }
+
+    fn write_device(device: &DmDevice, offset: usize, bytes: &[u8]) -> BioStatus {
+        let segment = BioSegment::alloc(bytes.len().div_ceil(BLOCK_SIZE), BioDirection::ToDevice);
+        segment.inner_dma_slice().write_bytes(0, bytes).unwrap();
+        submit_device_io(device, BioType::Write, offset, vec![segment])
+    }
+
+    #[ktest]
+    fn linear_target_remaps_reads_and_writes() {
+        let lower = Arc::new(MemoryDisk::new("linear-lower", 1, 8));
+        let source = vec![0x5au8; BLOCK_SIZE];
+        lower.write_bytes_at(2 * BLOCK_SIZE, &source);
+
+        let target = LinearTarget::new(lower.clone(), (2 * BLOCK_SIZE / SECTOR_SIZE) as u64);
+        let table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::new(target),
+        }])
+        .unwrap();
+        let dm = DmDevice::new("dm-linear-test".into(), DeviceId::null(), table);
+
+        let (status, read_back) = read_device(&dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, source);
+
+        let replacement = vec![0xa5u8; BLOCK_SIZE];
+        assert_eq!(write_device(&dm, 0, &replacement), BioStatus::Complete);
+        let mut lower_bytes = vec![0u8; BLOCK_SIZE];
+        lower.read_bytes_at(2 * BLOCK_SIZE, &mut lower_bytes);
+        assert_eq!(lower_bytes, replacement);
+    }
+
+    #[ktest]
+    fn dm_device_honors_submitted_bio_sid_offset() {
+        let lower = Arc::new(MemoryDisk::new("sid-offset-lower", 14, 8));
+        let first_block = vec![0x11u8; BLOCK_SIZE];
+        let second_block = vec![0x22u8; BLOCK_SIZE];
+        lower.write_bytes_at(0, &first_block);
+        lower.write_bytes_at(BLOCK_SIZE, &second_block);
+
+        let table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (4 * BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::new(LinearTarget::new(lower.clone(), 0)),
+        }])
+        .unwrap();
+        let dm = Arc::new(DmDevice::new(
+            "dm-sid-offset-test".into(),
+            DeviceId::null(),
+            table,
+        ));
+        let partition = OffsetBlockDevice {
+            name: "dm-sid-offset-test1",
+            id: DeviceId::null(),
+            inner: dm.clone(),
+            sid_offset: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+        };
+
+        let (status, read_back) = read_offset_device(&partition, &dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, second_block);
+    }
+
+    #[ktest]
+    fn zero_and_error_targets_have_expected_io_behavior() {
+        let zero_table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::<ZeroTarget>::default(),
+        }])
+        .unwrap();
+        let zero_dm = DmDevice::new("dm-zero-test".into(), DeviceId::null(), zero_table);
+        let (status, read_back) = read_device(&zero_dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::Complete);
+        assert_eq!(read_back, vec![0u8; BLOCK_SIZE]);
+
+        let error_table = DmTable::new(vec![DmTableSegment {
+            start_sector: 0,
+            len_sectors: (BLOCK_SIZE / SECTOR_SIZE) as u64,
+            target: Box::<ErrorTarget>::default(),
+        }])
+        .unwrap();
+        let error_dm = DmDevice::new("dm-error-test".into(), DeviceId::null(), error_table);
+        let (status, _) = read_device(&error_dm, 0, BLOCK_SIZE);
+        assert_eq!(status, BioStatus::IoError);
+    }
 }

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -22,6 +22,7 @@ macro_rules! __log_prefix {
     };
 }
 
+mod device;
 mod error;
 mod table;
 pub mod target;
@@ -29,6 +30,7 @@ pub mod target;
 use component::{ComponentInitError, init_component};
 
 pub use self::{
+    device::DmDevice,
     error::{DmError, DmErrorWithContext},
     table::{DmTable, DmTableSegment},
 };

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -5,7 +5,8 @@
 //! This component implements a small, table-driven virtual block-device layer
 //! inspired by Linux device-mapper. A mapped device is described by a table of
 //! sector ranges, each handled by a target that decides how the range is backed
-//! by lower devices.
+//! by lower devices. Devices are created from `dm-mod.create=`/`dm_mod.create=`
+//! kernel command-line entries.
 //!
 //! Reference: Linux device-mapper documentation
 //! <https://docs.kernel.org/admin-guide/device-mapper/>.
@@ -24,21 +25,56 @@ macro_rules! __log_prefix {
 
 mod device;
 mod error;
+mod parser;
 mod registry;
 mod table;
 pub mod target;
 
+use alloc::vec::Vec;
+
+use aster_block::BlockDevice;
 use component::{ComponentInitError, init_component};
+use spin::Once;
 
 pub use self::{
     device::DmDevice,
     error::{DmError, DmErrorWithContext},
+    parser::{DmCreateArg, parse_create_arg},
     registry::{create_device, list_devices, lookup_device, remove_device},
     table::{DmTable, DmTableSegment},
 };
 
+static DM_CREATE_ARGS: Once<Vec<DmCreateArg>> = Once::new();
+aster_cmdline::define_repeatable_kv_param!("dm_mod.create", DM_CREATE_ARGS);
+
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {
     registry::init().map_err(|_| ComponentInitError::Unknown)?;
+    Ok(())
+}
+
+#[init_component(kthread)]
+fn init_in_first_kthread() -> Result<(), ComponentInitError> {
+    let create_args = DM_CREATE_ARGS.get().cloned().unwrap_or_default();
+    for (index, arg) in create_args.iter().enumerate() {
+        match parse_create_arg(arg.as_str(), index) {
+            Ok(parsed) => match create_device(parsed.name.clone(), parsed.table) {
+                Ok(device) => {
+                    ostd::info!("created dm device '{}' ({:?})", device.name(), device.id());
+                }
+                Err(err) => {
+                    ostd::error!("failed to create dm device '{}': {:?}", parsed.name, err);
+                }
+            },
+            Err(err) => {
+                ostd::error!(
+                    "failed to parse dm-mod.create entry '{}': {:?}",
+                    arg.as_str(),
+                    err
+                );
+            }
+        }
+    }
+
     Ok(())
 }

--- a/kernel/comps/device-mapper/src/lib.rs
+++ b/kernel/comps/device-mapper/src/lib.rs
@@ -23,10 +23,15 @@ macro_rules! __log_prefix {
 }
 
 mod error;
+mod table;
+pub mod target;
 
 use component::{ComponentInitError, init_component};
 
-pub use self::error::{DmError, DmErrorWithContext};
+pub use self::{
+    error::{DmError, DmErrorWithContext},
+    table::{DmTable, DmTableSegment},
+};
 
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {

--- a/kernel/comps/device-mapper/src/parser.rs
+++ b/kernel/comps/device-mapper/src/parser.rs
@@ -60,7 +60,7 @@ pub struct ParsedDmCreate {
     pub table: DmTable,
 }
 
-pub fn parse_create_arg(
+pub(crate) fn parse_create_arg(
     arg: &str,
     fallback_index: usize,
 ) -> Result<ParsedDmCreate, DmErrorWithContext> {
@@ -141,7 +141,9 @@ fn parse_linear_target(args: &[&str]) -> Result<LinearTarget, DmErrorWithContext
     Ok(LinearTarget::new(device, start_sector))
 }
 
-pub fn lookup_block_device(name_or_id: &str) -> Result<Arc<dyn BlockDevice>, DmErrorWithContext> {
+pub(crate) fn lookup_block_device(
+    name_or_id: &str,
+) -> Result<Arc<dyn BlockDevice>, DmErrorWithContext> {
     if let Some(raw) = name_or_id.strip_prefix("dev:") {
         let id = parse_u64(Some(raw), "encoded device id")?;
         let device_id = DeviceId::from_encoded_u64(id)
@@ -183,14 +185,19 @@ mod tests {
     }
 
     #[ktest]
-    fn parse_create_arg_accepts_zero_and_error_segments() {
-        let parsed = parse_create_arg("demo: 0 8 zero; 8 8 error", 0).unwrap();
+    fn parse_create_arg_accepts_single_segment() {
+        let parsed = parse_create_arg("demo: 0 8 zero", 0).unwrap();
         assert_eq!(parsed.name, "demo");
-        assert_eq!(parsed.table.total_sectors(), 16);
+        assert_eq!(parsed.table.total_sectors(), 8);
         let segments = parsed.table.segments();
-        assert_eq!(segments.len(), 2);
+        assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].target.type_name(), "zero");
-        assert_eq!(segments[1].target.type_name(), "error");
+    }
+
+    #[ktest]
+    fn parse_create_arg_rejects_multiple_segments() {
+        let result = parse_create_arg("demo: 0 8 zero; 8 8 error", 0);
+        assert!(result.is_err());
     }
 
     #[ktest]

--- a/kernel/comps/device-mapper/src/parser.rs
+++ b/kernel/comps/device-mapper/src/parser.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use core::str::FromStr;
+
+use aster_block::BlockDevice;
+use aster_cmdline::parse::ParamError;
+use device_id::DeviceId;
+
+use crate::{
+    DmError, DmErrorWithContext,
+    registry::normalize_name,
+    table::{DmTable, DmTableSegment},
+    target::{DmTarget, error::ErrorTarget, linear::LinearTarget, zero::ZeroTarget},
+};
+
+/// One `dm-mod.create=` value from the kernel command line.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DmCreateArg(String);
+
+impl DmCreateArg {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for DmCreateArg {
+    type Err = ParamError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // A dm table value contains spaces, so on the kernel command line it is
+        // written as `dm_mod.create="<name>: <start> <len> <target> ..."`. The
+        // command-line tokenizer keeps the wrapping double quotes in the value,
+        // so strip one matching pair here, mirroring how Linux unquotes kernel
+        // parameter values in `lib/cmdline.c`.
+        let unquoted = strip_matching_quotes(s.trim());
+        if unquoted.is_empty() {
+            Err(ParamError::InvalidValue)
+        } else {
+            Ok(Self(unquoted.to_string()))
+        }
+    }
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .unwrap_or(value)
+}
+
+#[derive(Debug)]
+pub struct ParsedDmCreate {
+    pub name: String,
+    pub table: DmTable,
+}
+
+pub fn parse_create_arg(
+    arg: &str,
+    fallback_index: usize,
+) -> Result<ParsedDmCreate, DmErrorWithContext> {
+    let (raw_name, table_text) = split_name_and_table(arg)
+        .ok_or_else(|| DmError::InvalidTable.context("dm create argument must include a table"))?;
+    let name = normalize_name(raw_name.trim(), fallback_index);
+    let mut segments = Vec::new();
+    for line in table_text.split(';') {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        segments.push(parse_segment(line)?);
+    }
+
+    let table = DmTable::new(segments)
+        .map_err(|err| err.context("dm table segments are empty, overlapping, or invalid"))?;
+    Ok(ParsedDmCreate { name, table })
+}
+
+fn split_name_and_table(arg: &str) -> Option<(&str, &str)> {
+    if let Some((name, table)) = arg.split_once(':') {
+        return Some((name, table));
+    }
+    if let Some((name, table)) = arg.split_once(',') {
+        return Some((name, table));
+    }
+
+    // Linux dm-init accepts a richer comma-separated grammar. A whitespace-only
+    // value is interpreted as a single anonymous table.
+    Some(("-", arg))
+}
+
+fn parse_segment(line: &str) -> Result<DmTableSegment, DmErrorWithContext> {
+    let mut fields = line.split_whitespace();
+    let start_sector = parse_u64(fields.next(), "segment start sector")?;
+    let len_sectors = parse_u64(fields.next(), "segment length")?;
+    let target_name = fields
+        .next()
+        .ok_or_else(|| DmError::InvalidTable.context("segment target type is missing"))?;
+    let args: Vec<&str> = fields.collect();
+
+    let target: Box<dyn DmTarget> = match target_name {
+        "linear" => Box::new(parse_linear_target(&args)?),
+        "zero" => {
+            if !args.is_empty() {
+                return Err(DmError::InvalidTable.context("zero target takes no arguments"));
+            }
+            Box::<ZeroTarget>::default()
+        }
+        "error" => {
+            if !args.is_empty() {
+                return Err(DmError::InvalidTable.context("error target takes no arguments"));
+            }
+            Box::<ErrorTarget>::default()
+        }
+        _ => return Err(DmError::UnsupportedTarget.context("unsupported dm target")),
+    };
+    if let Some(size_sectors) = target.size_sectors()
+        && size_sectors != len_sectors
+    {
+        return Err(DmError::InvalidTable.context("target size does not match segment length"));
+    }
+
+    Ok(DmTableSegment {
+        start_sector,
+        len_sectors,
+        target,
+    })
+}
+
+fn parse_linear_target(args: &[&str]) -> Result<LinearTarget, DmErrorWithContext> {
+    if args.len() != 2 {
+        return Err(DmError::InvalidTable.context("linear target expects: <device> <start>"));
+    }
+    let device = lookup_block_device(args[0])?;
+    let start_sector = parse_u64(args.get(1).copied(), "linear target start sector")?;
+    Ok(LinearTarget::new(device, start_sector))
+}
+
+pub fn lookup_block_device(name_or_id: &str) -> Result<Arc<dyn BlockDevice>, DmErrorWithContext> {
+    if let Some(raw) = name_or_id.strip_prefix("dev:") {
+        let id = parse_u64(Some(raw), "encoded device id")?;
+        let device_id = DeviceId::from_encoded_u64(id)
+            .ok_or_else(|| DmError::InvalidArgument.context("encoded device id is invalid"))?;
+        return aster_block::lookup(device_id)
+            .ok_or_else(|| DmError::DeviceNotFound.context("block device id is not registered"));
+    }
+
+    aster_block::collect_all()
+        .into_iter()
+        .find(|device| device.name() == name_or_id)
+        .ok_or_else(|| DmError::DeviceNotFound.context("block device name is not registered"))
+}
+
+fn parse_u64(value: Option<&str>, what: &str) -> Result<u64, DmErrorWithContext> {
+    value
+        .ok_or_else(|| DmError::InvalidTable.context(alloc::format!("{} is missing", what)))?
+        .parse::<u64>()
+        .map_err(|_| DmError::InvalidTable.context(alloc::format!("{} is invalid", what)))
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::{DmCreateArg, parse_create_arg};
+    use crate::DmError;
+
+    #[ktest]
+    fn dm_create_arg_strips_surrounding_quotes() {
+        let arg = "\"dm-zero-test: 0 8 zero\"".parse::<DmCreateArg>().unwrap();
+        assert_eq!(arg.as_str(), "dm-zero-test: 0 8 zero");
+    }
+
+    #[ktest]
+    fn dm_create_arg_rejects_empty_value() {
+        assert!("".parse::<DmCreateArg>().is_err());
+        assert!("\"\"".parse::<DmCreateArg>().is_err());
+    }
+
+    #[ktest]
+    fn parse_create_arg_accepts_zero_and_error_segments() {
+        let parsed = parse_create_arg("demo: 0 8 zero; 8 8 error", 0).unwrap();
+        assert_eq!(parsed.name, "demo");
+        assert_eq!(parsed.table.total_sectors(), 16);
+        let segments = parsed.table.segments();
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].target.type_name(), "zero");
+        assert_eq!(segments[1].target.type_name(), "error");
+    }
+
+    #[ktest]
+    fn parse_create_arg_rejects_overlapping_segments() {
+        let result = parse_create_arg("demo: 0 8 zero; 4 8 error", 0);
+        assert!(result.is_err());
+    }
+
+    #[ktest]
+    fn parse_create_arg_rejects_unknown_target() {
+        let result = parse_create_arg("demo: 0 8 bogus", 0);
+        assert_eq!(result.unwrap_err().kind, DmError::UnsupportedTarget);
+    }
+}

--- a/kernel/comps/device-mapper/src/registry.rs
+++ b/kernel/comps/device-mapper/src/registry.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+
+use aster_block::{BlockDevice, MajorIdOwner};
+use device_id::{DeviceId, MinorId};
+use ostd::sync::Mutex;
+use spin::Once;
+
+use crate::{DmDevice, DmError, table::DmTable};
+
+const FIRST_MINOR: u32 = 0;
+
+static DM_MAJOR_ID: Once<MajorIdOwner> = Once::new();
+static DM_REGISTRY: Mutex<DmRegistry> = Mutex::new(DmRegistry::new());
+
+#[derive(Debug)]
+struct DmRegistry {
+    next_minor: u32,
+    devices_by_name: BTreeMap<String, Arc<DmDevice>>,
+}
+
+impl DmRegistry {
+    const fn new() -> Self {
+        Self {
+            next_minor: FIRST_MINOR,
+            devices_by_name: BTreeMap::new(),
+        }
+    }
+
+    fn allocate_id(&mut self) -> Result<DeviceId, DmError> {
+        let major = DM_MAJOR_ID.get().ok_or(DmError::NoDeviceId)?.get();
+        let minor = self.next_minor;
+        self.next_minor = self.next_minor.checked_add(1).ok_or(DmError::NoDeviceId)?;
+        Ok(DeviceId::new(major, MinorId::new(minor)))
+    }
+}
+
+pub fn init() -> Result<(), DmError> {
+    let major = aster_block::allocate_major().map_err(|_| DmError::NoDeviceId)?;
+    DM_MAJOR_ID.call_once(|| major);
+    Ok(())
+}
+
+pub fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmError> {
+    if name.is_empty() || name.contains('/') {
+        return Err(DmError::InvalidArgument);
+    }
+
+    let mut registry = DM_REGISTRY.lock();
+    if registry.devices_by_name.contains_key(&name) {
+        return Err(DmError::DeviceExists);
+    }
+
+    let id = registry.allocate_id()?;
+    let device = Arc::new(DmDevice::new(name.clone(), id, table));
+    aster_block::register(device.clone()).map_err(|_| DmError::DeviceExists)?;
+    registry.devices_by_name.insert(name, device.clone());
+    Ok(device)
+}
+
+pub fn remove_device(name: &str) -> Result<Arc<DmDevice>, DmError> {
+    let mut registry = DM_REGISTRY.lock();
+    let device = registry
+        .devices_by_name
+        .remove(name)
+        .ok_or(DmError::DeviceNotFound)?;
+    let _ = aster_block::unregister(device.id());
+    Ok(device)
+}
+
+pub fn lookup_device(name: &str) -> Option<Arc<DmDevice>> {
+    DM_REGISTRY.lock().devices_by_name.get(name).cloned()
+}
+
+pub fn list_devices() -> Vec<Arc<DmDevice>> {
+    DM_REGISTRY
+        .lock()
+        .devices_by_name
+        .values()
+        .cloned()
+        .collect()
+}
+
+pub fn default_name(index: usize) -> String {
+    alloc::format!("dm-{}", index)
+}
+
+pub fn normalize_name(raw: &str, fallback_index: usize) -> String {
+    if raw == "-" || raw.is_empty() {
+        default_name(fallback_index)
+    } else {
+        raw.to_string()
+    }
+}

--- a/kernel/comps/device-mapper/src/registry.rs
+++ b/kernel/comps/device-mapper/src/registry.rs
@@ -4,10 +4,9 @@ use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
     sync::Arc,
-    vec::Vec,
 };
 
-use aster_block::{BlockDevice, MajorIdOwner};
+use aster_block::MajorIdOwner;
 use device_id::{DeviceId, MinorId};
 use ostd::sync::Mutex;
 use spin::Once;
@@ -47,8 +46,8 @@ pub fn init() -> Result<(), DmError> {
     Ok(())
 }
 
-pub fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmError> {
-    if name.is_empty() || name.contains('/') {
+pub(crate) fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmError> {
+    if !is_valid_device_name(&name) {
         return Err(DmError::InvalidArgument);
     }
 
@@ -64,34 +63,18 @@ pub fn create_device(name: String, table: DmTable) -> Result<Arc<DmDevice>, DmEr
     Ok(device)
 }
 
-pub fn remove_device(name: &str) -> Result<Arc<DmDevice>, DmError> {
-    let mut registry = DM_REGISTRY.lock();
-    let device = registry
-        .devices_by_name
-        .remove(name)
-        .ok_or(DmError::DeviceNotFound)?;
-    let _ = aster_block::unregister(device.id());
-    Ok(device)
+fn is_valid_device_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name
+            .chars()
+            .any(|ch| ch == '/' || ch.is_control() || ch.is_whitespace())
 }
 
-pub fn lookup_device(name: &str) -> Option<Arc<DmDevice>> {
-    DM_REGISTRY.lock().devices_by_name.get(name).cloned()
-}
-
-pub fn list_devices() -> Vec<Arc<DmDevice>> {
-    DM_REGISTRY
-        .lock()
-        .devices_by_name
-        .values()
-        .cloned()
-        .collect()
-}
-
-pub fn default_name(index: usize) -> String {
+fn default_name(index: usize) -> String {
     alloc::format!("dm-{}", index)
 }
 
-pub fn normalize_name(raw: &str, fallback_index: usize) -> String {
+pub(crate) fn normalize_name(raw: &str, fallback_index: usize) -> String {
     if raw == "-" || raw.is_empty() {
         default_name(fallback_index)
     } else {

--- a/kernel/comps/device-mapper/src/table.rs
+++ b/kernel/comps/device-mapper/src/table.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use alloc::{boxed::Box, vec::Vec};
+
+use crate::{DmError, target::DmTarget};
+
+/// One mapped interval in a device-mapper table.
+#[derive(Debug)]
+pub struct DmTableSegment {
+    pub start_sector: u64,
+    pub len_sectors: u64,
+    pub target: Box<dyn DmTarget>,
+}
+
+impl DmTableSegment {
+    pub fn end_sector(&self) -> Option<u64> {
+        self.start_sector.checked_add(self.len_sectors)
+    }
+
+    pub fn contains_range(&self, start_sector: u64, end_sector: u64) -> bool {
+        let Some(segment_end) = self.end_sector() else {
+            return false;
+        };
+
+        self.start_sector <= start_sector && end_sector <= segment_end
+    }
+}
+
+/// A device-mapper table.
+///
+/// BIOs that cross target boundaries are rejected; callers must split them
+/// before dispatch.
+#[derive(Debug)]
+pub struct DmTable {
+    segments: Vec<DmTableSegment>,
+    total_sectors: u64,
+}
+
+impl DmTable {
+    pub fn new(segments: Vec<DmTableSegment>) -> Result<Self, DmError> {
+        if segments.is_empty() {
+            return Err(DmError::InvalidTable);
+        }
+
+        let mut previous_end = 0;
+        let mut total_sectors = 0;
+        for segment in &segments {
+            if segment.len_sectors == 0 {
+                return Err(DmError::InvalidTable);
+            }
+
+            let Some(end_sector) = segment.end_sector() else {
+                return Err(DmError::InvalidTable);
+            };
+            if segment.start_sector < previous_end {
+                return Err(DmError::InvalidTable);
+            }
+            previous_end = end_sector;
+            total_sectors = total_sectors.max(end_sector);
+        }
+
+        Ok(Self {
+            segments,
+            total_sectors,
+        })
+    }
+
+    pub fn total_sectors(&self) -> u64 {
+        self.total_sectors
+    }
+
+    pub fn segments(&self) -> &[DmTableSegment] {
+        &self.segments
+    }
+
+    pub fn find_segment(&self, start_sector: u64, end_sector: u64) -> Option<&DmTableSegment> {
+        self.segments
+            .iter()
+            .find(|segment| segment.contains_range(start_sector, end_sector))
+    }
+}

--- a/kernel/comps/device-mapper/src/table.rs
+++ b/kernel/comps/device-mapper/src/table.rs
@@ -28,22 +28,23 @@ impl DmTableSegment {
 
 /// A device-mapper table.
 ///
-/// BIOs that cross target boundaries are rejected; callers must split them
-/// before dispatch.
+/// The initial implementation supports a single segment. Multi-segment tables
+/// require splitting submitted BIOs at target boundaries, which the block BIO
+/// ownership model does not expose yet.
 #[derive(Debug)]
 pub struct DmTable {
     segments: Vec<DmTableSegment>,
-    total_sectors: u64,
+    total_sectors: usize,
 }
 
 impl DmTable {
     pub fn new(segments: Vec<DmTableSegment>) -> Result<Self, DmError> {
-        if segments.is_empty() {
+        if segments.len() != 1 {
             return Err(DmError::InvalidTable);
         }
 
         let mut previous_end = 0;
-        let mut total_sectors = 0;
+        let mut total_sectors = 0u64;
         for segment in &segments {
             if segment.len_sectors == 0 {
                 return Err(DmError::InvalidTable);
@@ -52,12 +53,13 @@ impl DmTable {
             let Some(end_sector) = segment.end_sector() else {
                 return Err(DmError::InvalidTable);
             };
-            if segment.start_sector < previous_end {
+            if segment.start_sector != previous_end {
                 return Err(DmError::InvalidTable);
             }
             previous_end = end_sector;
             total_sectors = total_sectors.max(end_sector);
         }
+        let total_sectors = usize::try_from(total_sectors).map_err(|_| DmError::InvalidTable)?;
 
         Ok(Self {
             segments,
@@ -65,7 +67,7 @@ impl DmTable {
         })
     }
 
-    pub fn total_sectors(&self) -> u64 {
+    pub fn total_sectors(&self) -> usize {
         self.total_sectors
     }
 
@@ -74,6 +76,13 @@ impl DmTable {
     }
 
     pub fn find_segment(&self, start_sector: u64, end_sector: u64) -> Option<&DmTableSegment> {
+        let Ok(total_sectors) = u64::try_from(self.total_sectors) else {
+            return None;
+        };
+        if end_sector > total_sectors {
+            return None;
+        }
+
         self.segments
             .iter()
             .find(|segment| segment.contains_range(start_sector, end_sector))

--- a/kernel/comps/device-mapper/src/target/error.rs
+++ b/kernel/comps/device-mapper/src/target/error.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `error` target.
+//!
+//! Every read and write fails with an I/O error. It is used to fence off
+//! regions that must never be accessed and to exercise error paths.
+//!
+//! Reference: Linux `Documentation/admin-guide/device-mapper/zero.rst`
+//! (the `error` target is documented alongside `zero`).
+
+use aster_block::bio::{BioStatus, SubmittedBio};
+
+use super::DmTarget;
+
+/// An `error` target.
+#[derive(Debug, Default)]
+pub struct ErrorTarget;
+
+impl DmTarget for ErrorTarget {
+    fn type_name(&self) -> &'static str {
+        "error"
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio, _target_start_sector: u64) {
+        bio.complete(BioStatus::IoError);
+    }
+}

--- a/kernel/comps/device-mapper/src/target/linear.rs
+++ b/kernel/comps/device-mapper/src/target/linear.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `linear` target.
+//!
+//! Maps a contiguous range of the mapped device onto a contiguous range of a
+//! lower device, shifting every sector by a fixed offset. This is the simplest
+//! device-mapper target and the building block for partition-like remapping.
+//!
+//! Reference: Linux `Documentation/admin-guide/device-mapper/linear.rst`.
+
+use alloc::sync::Arc;
+
+use aster_block::{
+    BlockDevice,
+    bio::{Bio, BioStatus, SubmittedBio},
+    id::Sid,
+};
+
+use super::DmTarget;
+
+/// A `linear` target backed by a lower block device.
+#[derive(Debug)]
+pub struct LinearTarget {
+    lower: Arc<dyn BlockDevice>,
+    /// The sector on the lower device that the segment's first sector maps to.
+    start_sector: u64,
+}
+
+impl LinearTarget {
+    /// Creates a `linear` target that forwards I/O to `lower`, shifting sectors
+    /// so that the segment's first sector lands on `start_sector`.
+    pub fn new(lower: Arc<dyn BlockDevice>, start_sector: u64) -> Self {
+        Self {
+            lower,
+            start_sector,
+        }
+    }
+}
+
+impl DmTarget for LinearTarget {
+    fn type_name(&self) -> &'static str {
+        "linear"
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64) {
+        // Reissue the request to the lower device with the same memory segments
+        // (which share the underlying DMA buffers) at the remapped sector.
+        let lower_start = Sid::new(self.start_sector + target_start_sector);
+        let lower_bio = Bio::new(bio.type_(), lower_start, bio.segments().to_vec(), None);
+        let status = lower_bio
+            .submit_and_wait(self.lower.as_ref())
+            .unwrap_or(BioStatus::IoError);
+        bio.complete(status);
+    }
+
+    fn flush(&self) -> BioStatus {
+        self.lower.sync().unwrap_or(BioStatus::IoError)
+    }
+}

--- a/kernel/comps/device-mapper/src/target/linear.rs
+++ b/kernel/comps/device-mapper/src/target/linear.rs
@@ -45,7 +45,21 @@ impl DmTarget for LinearTarget {
     fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64) {
         // Reissue the request to the lower device with the same memory segments
         // (which share the underlying DMA buffers) at the remapped sector.
-        let lower_start = Sid::new(self.start_sector + target_start_sector);
+        let request_sectors = bio.sid_range().end.to_raw() - bio.sid_range().start.to_raw();
+        let Some(lower_start_sector) = self.start_sector.checked_add(target_start_sector) else {
+            bio.complete(BioStatus::IoError);
+            return;
+        };
+        let Some(lower_end_sector) = lower_start_sector.checked_add(request_sectors) else {
+            bio.complete(BioStatus::IoError);
+            return;
+        };
+        if lower_end_sector > self.lower.metadata().nr_sectors as u64 {
+            bio.complete(BioStatus::IoError);
+            return;
+        }
+
+        let lower_start = Sid::new(lower_start_sector);
         let lower_bio = Bio::new(bio.type_(), lower_start, bio.segments().to_vec(), None);
         let status = lower_bio
             .submit_and_wait(self.lower.as_ref())

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Device-mapper targets.
+//!
+//! A target is the per-segment policy that turns a BIO addressed to the mapped
+//! device into concrete I/O on the underlying device(s).
+
+use aster_block::bio::{BioStatus, SubmittedBio};
+
+/// A device-mapper target.
+///
+/// Each table segment owns one target. The mapped device locates the segment
+/// covering an incoming BIO, translates the BIO's starting sector into the
+/// target-local coordinate (`target_start_sector`, i.e. the sector offset from
+/// the start of the segment), and hands the BIO to [`DmTarget::handle_bio`].
+///
+/// Implementations own the underlying device(s) and complete the BIO exactly
+/// once, either by forwarding the I/O downwards or by synthesizing a result.
+pub trait DmTarget: core::fmt::Debug + Send + Sync {
+    /// The target type name, matching the keyword used in a dm table line
+    /// (for example `linear` or `verity`).
+    fn type_name(&self) -> &'static str;
+
+    /// The size this target requires its segment to have, in 512-byte sectors.
+    ///
+    /// Targets that derive their geometry from on-disk metadata (such as
+    /// `verity`) return `Some` so the parser can reject a table whose declared
+    /// segment length disagrees with that geometry. Targets that adapt to any
+    /// length return `None`.
+    fn size_sectors(&self) -> Option<u64> {
+        None
+    }
+
+    /// Handles a BIO that falls entirely within this target's segment.
+    ///
+    /// `target_start_sector` is the sector offset of the BIO from the start of
+    /// the segment. The implementation must complete the BIO.
+    fn handle_bio(&self, bio: SubmittedBio, target_start_sector: u64);
+
+    /// Flushes any volatile state held by the target.
+    ///
+    /// Stateless targets that pass writes straight through have nothing of
+    /// their own to flush and report success.
+    fn flush(&self) -> BioStatus {
+        BioStatus::Complete
+    }
+}

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -5,7 +5,11 @@
 //! A target is the per-segment policy that turns a BIO addressed to the mapped
 //! device into concrete I/O on the underlying device(s).
 
+pub mod error;
 pub mod linear;
+pub mod zero;
+
+use alloc::vec::Vec;
 
 use aster_block::bio::{BioStatus, SubmittedBio};
 
@@ -46,4 +50,9 @@ pub trait DmTarget: core::fmt::Debug + Send + Sync {
     fn flush(&self) -> BioStatus {
         BioStatus::Complete
     }
+}
+
+/// Returns a zero-filled buffer of `len` bytes.
+pub(crate) fn zero_vec(len: usize) -> Vec<u8> {
+    alloc::vec![0u8; len]
 }

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -3,7 +3,12 @@
 //! Device-mapper targets.
 //!
 //! A target is the per-segment policy that turns a BIO addressed to the mapped
-//! device into concrete I/O on the underlying device(s).
+//! device into concrete I/O on the underlying device(s). The set mirrors the
+//! Linux device-mapper targets of the same name:
+//!
+//! - [`linear`]: remaps a contiguous sector range onto a lower device.
+//! - [`zero`]: serves zero-filled reads and discards writes.
+//! - [`error`]: fails every read and write.
 
 pub mod error;
 pub mod linear;
@@ -24,15 +29,14 @@ use aster_block::bio::{BioStatus, SubmittedBio};
 /// once, either by forwarding the I/O downwards or by synthesizing a result.
 pub trait DmTarget: core::fmt::Debug + Send + Sync {
     /// The target type name, matching the keyword used in a dm table line
-    /// (for example `linear` or `verity`).
+    /// (for example `linear` or `error`).
     fn type_name(&self) -> &'static str;
 
     /// The size this target requires its segment to have, in 512-byte sectors.
     ///
-    /// Targets that derive their geometry from on-disk metadata (such as
-    /// `verity`) return `Some` so the parser can reject a table whose declared
-    /// segment length disagrees with that geometry. Targets that adapt to any
-    /// length return `None`.
+    /// Targets that derive their geometry from fixed parameters return `Some`
+    /// so the parser can reject a table whose declared segment length disagrees
+    /// with that geometry. Targets that adapt to any length return `None`.
     fn size_sectors(&self) -> Option<u64> {
         None
     }

--- a/kernel/comps/device-mapper/src/target/mod.rs
+++ b/kernel/comps/device-mapper/src/target/mod.rs
@@ -5,6 +5,8 @@
 //! A target is the per-segment policy that turns a BIO addressed to the mapped
 //! device into concrete I/O on the underlying device(s).
 
+pub mod linear;
+
 use aster_block::bio::{BioStatus, SubmittedBio};
 
 /// A device-mapper target.

--- a/kernel/comps/device-mapper/src/target/zero.rs
+++ b/kernel/comps/device-mapper/src/target/zero.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `zero` target.
+//!
+//! Reads return zero-filled blocks and writes are silently discarded. It is
+//! useful as a placeholder backing store and for tests.
+//!
+//! Reference: Linux `Documentation/admin-guide/device-mapper/zero.rst`.
+
+use aster_block::bio::{BioStatus, BioType, SubmittedBio};
+use ostd::mm::VmIo;
+
+use super::{DmTarget, zero_vec};
+
+/// A `zero` target.
+#[derive(Debug, Default)]
+pub struct ZeroTarget;
+
+impl DmTarget for ZeroTarget {
+    fn type_name(&self) -> &'static str {
+        "zero"
+    }
+
+    fn handle_bio(&self, bio: SubmittedBio, _target_start_sector: u64) {
+        match bio.type_() {
+            BioType::Read => {
+                for segment in bio.segments() {
+                    let zeros = zero_vec(segment.nbytes());
+                    if segment.inner_dma_slice().write_bytes(0, &zeros).is_err() {
+                        bio.complete(BioStatus::IoError);
+                        return;
+                    }
+                }
+                bio.complete(BioStatus::Complete);
+            }
+            // Writes are discarded; a flush has nothing to persist.
+            BioType::Write | BioType::Flush => bio.complete(BioStatus::Complete),
+        }
+    }
+}

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_block::{BLOCK_SIZE, BlockDevice, SECTOR_SIZE};
+use aster_device_mapper::DmDevice;
 use aster_nvme::NvmeBlockDevice;
 use aster_virtio::device::block::device::BlockDevice as VirtIoBlockDevice;
 use device_id::DeviceId;
@@ -54,6 +55,8 @@ pub(super) fn init_in_first_kthread() {
 }
 
 pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> {
+    spawn_device_mapper_threads();
+
     for device in aster_block::collect_all() {
         let device = Arc::new(BlockFile::new(device));
         if let Some(devtmpfs_meta) = device.devtmpfs_meta() {
@@ -63,6 +66,24 @@ pub(super) fn init_in_first_process(path_resolver: &PathResolver) -> Result<()> 
     }
 
     Ok(())
+}
+
+fn spawn_device_mapper_threads() {
+    for device in aster_block::collect_all() {
+        if device.downcast_ref::<DmDevice>().is_none() {
+            continue;
+        }
+
+        let device_clone = device.clone();
+        let task_fn = move || {
+            info!("spawn the device-mapper block thread");
+            let dm_device = device_clone.downcast_ref::<DmDevice>().unwrap();
+            loop {
+                dm_device.handle_requests();
+            }
+        };
+        ThreadOptions::new(task_fn).spawn();
+    }
 }
 
 mod ioctl_defs {

--- a/kernel/src/driver/mod.rs
+++ b/kernel/src/driver/mod.rs
@@ -10,11 +10,10 @@ pub fn init() {
     // FIXME: Currently, we have to do this manually to ensure the crates containing the input
     // devices are linked and their `#[init_component]` hooks can run to register the devices with
     // the input core. We should find a way to avoid this in the future.
+    // Likewise, force the device-mapper component to be linked so its process-stage
+    // `#[init_component]` hook can create mapped devices requested through the
+    // `dm_mod.create=` kernel command line.
+    use aster_device_mapper as _;
     #[expect(unused_imports)]
     use aster_i8042::*;
-
-    // Likewise, force the device-mapper component to be linked so its
-    // `#[init_component]` hook runs and creates the mapped devices requested
-    // through the `dm_mod.create=` kernel command line.
-    use aster_device_mapper as _;
 }

--- a/kernel/src/driver/mod.rs
+++ b/kernel/src/driver/mod.rs
@@ -12,4 +12,9 @@ pub fn init() {
     // the input core. We should find a way to avoid this in the future.
     #[expect(unused_imports)]
     use aster_i8042::*;
+
+    // Likewise, force the device-mapper component to be linked so its
+    // `#[init_component]` hook runs and creates the mapped devices requested
+    // through the `dm_mod.create=` kernel command line.
+    use aster_device_mapper as _;
 }


### PR DESCRIPTION
Introduce `aster-device-mapper` (`kernel/comps/device-mapper`), a table-driven virtual block-device layer modeled on Linux device-mapper. It stacks on top of the existing `aster_block::BlockDevice` trait, supports the `linear`, `zero`, and `error` targets, and instantiates devices from `dm-mod.create=`/`dm_mod.create=` kernel command-line entries. The crate is `#![no_std]` and `#![deny(unsafe_code)]`. This is the first of two device-mapper PRs; `dm-verity` builds on it in a stacked follow-up.

Reference: <https://docs.kernel.org/admin-guide/device-mapper/>

## Overview

A device-mapper device (`DmDevice`) is a `BlockDevice` whose sectors are described by a `DmTable`: an ordered set of `DmTableSegment`s covering `[start_sector, start_sector + len_sectors)` in 512-byte (`SECTOR_SIZE`) units. Each segment owns one `Box<dyn DmTarget>`. On I/O, `DmDevice::handle_bio` computes the absolute sector range (`sid_range().start + sid_offset()` .. `end`), rejects out-of-range or empty BIOs with `BioStatus::IoError`, locates the covering segment via `DmTable::find_segment`, translates the request into a segment-local `target_start_sector`, and dispatches to `DmTarget::handle_bio`, which is contractually required to complete the BIO exactly once. `BioType::Flush` is fanned out to every target's `flush()`. The `DmTarget` trait also exposes `type_name()` and an optional `size_sectors()` used by the parser to reject tables whose declared length disagrees with a target's fixed geometry.

`DmTable::new` currently enforces exactly one segment. Multi-segment tables require splitting a submitted BIO at target boundaries, which the current BIO ownership model does not expose; the table representation is already segment-oriented so this can be lifted later without an API break.

## Targets

| Target | Behavior | Table syntax |
| --- | --- | --- |
| `linear` | Remaps the segment onto a lower device, shifting every sector by a fixed offset; reissues the BIO with the same DMA-backed memory segments via `submit_and_wait`, bounds-checked against the lower device's `nr_sectors`. `flush()` forwards to `lower.sync()`. | `<start> <len> linear <device> <lower_start_sector>` |
| `zero` | Reads return zero-filled blocks (`write_bytes` into each segment's DMA slice); writes and flushes are silently discarded with `BioStatus::Complete`. | `<start> <len> zero` |
| `error` | Every read and write fails with `BioStatus::IoError`. | `<start> <len> error` |

The `linear` `<device>` field accepts either a registered block-device name or an encoded id in `dev:<u64>` form, resolved through `aster_block::collect_all()` / `aster_block::lookup(DeviceId::from_encoded_u64(..))`.

## Creating devices

Devices are declared on the kernel command line. Because a table contains spaces, the value is double-quoted; the tokenizer keeps the quotes, so `DmCreateArg::from_str` strips one matching pair (mirroring `lib/cmdline.c`) and rejects empty values.

```
dm_mod.create="my-linear: 0 2048 linear vda 0"
```

Grammar: `<name>: <segment>[; <segment>...]`, each segment `<start_sector> <len_sectors> <target> [args...]`. A leading `-` (or empty) name is normalized to `dm-<index>`. `;` separates segments (multi-segment tables parse but are rejected by `DmTable::new` for now). The parameter is registered with `aster_cmdline::define_repeatable_kv_param!`, so multiple `dm_mod.create=` entries accumulate. Names are validated to exclude `/`, control, and whitespace characters; duplicates yield `DmError::DeviceExists`.

## Kernel integration

- `Components.toml` and `kernel/Cargo.toml` register the component; `kernel/src/driver/mod.rs` adds `use aster_device_mapper as _;` to force linkage so the process-stage `#[init_component(process)]` hook runs.
- Two init phases: `registry::init()` allocates a dm major via `aster_block::allocate_major()`; the process-stage hook parses each `dm_mod.create=` entry and calls `registry::create_device`, which allocates a `DeviceId`, constructs the `DmDevice`, and publishes it with `aster_block::register`.
- `kernel/src/device/registry/block.rs` gains `spawn_device_mapper_threads`, which spawns a kernel thread per `DmDevice` that loops on `handle_requests()` (dequeues from the internal `BioRequestSingleQueue`), matching how virtio-block and NVMe devices are serviced. The device then surfaces in devtmpfs like any other block device.

## Tests

`#[ktest]` coverage runs against an in-memory `MemoryDisk` backing device:

- `linear_target_remaps_reads_and_writes` — reads/writes through a `linear` target land at the shifted lower-device offset.
- `dm_device_honors_submitted_bio_sid_offset` — a partition-style `set_sid_offset` is applied before mapping.
- `zero_and_error_targets_have_expected_io_behavior` — `zero` reads return all-zero blocks and complete; `error` reads return `IoError`.
- Parser tests: quote stripping, empty-value rejection, single-segment acceptance, and rejection of multi-segment, overlapping, and unknown-target tables (`DmError::UnsupportedTarget`).

## Not included here

No ioctl-based `DM_*` control interface, no dynamic reload/suspend/resume, and no multi-segment tables yet. The `dm-verity` target and its hash-tree verification arrive in the stacked follow-up PR that builds directly on this component.