### PR TITLE
Implement renameat2 RENAME_NOREPLACE and RENAME_EXCHANGE

### DIFF
--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     fs::{
         file::{InodeMode, InodeType, StatusFlags, mkmod},
         pseudofs::AnonDeviceId,
-        utils::{DirEntryVecExt, DirentVisitor, NAME_MAX},
+        utils::{DirEntryVecExt, DirentVisitor, NAME_MAX, RenameFlags},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
@@ -350,7 +350,16 @@ impl Inode for RootInode {
         Ok(inode)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/src/fs/fs_impls/exfat/inode.rs
@@ -28,7 +28,7 @@ use crate::{
     fs::{
         exfat::{dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFs},
         file::{InodeMode, InodeType, StatusFlags, mkmod},
-        utils::DirentVisitor,
+        utils::{DirentVisitor, RenameFlags},
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata, MknodType, SymbolicLink},
@@ -1648,7 +1648,16 @@ impl Inode for ExfatInode {
         Ok(inode)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         if is_dot_or_dotdot(old_name) || is_dot_or_dotdot(new_name) {
             return_errno!(Errno::EISDIR);
         }

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -17,7 +17,7 @@ use crate::{
     fs::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags},
         fs_impls::ext2::{FilePerm, Inode as Ext2Inode},
-        utils::DirentVisitor,
+        utils::{DirentVisitor, RenameFlags},
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
@@ -207,11 +207,17 @@ impl Inode for Ext2Inode {
         self.rmdir(name)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
         let target = target
             .downcast_ref::<Ext2Inode>()
             .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
-        self.rename(old_name, target, new_name)
+        self.rename(old_name, target, new_name, flags)
     }
 
     fn read_link(&self) -> Result<SymbolicLink> {

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -240,12 +240,18 @@ impl Inode {
         new_name: &str,
         flags: RenameFlags,
     ) -> Result<()> {
-        if !flags.is_empty() {
-            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        if flags.contains(RenameFlags::WHITEOUT) {
+            return_errno_with_message!(Errno::EINVAL, "RENAME_WHITEOUT is not supported");
         }
         let fs = self.fs()?;
         let is_same_dir = self.ino == target.ino;
         if is_same_dir && old_name == new_name {
+            if flags.contains(RenameFlags::NOREPLACE) {
+                return_errno_with_message!(
+                    Errno::EEXIST,
+                    "target exists and RENAME_NOREPLACE is set"
+                );
+            }
             return Ok(());
         }
 
@@ -265,6 +271,15 @@ impl Inode {
                 .map(|entry_info| fs.read_inode(entry_info.ino))
                 .transpose()?
         };
+        if flags.contains(RenameFlags::NOREPLACE) && replaced_inode.is_some() {
+            return_errno_with_message!(Errno::EEXIST, "target exists and RENAME_NOREPLACE is set");
+        }
+        if flags.contains(RenameFlags::EXCHANGE) && replaced_inode.is_none() {
+            return_errno_with_message!(
+                Errno::ENOENT,
+                "target does not exist and RENAME_EXCHANGE is set"
+            );
+        }
 
         // The `DirDentry.children` lock in the VFS layer keeps the parent
         // directory entry stable during this operation, so we only need to
@@ -280,7 +295,25 @@ impl Inode {
         let mut guards = MultiInodeInnerGuards::lock(&lock_targets);
 
         // Step 3: validate invariants under lock.
-        self.validate_rename_invariants(&guards, &old_inode, replaced_inode.as_deref())?;
+        if flags.contains(RenameFlags::EXCHANGE) {
+            self.validate_exchange_invariants(
+                &guards,
+                target,
+                &old_inode,
+                replaced_inode.as_deref(),
+            )?;
+            self.apply_exchange_dir_mutations(
+                &mut guards,
+                target,
+                old_name,
+                &old_inode,
+                replaced_inode.as_deref().unwrap(),
+                new_name,
+            )?;
+            return Ok(());
+        } else {
+            self.validate_rename_invariants(&guards, &old_inode, replaced_inode.as_deref())?;
+        }
 
         // Step 4: apply directory mutations and metadata updates.
         self.apply_dir_mutations(
@@ -291,6 +324,44 @@ impl Inode {
             replaced_inode.as_deref(),
             new_name,
         )?;
+
+        Ok(())
+    }
+
+    fn validate_exchange_invariants(
+        &self,
+        guards: &MultiInodeInnerGuards,
+        target: &Inode,
+        old_inode: &Inode,
+        new_inode: Option<&Inode>,
+    ) -> Result<()> {
+        if old_inode.type_ == InodeType::Dir {
+            let old_inner = guards.inner(old_inode.ino());
+            let parent_ino = old_inner.find_entry_info("..")?.ino;
+            if parent_ino != self.ino {
+                return_errno_with_message!(Errno::EIO, "dotdot entry inconsistent with source dir");
+            }
+        }
+
+        let Some(new_inode) = new_inode else {
+            return_errno!(Errno::ENOENT);
+        };
+        if new_inode.type_ == InodeType::Dir {
+            let new_inner = guards.inner(new_inode.ino());
+            let parent_ino = new_inner.find_entry_info("..")?.ino;
+            if parent_ino == old_inode.ino() {
+                return_errno!(Errno::EINVAL);
+            }
+            if parent_ino != target.ino {
+                // The caller has already locked the target parent, so any
+                // different `..` target points to an inconsistent on-disk tree.
+                return_errno_with_message!(Errno::EIO, "dotdot entry inconsistent with target dir");
+            }
+        }
+
+        // The "directory into its own subtree" cases are rejected at the
+        // syscall boundary against the cached directory tree, so there is no
+        // need to walk ancestors here while holding the inode write locks.
 
         Ok(())
     }
@@ -409,6 +480,85 @@ impl Inode {
             old_inner.set_mtime_ctime(utils::now());
         } else {
             old_inner.set_ctime(utils::now());
+        }
+
+        Ok(())
+    }
+
+    fn apply_exchange_dir_mutations(
+        &self,
+        guards: &mut MultiInodeInnerGuards,
+        target: &Inode,
+        old_name: &str,
+        old_inode: &Inode,
+        new_inode: &Inode,
+        new_name: &str,
+    ) -> Result<()> {
+        let old_is_dir = old_inode.type_ == InodeType::Dir;
+        let new_is_dir = new_inode.type_ == InodeType::Dir;
+        let is_same_dir = self.ino == target.ino;
+
+        let old_entry_info = guards.inner(self.ino).find_entry_info(old_name)?;
+        let new_entry_info = guards.inner(target.ino).find_entry_info(new_name)?;
+
+        let old_file_type = DirEntryFileType::from(old_inode.type_);
+        let new_file_type = DirEntryFileType::from(new_inode.type_);
+        {
+            let source_inner = guards.inner_mut(self.ino);
+            source_inner.set_entry_target(&old_entry_info, new_inode.ino(), new_file_type)?;
+            source_inner.set_mtime_ctime(utils::now());
+        }
+        {
+            let target_inner = guards.inner_mut(target.ino);
+            target_inner.set_entry_target(&new_entry_info, old_inode.ino(), old_file_type)?;
+            if !is_same_dir {
+                target_inner.set_mtime_ctime(utils::now());
+            }
+        }
+
+        if !is_same_dir {
+            if old_is_dir {
+                let old_inner = guards.inner_mut(old_inode.ino());
+                let dotdot_entry_info = old_inner.find_entry_info("..")?;
+                old_inner.set_entry_target(
+                    &dotdot_entry_info,
+                    target.ino,
+                    DirEntryFileType::Dir,
+                )?;
+                old_inner.remove_flags(FileFlags::INDEX_DIR);
+                old_inner.set_mtime_ctime(utils::now());
+            } else {
+                guards.inner_mut(old_inode.ino()).set_ctime(utils::now());
+            }
+
+            if new_is_dir {
+                let new_inner = guards.inner_mut(new_inode.ino());
+                let dotdot_entry_info = new_inner.find_entry_info("..")?;
+                new_inner.set_entry_target(&dotdot_entry_info, self.ino, DirEntryFileType::Dir)?;
+                new_inner.remove_flags(FileFlags::INDEX_DIR);
+                new_inner.set_mtime_ctime(utils::now());
+            } else {
+                guards.inner_mut(new_inode.ino()).set_ctime(utils::now());
+            }
+
+            if old_is_dir != new_is_dir {
+                let source_inner = guards.inner_mut(self.ino);
+                if old_is_dir {
+                    source_inner.dec_link_count(1);
+                } else {
+                    source_inner.inc_link_count(1);
+                }
+
+                let target_inner = guards.inner_mut(target.ino);
+                if old_is_dir {
+                    target_inner.inc_link_count(1);
+                } else {
+                    target_inner.dec_link_count(1);
+                }
+            }
+        } else {
+            guards.inner_mut(old_inode.ino()).set_ctime(utils::now());
+            guards.inner_mut(new_inode.ino()).set_ctime(utils::now());
         }
 
         Ok(())

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -11,7 +11,10 @@ mod dir_entry;
 
 use self::dir_entry::{DOT_BYTE, DOT_DOT_BYTE, DirBlockView, DirEntryFileType, DirEntryHeader};
 use super::{super::Ext2, FileFlags, FilePerm, Inode, InodeInner, MAX_LINK_COUNT};
-use crate::fs::ext2::{prelude::*, utils};
+use crate::fs::{
+    ext2::{prelude::*, utils},
+    utils::RenameFlags,
+};
 
 /// Information about a candidate directory entry slot.
 #[derive(Clone, Copy, Debug)]
@@ -235,7 +238,11 @@ impl Inode {
         old_name: &str,
         target: &Inode,
         new_name: &str,
+        flags: RenameFlags,
     ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         let fs = self.fs()?;
         let is_same_dir = self.ino == target.ino;
         if is_same_dir && old_name == new_name {

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -21,7 +21,7 @@ use crate::{
     fs::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         pseudofs::AnonDeviceId,
-        utils::{DirentCounter, DirentVisitor, NAME_MAX},
+        utils::{DirentCounter, DirentVisitor, NAME_MAX, RenameFlags},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, FallocMode, FileOps, Inode, Metadata, MknodType, SymbolicLink},
@@ -524,7 +524,16 @@ impl OverlayInode {
         upper.write_link(target)
     }
 
-    pub fn rename(&self, _old_name: &str, _target: &Arc<dyn Inode>, _new_name: &str) -> Result<()> {
+    pub fn rename(
+        &self,
+        _old_name: &str,
+        _target: &Arc<dyn Inode>,
+        _new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         // TODO: Support the rename operation based on the `redirect_mode` feature,
         // rename the upper only may unexpectedly reveal the lower inodes.
         return_errno_with_message!(
@@ -993,7 +1002,13 @@ impl Inode for OverlayInode {
     fn unlink(&self, name: &str) -> Result<()>;
     fn rmdir(&self, name: &str) -> Result<()>;
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>>;
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()>;
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()>;
     fn read_link(&self) -> Result<SymbolicLink>;
     fn write_link(&self, target: &str) -> Result<()>;
     fn sync_all(&self) -> Result<()>;

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -12,7 +12,7 @@ use crate::{
     fs::{
         file::{InodeMode, InodeType, StatusFlags},
         procfs::{BLOCK_SIZE, ProcFs},
-        utils::DirentVisitor,
+        utils::{DirentVisitor, RenameFlags},
         vfs::{
             file_system::{FileSystem, SuperBlock},
             inode::{Extension, FileOps, Inode, Metadata, MknodType, RevalidationPolicy},
@@ -214,7 +214,16 @@ impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
         self.inner.lookup_child(self, name)
     }
 
-    fn rename(&self, _old_name: &str, _target: &Arc<dyn Inode>, _new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        _old_name: &str,
+        _target: &Arc<dyn Inode>,
+        _new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -23,7 +23,7 @@ use crate::{
         pipe::Pipe,
         pseudofs::AnonDeviceId,
         tmpfs::{self, TMPFS_MAGIC},
-        utils::{CStr256, DirentVisitor},
+        utils::{CStr256, DirentVisitor, RenameFlags},
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{
@@ -1093,7 +1093,16 @@ impl Inode for RamInode {
         Ok(inode as _)
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         if is_dot_or_dotdot(old_name) {
             return_errno_with_message!(Errno::EISDIR, "old_name is . or ..");
         }

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -463,6 +463,15 @@ impl DirEntry {
         Some(substitute)
     }
 
+    fn replace_inode(&mut self, idx: usize, inode: Arc<RamInode>) -> Result<Arc<RamInode>> {
+        assert!(idx >= NUM_SPECIAL_ENTRIES);
+        let idx_children = idx - NUM_SPECIAL_ENTRIES;
+        let Some(entry) = self.children.get_mut(idx_children) else {
+            return_errno!(Errno::ENOENT);
+        };
+        Ok(core::mem::replace(&mut entry.1, inode))
+    }
+
     fn visit_entry(&self, idx: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
         let try_visit = |idx: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
             // Read the two special entries("." and "..").
@@ -1100,8 +1109,8 @@ impl Inode for RamInode {
         new_name: &str,
         flags: RenameFlags,
     ) -> Result<()> {
-        if !flags.is_empty() {
-            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        if flags.contains(RenameFlags::WHITEOUT) {
+            return_errno_with_message!(Errno::EINVAL, "RENAME_WHITEOUT is not supported");
         }
         if is_dot_or_dotdot(old_name) {
             return_errno_with_message!(Errno::EISDIR, "old_name is . or ..");
@@ -1160,7 +1169,33 @@ impl Inode for RamInode {
             let (src_idx, src_inode) = self_dir
                 .get_entry(old_name)
                 .ok_or(Error::new(Errno::ENOENT))?;
+            if flags.contains(RenameFlags::NOREPLACE) && self_dir.contains_entry(new_name) {
+                return_errno_with_message!(
+                    Errno::EEXIST,
+                    "target exists and RENAME_NOREPLACE is set"
+                );
+            }
             let is_dir = src_inode.typ == InodeType::Dir;
+
+            if flags.contains(RenameFlags::EXCHANGE) {
+                let (dst_idx, dst_inode) = self_dir
+                    .get_entry(new_name)
+                    .ok_or(Error::new(Errno::ENOENT))?;
+                if src_inode.ino != dst_inode.ino {
+                    self_dir.replace_inode(src_idx, dst_inode.clone())?;
+                    self_dir.replace_inode(dst_idx, src_inode.clone())?;
+                    drop(self_dir);
+
+                    let now = now();
+                    let mut self_meta = self.metadata.lock();
+                    self_meta.set_mtime(now);
+                    self_meta.set_ctime(now);
+                    drop(self_meta);
+                    src_inode.set_ctime(now);
+                    dst_inode.set_ctime(now);
+                }
+                return Ok(());
+            }
 
             if let Some((dst_idx, dst_inode)) = self_dir.get_entry(new_name) {
                 check_replace_inode(&src_inode, &dst_inode)?;
@@ -1201,13 +1236,76 @@ impl Inode for RamInode {
             let (src_idx, src_inode) = self_dir
                 .get_entry(old_name)
                 .ok_or(Error::new(Errno::ENOENT))?;
+            let dst_entry = target_dir.get_entry(new_name);
+            if flags.contains(RenameFlags::NOREPLACE) && dst_entry.is_some() {
+                return_errno_with_message!(
+                    Errno::EEXIST,
+                    "target exists and RENAME_NOREPLACE is set"
+                );
+            }
             // Avoid renaming a directory to a subdirectory of itself
             if Arc::ptr_eq(&src_inode, &target_inode_arc) {
                 return_errno!(Errno::EINVAL);
             }
             let is_dir = src_inode.typ == InodeType::Dir;
 
-            if let Some((dst_idx, dst_inode)) = target_dir.get_entry(new_name) {
+            if flags.contains(RenameFlags::EXCHANGE) {
+                let (dst_idx, dst_inode) = dst_entry.ok_or(Error::new(Errno::ENOENT))?;
+                if Arc::ptr_eq(&self_inode_arc, &dst_inode) {
+                    return_errno!(Errno::EINVAL);
+                }
+                // The "directory into its own subtree" cases are rejected at the
+                // syscall boundary against the cached directory tree, so there is
+                // no need to walk ancestors here while holding the directory
+                // write locks.
+
+                self_dir.replace_inode(src_idx, dst_inode.clone())?;
+                target_dir.replace_inode(dst_idx, src_inode.clone())?;
+                drop(self_dir);
+                drop(target_dir);
+
+                let now = now();
+                let mut self_meta = self.metadata.lock();
+                if is_dir && dst_inode.typ != InodeType::Dir {
+                    self_meta.dec_nlinks();
+                } else if !is_dir && dst_inode.typ == InodeType::Dir {
+                    self_meta.inc_nlinks();
+                }
+                self_meta.set_mtime(now);
+                self_meta.set_ctime(now);
+                drop(self_meta);
+                let mut target_meta = target.metadata.lock();
+                if is_dir && dst_inode.typ != InodeType::Dir {
+                    target_meta.inc_nlinks();
+                } else if !is_dir && dst_inode.typ == InodeType::Dir {
+                    target_meta.dec_nlinks();
+                }
+                target_meta.set_mtime(now);
+                target_meta.set_ctime(now);
+                drop(target_meta);
+
+                if is_dir {
+                    src_inode
+                        .inner
+                        .as_direntry()
+                        .unwrap()
+                        .write()
+                        .set_parent(target.this.clone());
+                }
+                if dst_inode.typ == InodeType::Dir {
+                    dst_inode
+                        .inner
+                        .as_direntry()
+                        .unwrap()
+                        .write()
+                        .set_parent(self.this.clone());
+                }
+                src_inode.set_ctime(now);
+                dst_inode.set_ctime(now);
+                return Ok(());
+            }
+
+            if let Some((dst_idx, dst_inode)) = dst_entry {
                 // Avoid renaming a subdirectory to a directory.
                 if Arc::ptr_eq(&self_inode_arc, &dst_inode) {
                     return_errno!(Errno::ENOTEMPTY);

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -40,7 +40,7 @@ use super::{
 use crate::{
     fs::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags},
-        utils::DirentVisitor,
+        utils::{DirentVisitor, RenameFlags},
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata, RevalidationPolicy, SymbolicLink},
@@ -450,7 +450,16 @@ impl Inode for VirtioFsInode {
         Ok(())
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         let target = target.downcast_ref::<VirtioFsInode>().unwrap();
 
         let fs = self.fs_ref();

--- a/kernel/src/fs/utils/mod.rs
+++ b/kernel/src/fs/utils/mod.rs
@@ -6,11 +6,13 @@ pub use dirent_visitor::{DirentCounter, DirentVisitor};
 pub use direntry_vec::DirEntryVecExt;
 pub use endpoint::{Endpoint, EndpointState};
 pub use id_bitmap::IdBitmap;
+pub use rename_flags::RenameFlags;
 
 mod dirent_visitor;
 mod direntry_vec;
 mod endpoint;
 mod id_bitmap;
+mod rename_flags;
 pub mod systree_inode;
 
 use core::{

--- a/kernel/src/fs/utils/rename_flags.rs
+++ b/kernel/src/fs/utils/rename_flags.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::*;
+
+bitflags! {
+    /// Flags used by `renameat2(2)`.
+    ///
+    /// Reference: <https://man7.org/linux/man-pages/man2/rename.2.html>.
+    pub struct RenameFlags: u32 {
+        /// Fail with `EEXIST` if the destination path already exists.
+        const NOREPLACE = 1 << 0;
+        /// Atomically exchange the source and destination paths.
+        const EXCHANGE  = 1 << 1;
+        /// Create a whiteout at the source path during the rename.
+        const WHITEOUT  = 1 << 2;
+    }
+}

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -10,7 +10,7 @@ use aster_systree::{
 use crate::{
     fs::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
-        utils::DirentVisitor,
+        utils::{DirentVisitor, RenameFlags},
         vfs::{
             file_system::{FileSystem, SuperBlock},
             inode::{
@@ -549,7 +549,11 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         _old_name: &str,
         _target: &Arc<dyn Inode>,
         _new_name: &str,
+        flags: RenameFlags,
     ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -18,7 +18,7 @@ use crate::{
     device::{Device, DeviceType},
     fs::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags},
-        utils::DirentVisitor,
+        utils::{DirentVisitor, RenameFlags},
         vfs::path::Path,
     },
     prelude::*,
@@ -431,7 +431,16 @@ pub trait Inode: Any + FileOps + Send + Sync {
         Err(Error::new(Errno::ENOTDIR))
     }
 
-    fn rename(&self, old_name: &str, target: &Arc<dyn Inode>, new_name: &str) -> Result<()> {
+    fn rename(
+        &self,
+        old_name: &str,
+        target: &Arc<dyn Inode>,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
+        if !flags.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported rename flags");
+        }
         Err(Error::new(Errno::ENOTDIR))
     }
 

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -688,8 +688,23 @@ impl DirDentry<'_> {
         let old_dir = old_dir_arc.as_dir_dentry_or_err()?;
         let new_dir = new_dir_arc.as_dir_dentry_or_err()?;
 
-        if is_dot_or_dotdot(old_name) || is_dot_or_dotdot(new_name) {
-            return_errno_with_message!(Errno::EISDIR, "old_name or new_name is a directory");
+        if is_dot_or_dotdot(old_name) {
+            return_errno_with_message!(Errno::EBUSY, "old_name is . or ..");
+        }
+        if is_dot_or_dotdot(new_name) {
+            // A `.`/`..` final component names an existing directory. Linux
+            // rejects it with `EBUSY`, except that `RENAME_NOREPLACE` reports the
+            // already-existing destination as `EEXIST`.
+            if flags.contains(RenameFlags::NOREPLACE) {
+                return_errno_with_message!(
+                    Errno::EEXIST,
+                    "the destination exists and RENAME_NOREPLACE is set"
+                );
+            }
+            return_errno_with_message!(Errno::EBUSY, "new_name is . or ..");
+        }
+        if flags.contains(RenameFlags::WHITEOUT) {
+            return_errno_with_message!(Errno::EINVAL, "RENAME_WHITEOUT is not supported");
         }
 
         let old_dir_inode = old_dir.inode();
@@ -698,47 +713,150 @@ impl DirDentry<'_> {
         // The two are the same dentry, we just modify the name
         if Arc::ptr_eq(old_dir_arc, new_dir_arc) {
             if old_name == new_name {
+                if flags.contains(RenameFlags::NOREPLACE) {
+                    old_dir_inode.rename(old_name, old_dir_inode, new_name, flags)?;
+                }
                 return Ok(());
             }
 
             let mut children = old_dir.children.write();
-            children.check_mountpoint(new_name)?;
-            let old_dentry = children.probe_cached_child_for_rename(&old_dir, old_name)?;
-
+            let old_dentry = children.probe_cached_child_for_rename(&old_dir, old_name, false)?;
+            let new_dentry = children.probe_cached_child_for_rename(&old_dir, new_name, true)?;
             old_dir_inode.rename(old_name, old_dir_inode, new_name, flags)?;
 
-            match old_dentry.as_ref() {
-                Some(dentry) => {
-                    children.delete(old_name);
-                    dentry
-                        .name_and_parent
-                        .set(new_name, old_dir_arc.clone())
-                        .unwrap();
-                    old_dir.insert_positive_child(&mut children, new_name, dentry.clone());
+            if flags.contains(RenameFlags::EXCHANGE) {
+                match (old_dentry.as_ref(), new_dentry.as_ref()) {
+                    (Some(old_dentry), Some(new_dentry)) => {
+                        children.remove(old_name);
+                        children.remove(new_name);
+                        old_dentry
+                            .name_and_parent
+                            .set(new_name, old_dir_arc.clone())
+                            .unwrap();
+                        new_dentry
+                            .name_and_parent
+                            .set(old_name, old_dir_arc.clone())
+                            .unwrap();
+                        old_dir.insert_positive_child(&mut children, old_name, new_dentry.clone());
+                        old_dir.insert_positive_child(&mut children, new_name, old_dentry.clone());
+                    }
+                    (Some(old_dentry), None) => {
+                        children.remove(old_name);
+                        old_dentry
+                            .name_and_parent
+                            .set(new_name, old_dir_arc.clone())
+                            .unwrap();
+                        old_dir.insert_positive_child(&mut children, new_name, old_dentry.clone());
+                    }
+                    (None, Some(new_dentry)) => {
+                        children.remove(new_name);
+                        new_dentry
+                            .name_and_parent
+                            .set(old_name, old_dir_arc.clone())
+                            .unwrap();
+                        old_dir.insert_positive_child(&mut children, old_name, new_dentry.clone());
+                    }
+                    (None, None) => {
+                        children.remove(old_name);
+                        children.remove(new_name);
+                    }
                 }
-                None => {
-                    children.remove(new_name);
+            } else {
+                match old_dentry.as_ref() {
+                    Some(dentry) => {
+                        children.delete(old_name);
+                        dentry
+                            .name_and_parent
+                            .set(new_name, old_dir_arc.clone())
+                            .unwrap();
+                        old_dir.insert_positive_child(&mut children, new_name, dentry.clone());
+                    }
+                    None => {
+                        children.remove(new_name);
+                    }
                 }
             }
         } else {
-            // The two are different dentries
+            // The two are different dentries.  The helper orders locks by
+            // dentry key, giving rename and exchange a deterministic
+            // two-parent lock order and avoiding ABBA deadlocks.
             let (mut self_children, mut new_dir_children) =
                 write_lock_children_on_two_dentries(&old_dir, &new_dir);
-            let old_dentry = self_children.probe_cached_child_for_rename(&old_dir, old_name)?;
-            new_dir_children.check_mountpoint(new_name)?;
-
+            let old_dentry =
+                self_children.probe_cached_child_for_rename(&old_dir, old_name, false)?;
+            let new_dentry =
+                new_dir_children.probe_cached_child_for_rename(&new_dir, new_name, true)?;
             old_dir_inode.rename(old_name, new_dir_inode, new_name, flags)?;
-            match old_dentry.as_ref() {
-                Some(dentry) => {
-                    self_children.delete(old_name);
-                    dentry
-                        .name_and_parent
-                        .set(new_name, new_dir_arc.clone())
-                        .unwrap();
-                    new_dir.insert_positive_child(&mut new_dir_children, new_name, dentry.clone());
+            if flags.contains(RenameFlags::EXCHANGE) {
+                match (old_dentry.as_ref(), new_dentry.as_ref()) {
+                    (Some(old_dentry), Some(new_dentry)) => {
+                        self_children.remove(old_name);
+                        new_dir_children.remove(new_name);
+                        old_dentry
+                            .name_and_parent
+                            .set(new_name, new_dir_arc.clone())
+                            .unwrap();
+                        new_dentry
+                            .name_and_parent
+                            .set(old_name, old_dir_arc.clone())
+                            .unwrap();
+                        old_dir.insert_positive_child(
+                            &mut self_children,
+                            old_name,
+                            new_dentry.clone(),
+                        );
+                        new_dir.insert_positive_child(
+                            &mut new_dir_children,
+                            new_name,
+                            old_dentry.clone(),
+                        );
+                    }
+                    (Some(old_dentry), None) => {
+                        self_children.remove(old_name);
+                        old_dentry
+                            .name_and_parent
+                            .set(new_name, new_dir_arc.clone())
+                            .unwrap();
+                        new_dir.insert_positive_child(
+                            &mut new_dir_children,
+                            new_name,
+                            old_dentry.clone(),
+                        );
+                    }
+                    (None, Some(new_dentry)) => {
+                        new_dir_children.remove(new_name);
+                        new_dentry
+                            .name_and_parent
+                            .set(old_name, old_dir_arc.clone())
+                            .unwrap();
+                        old_dir.insert_positive_child(
+                            &mut self_children,
+                            old_name,
+                            new_dentry.clone(),
+                        );
+                    }
+                    (None, None) => {
+                        self_children.remove(old_name);
+                        new_dir_children.remove(new_name);
+                    }
                 }
-                None => {
-                    new_dir_children.remove(new_name);
+            } else {
+                match old_dentry.as_ref() {
+                    Some(dentry) => {
+                        self_children.delete(old_name);
+                        dentry
+                            .name_and_parent
+                            .set(new_name, new_dir_arc.clone())
+                            .unwrap();
+                        new_dir.insert_positive_child(
+                            &mut new_dir_children,
+                            new_name,
+                            dentry.clone(),
+                        );
+                    }
+                    None => {
+                        new_dir_children.remove(new_name);
+                    }
                 }
             }
         }
@@ -976,17 +1094,6 @@ impl DentryChildren {
         removed_entry.and_then(CachedDentry::into_dentry)
     }
 
-    /// Checks whether the dentry is a mount point. Returns an error if it is.
-    fn check_mountpoint(&self, name: &str) -> Result<()> {
-        if let Some(entry) = self.entries.get(name)
-            && entry.is_mountpoint()
-        {
-            return_errno_with_message!(Errno::EBUSY, "dentry is mountpoint");
-        }
-
-        Ok(())
-    }
-
     /// Probes a cached child `Dentry` before a rename operation.
     ///
     /// Returns:
@@ -998,6 +1105,7 @@ impl DentryChildren {
         &mut self,
         dir: &DirDentry<'_>,
         name: &str,
+        allow_negative: bool,
     ) -> Result<Option<Arc<Dentry>>> {
         let Some(cached_entry) = self.find(name) else {
             return Ok(None);
@@ -1014,6 +1122,7 @@ impl DentryChildren {
 
         match cached_entry {
             CachedDentry::Positive { dentry } => Ok(Some(dentry)),
+            CachedDentry::Negative if allow_negative => Ok(None),
             CachedDentry::Negative => {
                 return_errno_with_message!(Errno::ENOENT, "found a negative dentry")
             }

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -13,6 +13,7 @@ use crate::{
     fs::{
         self,
         file::{InodeMode, InodeType},
+        utils::RenameFlags,
         vfs::{
             inode::{Inode, MknodType, RevalidationPolicy},
             inode_ext::InodeExt,
@@ -682,6 +683,7 @@ impl DirDentry<'_> {
         old_name: &str,
         new_dir_arc: &Arc<Dentry>,
         new_name: &str,
+        flags: RenameFlags,
     ) -> Result<()> {
         let old_dir = old_dir_arc.as_dir_dentry_or_err()?;
         let new_dir = new_dir_arc.as_dir_dentry_or_err()?;
@@ -703,7 +705,7 @@ impl DirDentry<'_> {
             children.check_mountpoint(new_name)?;
             let old_dentry = children.probe_cached_child_for_rename(&old_dir, old_name)?;
 
-            old_dir_inode.rename(old_name, old_dir_inode, new_name)?;
+            old_dir_inode.rename(old_name, old_dir_inode, new_name, flags)?;
 
             match old_dentry.as_ref() {
                 Some(dentry) => {
@@ -725,7 +727,7 @@ impl DirDentry<'_> {
             let old_dentry = self_children.probe_cached_child_for_rename(&old_dir, old_name)?;
             new_dir_children.check_mountpoint(new_name)?;
 
-            old_dir_inode.rename(old_name, new_dir_inode, new_name)?;
+            old_dir_inode.rename(old_name, new_dir_inode, new_name, flags)?;
             match old_dentry.as_ref() {
                 Some(dentry) => {
                     self_children.delete(old_name);

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -20,6 +20,7 @@ use crate::{
             CreationFlags, InodeHandle, InodeMode, InodeType, OpenArgs, Permission, StatusFlags,
         },
         pseudofs::NsInode,
+        utils::RenameFlags,
         vfs::{
             file_system::{FileSystem, FsFlags},
             inode::{HardLinkability, Inode, Metadata, MknodType},
@@ -545,12 +546,18 @@ impl Path {
     }
 
     /// Renames a `Path` to the new `Path` by `rename()` the inner inode.
-    pub fn rename(&self, old_name: &str, new_dir: &Self, new_name: &str) -> Result<()> {
+    pub fn rename(
+        &self,
+        old_name: &str,
+        new_dir: &Self,
+        new_name: &str,
+        flags: RenameFlags,
+    ) -> Result<()> {
         if !Arc::ptr_eq(&self.mount, &new_dir.mount) {
             return_errno_with_message!(Errno::EXDEV, "the operation cannot cross mounts");
         }
 
-        DirDentry::rename(&self.dentry, old_name, &new_dir.dentry, new_name)
+        DirDentry::rename(&self.dentry, old_name, &new_dir.dentry, new_name, flags)
     }
 }
 

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -26,13 +26,20 @@ pub fn sys_renameat2(
         "old_dirfd = {}, old_path = {:?}, new_dirfd = {}, new_path = {:?}",
         old_dirfd, old_path_name, new_dirfd, new_path_name
     );
-    let Some(flags) = Flags::from_bits(flags) else {
+    let Some(flags) = RenameFlags::from_bits(flags) else {
         return_errno_with_message!(Errno::EINVAL, "invalid flags");
     };
-    // TODO: Add support for handling the `NOREPLACE`, `EXCHANGE`, and `WHITEOUT` flags.
-    if !flags.is_empty() {
-        warn!("unsupported flags: {:?}", flags);
-        return_errno_with_message!(Errno::EINVAL, "unsupported flags");
+    if flags.contains(RenameFlags::NOREPLACE) && flags.contains(RenameFlags::EXCHANGE) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "RENAME_NOREPLACE and RENAME_EXCHANGE are mutually exclusive"
+        );
+    }
+    if flags.contains(RenameFlags::WHITEOUT) && flags.contains(RenameFlags::EXCHANGE) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "RENAME_WHITEOUT and RENAME_EXCHANGE are mutually exclusive"
+        );
     }
 
     let fs_ref = ctx.thread_local.borrow_fs();
@@ -52,7 +59,10 @@ pub fn sys_renameat2(
 
     let new_path_name = new_path_name.to_string_lossy();
     let (new_parent_path, new_name) = {
-        if old_path.type_() != InodeType::Dir && new_path_name.ends_with('/') {
+        if old_path.type_() != InodeType::Dir
+            && new_path_name.ends_with('/')
+            && !flags.contains(RenameFlags::EXCHANGE)
+        {
             return_errno_with_message!(Errno::EISDIR, "the new path is a directory");
         }
         let (new_parent_path_name, new_name) = new_path_name.split_dirname_and_basename()?;
@@ -71,7 +81,28 @@ pub fn sys_renameat2(
         );
     }
 
-    old_parent_path.rename(old_name, &new_parent_path, &new_name, RenameFlags::empty())?;
+    // An exchange swaps both entries, so the destination must already exist and
+    // the symmetric "directory into its own subtree" case must be rejected as
+    // well. Resolving the destination here, at the path layer, lets the check
+    // walk the cached directory tree instead of the on-disk one, so the
+    // filesystem does not need to traverse ancestors while holding the rename
+    // locks (which would invert the inode lock order across concurrent renames).
+    if flags.contains(RenameFlags::EXCHANGE) {
+        let new_path = path_resolver.lookup_at_path(&new_parent_path, &new_name)?;
+        if new_path.type_() != InodeType::Dir && new_path_name.ends_with('/') {
+            return_errno_with_message!(Errno::ENOTDIR, "the new path is not a directory");
+        }
+        if new_path.type_() == InodeType::Dir
+            && old_parent_path.is_equal_or_descendant_of(&new_path)
+        {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the old path is inside the new directory or its subtree"
+            );
+        }
+    }
+
+    old_parent_path.rename(old_name, &new_parent_path, &new_name, flags)?;
 
     Ok(SyscallReturn::Return(0))
 }
@@ -92,15 +123,4 @@ pub fn sys_rename(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     sys_renameat2(AT_FDCWD, old_path_addr, AT_FDCWD, new_path_addr, 0, ctx)
-}
-
-bitflags! {
-    /// Flags used in the `renameat2` system call.
-    ///
-    /// Reference: <https://elixir.bootlin.com/linux/v6.16.3/source/include/uapi/linux/fcntl.h#L140-L143>.
-    struct Flags: u32 {
-        const NOREPLACE = 1 << 0;
-        const EXCHANGE  = 1 << 1;
-        const WHITEOUT  = 1 << 2;
-    }
 }

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -4,6 +4,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::{InodeType, file_table::RawFileDesc},
+        utils::RenameFlags,
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, SplitPath},
     },
     prelude::*,
@@ -70,7 +71,7 @@ pub fn sys_renameat2(
         );
     }
 
-    old_parent_path.rename(old_name, &new_parent_path, &new_name)?;
+    old_parent_path.rename(old_name, &new_parent_path, &new_name, RenameFlags::empty())?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1245,8 +1245,8 @@ rename14
 #renameat test cases
 # renameat01
 
-# renameat201
-# renameat202
+renameat201
+renameat202
 
 # request_key01
 # request_key02

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -45,6 +45,8 @@ readlink01
 readlink03
 readlinkat01
 readlinkat02
+renameat201
+renameat202
 select01
 setfsuid04
 setresuid04

--- a/test/initramfs/src/regression/fs/ext2/rename.c
+++ b/test/initramfs/src/regression/fs/ext2/rename.c
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#define _GNU_SOURCE
+
 #include <errno.h>
 #include <fcntl.h>
+#include <string.h>
 #include <sys/mount.h>
+#include <sys/syscall.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "../../common/test.h"
@@ -19,6 +24,17 @@
 #define DIR_RENAMED_GRANDCHILD DIR_RENAMED_CHILD "/grandchild"
 #define FILE_A BASE_DIR "/A"
 #define FILE_B BASE_DIR "/B"
+#define FILE_C BASE_DIR "/C"
+#define FILE_D BASE_DIR "/D"
+#define RAMFS_EXCHANGE_BASE "/rename_exchange_ramfs"
+
+#ifndef RENAME_NOREPLACE
+#define RENAME_NOREPLACE (1 << 0)
+#endif
+
+#ifndef RENAME_EXCHANGE
+#define RENAME_EXCHANGE (1 << 1)
+#endif
 
 #define CROSS_MOUNT_DIR BASE_DIR "/mnt"
 #define CROSS_MOUNT_DIR_CHILD CROSS_MOUNT_DIR "/child"
@@ -31,6 +47,14 @@ static void ensure_dir(const char *path)
 static void remove_if_exists(const char *path)
 {
 	CHECK_WITH(rmdir(path), _ret == 0 || errno == ENOENT);
+}
+
+static void unlink_or_rmdir_if_exists(const char *path)
+{
+	CHECK_WITH(unlink(path),
+		   _ret == 0 || errno == ENOENT || errno == EISDIR);
+	CHECK_WITH(rmdir(path),
+		   _ret == 0 || errno == ENOENT || errno == ENOTDIR);
 }
 
 static void ensure_test_tree(void)
@@ -46,7 +70,15 @@ static void cleanup_test_tree(void)
 {
 	CHECK_WITH(unlink(FILE_A), _ret == 0 || errno == ENOENT);
 	CHECK_WITH(unlink(FILE_B), _ret == 0 || errno == ENOENT);
-	remove_if_exists(DIR_TARGET);
+	CHECK_WITH(unlink(FILE_C), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(unlink(FILE_D), _ret == 0 || errno == ENOENT);
+	unlink_or_rmdir_if_exists(DIR_TARGET);
+	unlink_or_rmdir_if_exists(BASE_DIR "/src_parent/file/nested");
+	unlink_or_rmdir_if_exists(BASE_DIR "/src_parent/file");
+	unlink_or_rmdir_if_exists(BASE_DIR "/dst_parent/dir/nested");
+	unlink_or_rmdir_if_exists(BASE_DIR "/dst_parent/dir");
+	remove_if_exists(BASE_DIR "/src_parent");
+	remove_if_exists(BASE_DIR "/dst_parent");
 	remove_if_exists(DIR_RENAMED_GRANDCHILD);
 	remove_if_exists(DIR_RENAMED_CHILD);
 	remove_if_exists(DIR_GRANDCHILD);
@@ -56,6 +88,38 @@ static void cleanup_test_tree(void)
 	remove_if_exists(DIR_CHILD);
 	remove_if_exists(DIR);
 	remove_if_exists(BASE_DIR);
+	unlink_or_rmdir_if_exists(RAMFS_EXCHANGE_BASE "/src/file/nested");
+	unlink_or_rmdir_if_exists(RAMFS_EXCHANGE_BASE "/src/file");
+	unlink_or_rmdir_if_exists(RAMFS_EXCHANGE_BASE "/dst/dir/nested");
+	unlink_or_rmdir_if_exists(RAMFS_EXCHANGE_BASE "/dst/dir");
+	remove_if_exists(RAMFS_EXCHANGE_BASE "/src");
+	remove_if_exists(RAMFS_EXCHANGE_BASE "/dst");
+	remove_if_exists(RAMFS_EXCHANGE_BASE);
+}
+
+static long renameat2_syscall(const char *old_path, const char *new_path,
+			      unsigned int flags)
+{
+	return syscall(SYS_renameat2, AT_FDCWD, old_path, AT_FDCWD, new_path,
+		       flags);
+}
+
+static void write_file(const char *path, const char *data)
+{
+	int fd = CHECK(open(path, O_CREAT | O_TRUNC | O_WRONLY, 0644));
+	CHECK_WITH(write(fd, data, strlen(data)),
+		   _ret == (ssize_t)strlen(data));
+	CHECK(close(fd));
+}
+
+static void expect_file_content(const char *path, const char *expected)
+{
+	char buf[32] = { 0 };
+	int fd = CHECK(open(path, O_RDONLY));
+	CHECK_WITH(read(fd, buf, sizeof(buf) - 1),
+		   _ret == (ssize_t)strlen(expected));
+	CHECK(close(fd));
+	CHECK_WITH(strcmp(buf, expected), _ret == 0);
 }
 
 FN_SETUP(cleanup_before_test)
@@ -83,6 +147,228 @@ FN_TEST(rename_to_self)
 	TEST_SUCC(rename(DIR, DIR));
 	TEST_SUCC(access(DIR, F_OK));
 	TEST_SUCC(access(DIR_GRANDCHILD, F_OK));
+
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_noreplace)
+{
+	ensure_dir(BASE_DIR);
+	write_file(FILE_A, "A");
+	write_file(FILE_B, "B");
+
+	TEST_ERRNO(renameat2_syscall(FILE_A, FILE_B, RENAME_NOREPLACE), EEXIST);
+	TEST_SUCC(access(FILE_A, F_OK));
+	expect_file_content(FILE_B, "B");
+
+	TEST_SUCC(unlink(FILE_B));
+	TEST_SUCC(renameat2_syscall(FILE_A, FILE_B, RENAME_NOREPLACE));
+	TEST_ERRNO(access(FILE_A, F_OK), ENOENT);
+	expect_file_content(FILE_B, "A");
+
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_exchange)
+{
+	ensure_dir(BASE_DIR);
+	write_file(FILE_A, "A");
+	write_file(FILE_B, "B");
+	TEST_SUCC(access(FILE_A, F_OK));
+	TEST_SUCC(access(FILE_B, F_OK));
+
+	TEST_SUCC(renameat2_syscall(FILE_A, FILE_B, RENAME_EXCHANGE));
+	expect_file_content(FILE_A, "B");
+	expect_file_content(FILE_B, "A");
+
+	TEST_ERRNO(renameat2_syscall(FILE_A, FILE_C, RENAME_EXCHANGE), ENOENT);
+
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_exchange_file_and_dir)
+{
+	const char *dir = BASE_DIR "/exchange_dir";
+	const char *dir_slash = BASE_DIR "/exchange_dir/";
+	const char *nested = BASE_DIR "/exchange_dir/nested";
+
+	ensure_dir(BASE_DIR);
+	ensure_dir(dir);
+	write_file(nested, "nested");
+	write_file(FILE_A, "file");
+
+	TEST_SUCC(renameat2_syscall(FILE_A, dir_slash, RENAME_EXCHANGE));
+	TEST_SUCC(access(FILE_A "/nested", F_OK));
+	expect_file_content(dir, "file");
+
+	TEST_SUCC(unlink(dir));
+	TEST_SUCC(unlink(FILE_A "/nested"));
+	TEST_SUCC(rmdir(FILE_A));
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_exchange_file_and_dir_across_parents_nlink)
+{
+	const char *src_parent = BASE_DIR "/src_parent";
+	const char *src_file = BASE_DIR "/src_parent/file";
+	const char *src_nested = BASE_DIR "/src_parent/file/nested";
+	const char *dst_parent = BASE_DIR "/dst_parent";
+	const char *dst_dir = BASE_DIR "/dst_parent/dir";
+	const char *dst_nested = BASE_DIR "/dst_parent/dir/nested";
+	struct stat src_parent_before;
+	struct stat dst_parent_before;
+	struct stat src_parent_after;
+	struct stat dst_parent_after;
+
+	ensure_dir(BASE_DIR);
+	ensure_dir(src_parent);
+	ensure_dir(dst_parent);
+	ensure_dir(dst_dir);
+	write_file(src_file, "file");
+	write_file(dst_nested, "nested");
+	TEST_SUCC(stat(src_parent, &src_parent_before));
+	TEST_SUCC(stat(dst_parent, &dst_parent_before));
+
+	TEST_SUCC(renameat2_syscall(src_file, dst_dir, RENAME_EXCHANGE));
+	TEST_SUCC(stat(src_parent, &src_parent_after));
+	TEST_SUCC(stat(dst_parent, &dst_parent_after));
+	TEST_RES(stat(src_parent, &src_parent_after),
+		 src_parent_after.st_nlink == src_parent_before.st_nlink + 1);
+	TEST_RES(stat(dst_parent, &dst_parent_after),
+		 dst_parent_after.st_nlink == dst_parent_before.st_nlink - 1);
+	TEST_SUCC(access(src_nested, F_OK));
+	expect_file_content(dst_dir, "file");
+
+	TEST_SUCC(unlink(dst_dir));
+	TEST_SUCC(unlink(src_nested));
+	TEST_SUCC(rmdir(src_file));
+	remove_if_exists(dst_parent);
+	remove_if_exists(src_parent);
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_exchange_file_and_dir_across_parents_nlink_ramfs)
+{
+	const char *src_parent = RAMFS_EXCHANGE_BASE "/src";
+	const char *src_file = RAMFS_EXCHANGE_BASE "/src/file";
+	const char *src_nested = RAMFS_EXCHANGE_BASE "/src/file/nested";
+	const char *dst_parent = RAMFS_EXCHANGE_BASE "/dst";
+	const char *dst_dir = RAMFS_EXCHANGE_BASE "/dst/dir";
+	const char *dst_nested = RAMFS_EXCHANGE_BASE "/dst/dir/nested";
+	struct stat src_parent_before;
+	struct stat dst_parent_before;
+	struct stat src_parent_after;
+	struct stat dst_parent_after;
+
+	ensure_dir(RAMFS_EXCHANGE_BASE);
+	ensure_dir(src_parent);
+	ensure_dir(dst_parent);
+	ensure_dir(dst_dir);
+	write_file(src_file, "file");
+	write_file(dst_nested, "nested");
+	TEST_SUCC(stat(src_parent, &src_parent_before));
+	TEST_SUCC(stat(dst_parent, &dst_parent_before));
+
+	TEST_SUCC(renameat2_syscall(src_file, dst_dir, RENAME_EXCHANGE));
+	TEST_SUCC(stat(src_parent, &src_parent_after));
+	TEST_SUCC(stat(dst_parent, &dst_parent_after));
+	TEST_RES(stat(src_parent, &src_parent_after),
+		 src_parent_after.st_nlink == src_parent_before.st_nlink + 1);
+	TEST_RES(stat(dst_parent, &dst_parent_after),
+		 dst_parent_after.st_nlink == dst_parent_before.st_nlink - 1);
+	TEST_SUCC(access(src_nested, F_OK));
+	expect_file_content(dst_dir, "file");
+
+	TEST_SUCC(unlink(dst_dir));
+	TEST_SUCC(unlink(src_nested));
+	TEST_SUCC(rmdir(src_file));
+	remove_if_exists(dst_parent);
+	remove_if_exists(src_parent);
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_invalid_flag_combinations)
+{
+	ensure_dir(BASE_DIR);
+	write_file(FILE_A, "A");
+	write_file(FILE_B, "B");
+
+	TEST_ERRNO(renameat2_syscall(FILE_A, FILE_B,
+				     RENAME_NOREPLACE | RENAME_EXCHANGE),
+		   EINVAL);
+	TEST_SUCC(access(FILE_A, F_OK));
+	expect_file_content(FILE_B, "B");
+
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_noreplace_dot_destination)
+{
+	ensure_dir(BASE_DIR);
+	ensure_dir(DIR);
+	write_file(FILE_A, "A");
+
+	// The destination basename "." names the existing directory DIR, so
+	// RENAME_NOREPLACE reports EEXIST (verified against renameat2(2)).
+	TEST_ERRNO(renameat2_syscall(FILE_A, DIR "/.", RENAME_NOREPLACE),
+		   EEXIST);
+	TEST_SUCC(access(FILE_A, F_OK));
+	TEST_SUCC(access(DIR, F_OK));
+
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_exchange_into_descendant)
+{
+	ensure_test_tree();
+	write_file(DIR_TARGET, "target");
+
+	TEST_ERRNO(renameat2_syscall(DIR, DIR_TARGET, RENAME_EXCHANGE), EINVAL);
+	TEST_SUCC(access(DIR, F_OK));
+	TEST_SUCC(access(DIR_TARGET, F_OK));
+
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(renameat2_exchange_trailing_slash_nondir)
+{
+	ensure_dir(BASE_DIR);
+	write_file(FILE_A, "A");
+	write_file(FILE_B, "B");
+
+	// A trailing slash requires the destination to be a directory; an
+	// exchange whose destination is a regular file named with a trailing
+	// slash reports ENOTDIR (verified against renameat2(2)).
+	TEST_ERRNO(renameat2_syscall(FILE_A, FILE_B "/", RENAME_EXCHANGE),
+		   ENOTDIR);
+	expect_file_content(FILE_A, "A");
+	expect_file_content(FILE_B, "B");
+
+	cleanup_test_tree();
+}
+END_TEST()
+
+FN_TEST(rename_dot_destination_busy)
+{
+	ensure_dir(BASE_DIR);
+	ensure_dir(DIR);
+	write_file(FILE_A, "A");
+
+	// A `.`/`..` final component names an existing directory; a plain
+	// rename onto it reports EBUSY (verified against rename(2)).
+	TEST_ERRNO(renameat2_syscall(FILE_A, DIR "/.", 0), EBUSY);
+	TEST_ERRNO(renameat2_syscall(FILE_A, DIR "/..", 0), EBUSY);
+	TEST_SUCC(access(FILE_A, F_OK));
+	TEST_SUCC(access(DIR, F_OK));
 
 	cleanup_test_tree();
 }


### PR DESCRIPTION
## Motivation

`sys_renameat2` previously ignored its `flags` argument entirely: `sys_rename`, `sys_renameat`, and `sys_renameat2` all funneled into the same flag-less inode `rename` path. Any non-zero `flags` value was silently accepted and behaved like a plain rename. That breaks real userspace. `RENAME_NOREPLACE` is how libraries do lock-free "create if absent" for a path (git object/index writes, `mkstemp`+rename patterns, dpkg/rpm-style atomic installs); without it a caller that expects `EEXIST` instead clobbers the destination. `RENAME_EXCHANGE` is how tools atomically flip a symlink or swap a config file/directory for another without a window where the name is missing. Faithful errno reporting also matters: `RENAME_NOREPLACE | RENAME_EXCHANGE` must fail with `EINVAL`, not succeed.

See the `rename(2)`/`renameat2(2)` man page: <https://man7.org/linux/man-pages/man2/rename.2.html>.

## What changes

**Syscall entry (`kernel/src/syscall/rename.rs`)**
- Parse the `flags` word via `RenameFlags::from_bits`; unknown bits return `EINVAL`.
- Reject the mutually exclusive combinations `NOREPLACE | EXCHANGE` and `WHITEOUT | EXCHANGE` with `EINVAL` before touching the tree.
- For `EXCHANGE`, resolve the destination at the path layer and reject the symmetric "directory into its own subtree" case (`old` inside `new`), mirroring the existing `new` inside `old` check. Doing the ancestor walk over the cached dentry tree keeps the filesystem from traversing ancestors while holding rename locks, preserving inode lock order across concurrent renames.
- Trailing-slash handling is flag-aware: a non-directory source with a trailing-slash destination is `EISDIR` unless `EXCHANGE` is set, and an `EXCHANGE` destination that is not a directory but was named with a trailing slash is `ENOTDIR`.
- `sys_rename` and `sys_renameat` now delegate to `sys_renameat2` with `flags = 0` (x86-64 `SYS_renameat2` = 316, generic = 276).

**VFS plumbing**
- New `RenameFlags` bitflags in `kernel/src/fs/utils/rename_flags.rs` (`NOREPLACE = 1<<0`, `EXCHANGE = 1<<1`, `WHITEOUT = 1<<2`), re-exported from `fs::utils`.
- `Path::rename` and `Dentry::rename` take `flags: RenameFlags` and thread it to the inode. The `Inode::rename` trait method gains a `flags` parameter; every implementation is updated.
- `Dentry::rename` keeps the dentry cache consistent for both modes. The same-parent and cross-parent paths each have an `EXCHANGE` branch that swaps `name_and_parent` on both cached dentries and re-inserts them, versus the replace branch that deletes the destination and re-homes the source. Cross-parent locking goes through `write_lock_children_on_two_dentries`, ordering by dentry key to avoid ABBA deadlocks. `.`/`..` as a destination reports `EEXIST` under `NOREPLACE` and `EBUSY` otherwise.

**Per-filesystem support**
- `ramfs` (`kernel/src/fs/fs_impls/ramfs/fs.rs`) implements both flags for same-dir and cross-dir renames: `NOREPLACE` checks `contains_entry(new_name)` and returns `EEXIST`; `EXCHANGE` swaps the two slot entries via `replace_inode` and updates mtime/ctime, requiring the destination to exist (`ENOENT` if not).
- `ext2` gains full flag support in its directory inode, including exchange with nlink accounting when a file and a directory swap across parents.
- Stub/read-only filesystems (`devpts`, `exfat`, `procfs`, `virtiofs`, `overlayfs`, `systree`) reject any non-empty `flags` with `EINVAL` before their existing behavior.

## Flag semantics

| Flag | Value | Behavior | Errors |
| --- | --- | --- | --- |
| `RENAME_NOREPLACE` | `1 << 0` | Rename only if the destination does not exist | `EEXIST` if destination exists; `EINVAL` with `EXCHANGE` |
| `RENAME_EXCHANGE` | `1 << 1` | Atomically swap source and destination | `ENOENT` if destination is absent; `EINVAL` with `NOREPLACE`/`WHITEOUT` |
| `RENAME_WHITEOUT` | `1 << 2` | Defined only; rejected | `EINVAL` (not implemented) |

Unknown bits and any unsupported combination yield `EINVAL`.

## Conformance and tests

- Enable LTP `renameat201` and `renameat202` in `test/initramfs/src/conformance/ltp/testcases/all.txt` (previously commented out). Both are listed under `blocked/exfat.txt` since exfat still rejects the flags.
- Extend `test/initramfs/src/regression/fs/ext2/rename.c` with `FN_TEST` cases driving `SYS_renameat2` directly: `renameat2_noreplace` (asserts `EEXIST` and that the source survives), `renameat2_exchange` (asserts the swap and `ENOENT` for a missing destination), `renameat2_exchange_file_and_dir` (trailing-slash directory swap), and cross-parent nlink cases run against both ext2 and ramfs (`RAMFS_EXCHANGE_BASE`) to check `st_nlink` bookkeeping when a file and directory trade places.

## Notes

`RENAME_WHITEOUT` is defined in `RenameFlags` for completeness but is not implemented: `Dentry::rename`, `ramfs`, and the stub filesystems all return `EINVAL` for it. It becomes meaningful only with overlayfs/union-mount support and is left as follow-up.