### PR TITLE
Report file birth time via statx (STATX_BTIME)

### DIFF
--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -224,7 +224,7 @@ impl PseudoInode {
             gid,
             container_dev_id: dev_id,
             self_dev_id: None,
-            birth_at: None,
+            birth_at: Some(now),
         };
 
         PseudoInode {

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -292,6 +292,7 @@ struct InodeMeta {
     size: usize,
     blocks: usize,
     atime: Duration,
+    btime: Duration,
     mtime: Duration,
     ctime: Duration,
     mode: InodeMode,
@@ -307,6 +308,7 @@ impl InodeMeta {
             size: 0,
             blocks: 0,
             atime: now,
+            btime: now,
             mtime: now,
             ctime: now,
             mode,
@@ -322,6 +324,7 @@ impl InodeMeta {
             size: NUM_SPECIAL_ENTRIES,
             blocks: 1,
             atime: now,
+            btime: now,
             mtime: now,
             ctime: now,
             mode,
@@ -1309,7 +1312,7 @@ impl Inode for RamInode {
             } else {
                 DeviceId::from_encoded_u64(rdev)
             },
-            birth_at: None,
+            birth_at: Some(inode_metadata.btime),
         }
     }
 

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -87,7 +87,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             gid: Gid::new_root(),
             container_dev_id: sb.container_dev_id,
             self_dev_id: None,
-            birth_at: None,
+            birth_at: Some(now),
         }
     }
 

--- a/kernel/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/src/fs/vfs/fs_apis/inode.rs
@@ -163,7 +163,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: None,
-            birth_at: None,
+            birth_at: Some(now),
         }
     }
 
@@ -189,7 +189,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: None,
-            birth_at: None,
+            birth_at: Some(now),
         }
     }
 
@@ -215,7 +215,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: None,
-            birth_at: None,
+            birth_at: Some(now),
         }
     }
 
@@ -242,7 +242,7 @@ impl Metadata {
             gid: Gid::new_root(),
             container_dev_id,
             self_dev_id: Some(device.id()),
-            birth_at: None,
+            birth_at: Some(now),
         }
     }
 }

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -152,7 +152,6 @@ impl Statx {
         };
 
         Self {
-            // FIXME: All zero fields below are dummy implementations that need to be improved in the future.
             stx_mask,
             stx_blksize: info.optimal_block_size as u32,
             stx_attributes,

--- a/test/initramfs/src/regression/fs/statx/btime.c
+++ b/test/initramfs/src/regression/fs/statx/btime.c
@@ -114,7 +114,7 @@ FN_TEST(statx_btime_not_requested)
 	struct statx stx;
 	TEST_SUCC(syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_BASIC_STATS,
 			  &stx));
-	TEST_RES(0, (stx.stx_mask & STATX_BTIME) == 0);
+	TEST_RES(0, (stx.stx_mask & STATX_BTIME) != 0);
 }
 END_TEST()
 
@@ -122,7 +122,8 @@ FN_TEST(statx_btime_ramfs)
 {
 	struct statx stx;
 	TEST_SUCC(syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_BTIME, &stx));
-	TEST_RES(0, stx.stx_btime.tv_sec == 0 && stx.stx_btime.tv_nsec == 0);
+	TEST_RES(0, (stx.stx_mask & STATX_BTIME) != 0);
+	TEST_RES(0, stx.stx_btime.tv_sec != 0 || stx.stx_btime.tv_nsec != 0);
 }
 END_TEST()
 


### PR DESCRIPTION
### Summary

`statx(2)` already carried the plumbing to expose a file's creation ("birth") time — `Metadata::birth_at: Option<Duration>` in `kernel/src/fs/vfs/fs_apis/inode.rs`, and the mask logic in `Statx::new` that folds `StatxMask::STATX_BTIME` (`0x800`) into `stx_mask` and copies `birth_at` into `stx_btime` whenever the field is `Some`. The problem: every producer left `birth_at: None`, so the branch was dead code and `stx_btime` was always zero with the bit clear.

This change populates `birth_at` at the sources so the existing logic actually fires:

- `ramfs` (`fs_impls/ramfs/fs.rs`): add a `btime: Duration` field to `InodeMeta`, initialize it to `now` in both `new` and the special-entries constructor, and return `birth_at: Some(inode_metadata.btime)` from `RamInode::metadata`. Unlike `mtime`/`ctime`, `btime` is written once at creation and never touched afterward.
- `pseudofs`, `systree` (`fs/utils/systree_inode.rs`), and the four `Metadata` builders in `fs_apis/inode.rs` (dir, file, block/char device): set `birth_at: Some(now)` instead of `None`.
- Drop the now-stale `// FIXME: All zero fields below are dummy implementations...` comment above `stx_mask` in `syscall/statx.rs`, since `stx_btime` is no longer a dummy.

Filesystems that do not record a creation time keep `birth_at: None` and are unchanged: `Statx::new` simply omits `STATX_BTIME` from the returned mask, so callers see the birth time as unsupported rather than as a bogus zero. This mirrors Linux, where filesystems like ext2 clear `STATX_BTIME` for the same reason (see [statx(2)](https://man7.org/linux/man-pages/man2/statx.2.html), "the returned mask" / `stx_btime`).

### Behavior

For an in-memory inode, `statx()` now reports `STATX_BTIME` in `stx_mask` and a non-zero `stx_btime` fixed at creation. The bit is reported when supported, per the man page, independent of whether the caller included `STATX_BTIME` in its request mask — a superset return is permitted.

### Test

`test/initramfs/src/regression/fs/statx/btime.c` is updated to match the new contract:

- `statx_btime_not_requested`: asserts `STATX_BTIME` is now *present* in `stx_mask` even for a `STATX_BASIC_STATS` request.
- `statx_btime_ramfs`: asserts the bit is set and that `stx_btime` is non-zero (either `tv_sec` or `tv_nsec`), replacing the old expectation of an all-zero timestamp.