### PR TITLE
Add seccomp with strict and classic-BPF filter modes

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
@@ -29,10 +29,8 @@ Unsupported operations:
 * `PR_MCE_KILL` and `PR_MCE_KILL_GET`
 * `PR_SET_MM` and `PR_SET_VMA`
 * `PR_MPX_ENABLE_MANAGEMENT` and `PR_MPX_DISABLE_MANAGEMENT`
-* `PR_GET_NO_NEW_PRIVS` and `PR_SET_NO_NEW_PRIVS`
 * `PR_PAC_RESET_KEYS`
 * `PR_SET_PTRACER`
-* `PR_GET_SECCOMP` and `PR_SET_SECCOMP`
 * `PR_GET_SPECULATION_CTRL` and `PR_SET_SPECULATION_CTRL`
 * `PR_SVE_GET_VL` and `PR_SVE_SET_VL`
 * `PR_SET_SYSCALL_USER_DISPATCH`
@@ -49,6 +47,59 @@ Unsupported operations:
 
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/prctl.2.html).
+
+### `seccomp`
+
+Asterinas implements both secure computing modes. `SECCOMP_MODE_STRICT`
+restricts a thread to `read`, `write`, `_exit`, and `rt_sigreturn`.
+`SECCOMP_MODE_FILTER` runs a thread's chain of classic-BPF filters at the
+system-call entry and applies the most restrictive action they return. Filters
+may only be installed by a thread that has set `no_new_privs` or that holds
+`CAP_SYS_ADMIN`; otherwise installation fails with `EACCES`. Seccomp state
+(mode, filters, and `no_new_privs`) is inherited across fork, clone, and execve.
+
+Supported functionality in SCML:
+
+```c
+{{#include seccomp.scml}}
+```
+
+Supported filter return actions:
+* `SECCOMP_RET_ALLOW`
+* `SECCOMP_RET_LOG`
+* `SECCOMP_RET_ERRNO` (the errno is clamped to `MAX_ERRNO`, i.e. `4095`)
+* `SECCOMP_RET_TRAP` (delivers `SIGSYS` with `si_code`, `si_call_addr`,
+  `si_syscall`, and `si_arch` filled in)
+* `SECCOMP_RET_KILL_THREAD`
+* `SECCOMP_RET_KILL_PROCESS`
+
+Recognized but not yet implemented (each safely falls back to returning
+`ENOSYS` for the filtered call):
+* `SECCOMP_RET_TRACE` (no `ptrace` seccomp tracer)
+* `SECCOMP_RET_USER_NOTIF` (no user-space notification via `SECCOMP_IOCTL_NOTIF_*`)
+
+Seccomp filters are read-only classic-BPF programs, so only the instruction
+subset that operates on `seccomp_data` and the BPF scratch memory is accepted.
+A program is rejected at install time if it uses any other instruction, exceeds
+`BPF_MAXINSNS`, jumps out of range, or does not end in a `BPF_RET`.
+
+| Class | Supported | Not supported |
+|---|---|---|
+| `BPF_LD`/`BPF_LDX` | `W ABS` (loads a `seccomp_data` word), `W IMM`, `W MEM` | `H`/`B` sizes, `LEN`, packet/`IND` addressing |
+| `BPF_ST`/`BPF_STX` | scratch-memory store | — |
+| `BPF_ALU` | `ADD SUB MUL DIV OR AND LSH RSH MOD XOR NEG` (`K` and `X`) | — |
+| `BPF_JMP` | `JA`, `JEQ JGT JGE JSET` (`K` and `X`) | `CALL` |
+| `BPF_RET` | `K`, `A` | — |
+| `BPF_MISC` | `TAX`, `TXA` | — |
+
+Unsupported flags:
+* `SECCOMP_FILTER_FLAG_TSYNC` (synchronizing filters across all threads)
+* `SECCOMP_FILTER_FLAG_NEW_LISTENER` and `SECCOMP_FILTER_FLAG_TSYNC_ESRCH`
+  (tied to user notification)
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/seccomp.2.html) and
+the kernel's `Documentation/userspace-api/seccomp_filter.rst`.
 
 ### `capget` and `capset`
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/prctl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/prctl.scml
@@ -15,3 +15,12 @@ prctl(op = PR_GET_CHILD_SUBREAPER | PR_SET_CHILD_SUBREAPER, isset);
 
 // Retrieve or set the timer slack value (nanoseconds)
 prctl(op = PR_GET_TIMERSLACK | PR_SET_TIMERSLACK, slack_ns);
+
+// Retrieve or set the "no new privileges" bit. Once set, it cannot be unset and
+// is inherited across fork, clone, and execve.
+prctl(op = PR_GET_NO_NEW_PRIVS | PR_SET_NO_NEW_PRIVS, ..);
+
+// Retrieve or set the secure computing mode. PR_SET_SECCOMP selects
+// SECCOMP_MODE_STRICT (no filter) or SECCOMP_MODE_FILTER (with a classic-BPF
+// `sock_fprog`); PR_GET_SECCOMP returns the current mode.
+prctl(op = PR_GET_SECCOMP | PR_SET_SECCOMP, ..);

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/seccomp.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/seccomp.scml
@@ -1,0 +1,20 @@
+// Enter the strict secure computing mode. Afterwards only read(2), write(2),
+// _exit(2) (but not exit_group(2)), and rt_sigreturn(2) are permitted; any
+// other system call kills the thread with SIGKILL.
+seccomp(operation = SECCOMP_SET_MODE_STRICT, flags, args);
+
+// Install a classic-BPF filter for the calling thread. The filter is appended
+// to the thread's filter chain and inherited across fork, clone, and execve.
+// SECCOMP_FILTER_FLAG_LOG logs every non-allow action of this filter;
+// SECCOMP_FILTER_FLAG_SPEC_ALLOW is accepted for Linux compatibility but has no
+// effect, as Asterinas applies no speculation-mitigation here.
+seccomp(
+    operation = SECCOMP_SET_MODE_FILTER,
+    flags = SECCOMP_FILTER_FLAG_LOG | SECCOMP_FILTER_FLAG_SPEC_ALLOW,
+    args
+);
+
+// Query whether the kernel recognizes a given filter return action. The action
+// is read from `args`; exact action values are supported while values carrying
+// data bits are rejected, matching Linux.
+seccomp(operation = SECCOMP_GET_ACTION_AVAIL, flags, args);

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -57,7 +57,9 @@ use crate::{
 /// - CapEff: Effective capabilities.
 /// - CapBnd: Bounding set.
 /// - CapAmb: Ambient capabilities.
+/// - NoNewPrivs: Whether the no_new_privs attribute is set.
 /// - Seccomp: Seccomp mode.
+/// - Seccomp_filters: Number of installed seccomp filters.
 /// - Cpus_allowed: CPUs allowed for this process.
 /// - Cpus_allowed_list: List of CPUs allowed for this process.
 /// - Mems_allowed: Memory nodes allowed for this process.
@@ -192,6 +194,21 @@ impl ProcFileOps for StatusFileOps {
             credentials.bounding_capset().bits()
         )?;
         writeln!(printer, "CapAmb:\t{:016x}", AMBIENT_CAPSET.bits())?;
+        writeln!(
+            printer,
+            "NoNewPrivs:\t{}",
+            posix_thread.no_new_privs() as u32
+        )?;
+        writeln!(
+            printer,
+            "Seccomp:\t{}",
+            posix_thread.seccomp_mode().as_u32()
+        )?;
+        writeln!(
+            printer,
+            "Seccomp_filters:\t{}",
+            posix_thread.seccomp_filter_count()
+        )?;
 
         Ok(printer.bytes_written())
     }

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -29,6 +29,7 @@ use crate::{
         NsProxy, UserNamespace,
         pid_file::PidFile,
         posix_thread::{PosixThread, ThreadLocal, allocate_posix_tid},
+        seccomp::SeccompState,
         stats::PROCESS_CREATION_COUNTER,
     },
     sched::Nice,
@@ -411,6 +412,9 @@ fn clone_child_task(
     // Clone default timer slack
     let default_timer_slack_ns = posix_thread.timer_slack_ns();
 
+    // Inherit seccomp and no_new_privs.
+    let seccomp = SeccompState::fork_from(posix_thread.seccomp_state());
+
     if clone_flags.contains(CloneFlags::CLONE_NEWNS) {
         child_fs
             .resolver()
@@ -457,7 +461,8 @@ fn clone_child_task(
         .fpu_context(child_fpu_context)
         .user_ns(child_user_ns)
         .ns_proxy(child_ns_proxy)
-        .default_timer_slack_ns(default_timer_slack_ns);
+        .default_timer_slack_ns(default_timer_slack_ns)
+        .seccomp(seccomp);
         #[cfg(target_arch = "x86_64")]
         {
             thread_builder = thread_builder.fs_base(child_fs_base).gs_base(child_gs_base);
@@ -546,6 +551,9 @@ fn clone_child_process(
     // Clone default timer slack
     let default_timer_slack_ns = posix_thread.timer_slack_ns();
 
+    // Inherit seccomp and no_new_privs.
+    let seccomp = SeccompState::fork_from(posix_thread.seccomp_state());
+
     if clone_flags.contains(CloneFlags::CLONE_NEWNS) {
         child_fs
             .resolver()
@@ -593,6 +601,7 @@ fn clone_child_process(
             .user_ns(child_user_ns.clone())
             .ns_proxy(child_ns_proxy)
             .default_timer_slack_ns(default_timer_slack_ns)
+            .seccomp(seccomp)
         };
         #[cfg(target_arch = "x86_64")]
         {

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -168,7 +168,12 @@ fn do_execve_no_return(
     // This prevents race conditions when checking access permissions while opening
     // `/proc/[pid]/mem` or `/proc/[pid]/maps`.
     let (vmar_guard, old_vmar) = activate_vmar(ctx, new_vmar);
-    apply_caps_from_exec(process, ctx.credentials_mut(), elf_file.inode())?;
+    apply_caps_from_exec(
+        process,
+        posix_thread.no_new_privs(),
+        ctx.credentials_mut(),
+        elf_file.inode(),
+    )?;
     drop(vmar_guard);
     drop(old_vmar);
 
@@ -308,11 +313,12 @@ fn set_cpu_context(
 /// The capabilities will be updated accordingly.
 fn apply_caps_from_exec(
     process: &Process,
+    no_new_privs: bool,
     credentials: Credentials<ReadWriteOp>,
     elf_inode: &Arc<dyn Inode>,
 ) -> Result<()> {
-    set_uid_from_elf(process, &credentials, elf_inode)?;
-    set_gid_from_elf(process, &credentials, elf_inode)?;
+    set_uid_from_elf(process, no_new_privs, &credentials, elf_inode)?;
+    set_gid_from_elf(process, no_new_privs, &credentials, elf_inode)?;
     credentials.set_keep_capabilities(false)?;
 
     Ok(())
@@ -324,10 +330,11 @@ fn apply_caps_from_exec(
 /// inode's UID.
 fn set_uid_from_elf(
     current: &Process,
+    no_new_privs: bool,
     credentials: &Credentials<ReadWriteOp>,
     elf_inode: &Arc<dyn Inode>,
 ) -> Result<()> {
-    if elf_inode.mode()?.has_set_uid() {
+    if !no_new_privs && elf_inode.mode()?.has_set_uid() {
         let uid = elf_inode.owner()?;
         credentials.set_euid(uid);
 
@@ -345,10 +352,11 @@ fn set_uid_from_elf(
 /// inode's GID.
 fn set_gid_from_elf(
     current: &Process,
+    no_new_privs: bool,
     credentials: &Credentials<ReadWriteOp>,
     elf_inode: &Arc<dyn Inode>,
 ) -> Result<()> {
-    if elf_inode.mode()?.has_set_gid() {
+    if !no_new_privs && elf_inode.mode()?.has_set_gid() {
         let gid = elf_inode.group()?;
         credentials.set_egid(gid);
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -15,6 +15,7 @@ mod process_filter;
 mod process_vm;
 mod program_loader;
 pub mod rlimit;
+pub mod seccomp;
 pub mod signal;
 mod stats;
 mod status;

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -19,6 +19,7 @@ use crate::{
     process::{
         Credentials, NsProxy, Process, UserNamespace,
         posix_thread::{name::ThreadName, thread_local::SuppUserContext},
+        seccomp::SeccompState,
         signal::{sig_mask::AtomicSigMask, sig_queues::SigQueues},
     },
     sched::{Nice, SchedPolicy},
@@ -49,6 +50,7 @@ pub struct PosixThreadBuilder {
     user_ns: Option<Arc<UserNamespace>>,
     ns_proxy: Option<Arc<NsProxy>>,
     default_timer_slack_ns: u64,
+    seccomp: SeccompState,
 }
 
 impl PosixThreadBuilder {
@@ -77,6 +79,7 @@ impl PosixThreadBuilder {
             user_ns: None,
             ns_proxy: None,
             default_timer_slack_ns: 50_000, // 50 usec default slack
+            seccomp: SeccompState::new(),
         }
     }
 
@@ -148,6 +151,11 @@ impl PosixThreadBuilder {
         self
     }
 
+    pub fn seccomp(mut self, seccomp: SeccompState) -> Self {
+        self.seccomp = seccomp;
+        self
+    }
+
     pub fn build(self) -> Arc<Task> {
         let Self {
             tid,
@@ -167,6 +175,7 @@ impl PosixThreadBuilder {
             user_ns,
             ns_proxy,
             default_timer_slack_ns,
+            seccomp,
         } = self;
 
         let file_table = file_table.unwrap_or_else(|| RwArc::new(FileTable::new()));
@@ -206,6 +215,7 @@ impl PosixThreadBuilder {
                     tracees: Once::new(),
                     exit_code: AtomicU32::new(0),
                     personality: AtomicU32::new(0),
+                    seccomp,
                 }
             };
 

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -21,6 +21,7 @@ use crate::{
         ExitCode, Pid,
         namespace::nsproxy::NsProxy,
         posix_thread::ptrace::TraceeStatus,
+        seccomp::{SeccompFilter, SeccompFilterChain, SeccompMode, SeccompState},
         signal::{PauseReason, PollHandle, sig_mask::SigMask},
     },
     thread::{Thread, Tid},
@@ -107,6 +108,10 @@ pub struct PosixThread {
 
     /// The personality value for this thread.
     personality: AtomicU32,
+
+    /// Secure computing mode state. Linux keeps seccomp and no_new_privs as
+    /// per-thread attributes that are inherited across fork, clone, and execve.
+    seccomp: SeccompState,
 }
 
 impl PosixThread {
@@ -342,6 +347,45 @@ impl PosixThread {
     /// Returns the exit code of this thread.
     pub fn exit_code(&self) -> ExitCode {
         self.exit_code.load(Ordering::Relaxed)
+    }
+
+    /// Returns whether `PR_SET_NO_NEW_PRIVS` has been enabled.
+    pub fn no_new_privs(&self) -> bool {
+        self.seccomp.no_new_privs()
+    }
+
+    /// Enables `no_new_privs`. Once enabled it cannot be cleared.
+    pub fn set_no_new_privs(&self) {
+        self.seccomp.set_no_new_privs();
+    }
+
+    /// Returns the currently active seccomp mode.
+    pub fn seccomp_mode(&self) -> SeccompMode {
+        self.seccomp.mode()
+    }
+
+    /// Enables strict seccomp mode.
+    pub fn enable_seccomp_strict(&self) -> Result<()> {
+        self.seccomp.enable_strict()
+    }
+
+    /// Appends a seccomp filter and enters filter mode.
+    pub fn append_seccomp_filter(&self, filter: SeccompFilter) -> Result<()> {
+        self.seccomp.append_filter(filter)
+    }
+
+    /// Returns the immutable seccomp filter chain, if any.
+    pub fn seccomp_filter_chain(&self) -> Option<Arc<SeccompFilterChain>> {
+        self.seccomp.filter_chain()
+    }
+
+    /// Returns the number of installed seccomp filters.
+    pub fn seccomp_filter_count(&self) -> usize {
+        self.seccomp.filter_count()
+    }
+
+    pub(in crate::process) fn seccomp_state(&self) -> &SeccompState {
+        &self.seccomp
     }
 }
 

--- a/kernel/src/process/seccomp/bpf.rs
+++ b/kernel/src/process/seccomp/bpf.rs
@@ -1,0 +1,791 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The classic-BPF (cBPF) subset that seccomp filters are written in.
+//!
+//! Seccomp filters are read-only cBPF programs: they observe a [`SeccompData`]
+//! descriptor of the system call and return a 32-bit action, with no access to
+//! packets, maps, or memory writes beyond the 16-word scratch area. [`run_filter`]
+//! interprets that subset and [`validate_filter`] rejects malformed programs at
+//! install time, so an accepted program can never reach an undefined state while
+//! a system call is on the hot path.
+//!
+//! The opcodes and encodings follow Linux `linux/filter.h`,
+//! `linux/bpf_common.h`, and `Documentation/networking/filter.rst`.
+
+use super::{SECCOMP_RET_KILL_PROCESS, SeccompData, SockFilter};
+use crate::prelude::*;
+
+/// The maximum number of instructions in a seccomp filter (`BPF_MAXINSNS`).
+pub const BPF_MAXINSNS: usize = 4096;
+
+/// Validates a classic-BPF program before it is installed as a seccomp filter.
+///
+/// A program is accepted only if it is non-empty and within [`BPF_MAXINSNS`],
+/// uses only the supported read-only opcodes, keeps every jump target, scratch
+/// slot, and `seccomp_data` load offset in range, and ends in a `BPF_RET`.
+/// Rejecting these statically lets [`run_filter`] stay branch-light and means a
+/// validated program cannot fault at evaluation time.
+pub fn validate_filter(program: &[SockFilter]) -> Result<()> {
+    if program.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "empty BPF program");
+    }
+    if program.len() > BPF_MAXINSNS {
+        return_errno_with_message!(Errno::EINVAL, "BPF program is too large");
+    }
+
+    for (idx, insn) in program.iter().enumerate() {
+        validate_instruction(insn)?;
+
+        let next_idx = idx + 1;
+        if is_cond_jump(insn.code) {
+            validate_jump_target(next_idx, insn.jt as usize, program.len())?;
+            validate_jump_target(next_idx, insn.jf as usize, program.len())?;
+        } else if insn.code == bpf_jmp_k(BPF_JA) {
+            validate_jump_target(next_idx, insn.k as usize, program.len())?;
+        }
+    }
+
+    let Some(last) = program.last() else {
+        return_errno_with_message!(Errno::EINVAL, "empty BPF program");
+    };
+    if (last.code & BPF_CLASS_MASK) != BPF_RET {
+        return_errno_with_message!(Errno::EINVAL, "BPF program does not end with RET");
+    }
+
+    check_load_and_stores(program)?;
+
+    Ok(())
+}
+
+/// Rejects programs that read a scratch-memory slot before it is written on some
+/// path. This mirrors Linux's `check_load_and_stores`: a per-instruction mask of
+/// initialized slots is propagated across the (forward-only) jumps, and a
+/// `BPF_LD|BPF_MEM`/`BPF_LDX|BPF_MEM` from a slot that is not provably
+/// initialized is `EINVAL`. Run after instruction/jump validation, so memory
+/// slots and jump targets are already in range.
+fn check_load_and_stores(program: &[SockFilter]) -> Result<()> {
+    // Each bit of a mask marks a scratch slot as initialized; bits start set and
+    // are cleared as paths that leave a slot uninitialized merge in.
+    let mut masks = vec![u16::MAX; program.len()];
+    let mut valid = 0u16;
+
+    for (pc, insn) in program.iter().enumerate() {
+        valid &= masks[pc];
+
+        let code = insn.code;
+        if code == bpf_st() || code == bpf_stx() {
+            valid |= 1 << insn.k;
+        } else if code == bpf_ld_mem(BPF_W) || code == bpf_ldx_mem(BPF_W) {
+            if valid & (1 << insn.k) == 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "BPF load from uninitialized scratch memory"
+                );
+            }
+        } else if code == bpf_jmp_k(BPF_JA) {
+            masks[pc + 1 + insn.k as usize] &= valid;
+            valid = u16::MAX;
+        } else if is_cond_jump(code) {
+            masks[pc + 1 + insn.jt as usize] &= valid;
+            masks[pc + 1 + insn.jf as usize] &= valid;
+            valid = u16::MAX;
+        }
+    }
+
+    Ok(())
+}
+
+/// Evaluates a validated classic-BPF program against `data` and returns the raw
+/// 32-bit seccomp action it produces.
+///
+/// The program counter, accumulator, index register, and 16-word scratch area
+/// follow the classic-BPF machine. Any state that a validated program cannot
+/// reach (for example an unsupported opcode) fails closed by returning
+/// `SECCOMP_RET_KILL_PROCESS`.
+pub fn run_filter(program: &[SockFilter], data: &SeccompData) -> u32 {
+    let mut acc = 0u32;
+    let mut x = 0u32;
+    let mut mem = [0u32; BPF_MEMWORDS];
+    let mut pc = 0usize;
+
+    loop {
+        let Some(insn) = program.get(pc) else {
+            return SECCOMP_RET_KILL_PROCESS;
+        };
+        pc += 1;
+
+        match insn.code {
+            code if code == bpf_ld_abs(BPF_W) => {
+                let Some(val) = load_seccomp_word(data, insn.k) else {
+                    return SECCOMP_RET_KILL_PROCESS;
+                };
+                acc = val;
+            }
+            code if code == bpf_ld_abs(BPF_H) || code == bpf_ld_abs(BPF_B) => {
+                return SECCOMP_RET_KILL_PROCESS;
+            }
+            code if code == bpf_ld_imm(BPF_W) => {
+                acc = insn.k;
+            }
+            code if code == bpf_ld_len(BPF_W) => {
+                return SECCOMP_RET_KILL_PROCESS;
+            }
+            code if code == bpf_ld_mem(BPF_W) => {
+                let Some(val) = mem.get(insn.k as usize) else {
+                    return SECCOMP_RET_KILL_PROCESS;
+                };
+                acc = *val;
+            }
+            code if code == bpf_ldx_imm(BPF_W) => {
+                x = insn.k;
+            }
+            code if code == bpf_ldx_mem(BPF_W) => {
+                let Some(val) = mem.get(insn.k as usize) else {
+                    return SECCOMP_RET_KILL_PROCESS;
+                };
+                x = *val;
+            }
+            code if code == bpf_st() => {
+                let Some(slot) = mem.get_mut(insn.k as usize) else {
+                    return SECCOMP_RET_KILL_PROCESS;
+                };
+                *slot = acc;
+            }
+            code if code == bpf_stx() => {
+                let Some(slot) = mem.get_mut(insn.k as usize) else {
+                    return SECCOMP_RET_KILL_PROCESS;
+                };
+                *slot = x;
+            }
+            code if code == bpf_alu_k(BPF_ADD) => acc = acc.wrapping_add(insn.k),
+            code if code == bpf_alu_x(BPF_ADD) => acc = acc.wrapping_add(x),
+            code if code == bpf_alu_k(BPF_SUB) => acc = acc.wrapping_sub(insn.k),
+            code if code == bpf_alu_x(BPF_SUB) => acc = acc.wrapping_sub(x),
+            code if code == bpf_alu_k(BPF_MUL) => acc = acc.wrapping_mul(insn.k),
+            code if code == bpf_alu_x(BPF_MUL) => acc = acc.wrapping_mul(x),
+            code if code == bpf_alu_k(BPF_DIV) => {
+                if insn.k == 0 {
+                    return SECCOMP_RET_KILL_PROCESS;
+                }
+                acc /= insn.k;
+            }
+            code if code == bpf_alu_x(BPF_DIV) => {
+                if x == 0 {
+                    return SECCOMP_RET_KILL_PROCESS;
+                }
+                acc /= x;
+            }
+            code if code == bpf_alu_k(BPF_OR) => acc |= insn.k,
+            code if code == bpf_alu_x(BPF_OR) => acc |= x,
+            code if code == bpf_alu_k(BPF_AND) => acc &= insn.k,
+            code if code == bpf_alu_x(BPF_AND) => acc &= x,
+            code if code == bpf_alu_k(BPF_LSH) => acc = acc.wrapping_shl(insn.k),
+            code if code == bpf_alu_x(BPF_LSH) => acc = acc.wrapping_shl(x),
+            code if code == bpf_alu_k(BPF_RSH) => acc = acc.wrapping_shr(insn.k),
+            code if code == bpf_alu_x(BPF_RSH) => acc = acc.wrapping_shr(x),
+            code if code == bpf_alu_k(BPF_MOD) => {
+                if insn.k == 0 {
+                    return SECCOMP_RET_KILL_PROCESS;
+                }
+                acc %= insn.k;
+            }
+            code if code == bpf_alu_x(BPF_MOD) => {
+                if x == 0 {
+                    return SECCOMP_RET_KILL_PROCESS;
+                }
+                acc %= x;
+            }
+            code if code == bpf_alu_k(BPF_XOR) => acc ^= insn.k,
+            code if code == bpf_alu_x(BPF_XOR) => acc ^= x,
+            code if code == bpf_alu_neg() => acc = 0u32.wrapping_sub(acc),
+            code if code == bpf_jmp_k(BPF_JA) => pc = pc.saturating_add(insn.k as usize),
+            code if code == bpf_jmp_k(BPF_JEQ) => {
+                pc += if acc == insn.k {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_jmp_x(BPF_JEQ) => {
+                pc += if acc == x {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_jmp_k(BPF_JGT) => {
+                pc += if acc > insn.k {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_jmp_x(BPF_JGT) => {
+                pc += if acc > x {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_jmp_k(BPF_JGE) => {
+                pc += if acc >= insn.k {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_jmp_x(BPF_JGE) => {
+                pc += if acc >= x {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_jmp_k(BPF_JSET) => {
+                pc += if acc & insn.k != 0 {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_jmp_x(BPF_JSET) => {
+                pc += if acc & x != 0 {
+                    insn.jt as usize
+                } else {
+                    insn.jf as usize
+                };
+            }
+            code if code == bpf_ret_k() => return insn.k,
+            code if code == bpf_ret_a() => return acc,
+            code if code == bpf_misc_tax() => x = acc,
+            code if code == bpf_misc_txa() => acc = x,
+            _ => return SECCOMP_RET_KILL_PROCESS,
+        }
+    }
+}
+
+fn validate_instruction(insn: &SockFilter) -> Result<()> {
+    match insn.code {
+        code if code == bpf_ld_abs(BPF_W) => validate_seccomp_load_offset(insn.k),
+        code if code == bpf_ld_imm(BPF_W) => Ok(()),
+        code if code == bpf_ld_mem(BPF_W)
+            || code == bpf_ldx_mem(BPF_W)
+            || code == bpf_st()
+            || code == bpf_stx() =>
+        {
+            validate_mem_slot(insn.k)
+        }
+        code if code == bpf_ldx_imm(BPF_W) => Ok(()),
+        code if is_alu(code) => validate_alu_instruction(insn),
+        code if is_jump(code) => {
+            if code == bpf_jmp_k(BPF_JA) {
+                return Ok(());
+            }
+            if !is_cond_jump(code) {
+                return_errno_with_message!(Errno::EINVAL, "unsupported BPF jump instruction");
+            }
+            Ok(())
+        }
+        code if code == bpf_ret_k() || code == bpf_ret_a() => Ok(()),
+        code if code == bpf_misc_tax() || code == bpf_misc_txa() => Ok(()),
+        _ => Err(Error::with_message(
+            Errno::EINVAL,
+            "unsupported seccomp BPF instruction",
+        )),
+    }
+}
+
+fn validate_alu_instruction(insn: &SockFilter) -> Result<()> {
+    match insn.code {
+        code if code == bpf_alu_k(BPF_DIV) && insn.k == 0 => {
+            return_errno_with_message!(Errno::EINVAL, "BPF division by zero")
+        }
+        code if code == bpf_alu_k(BPF_MOD) && insn.k == 0 => {
+            return_errno_with_message!(Errno::EINVAL, "BPF modulo by zero")
+        }
+        code if (code == bpf_alu_k(BPF_LSH) || code == bpf_alu_k(BPF_RSH)) && insn.k >= 32 => {
+            return_errno_with_message!(Errno::EINVAL, "BPF shift is out of range")
+        }
+        code if code == bpf_alu_k(BPF_ADD)
+            || code == bpf_alu_x(BPF_ADD)
+            || code == bpf_alu_k(BPF_SUB)
+            || code == bpf_alu_x(BPF_SUB)
+            || code == bpf_alu_k(BPF_MUL)
+            || code == bpf_alu_x(BPF_MUL)
+            || code == bpf_alu_x(BPF_DIV)
+            || code == bpf_alu_k(BPF_OR)
+            || code == bpf_alu_x(BPF_OR)
+            || code == bpf_alu_k(BPF_AND)
+            || code == bpf_alu_x(BPF_AND)
+            || code == bpf_alu_x(BPF_LSH)
+            || code == bpf_alu_x(BPF_RSH)
+            || code == bpf_alu_x(BPF_MOD)
+            || code == bpf_alu_k(BPF_XOR)
+            || code == bpf_alu_x(BPF_XOR)
+            || code == bpf_alu_neg() =>
+        {
+            Ok(())
+        }
+        _ => return_errno_with_message!(Errno::EINVAL, "unsupported BPF ALU instruction"),
+    }
+}
+
+fn validate_jump_target(next_idx: usize, offset: usize, program_len: usize) -> Result<()> {
+    let Some(target) = next_idx.checked_add(offset) else {
+        return_errno_with_message!(Errno::EINVAL, "BPF jump target overflows");
+    };
+    if target >= program_len {
+        return_errno_with_message!(Errno::EINVAL, "BPF jump target is out of bounds");
+    }
+    Ok(())
+}
+
+fn validate_seccomp_load_offset(offset: u32) -> Result<()> {
+    if load_seccomp_word(&SeccompData::default(), offset).is_none() {
+        return_errno_with_message!(Errno::EINVAL, "invalid seccomp_data load offset");
+    }
+    Ok(())
+}
+
+fn validate_mem_slot(slot: u32) -> Result<()> {
+    if slot as usize >= BPF_MEMWORDS {
+        return_errno_with_message!(Errno::EINVAL, "invalid BPF scratch memory slot");
+    }
+    Ok(())
+}
+
+fn load_seccomp_word(data: &SeccompData, offset: u32) -> Option<u32> {
+    match offset {
+        0 => Some(data.nr as u32),
+        4 => Some(data.arch),
+        8 => Some(data.instruction_pointer as u32),
+        12 => Some((data.instruction_pointer >> 32) as u32),
+        16 => Some(data.args[0] as u32),
+        20 => Some((data.args[0] >> 32) as u32),
+        24 => Some(data.args[1] as u32),
+        28 => Some((data.args[1] >> 32) as u32),
+        32 => Some(data.args[2] as u32),
+        36 => Some((data.args[2] >> 32) as u32),
+        40 => Some(data.args[3] as u32),
+        44 => Some((data.args[3] >> 32) as u32),
+        48 => Some(data.args[4] as u32),
+        52 => Some((data.args[4] >> 32) as u32),
+        56 => Some(data.args[5] as u32),
+        60 => Some((data.args[5] >> 32) as u32),
+        _ => None,
+    }
+}
+
+fn is_alu(code: u16) -> bool {
+    (code & BPF_CLASS_MASK) == BPF_ALU
+}
+
+fn is_jump(code: u16) -> bool {
+    (code & BPF_CLASS_MASK) == BPF_JMP
+}
+
+fn is_cond_jump(code: u16) -> bool {
+    matches!(
+        code,
+        c if c == bpf_jmp_k(BPF_JEQ)
+            || c == bpf_jmp_x(BPF_JEQ)
+            || c == bpf_jmp_k(BPF_JGT)
+            || c == bpf_jmp_x(BPF_JGT)
+            || c == bpf_jmp_k(BPF_JGE)
+            || c == bpf_jmp_x(BPF_JGE)
+            || c == bpf_jmp_k(BPF_JSET)
+            || c == bpf_jmp_x(BPF_JSET)
+    )
+}
+
+const BPF_CLASS_MASK: u16 = 0x07;
+const BPF_LD: u16 = 0x00;
+const BPF_LDX: u16 = 0x01;
+const BPF_ST: u16 = 0x02;
+const BPF_STX: u16 = 0x03;
+const BPF_ALU: u16 = 0x04;
+const BPF_JMP: u16 = 0x05;
+const BPF_RET: u16 = 0x06;
+const BPF_MISC: u16 = 0x07;
+
+const BPF_W: u16 = 0x00;
+const BPF_H: u16 = 0x08;
+const BPF_B: u16 = 0x10;
+
+const BPF_IMM: u16 = 0x00;
+const BPF_ABS: u16 = 0x20;
+const BPF_MEM: u16 = 0x60;
+const BPF_LEN: u16 = 0x80;
+
+const BPF_ADD: u16 = 0x00;
+const BPF_SUB: u16 = 0x10;
+const BPF_MUL: u16 = 0x20;
+const BPF_DIV: u16 = 0x30;
+const BPF_OR: u16 = 0x40;
+const BPF_AND: u16 = 0x50;
+const BPF_LSH: u16 = 0x60;
+const BPF_RSH: u16 = 0x70;
+const BPF_NEG: u16 = 0x80;
+const BPF_MOD: u16 = 0x90;
+const BPF_XOR: u16 = 0xa0;
+
+const BPF_JA: u16 = 0x00;
+const BPF_JEQ: u16 = 0x10;
+const BPF_JGT: u16 = 0x20;
+const BPF_JGE: u16 = 0x30;
+const BPF_JSET: u16 = 0x40;
+
+const BPF_K: u16 = 0x00;
+const BPF_X: u16 = 0x08;
+const BPF_A: u16 = 0x10;
+
+const BPF_TAX: u16 = 0x00;
+const BPF_TXA: u16 = 0x80;
+const BPF_MEMWORDS: usize = 16;
+
+const fn bpf_ld_abs(size: u16) -> u16 {
+    BPF_LD | size | BPF_ABS
+}
+
+const fn bpf_ld_imm(size: u16) -> u16 {
+    BPF_LD | size | BPF_IMM
+}
+
+const fn bpf_ld_len(size: u16) -> u16 {
+    BPF_LD | size | BPF_LEN
+}
+
+const fn bpf_ld_mem(size: u16) -> u16 {
+    BPF_LD | size | BPF_MEM
+}
+
+const fn bpf_ldx_imm(size: u16) -> u16 {
+    BPF_LDX | size | BPF_IMM
+}
+
+const fn bpf_ldx_mem(size: u16) -> u16 {
+    BPF_LDX | size | BPF_MEM
+}
+
+const fn bpf_st() -> u16 {
+    BPF_ST
+}
+
+const fn bpf_stx() -> u16 {
+    BPF_STX
+}
+
+const fn bpf_alu_k(op: u16) -> u16 {
+    BPF_ALU | op | BPF_K
+}
+
+const fn bpf_alu_x(op: u16) -> u16 {
+    BPF_ALU | op | BPF_X
+}
+
+const fn bpf_alu_neg() -> u16 {
+    BPF_ALU | BPF_NEG
+}
+
+const fn bpf_jmp_k(op: u16) -> u16 {
+    BPF_JMP | op | BPF_K
+}
+
+const fn bpf_jmp_x(op: u16) -> u16 {
+    BPF_JMP | op | BPF_X
+}
+
+const fn bpf_ret_k() -> u16 {
+    BPF_RET | BPF_K
+}
+
+const fn bpf_ret_a() -> u16 {
+    BPF_RET | BPF_A
+}
+
+const fn bpf_misc_tax() -> u16 {
+    BPF_MISC | BPF_TAX
+}
+
+const fn bpf_misc_txa() -> u16 {
+    BPF_MISC | BPF_TXA
+}
+
+/// Builds a single-instruction `BPF_RET | BPF_K` program returning `value`,
+/// used by the seccomp filter-chain and state tests in the parent module.
+#[cfg(ktest)]
+pub(super) fn ret_program(value: u32) -> Box<[SockFilter]> {
+    Box::new([SockFilter {
+        code: bpf_ret_k(),
+        jt: 0,
+        jf: 0,
+        k: value,
+    }])
+}
+
+/// Builds a valid `len`-instruction program: `len - 1` harmless loads of the
+/// syscall number followed by `BPF_RET value`. Used by the chain-length test.
+#[cfg(ktest)]
+pub(super) fn padded_program(len: usize, value: u32) -> Box<[SockFilter]> {
+    let mut program = Vec::with_capacity(len);
+    for _ in 1..len {
+        program.push(SockFilter {
+            code: bpf_ld_abs(BPF_W),
+            jt: 0,
+            jf: 0,
+            k: 0,
+        });
+    }
+    program.push(SockFilter {
+        code: bpf_ret_k(),
+        jt: 0,
+        jf: 0,
+        k: value,
+    });
+    program.into_boxed_slice()
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::{
+        super::{AUDIT_ARCH_NATIVE, SECCOMP_RET_ALLOW, SECCOMP_RET_ERRNO},
+        *,
+    };
+
+    fn stmt(code: u16, k: u32) -> SockFilter {
+        SockFilter {
+            code,
+            jt: 0,
+            jf: 0,
+            k,
+        }
+    }
+
+    fn jump(code: u16, k: u32, jt: u8, jf: u8) -> SockFilter {
+        SockFilter { code, jt, jf, k }
+    }
+
+    fn sample_data(nr: i32) -> SeccompData {
+        SeccompData {
+            nr,
+            arch: AUDIT_ARCH_NATIVE,
+            instruction_pointer: 0x1234_5678_9abc_def0,
+            args: [1, 2, 3, 4, 5, 6],
+        }
+    }
+
+    #[ktest]
+    fn seccomp() {
+        seccomp_allow_program_runs();
+        seccomp_syscall_whitelist_can_return_errno();
+        seccomp_arch_check_can_kill_mismatches();
+        seccomp_alu_memory_and_ret_a_work();
+        seccomp_alu_and_index_register_opcodes_evaluate();
+        seccomp_conditional_jumps_select_the_taken_branch();
+        seccomp_x_form_conditional_jumps_evaluate();
+        seccomp_data_word_loads_can_filter_arguments();
+        seccomp_invalid_programs_are_rejected();
+        seccomp_ja_zero_can_fall_through_to_next_instruction();
+    }
+
+    #[ktest]
+    fn seccomp_allow_program_runs() {
+        let program = [stmt(bpf_ret_k(), SECCOMP_RET_ALLOW)];
+        assert!(validate_filter(&program).is_ok());
+        assert_eq!(run_filter(&program, &sample_data(39)), SECCOMP_RET_ALLOW);
+    }
+
+    #[ktest]
+    fn seccomp_alu_and_index_register_opcodes_evaluate() {
+        // A = (nr + 10) & 0xff, exercising an ALU K op, TAX, an immediate load,
+        // an ALU X op, and RET A.
+        let program = [
+            stmt(bpf_ld_abs(BPF_W), 0),
+            stmt(bpf_alu_k(BPF_ADD), 10),
+            stmt(bpf_misc_tax(), 0),
+            stmt(bpf_ld_imm(BPF_W), 0xff),
+            stmt(bpf_alu_x(BPF_AND), 0),
+            stmt(bpf_ret_a(), 0),
+        ];
+        assert!(validate_filter(&program).is_ok());
+        assert_eq!(run_filter(&program, &sample_data(5)), 15);
+
+        // X-form comparison: TXA loads X into A, then `JGT X` compares the
+        // loaded syscall number against X.
+        let program = [
+            stmt(bpf_ldx_imm(BPF_W), 100),
+            stmt(bpf_misc_txa(), 0),
+            stmt(bpf_ld_abs(BPF_W), 0),
+            jump(bpf_jmp_x(BPF_JGT), 0, 0, 1),
+            stmt(bpf_ret_k(), SECCOMP_RET_ALLOW),
+            stmt(bpf_ret_k(), SECCOMP_RET_ERRNO),
+        ];
+        assert!(validate_filter(&program).is_ok());
+        assert_eq!(run_filter(&program, &sample_data(200)), SECCOMP_RET_ALLOW);
+        assert_eq!(run_filter(&program, &sample_data(50)), SECCOMP_RET_ERRNO);
+    }
+
+    #[ktest]
+    fn seccomp_conditional_jumps_select_the_taken_branch() {
+        // Each program loads the syscall number, runs one conditional jump that
+        // falls through to ALLOW when taken and skips to ERRNO otherwise.
+        let eval = |code: u16, k: u32, nr: i32| {
+            let program = [
+                stmt(bpf_ld_abs(BPF_W), 0),
+                jump(code, k, 0, 1),
+                stmt(bpf_ret_k(), SECCOMP_RET_ALLOW),
+                stmt(bpf_ret_k(), SECCOMP_RET_ERRNO),
+            ];
+            assert!(validate_filter(&program).is_ok());
+            run_filter(&program, &sample_data(nr))
+        };
+
+        assert_eq!(eval(bpf_jmp_k(BPF_JEQ), 5, 5), SECCOMP_RET_ALLOW);
+        assert_eq!(eval(bpf_jmp_k(BPF_JEQ), 6, 5), SECCOMP_RET_ERRNO);
+        assert_eq!(eval(bpf_jmp_k(BPF_JGT), 3, 5), SECCOMP_RET_ALLOW);
+        assert_eq!(eval(bpf_jmp_k(BPF_JGT), 5, 5), SECCOMP_RET_ERRNO);
+        assert_eq!(eval(bpf_jmp_k(BPF_JGE), 5, 5), SECCOMP_RET_ALLOW);
+        assert_eq!(eval(bpf_jmp_k(BPF_JGE), 6, 5), SECCOMP_RET_ERRNO);
+        assert_eq!(eval(bpf_jmp_k(BPF_JSET), 0x4, 5), SECCOMP_RET_ALLOW);
+        assert_eq!(eval(bpf_jmp_k(BPF_JSET), 0x8, 5), SECCOMP_RET_ERRNO);
+    }
+
+    #[ktest]
+    fn seccomp_x_form_conditional_jumps_evaluate() {
+        // Load args[0] into X and args[1] into A, then branch on A vs X.
+        let eval = |code: u16, a: u64, x: u64| {
+            let program = [
+                stmt(bpf_ld_abs(BPF_W), 16),
+                stmt(bpf_misc_tax(), 0),
+                stmt(bpf_ld_abs(BPF_W), 24),
+                jump(code, 0, 0, 1),
+                stmt(bpf_ret_k(), SECCOMP_RET_ALLOW),
+                stmt(bpf_ret_k(), SECCOMP_RET_ERRNO),
+            ];
+            assert!(validate_filter(&program).is_ok());
+            let mut data = sample_data(0);
+            data.args = [x, a, 0, 0, 0, 0];
+            run_filter(&program, &data)
+        };
+
+        assert_eq!(eval(bpf_jmp_x(BPF_JEQ), 5, 5), SECCOMP_RET_ALLOW);
+        assert_eq!(eval(bpf_jmp_x(BPF_JEQ), 5, 6), SECCOMP_RET_ERRNO);
+        assert_eq!(eval(bpf_jmp_x(BPF_JGE), 7, 5), SECCOMP_RET_ALLOW);
+        assert_eq!(eval(bpf_jmp_x(BPF_JGE), 4, 5), SECCOMP_RET_ERRNO);
+        assert_eq!(eval(bpf_jmp_x(BPF_JSET), 0x6, 0x4), SECCOMP_RET_ALLOW);
+        assert_eq!(eval(bpf_jmp_x(BPF_JSET), 0x1, 0x4), SECCOMP_RET_ERRNO);
+    }
+
+    #[ktest]
+    fn seccomp_data_word_loads_can_filter_arguments() {
+        // Deny based on the first syscall argument, the way real profiles match
+        // arguments: ERRNO when args[0] == 42, ALLOW otherwise.
+        let program = [
+            stmt(bpf_ld_abs(BPF_W), 16),
+            jump(bpf_jmp_k(BPF_JEQ), 42, 0, 1),
+            stmt(bpf_ret_k(), SECCOMP_RET_ERRNO | Errno::EPERM as u32),
+            stmt(bpf_ret_k(), SECCOMP_RET_ALLOW),
+        ];
+        assert!(validate_filter(&program).is_ok());
+        let mut data = sample_data(0);
+        data.args = [42, 0, 0, 0, 0, 0];
+        assert_eq!(
+            run_filter(&program, &data),
+            SECCOMP_RET_ERRNO | Errno::EPERM as u32
+        );
+        data.args[0] = 7;
+        assert_eq!(run_filter(&program, &data), SECCOMP_RET_ALLOW);
+
+        // The high 32 bits of a 64-bit field are a separate word load.
+        let high_word = [stmt(bpf_ld_abs(BPF_W), 20), stmt(bpf_ret_a(), 0)];
+        assert!(validate_filter(&high_word).is_ok());
+        let mut data = sample_data(0);
+        data.args[0] = 0x1234_5678_9abc_def0;
+        assert_eq!(run_filter(&high_word, &data), 0x1234_5678);
+    }
+
+    #[ktest]
+    fn seccomp_syscall_whitelist_can_return_errno() {
+        let program = [
+            stmt(bpf_ld_abs(BPF_W), 0),
+            jump(bpf_jmp_k(BPF_JEQ), 1, 0, 1),
+            stmt(bpf_ret_k(), SECCOMP_RET_ALLOW),
+            stmt(bpf_ret_k(), SECCOMP_RET_ERRNO | Errno::EPERM as u32),
+        ];
+        assert!(validate_filter(&program).is_ok());
+        assert_eq!(run_filter(&program, &sample_data(1)), SECCOMP_RET_ALLOW);
+        assert_eq!(
+            run_filter(&program, &sample_data(39)),
+            SECCOMP_RET_ERRNO | Errno::EPERM as u32
+        );
+    }
+
+    #[ktest]
+    fn seccomp_arch_check_can_kill_mismatches() {
+        let program = [
+            stmt(bpf_ld_abs(BPF_W), 4),
+            jump(bpf_jmp_k(BPF_JEQ), AUDIT_ARCH_NATIVE, 1, 0),
+            stmt(bpf_ret_k(), SECCOMP_RET_KILL_PROCESS),
+            stmt(bpf_ret_k(), SECCOMP_RET_ALLOW),
+        ];
+        assert!(validate_filter(&program).is_ok());
+        assert_eq!(run_filter(&program, &sample_data(0)), SECCOMP_RET_ALLOW);
+
+        let mut data = sample_data(0);
+        data.arch = 0;
+        assert_eq!(run_filter(&program, &data), SECCOMP_RET_KILL_PROCESS);
+    }
+
+    #[ktest]
+    fn seccomp_alu_memory_and_ret_a_work() {
+        let program = [
+            stmt(bpf_ld_imm(BPF_W), SECCOMP_RET_ERRNO),
+            stmt(bpf_st(), 0),
+            stmt(bpf_ld_imm(BPF_W), Errno::EACCES as u32),
+            stmt(bpf_ldx_mem(BPF_W), 0),
+            stmt(bpf_alu_x(BPF_OR), 0),
+            stmt(bpf_ret_a(), 0),
+        ];
+        assert!(validate_filter(&program).is_ok());
+        assert_eq!(
+            run_filter(&program, &sample_data(0)),
+            SECCOMP_RET_ERRNO | Errno::EACCES as u32
+        );
+    }
+
+    #[ktest]
+    fn seccomp_invalid_programs_are_rejected() {
+        assert!(validate_filter(&[]).is_err());
+        assert!(validate_filter(&[stmt(bpf_ld_abs(BPF_W), 64), stmt(bpf_ret_a(), 0)]).is_err());
+        assert!(
+            validate_filter(&[jump(bpf_jmp_k(BPF_JA), 4, 0, 0), stmt(bpf_ret_k(), 0)]).is_err()
+        );
+        assert!(validate_filter(&[stmt(bpf_ld_imm(BPF_W), 0)]).is_err());
+        assert!(validate_filter(&[stmt(bpf_ld_abs(BPF_H), 0), stmt(bpf_ret_a(), 0)]).is_err());
+
+        // Reading a scratch slot before it is written is rejected, but reading
+        // it after a store is accepted.
+        assert!(validate_filter(&[stmt(bpf_ld_mem(BPF_W), 0), stmt(bpf_ret_a(), 0)]).is_err());
+        assert!(
+            validate_filter(&[
+                stmt(bpf_ld_imm(BPF_W), 1),
+                stmt(bpf_st(), 0),
+                stmt(bpf_ld_mem(BPF_W), 0),
+                stmt(bpf_ret_a(), 0)
+            ])
+            .is_ok()
+        );
+    }
+
+    #[ktest]
+    fn seccomp_ja_zero_can_fall_through_to_next_instruction() {
+        let program = [
+            jump(bpf_jmp_k(BPF_JA), 0, 0, 0),
+            stmt(bpf_ret_k(), SECCOMP_RET_ALLOW),
+        ];
+        assert!(validate_filter(&program).is_ok());
+        assert_eq!(run_filter(&program, &sample_data(0)), SECCOMP_RET_ALLOW);
+    }
+}

--- a/kernel/src/process/seccomp/mod.rs
+++ b/kernel/src/process/seccomp/mod.rs
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Secure computing (seccomp) mode support.
+//!
+//! Seccomp lets a thread irreversibly restrict the system calls it may make,
+//! which is a building block for sandboxes and container runtimes. This module
+//! implements the kernel-side pieces shared by [`seccomp(2)`], [`prctl(2)`], and
+//! the system-call dispatch hook.
+//!
+//! # Modes
+//!
+//! - [`SeccompMode::Strict`] permits only `read`, `write`, `_exit`, and
+//!   `rt_sigreturn`; any other call kills the thread with `SIGKILL`.
+//! - [`SeccompMode::Filter`] evaluates a chain of classic-BPF programs against a
+//!   [`SeccompData`] descriptor of the call and applies the action they return.
+//!
+//! # Filter chain
+//!
+//! Each `SECCOMP_SET_MODE_FILTER` prepends one [`SeccompFilter`] to an
+//! append-only, immutable [`SeccompFilterChain`] held behind an `Arc`. A chain
+//! is never mutated after creation, so evaluating it only clones the head `Arc`
+//! and walks the links; sharing the `Arc` also lets a forked child inherit its
+//! parent's filters for free. Following Linux, every filter in the chain runs
+//! and the numerically smallest (most restrictive) action wins; ties keep the
+//! data of the newest filter.
+//!
+//! # Hot path
+//!
+//! The dispatch hook must add no measurable cost to threads that never use
+//! seccomp: such a thread pays a single relaxed atomic load of the mode, which
+//! reports [`SeccompMode::Disabled`] and returns immediately. Only once a thread
+//! is in filter mode does the hook take the per-thread chain lock long enough to
+//! clone the head `Arc`, then build a [`SeccompData`] descriptor and evaluate.
+//!
+//! # Classic BPF
+//!
+//! The read-only cBPF subset that seccomp filters use lives in the [`bpf`]
+//! submodule: [`run_filter`] interprets it and [`validate_filter`] rejects
+//! malformed programs at install time so an accepted program can never reach an
+//! undefined state at run time.
+//!
+//! The constants and ABI structures follow Linux `linux/seccomp.h`,
+//! `linux/filter.h`, `linux/bpf_common.h`, and
+//! `Documentation/userspace-api/seccomp_filter.rst`.
+//!
+//! [`seccomp(2)`]: https://man7.org/linux/man-pages/man2/seccomp.2.html
+//! [`prctl(2)`]: https://man7.org/linux/man-pages/man2/prctl.2.html
+
+mod bpf;
+
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+pub use bpf::{BPF_MAXINSNS, run_filter, validate_filter};
+
+use crate::prelude::*;
+
+pub const SECCOMP_MODE_DISABLED: u32 = 0;
+pub const SECCOMP_MODE_STRICT: u32 = 1;
+pub const SECCOMP_MODE_FILTER: u32 = 2;
+
+pub const SECCOMP_SET_MODE_STRICT: u32 = 0;
+pub const SECCOMP_SET_MODE_FILTER: u32 = 1;
+pub const SECCOMP_GET_ACTION_AVAIL: u32 = 2;
+
+pub const SECCOMP_RET_KILL_PROCESS: u32 = 0x8000_0000;
+pub const SECCOMP_RET_KILL_THREAD: u32 = 0x0000_0000;
+pub const SECCOMP_RET_TRAP: u32 = 0x0003_0000;
+pub const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
+pub const SECCOMP_RET_TRACE: u32 = 0x7ff0_0000;
+pub const SECCOMP_RET_LOG: u32 = 0x7ffc_0000;
+pub const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
+pub const SECCOMP_RET_USER_NOTIF: u32 = 0x7fc0_0000;
+pub const SECCOMP_RET_ACTION_FULL: u32 = 0xffff_0000;
+pub const SECCOMP_RET_DATA: u32 = 0x0000_ffff;
+
+pub const SECCOMP_FILTER_FLAG_LOG: u32 = 1 << 1;
+pub const SECCOMP_FILTER_FLAG_SPEC_ALLOW: u32 = 1 << 2;
+
+/// The maximum cumulative instruction count across a thread's whole filter
+/// chain, matching Linux's `MAX_INSNS_PER_PATH`.
+const MAX_INSNS_PER_PATH: usize = 32768;
+/// The per-installed-filter penalty added to the cumulative count, matching
+/// Linux's accounting in `seccomp_attach_filter`.
+const SECCOMP_FILTER_PENALTY: usize = 4;
+
+#[cfg(target_arch = "x86_64")]
+pub const AUDIT_ARCH_NATIVE: u32 = 0xc000_003e;
+#[cfg(target_arch = "riscv64")]
+pub const AUDIT_ARCH_NATIVE: u32 = 0xc000_00f3;
+#[cfg(target_arch = "loongarch64")]
+pub const AUDIT_ARCH_NATIVE: u32 = 0xc000_0102;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SeccompMode {
+    Disabled = SECCOMP_MODE_DISABLED,
+    Strict = SECCOMP_MODE_STRICT,
+    Filter = SECCOMP_MODE_FILTER,
+}
+
+impl SeccompMode {
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub struct SeccompData {
+    pub nr: i32,
+    pub arch: u32,
+    pub instruction_pointer: u64,
+    pub args: [u64; 6],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub struct SockFilter {
+    pub code: u16,
+    pub jt: u8,
+    pub jf: u8,
+    pub k: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SeccompAction {
+    Allow,
+    Log,
+    Errno(u16),
+    Trap(u16),
+    Trace(u16),
+    UserNotif(u16),
+    KillThread,
+    KillProcess,
+}
+
+impl SeccompAction {
+    pub fn from_ret(ret: u32) -> Self {
+        let data = (ret & SECCOMP_RET_DATA) as u16;
+        match ret & SECCOMP_RET_ACTION_FULL {
+            SECCOMP_RET_ALLOW => Self::Allow,
+            SECCOMP_RET_LOG => Self::Log,
+            SECCOMP_RET_ERRNO => Self::Errno(data),
+            SECCOMP_RET_TRAP => Self::Trap(data),
+            SECCOMP_RET_TRACE => Self::Trace(data),
+            SECCOMP_RET_USER_NOTIF => Self::UserNotif(data),
+            SECCOMP_RET_KILL_PROCESS => Self::KillProcess,
+            SECCOMP_RET_KILL_THREAD => Self::KillThread,
+            _ => Self::KillProcess,
+        }
+    }
+
+    /// The chain selects the action with the smallest precedence value, so the
+    /// ordering here encodes "most restrictive wins" from Linux's
+    /// `seccomp_run_filters`.
+    fn precedence(self) -> u8 {
+        match self {
+            Self::KillProcess => 0,
+            Self::KillThread => 1,
+            Self::Trap(_) => 2,
+            Self::Errno(_) => 3,
+            Self::UserNotif(_) => 4,
+            Self::Trace(_) => 5,
+            Self::Log => 6,
+            Self::Allow => 7,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SeccompFilter {
+    program: Box<[SockFilter]>,
+    log_non_allow: bool,
+}
+
+impl SeccompFilter {
+    pub fn new(program: Box<[SockFilter]>, flags: u32) -> Result<Self> {
+        validate_filter_flags(flags)?;
+        validate_filter(&program)?;
+        Ok(Self {
+            program,
+            log_non_allow: flags & SECCOMP_FILTER_FLAG_LOG != 0,
+        })
+    }
+
+    pub fn evaluate(&self, data: &SeccompData) -> u32 {
+        run_filter(&self.program, data)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SeccompEvaluation {
+    pub action: SeccompAction,
+    pub should_log: bool,
+}
+
+#[derive(Debug)]
+pub struct SeccompFilterChain {
+    filter: SeccompFilter,
+    previous: Option<Arc<SeccompFilterChain>>,
+}
+
+impl SeccompFilterChain {
+    pub fn new(filter: SeccompFilter, previous: Option<Arc<Self>>) -> Arc<Self> {
+        Arc::new(Self { filter, previous })
+    }
+
+    /// The number of filters in the chain, as reported by
+    /// `/proc/[pid]/status`'s `Seccomp_filters` line.
+    pub fn count(&self) -> usize {
+        let mut count = 0;
+        let mut current = Some(self);
+        while let Some(chain) = current {
+            count += 1;
+            current = chain.previous.as_deref();
+        }
+        count
+    }
+
+    pub fn evaluate_with_metadata(&self, data: &SeccompData) -> SeccompEvaluation {
+        let mut selected = SeccompAction::Allow;
+        let mut should_log = false;
+        let mut current = Some(self);
+
+        while let Some(chain) = current {
+            let action = SeccompAction::from_ret(chain.filter.evaluate(data));
+            if chain.filter.log_non_allow && !matches!(action, SeccompAction::Allow) {
+                should_log = true;
+            }
+            // Linux runs every filter and, for equal precedence, keeps the
+            // newest filter's data. Since the chain is newest-first, do not
+            // replace the selected action on ties.
+            if action.precedence() < selected.precedence() {
+                selected = action;
+            }
+            current = chain.previous.as_deref();
+        }
+
+        SeccompEvaluation {
+            action: selected,
+            should_log,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SeccompState {
+    mode: AtomicU32,
+    no_new_privs: AtomicBool,
+    filter_chain: RwLock<Option<Arc<SeccompFilterChain>>>,
+}
+
+impl SeccompState {
+    pub fn new() -> Self {
+        Self {
+            mode: AtomicU32::new(SECCOMP_MODE_DISABLED),
+            no_new_privs: AtomicBool::new(false),
+            filter_chain: RwLock::new(None),
+        }
+    }
+
+    pub fn fork_from(parent: &Self) -> Self {
+        Self {
+            mode: AtomicU32::new(parent.mode().as_u32()),
+            no_new_privs: AtomicBool::new(parent.no_new_privs()),
+            filter_chain: RwLock::new(parent.filter_chain()),
+        }
+    }
+
+    pub fn mode(&self) -> SeccompMode {
+        // Only `enable_strict`, `append_filter`, and `fork_from` ever write this
+        // atomic, so it always holds a valid discriminant; an unexpected value
+        // degrades safely to the most permissive mode rather than panicking on
+        // this per-syscall hot path.
+        match self.mode.load(Ordering::Relaxed) {
+            SECCOMP_MODE_STRICT => SeccompMode::Strict,
+            SECCOMP_MODE_FILTER => SeccompMode::Filter,
+            _ => SeccompMode::Disabled,
+        }
+    }
+
+    pub fn no_new_privs(&self) -> bool {
+        self.no_new_privs.load(Ordering::Relaxed)
+    }
+
+    pub fn set_no_new_privs(&self) {
+        self.no_new_privs.store(true, Ordering::Relaxed);
+    }
+
+    pub fn filter_chain(&self) -> Option<Arc<SeccompFilterChain>> {
+        self.filter_chain.read().clone()
+    }
+
+    /// The number of installed filters, for `/proc/[pid]/status`.
+    pub fn filter_count(&self) -> usize {
+        self.filter_chain
+            .read()
+            .as_ref()
+            .map_or(0, |chain| chain.count())
+    }
+
+    pub fn enable_strict(&self) -> Result<()> {
+        self.mode
+            .compare_exchange(
+                SECCOMP_MODE_DISABLED,
+                SECCOMP_MODE_STRICT,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .map(|_| ())
+            .map_err(|_| Error::with_message(Errno::EINVAL, "seccomp mode is already enabled"))
+    }
+
+    pub fn append_filter(&self, filter: SeccompFilter) -> Result<()> {
+        // Hold the chain lock across the mode transition so the chain is never
+        // observed empty while the mode reads `Filter`. The transition mirrors
+        // `enable_strict`: `Disabled` becomes `Filter`, an existing `Filter`
+        // accepts another filter, and `Strict` is never downgraded to `Filter`.
+        let mut chain = self.filter_chain.write();
+
+        // Bound the cumulative program length across the whole chain, like
+        // Linux's `MAX_INSNS_PER_PATH`, so an unprivileged thread cannot stack
+        // filters to make every system call arbitrarily expensive. Each
+        // already-installed filter also costs a small fixed penalty, matching
+        // the kernel.
+        let mut total = filter.program.len();
+        let mut node = chain.as_deref();
+        while let Some(current) = node {
+            total += current.filter.program.len() + SECCOMP_FILTER_PENALTY;
+            node = current.previous.as_deref();
+        }
+        if total > MAX_INSNS_PER_PATH {
+            return_errno_with_message!(Errno::ENOMEM, "seccomp filter chain is too large");
+        }
+
+        match self.mode.compare_exchange(
+            SECCOMP_MODE_DISABLED,
+            SECCOMP_MODE_FILTER,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) | Err(SECCOMP_MODE_FILTER) => {}
+            Err(_) => return_errno_with_message!(
+                Errno::EINVAL,
+                "cannot add seccomp filters in strict mode"
+            ),
+        }
+        let new_chain = SeccompFilterChain::new(filter, chain.clone());
+        *chain = Some(new_chain);
+        Ok(())
+    }
+}
+
+impl Default for SeccompState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn is_action_available(action: u32) -> bool {
+    if action & !SECCOMP_RET_ACTION_FULL != 0 {
+        return false;
+    }
+
+    matches!(
+        action,
+        SECCOMP_RET_KILL_PROCESS
+            | SECCOMP_RET_KILL_THREAD
+            | SECCOMP_RET_TRAP
+            | SECCOMP_RET_ERRNO
+            | SECCOMP_RET_TRACE
+            | SECCOMP_RET_LOG
+            | SECCOMP_RET_ALLOW
+            | SECCOMP_RET_USER_NOTIF
+    )
+}
+
+pub fn validate_filter_flags(flags: u32) -> Result<()> {
+    let supported = SECCOMP_FILTER_FLAG_LOG | SECCOMP_FILTER_FLAG_SPEC_ALLOW;
+    if flags & !supported != 0 {
+        return_errno_with_message!(Errno::EINVAL, "unsupported seccomp filter flags");
+    }
+    Ok(())
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::*;
+
+    fn sample_data(nr: i32) -> SeccompData {
+        SeccompData {
+            nr,
+            arch: AUDIT_ARCH_NATIVE,
+            instruction_pointer: 0x1234_5678_9abc_def0,
+            args: [1, 2, 3, 4, 5, 6],
+        }
+    }
+
+    fn filter(ret: u32) -> SeccompFilter {
+        SeccompFilter::new(bpf::ret_program(ret), 0).unwrap()
+    }
+
+    #[ktest]
+    fn seccomp() {
+        seccomp_chain_keeps_most_restrictive_action();
+        seccomp_chain_keeps_newest_data_for_equal_precedence();
+        seccomp_state_transitions_are_one_way();
+        seccomp_fork_inherits_state_and_shares_chain();
+        seccomp_state_bounds_total_filter_instructions();
+    }
+
+    #[ktest]
+    fn seccomp_chain_keeps_most_restrictive_action() {
+        let chain = SeccompFilterChain::new(filter(SECCOMP_RET_ALLOW), None);
+        let chain = SeccompFilterChain::new(
+            filter(SECCOMP_RET_ERRNO | Errno::EACCES as u32),
+            Some(chain),
+        );
+        let chain = SeccompFilterChain::new(filter(SECCOMP_RET_KILL_PROCESS), Some(chain));
+
+        assert_eq!(
+            chain.evaluate_with_metadata(&sample_data(0)).action,
+            SeccompAction::KillProcess
+        );
+    }
+
+    #[ktest]
+    fn seccomp_chain_keeps_newest_data_for_equal_precedence() {
+        let chain = SeccompFilterChain::new(filter(SECCOMP_RET_ERRNO | Errno::EPERM as u32), None);
+        let chain = SeccompFilterChain::new(
+            filter(SECCOMP_RET_ERRNO | Errno::EACCES as u32),
+            Some(chain),
+        );
+
+        assert_eq!(
+            chain.evaluate_with_metadata(&sample_data(0)).action,
+            SeccompAction::Errno(Errno::EACCES as u16)
+        );
+    }
+
+    #[ktest]
+    fn seccomp_state_transitions_are_one_way() {
+        // `Disabled` enters `Filter` and then accepts further filters.
+        let state = SeccompState::new();
+        assert_eq!(state.mode(), SeccompMode::Disabled);
+        assert!(state.filter_chain().is_none());
+        state.append_filter(filter(SECCOMP_RET_ALLOW)).unwrap();
+        assert_eq!(state.mode(), SeccompMode::Filter);
+        assert!(state.filter_chain().is_some());
+        state.append_filter(filter(SECCOMP_RET_ALLOW)).unwrap();
+        assert_eq!(state.mode(), SeccompMode::Filter);
+
+        // `Strict` is one-way and rejects both a second enable and any filter.
+        let state = SeccompState::new();
+        state.enable_strict().unwrap();
+        assert_eq!(state.mode(), SeccompMode::Strict);
+        assert_eq!(state.enable_strict().unwrap_err().error(), Errno::EINVAL);
+        assert_eq!(
+            state
+                .append_filter(filter(SECCOMP_RET_ALLOW))
+                .unwrap_err()
+                .error(),
+            Errno::EINVAL
+        );
+        assert_eq!(state.mode(), SeccompMode::Strict);
+    }
+
+    #[ktest]
+    fn seccomp_fork_inherits_state_and_shares_chain() {
+        let parent = SeccompState::new();
+        parent.set_no_new_privs();
+        parent.append_filter(filter(SECCOMP_RET_ALLOW)).unwrap();
+
+        let child = SeccompState::fork_from(&parent);
+        assert!(child.no_new_privs());
+        assert_eq!(child.mode(), SeccompMode::Filter);
+        assert!(Arc::ptr_eq(
+            &parent.filter_chain().unwrap(),
+            &child.filter_chain().unwrap()
+        ));
+    }
+
+    #[ktest]
+    fn seccomp_state_bounds_total_filter_instructions() {
+        let state = SeccompState::new();
+        let big =
+            || SeccompFilter::new(bpf::padded_program(BPF_MAXINSNS, SECCOMP_RET_ALLOW), 0).unwrap();
+
+        // Each maximum-size filter consumes most of the cumulative budget, so
+        // after a few installs the next one must be rejected with `ENOMEM`.
+        let mut installed = 0;
+        let mut hit_limit = false;
+        for _ in 0..16 {
+            match state.append_filter(big()) {
+                Ok(()) => installed += 1,
+                Err(err) => {
+                    assert_eq!(err.error(), Errno::ENOMEM);
+                    hit_limit = true;
+                    break;
+                }
+            }
+        }
+        assert!(installed >= 1);
+        assert!(hit_limit);
+    }
+}

--- a/kernel/src/process/signal/c_types.rs
+++ b/kernel/src/process/signal/c_types.rs
@@ -55,6 +55,13 @@ impl siginfo_t {
         self.siginfo_fields.sigfault_mut().addr = si_addr;
     }
 
+    pub fn set_sigsys(&mut self, call_addr: Vaddr, syscall: i32, arch: u32) {
+        let sigsys = self.siginfo_fields.sigsys_mut();
+        sigsys.call_addr = call_addr;
+        sigsys.syscall = syscall;
+        sigsys.arch = arch;
+    }
+
     pub fn set_pid_uid(&mut self, pid: Pid, uid: Uid) {
         let pid_uid = {
             let pid_uid = siginfo_piduid_t { pid, uid };
@@ -80,6 +87,12 @@ impl siginfo_t {
     pub fn si_addr(&self) -> Vaddr {
         self.siginfo_fields.sigfault().addr
     }
+
+    #[cfg(ktest)]
+    pub fn sigsys_fields(&self) -> (Vaddr, i32, u32) {
+        let sigsys = self.siginfo_fields.sigsys();
+        (sigsys.call_addr, sigsys.syscall, sigsys.arch)
+    }
 }
 
 #[pod_union]
@@ -89,6 +102,7 @@ union siginfo_fields_t {
     bytes: [u8; 128 - size_of::<i32>() * 4],
     common: siginfo_common_t,
     sigfault: siginfo_sigfault_t,
+    sigsys: siginfo_sigsys_t,
 }
 
 impl Default for siginfo_fields_t {
@@ -174,6 +188,14 @@ struct siginfo_sigfault_t {
     addr: Vaddr, //*const c_void
     addr_lsb: i16,
     first: siginfo_sigfault_first_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct siginfo_sigsys_t {
+    call_addr: Vaddr, //*const c_void
+    syscall: i32,
+    arch: u32,
 }
 
 #[pod_union]

--- a/kernel/src/process/signal/constants.rs
+++ b/kernel/src/process/signal/constants.rs
@@ -112,3 +112,5 @@ pub const TRAP_BRANCH: i32 = 3;
 pub const TRAP_HWBKPT: i32 = 4;
 pub const TRAP_UNK: i32 = 5;
 pub const TRAP_PERF: i32 = 6;
+
+pub const SYS_SECCOMP: i32 = 1;

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -118,6 +118,7 @@ macro_rules! import_generic_syscall_entries {
             sched_setparam::sys_sched_setparam,
             sched_setscheduler::sys_sched_setscheduler,
             sched_yield::sys_sched_yield,
+            seccomp::sys_seccomp,
             semctl::sys_semctl,
             semget::sys_semget,
             semop::{sys_semop, sys_semtimedop},
@@ -392,6 +393,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_SCHED_SETATTR = 274          => sys_sched_setattr(args[..3]);
             SYS_SCHED_GETATTR = 275          => sys_sched_getattr(args[..4]);
             SYS_RENAMEAT2 = 276              => sys_renameat2(args[..5]);
+            SYS_SECCOMP = 277                => sys_seccomp(args[..3]);
             SYS_GETRANDOM = 278              => sys_getrandom(args[..3]);
             SYS_MEMFD_CREATE = 279           => sys_memfd_create(args[..2]);
             SYS_EXECVEAT = 281               => sys_execveat(args[..5], &mut user_ctx);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -121,6 +121,7 @@ use super::{
     sched_setparam::sys_sched_setparam,
     sched_setscheduler::sys_sched_setscheduler,
     sched_yield::sys_sched_yield,
+    seccomp::sys_seccomp,
     select::sys_select,
     semctl::sys_semctl,
     semget::sys_semget,
@@ -407,6 +408,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_SCHED_SETATTR = 314    => sys_sched_setattr(args[..3]);
     SYS_SCHED_GETATTR = 315    => sys_sched_getattr(args[..4]);
     SYS_RENAMEAT2 = 316        => sys_renameat2(args[..5]);
+    SYS_SECCOMP = 317          => sys_seccomp(args[..3]);
     SYS_GETRANDOM = 318        => sys_getrandom(args[..3]);
     SYS_MEMFD_CREATE = 319     => sys_memfd_create(args[..2]);
     SYS_EXECVEAT = 322         => sys_execveat(args[..5], &mut user_ctx);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -134,6 +134,7 @@ mod sched_setattr;
 mod sched_setparam;
 mod sched_setscheduler;
 mod sched_yield;
+mod seccomp;
 mod select;
 mod semctl;
 mod semget;
@@ -373,12 +374,21 @@ impl SyscallArgument {
 
 pub fn handle_syscall(ctx: &Context, user_ctx: &mut UserContext) {
     let syscall_frame = SyscallArgument::new_from_context(user_ctx);
-    let syscall_return = arch::syscall_dispatch(
+    let syscall_return = match seccomp::check(
         syscall_frame.syscall_number,
-        syscall_frame.args,
+        &syscall_frame.args,
         ctx,
         user_ctx,
-    );
+    ) {
+        Ok(Some(return_value)) => Ok(return_value),
+        Ok(None) => arch::syscall_dispatch(
+            syscall_frame.syscall_number,
+            syscall_frame.args,
+            ctx,
+            user_ctx,
+        ),
+        Err(err) => Err(err),
+    };
 
     match syscall_return {
         Ok(return_value) => {

--- a/kernel/src/syscall/prctl.rs
+++ b/kernel/src/syscall/prctl.rs
@@ -8,6 +8,7 @@ use crate::{
     process::{
         credentials::{SecureBits, capabilities::CapSet},
         posix_thread::{ContextPthreadAdminApi, MAX_THREAD_NAME_LEN},
+        seccomp::{SECCOMP_MODE_FILTER, SECCOMP_MODE_STRICT},
         signal::sig_num::SigNum,
     },
 };
@@ -121,6 +122,30 @@ pub fn sys_prctl(
             ctx.user_space()
                 .write_val(write_addr, &(process.is_child_subreaper() as u32))?;
         }
+        PrctlCmd::PR_SET_NO_NEW_PRIVS => {
+            ctx.posix_thread.set_no_new_privs();
+        }
+        PrctlCmd::PR_GET_NO_NEW_PRIVS => {
+            return Ok(SyscallReturn::Return(ctx.posix_thread.no_new_privs() as _));
+        }
+        PrctlCmd::PR_SET_SECCOMP(mode, filter_addr) => match mode {
+            SECCOMP_MODE_STRICT => {
+                if filter_addr != 0 {
+                    return_errno_with_message!(
+                        Errno::EINVAL,
+                        "strict seccomp mode does not take a filter"
+                    );
+                }
+                ctx.posix_thread.enable_seccomp_strict()?;
+            }
+            SECCOMP_MODE_FILTER => super::seccomp::install_filter(0, filter_addr, ctx)?,
+            _ => return_errno_with_message!(Errno::EINVAL, "invalid seccomp mode"),
+        },
+        PrctlCmd::PR_GET_SECCOMP => {
+            return Ok(SyscallReturn::Return(
+                ctx.posix_thread.seccomp_mode().as_u32() as _,
+            ));
+        }
     }
 
     Ok(SyscallReturn::Return(0))
@@ -134,6 +159,8 @@ const PR_GET_KEEPCAPS: i32 = 7;
 const PR_SET_KEEPCAPS: i32 = 8;
 const PR_SET_NAME: i32 = 15;
 const PR_GET_NAME: i32 = 16;
+const PR_GET_SECCOMP: i32 = 21;
+const PR_SET_SECCOMP: i32 = 22;
 const PR_CAPBSET_READ: i32 = 23;
 const PR_CAPBSET_DROP: i32 = 24;
 const PR_GET_SECUREBITS: i32 = 27;
@@ -142,6 +169,8 @@ const PR_SET_TIMERSLACK: i32 = 29;
 const PR_GET_TIMERSLACK: i32 = 30;
 const PR_SET_CHILD_SUBREAPER: i32 = 36;
 const PR_GET_CHILD_SUBREAPER: i32 = 37;
+const PR_SET_NO_NEW_PRIVS: i32 = 38;
+const PR_GET_NO_NEW_PRIVS: i32 = 39;
 
 #[expect(non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
@@ -162,6 +191,10 @@ pub enum PrctlCmd {
     PR_GET_TIMERSLACK,
     PR_SET_CHILD_SUBREAPER(bool),
     PR_GET_CHILD_SUBREAPER(Vaddr),
+    PR_SET_NO_NEW_PRIVS,
+    PR_GET_NO_NEW_PRIVS,
+    PR_SET_SECCOMP(u32, Vaddr),
+    PR_GET_SECCOMP,
 }
 
 #[repr(u64)]
@@ -173,7 +206,15 @@ pub enum Dumpable {
 }
 
 impl PrctlCmd {
-    fn from_args(option: i32, arg2: u64, _arg3: u64, _arg4: u64, _arg5: u64) -> Result<PrctlCmd> {
+    fn from_args(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> Result<PrctlCmd> {
+        if matches!(
+            option,
+            PR_SET_NO_NEW_PRIVS | PR_GET_NO_NEW_PRIVS | PR_GET_SECCOMP
+        ) && (arg3 != 0 || arg4 != 0 || arg5 != 0)
+        {
+            return_errno_with_message!(Errno::EINVAL, "unused prctl arguments must be zero");
+        }
+
         match option {
             PR_SET_PDEATHSIG => {
                 let signum = SigNum::try_from(arg2 as u8)?;
@@ -196,6 +237,33 @@ impl PrctlCmd {
             PR_GET_TIMERSLACK => Ok(PrctlCmd::PR_GET_TIMERSLACK),
             PR_SET_CHILD_SUBREAPER => Ok(PrctlCmd::PR_SET_CHILD_SUBREAPER(arg2 > 0)),
             PR_GET_CHILD_SUBREAPER => Ok(PrctlCmd::PR_GET_CHILD_SUBREAPER(arg2 as _)),
+            PR_SET_NO_NEW_PRIVS => {
+                if arg2 != 1 {
+                    return_errno_with_message!(Errno::EINVAL, "invalid no_new_privs value");
+                }
+                Ok(PrctlCmd::PR_SET_NO_NEW_PRIVS)
+            }
+            PR_GET_NO_NEW_PRIVS => {
+                if arg2 != 0 {
+                    return_errno_with_message!(Errno::EINVAL, "unused prctl argument must be zero");
+                }
+                Ok(PrctlCmd::PR_GET_NO_NEW_PRIVS)
+            }
+            PR_SET_SECCOMP => {
+                if arg4 != 0 || arg5 != 0 {
+                    return_errno_with_message!(
+                        Errno::EINVAL,
+                        "unused prctl arguments must be zero"
+                    );
+                }
+                Ok(PrctlCmd::PR_SET_SECCOMP(arg2 as u32, arg3 as _))
+            }
+            PR_GET_SECCOMP => {
+                if arg2 != 0 {
+                    return_errno_with_message!(Errno::EINVAL, "unused prctl argument must be zero");
+                }
+                Ok(PrctlCmd::PR_GET_SECCOMP)
+            }
             _ => {
                 debug!("prctl cmd number: {}", option);
                 return_errno_with_message!(Errno::EINVAL, "unsupported prctl command");

--- a/kernel/src/syscall/seccomp.rs
+++ b/kernel/src/syscall/seccomp.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::{mm::VmIo, user::UserContextApi};
+
+use super::{SyscallReturn, arch};
+use crate::{
+    prelude::*,
+    process::{
+        TermStatus,
+        credentials::capabilities::CapSet,
+        posix_thread::{do_exit, do_exit_group},
+        seccomp::{
+            AUDIT_ARCH_NATIVE, BPF_MAXINSNS, SECCOMP_GET_ACTION_AVAIL, SECCOMP_SET_MODE_FILTER,
+            SECCOMP_SET_MODE_STRICT, SeccompAction, SeccompData, SeccompFilter, SeccompMode,
+            SockFilter, is_action_available, validate_filter_flags,
+        },
+        signal::{
+            c_types::siginfo_t,
+            constants::{SIGKILL, SIGSYS, SYS_SECCOMP},
+            signals::raw::RawSignal,
+        },
+    },
+    security::lsm::hooks as lsm_hooks,
+};
+
+const MAX_ERRNO: u16 = 4095;
+const SOCK_FPROG_FILTER_OFFSET: usize = 8;
+
+pub fn sys_seccomp(
+    operation: u32,
+    flags: u32,
+    args_addr: Vaddr,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    match operation {
+        SECCOMP_SET_MODE_STRICT => {
+            if flags != 0 || args_addr != 0 {
+                return_errno_with_message!(Errno::EINVAL, "invalid strict seccomp arguments");
+            }
+            ctx.posix_thread.enable_seccomp_strict()?;
+            Ok(SyscallReturn::Return(0))
+        }
+        SECCOMP_SET_MODE_FILTER => {
+            install_filter(flags, args_addr, ctx)?;
+            Ok(SyscallReturn::Return(0))
+        }
+        SECCOMP_GET_ACTION_AVAIL => {
+            if flags != 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "invalid seccomp action-availability arguments"
+                );
+            }
+            let action = ctx.user_space().read_val::<u32>(args_addr)?;
+            if is_action_available(action) {
+                Ok(SyscallReturn::Return(0))
+            } else {
+                return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported seccomp action");
+            }
+        }
+        _ => return_errno_with_message!(Errno::EINVAL, "unsupported seccomp operation"),
+    }
+}
+
+/// Per `seccomp(2)`, a thread may install a filter only if it has set
+/// `no_new_privs` or holds `CAP_SYS_ADMIN`; this keeps an unprivileged filter
+/// from being used to gain privileges across a later `execve`.
+fn may_install_filter(ctx: &Context) -> bool {
+    if ctx.posix_thread.no_new_privs() {
+        return true;
+    }
+
+    let user_ns = ctx.thread_local.borrow_user_ns();
+    lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+        user_ns.as_ref(),
+        ctx.posix_thread,
+        CapSet::SYS_ADMIN,
+    ))
+    .is_ok()
+}
+
+pub fn install_filter(flags: u32, fprog_addr: Vaddr, ctx: &Context) -> Result<()> {
+    validate_filter_flags(flags)?;
+    if fprog_addr == 0 {
+        return_errno_with_message!(Errno::EFAULT, "seccomp filter program pointer is NULL");
+    }
+    if !may_install_filter(ctx) {
+        return_errno_with_message!(
+            Errno::EACCES,
+            "installing a seccomp filter requires CAP_SYS_ADMIN or no_new_privs"
+        );
+    }
+
+    let len = ctx.user_space().read_val::<u16>(fprog_addr)?;
+    let filter_ptr_addr = checked_user_addr_add(fprog_addr, SOCK_FPROG_FILTER_OFFSET)?;
+    let filter_addr = ctx.user_space().read_val::<Vaddr>(filter_ptr_addr)?;
+    if len == 0 {
+        return_errno_with_message!(Errno::EINVAL, "empty seccomp filter program");
+    }
+    let len = len as usize;
+    if len > BPF_MAXINSNS {
+        return_errno_with_message!(Errno::EINVAL, "seccomp filter program is too large");
+    }
+    if filter_addr == 0 {
+        return_errno_with_message!(Errno::EFAULT, "seccomp filter pointer is NULL");
+    }
+
+    let mut program = Vec::new();
+    program.try_reserve_exact(len).map_err(|_| {
+        Error::with_message(
+            Errno::ENOMEM,
+            "cannot allocate memory for seccomp filter program",
+        )
+    })?;
+
+    let mut addr = filter_addr;
+    for idx in 0..len {
+        let insn = ctx.user_space().read_val::<SockFilter>(addr)?;
+        program.push(insn);
+        if idx + 1 != len {
+            addr = checked_user_addr_add(addr, size_of::<SockFilter>())?;
+        }
+    }
+
+    let filter = SeccompFilter::new(program.into_boxed_slice(), flags)?;
+    ctx.posix_thread.append_seccomp_filter(filter)?;
+    Ok(())
+}
+
+pub fn check(
+    syscall_number: u64,
+    args: &[u64; 6],
+    ctx: &Context,
+    user_ctx: &mut ostd::arch::cpu::context::UserContext,
+) -> Result<Option<SyscallReturn>> {
+    let mode = ctx.posix_thread.seccomp_mode();
+    match mode {
+        SeccompMode::Disabled => Ok(None),
+        SeccompMode::Strict => Ok(check_strict(syscall_number, ctx, user_ctx)),
+        SeccompMode::Filter => Ok(check_filter(syscall_number, args, ctx, user_ctx)),
+    }
+}
+
+fn check_strict(
+    syscall_number: u64,
+    ctx: &Context,
+    user_ctx: &mut ostd::arch::cpu::context::UserContext,
+) -> Option<SyscallReturn> {
+    if is_strict_allowed_syscall(syscall_number) {
+        return None;
+    }
+
+    do_exit(TermStatus::Killed(SIGKILL), ctx, user_ctx);
+    Some(SyscallReturn::NoReturn)
+}
+
+fn check_filter(
+    syscall_number: u64,
+    args: &[u64; 6],
+    ctx: &Context,
+    user_ctx: &mut ostd::arch::cpu::context::UserContext,
+) -> Option<SyscallReturn> {
+    let chain = ctx.posix_thread.seccomp_filter_chain()?;
+
+    let data = SeccompData {
+        nr: syscall_number as i32,
+        arch: AUDIT_ARCH_NATIVE,
+        instruction_pointer: user_ctx.instruction_pointer() as u64,
+        args: *args,
+    };
+
+    let evaluation = chain.evaluate_with_metadata(&data);
+    if evaluation.should_log || matches!(evaluation.action, SeccompAction::Log) {
+        log_seccomp_action(ctx, syscall_number, evaluation.action);
+    }
+
+    match evaluation.action {
+        SeccompAction::Allow => None,
+        SeccompAction::Log => None,
+        SeccompAction::Errno(errno) => Some(errno_action_return(errno)),
+        SeccompAction::Trap(errno) => {
+            let mut info = siginfo_t::new(SIGSYS, SYS_SECCOMP);
+            info.si_errno = errno as i32;
+            info.set_sigsys(
+                user_ctx.instruction_pointer(),
+                syscall_number as i32,
+                AUDIT_ARCH_NATIVE,
+            );
+            ctx.posix_thread
+                .enqueue_signal(Box::new(RawSignal::new(info)));
+            Some(SyscallReturn::NoReturn)
+        }
+        SeccompAction::Trace(_) | SeccompAction::UserNotif(_) => Some(enosys_return()),
+        SeccompAction::KillThread => {
+            do_exit(TermStatus::Killed(SIGSYS), ctx, user_ctx);
+            Some(SyscallReturn::NoReturn)
+        }
+        SeccompAction::KillProcess => {
+            do_exit_group(TermStatus::Killed(SIGSYS), ctx, user_ctx);
+            Some(SyscallReturn::NoReturn)
+        }
+    }
+}
+
+fn errno_action_return(errno: u16) -> SyscallReturn {
+    let errno = errno.min(MAX_ERRNO) as i32;
+    SyscallReturn::Return((-errno) as isize)
+}
+
+fn enosys_return() -> SyscallReturn {
+    SyscallReturn::Return(-(Errno::ENOSYS as isize))
+}
+
+fn log_seccomp_action(ctx: &Context, syscall_number: u64, action: SeccompAction) {
+    info!(
+        "seccomp log: pid={}, tid={}, syscall={}, action={:?}",
+        ctx.process.pid(),
+        ctx.posix_thread.tid(),
+        syscall_number,
+        action
+    );
+}
+
+fn checked_user_addr_add(addr: Vaddr, offset: usize) -> Result<Vaddr> {
+    addr.checked_add(offset)
+        .ok_or_else(|| Error::with_message(Errno::EFAULT, "user address overflows"))
+}
+
+fn is_strict_allowed_syscall(syscall_number: u64) -> bool {
+    matches!(
+        syscall_number,
+        arch::SYS_READ | arch::SYS_WRITE | arch::SYS_EXIT | arch::SYS_RT_SIGRETURN
+    )
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::*;
+
+    #[ktest]
+    fn seccomp() {
+        seccomp_sock_fprog_layout_matches_linux_uapi();
+        seccomp_strict_mode_uses_linux_allowlist();
+        seccomp_errno_action_is_limited_to_max_errno();
+        seccomp_sigsys_info_can_carry_seccomp_metadata();
+    }
+
+    #[ktest]
+    fn seccomp_sock_fprog_layout_matches_linux_uapi() {
+        let pointer_align = align_of::<Vaddr>();
+        let expected_offset = size_of::<u16>().div_ceil(pointer_align) * pointer_align;
+        assert_eq!(SOCK_FPROG_FILTER_OFFSET, expected_offset);
+    }
+
+    #[ktest]
+    fn seccomp_strict_mode_uses_linux_allowlist() {
+        assert!(is_strict_allowed_syscall(arch::SYS_READ));
+        assert!(is_strict_allowed_syscall(arch::SYS_WRITE));
+        assert!(is_strict_allowed_syscall(arch::SYS_EXIT));
+        assert!(is_strict_allowed_syscall(arch::SYS_RT_SIGRETURN));
+        assert!(!is_strict_allowed_syscall(arch::SYS_EXIT_GROUP));
+    }
+
+    #[ktest]
+    fn seccomp_errno_action_is_limited_to_max_errno() {
+        let SyscallReturn::Return(eperm) = errno_action_return(Errno::EPERM as u16) else {
+            panic!("errno action must return to userspace");
+        };
+        let SyscallReturn::Return(max_errno) = errno_action_return(MAX_ERRNO + 1) else {
+            panic!("errno action must return to userspace");
+        };
+
+        assert_eq!(eperm, -1);
+        assert_eq!(max_errno, -4095);
+    }
+
+    #[ktest]
+    fn seccomp_sigsys_info_can_carry_seccomp_metadata() {
+        let mut info = siginfo_t::new(SIGSYS, SYS_SECCOMP);
+        info.si_errno = Errno::EPERM as i32;
+        info.set_sigsys(0x1234, arch::SYS_GETPID as i32, AUDIT_ARCH_NATIVE);
+
+        assert_eq!(info.si_signo, SIGSYS.as_u8() as i32);
+        assert_eq!(info.si_errno, Errno::EPERM as i32);
+        assert_eq!(info.si_code, SYS_SECCOMP);
+        assert_eq!(
+            info.sigsys_fields(),
+            (0x1234, arch::SYS_GETPID as i32, AUDIT_ARCH_NATIVE)
+        );
+    }
+}

--- a/test/initramfs/src/regression/security/Makefile
+++ b/test/initramfs/src/regression/security/Makefile
@@ -4,5 +4,6 @@ SUBDIRS := \
 	capability \
 	lsm \
 	namespace \
+	seccomp \
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -15,6 +15,11 @@ set -e
 ./lsm/module_selection
 ./lsm/yama
 
+./seccomp/basic
+./seccomp/exec
+./seccomp/status
+./seccomp/whitelist
+
 ./namespace/cgroup_ns
 ./namespace/ipc_ns_sem
 ./namespace/mnt_ns

--- a/test/initramfs/src/regression/security/seccomp/Makefile
+++ b/test/initramfs/src/regression/security/seccomp/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/security/seccomp/basic.c
+++ b/test/initramfs/src/regression/security/seccomp/basic.c
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/capability.h"
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <signal.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__x86_64__)
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_X86_64
+#elif defined(__riscv) && __riscv_xlen == 64
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_RISCV64
+#elif defined(__loongarch64)
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_LOONGARCH64
+#else
+#error "unsupported seccomp test architecture"
+#endif
+
+#define SECCOMP_RET_UNKNOWN_ACTION 0x12340000U
+#define SYS_SECCOMP 1
+
+static volatile sig_atomic_t trap_received;
+
+static int seccomp_syscall(unsigned int operation, unsigned int flags,
+			   void *args)
+{
+	return syscall(SYS_seccomp, operation, flags, args);
+}
+
+static void install_syscall_action_filter(long syscall_nr, uint32_t action)
+{
+	struct sock_filter filter[] = {
+		BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+			 offsetof(struct seccomp_data, arch)),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_NATIVE, 1, 0),
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+		BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+			 offsetof(struct seccomp_data, nr)),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, syscall_nr, 0, 1),
+		BPF_STMT(BPF_RET | BPF_K, action),
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+	};
+	struct sock_fprog prog = {
+		.len = sizeof(filter) / sizeof(filter[0]),
+		.filter = filter,
+	};
+
+	CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+	CHECK(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0, &prog));
+}
+
+static void install_errno_getpid_filter(void)
+{
+	install_syscall_action_filter(SYS_getpid, SECCOMP_RET_ERRNO | EPERM);
+}
+
+static void sigsys_handler(int sig, siginfo_t *info, void *ctx)
+{
+	(void)ctx;
+
+	if (sig != SIGSYS || info->si_code != SYS_SECCOMP ||
+	    info->si_errno != EACCES || info->si_syscall != SYS_getpid ||
+	    info->si_arch != AUDIT_ARCH_NATIVE || info->si_call_addr == NULL) {
+		_exit(EXIT_FAILURE);
+	}
+
+	trap_received = 1;
+}
+
+static void wait_for_success(pid_t pid)
+{
+	int status;
+
+	CHECK_WITH(waitpid(pid, &status, 0),
+		   _ret == pid && WIFEXITED(status) &&
+			   WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+
+static void wait_for_signal(pid_t pid, int signal)
+{
+	int status;
+
+	CHECK_WITH(waitpid(pid, &status, 0),
+		   _ret == pid && WIFSIGNALED(status) &&
+			   WTERMSIG(status) == signal);
+}
+
+FN_TEST(no_new_privs_prctl_roundtrip)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK_WITH(prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0), _ret == 0);
+		CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+		CHECK_WITH(prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0), _ret == 1);
+		CHECK_WITH(prctl(PR_SET_NO_NEW_PRIVS, 0, 0, 0, 0),
+			   _ret == -1 && errno == EINVAL);
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(get_action_avail)
+{
+	uint32_t action = SECCOMP_RET_ERRNO;
+
+	TEST_SUCC(seccomp_syscall(SECCOMP_GET_ACTION_AVAIL, 0, &action));
+
+	action = SECCOMP_RET_UNKNOWN_ACTION;
+	TEST_ERRNO(seccomp_syscall(SECCOMP_GET_ACTION_AVAIL, 0, &action),
+		   EOPNOTSUPP);
+
+	action = SECCOMP_RET_ALLOW | 1;
+	TEST_ERRNO(seccomp_syscall(SECCOMP_GET_ACTION_AVAIL, 0, &action),
+		   EOPNOTSUPP);
+
+	TEST_ERRNO(seccomp_syscall(SECCOMP_GET_ACTION_AVAIL, 1, &action),
+		   EINVAL);
+	TEST_ERRNO(seccomp_syscall(SECCOMP_GET_ACTION_AVAIL, 0, NULL), EFAULT);
+}
+END_TEST()
+
+FN_TEST(strict_mode_kills_disallowed_syscall)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(prctl(PR_SET_SECCOMP, SECCOMP_MODE_STRICT, 0, 0, 0));
+		syscall(SYS_getpid);
+		syscall(SYS_exit, EXIT_FAILURE);
+		__builtin_unreachable();
+	}
+
+	wait_for_signal(pid, SIGKILL);
+}
+END_TEST()
+
+FN_TEST(filter_can_be_installed_with_prctl)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		struct sock_filter filter[] = {
+			BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+		};
+		struct sock_fprog prog = {
+			.len = sizeof(filter) / sizeof(filter[0]),
+			.filter = filter,
+		};
+
+		drop_capability(CAP_SYS_ADMIN);
+		CHECK_WITH(prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog, 0,
+				 0),
+			   _ret == -1 && errno == EACCES);
+
+		CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+		CHECK(prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog, 0, 0));
+		CHECK_WITH(prctl(PR_GET_SECCOMP, 0, 0, 0, 0),
+			   _ret == SECCOMP_MODE_FILTER);
+		CHECK_WITH(syscall(SYS_getpid), _ret > 0);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_errno_and_allow)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		char byte = 0;
+
+		install_errno_getpid_filter();
+
+		errno = 0;
+		CHECK_WITH(syscall(SYS_getpid), _ret == -1 && errno == EPERM);
+		CHECK_WITH(write(STDOUT_FILENO, &byte, 0), _ret == 0);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_log_allows_syscall)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getpid, SECCOMP_RET_LOG);
+		CHECK_WITH(syscall(SYS_getpid), _ret >= 0);
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_trap_delivers_sigsys)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getpid, SECCOMP_RET_TRAP);
+		syscall(SYS_getpid);
+		_exit(EXIT_FAILURE);
+	}
+
+	wait_for_signal(pid, SIGSYS);
+}
+END_TEST()
+
+FN_TEST(filter_trap_siginfo)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		struct sigaction sa;
+
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_sigaction = sigsys_handler;
+		sa.sa_flags = SA_SIGINFO;
+		CHECK(sigaction(SIGSYS, &sa, NULL));
+
+		install_syscall_action_filter(SYS_getpid,
+					      SECCOMP_RET_TRAP | EACCES);
+		syscall(SYS_getpid);
+		CHECK_WITH(trap_received, _ret == 1);
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_kill_process_terminates_child)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getpid,
+					      SECCOMP_RET_KILL_PROCESS);
+		syscall(SYS_getpid);
+		_exit(EXIT_FAILURE);
+	}
+
+	wait_for_signal(pid, SIGSYS);
+}
+END_TEST()
+
+FN_TEST(filter_kill_thread_terminates_child)
+{
+	pid_t pid;
+
+	// In a single-threaded process, KILL_THREAD terminates the only thread,
+	// so the process exits as if killed by SIGSYS.
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getpid,
+					      SECCOMP_RET_KILL_THREAD);
+		syscall(SYS_getpid);
+		_exit(EXIT_FAILURE);
+	}
+
+	wait_for_signal(pid, SIGSYS);
+}
+END_TEST()
+
+FN_TEST(filter_chain_applies_most_restrictive_action)
+{
+	pid_t pid;
+
+	// Most restrictive wins: an older filter that denies `getppid` with
+	// EPERM beats a newer filter that allows it.
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getppid,
+					      SECCOMP_RET_ERRNO | EPERM);
+		install_syscall_action_filter(SYS_getppid, SECCOMP_RET_ALLOW);
+
+		errno = 0;
+		CHECK_WITH(syscall(SYS_getppid), _ret == -1 && errno == EPERM);
+		_exit(EXIT_SUCCESS);
+	}
+	wait_for_success(pid);
+
+	// Equal precedence keeps the newest filter's data: a newer EACCES beats
+	// an older EPERM.
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getppid,
+					      SECCOMP_RET_ERRNO | EPERM);
+		install_syscall_action_filter(SYS_getppid,
+					      SECCOMP_RET_ERRNO | EACCES);
+
+		errno = 0;
+		CHECK_WITH(syscall(SYS_getppid), _ret == -1 && errno == EACCES);
+		_exit(EXIT_SUCCESS);
+	}
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_errno_clamps_to_max_errno)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getpid,
+					      SECCOMP_RET_ERRNO | 0xffff);
+
+		errno = 0;
+		CHECK_WITH(syscall(SYS_getpid), _ret == -1 && errno == 4095);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_trace_and_user_notif_fallback_to_enosys)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getpid, SECCOMP_RET_TRACE);
+		errno = 0;
+		CHECK_WITH(syscall(SYS_getpid), _ret == -1 && errno == ENOSYS);
+		_exit(EXIT_SUCCESS);
+	}
+	wait_for_success(pid);
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_syscall_action_filter(SYS_getpid,
+					      SECCOMP_RET_USER_NOTIF);
+		errno = 0;
+		CHECK_WITH(syscall(SYS_getpid), _ret == -1 && errno == ENOSYS);
+		_exit(EXIT_SUCCESS);
+	}
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_and_no_new_privs_are_inherited_by_fork)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		pid_t grandchild;
+
+		install_errno_getpid_filter();
+
+		grandchild = CHECK(fork());
+		if (grandchild == 0) {
+			CHECK_WITH(prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0),
+				   _ret == 1);
+			errno = 0;
+			CHECK_WITH(syscall(SYS_getpid),
+				   _ret == -1 && errno == EPERM);
+			_exit(EXIT_SUCCESS);
+		}
+
+		wait_for_success(grandchild);
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_requires_no_new_privs_or_cap_sys_admin)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		struct sock_filter filter[] = {
+			BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+		};
+		struct sock_fprog prog = {
+			.len = sizeof(filter) / sizeof(filter[0]),
+			.filter = filter,
+		};
+
+		drop_capability(CAP_SYS_ADMIN);
+
+		CHECK_WITH(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0, &prog),
+			   _ret == -1 && errno == EACCES);
+
+		CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+		CHECK(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0, &prog));
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+FN_TEST(filter_install_rejects_invalid_input)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		struct sock_filter allow[] = {
+			BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+		};
+		struct sock_fprog prog = {
+			.len = sizeof(allow) / sizeof(allow[0]),
+			.filter = allow,
+		};
+
+		// An unsupported flag is rejected before any privilege check.
+		CHECK_WITH(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0x100,
+					   &prog),
+			   _ret == -1 && errno == EINVAL);
+		// A NULL program pointer faults.
+		CHECK_WITH(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0, NULL),
+			   _ret == -1 && errno == EFAULT);
+
+		CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+
+		// An empty program is rejected.
+		struct sock_fprog empty = { .len = 0, .filter = allow };
+		CHECK_WITH(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0, &empty),
+			   _ret == -1 && errno == EINVAL);
+
+		// A load from an out-of-range seccomp_data offset is rejected by
+		// the verifier.
+		struct sock_filter bad[] = {
+			BPF_STMT(BPF_LD | BPF_W | BPF_ABS, 64),
+			BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+		};
+		struct sock_fprog bad_prog = {
+			.len = sizeof(bad) / sizeof(bad[0]),
+			.filter = bad,
+		};
+		CHECK_WITH(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0,
+					   &bad_prog),
+			   _ret == -1 && errno == EINVAL);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/seccomp/exec.c
+++ b/test/initramfs/src/regression/security/seccomp/exec.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Proves that a seccomp filter and `no_new_privs` are preserved across
+// `execve`, by installing a `getppid`-denying filter and then executing a
+// helper (`exec_child`) that checks the filter is still active. Linux keeps the
+// seccomp state attached to the thread across `execve`; see seccomp(2).
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__x86_64__)
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_X86_64
+#elif defined(__riscv) && __riscv_xlen == 64
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_RISCV64
+#elif defined(__loongarch64)
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_LOONGARCH64
+#else
+#error "unsupported seccomp test architecture"
+#endif
+
+static char child_path[4096];
+
+static void install_getppid_errno_filter(void)
+{
+	struct sock_filter filter[] = {
+		BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+			 offsetof(struct seccomp_data, arch)),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_NATIVE, 1, 0),
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+		BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+			 offsetof(struct seccomp_data, nr)),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_getppid, 0, 1),
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM),
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+	};
+	struct sock_fprog prog = {
+		.len = sizeof(filter) / sizeof(filter[0]),
+		.filter = filter,
+	};
+
+	CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+	CHECK(syscall(SYS_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog));
+}
+
+FN_SETUP(child_path)
+{
+	CHECK(readlink("/proc/self/exe", child_path, sizeof(child_path) - 10));
+	strcat(child_path, "_child");
+}
+END_SETUP()
+
+FN_TEST(filter_and_no_new_privs_survive_execve)
+{
+	pid_t pid;
+	int status;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		install_getppid_errno_filter();
+		CHECK(execl(child_path, child_path, (char *)NULL));
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/seccomp/exec_child.c
+++ b/test/initramfs/src/regression/security/seccomp/exec_child.c
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Helper executed by `exec.c` to verify that a seccomp filter and the
+// `no_new_privs` bit installed before `execve` are still in force afterwards.
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+FN_TEST(seccomp_is_inherited_across_execve)
+{
+	// `no_new_privs` survives `execve`.
+	TEST_RES(prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0), _ret == 1);
+
+	// The filter installed before `execve` still denies `getppid`.
+	TEST_ERRNO(syscall(SYS_getppid), EPERM);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/seccomp/status.c
+++ b/test/initramfs/src/regression/security/seccomp/status.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Verifies that `/proc/[pid]/status` reports the thread's seccomp state, the
+// way userspace tools (e.g. systemd, container introspection) observe it:
+//
+//   NoNewPrivs:      <0|1>
+//   Seccomp:         <0 disabled | 1 strict | 2 filter>
+//   Seccomp_filters: <number of installed filters>
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <fcntl.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stdint.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// Reads an integer-valued field such as "Seccomp" from /proc/self/status. The
+// read itself must be permitted by any installed filter, so the tests below use
+// allow-all filters.
+static long read_status_field(const char *name)
+{
+	char buf[8192];
+	int fd = CHECK(open("/proc/self/status", O_RDONLY));
+	ssize_t len = CHECK(read(fd, buf, sizeof(buf) - 1));
+	CHECK(close(fd));
+	buf[len] = '\0';
+
+	char key[64];
+	int klen = snprintf(key, sizeof(key), "\n%s:", name);
+	char *pos = strstr(buf, key);
+	if (pos == NULL) {
+		return -1;
+	}
+	pos += klen;
+	while (*pos == ' ' || *pos == '\t')
+		pos++;
+	return atol(pos);
+}
+
+static void install_allow_filter(void)
+{
+	struct sock_filter filter[] = {
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+	};
+	struct sock_fprog prog = {
+		.len = sizeof(filter) / sizeof(filter[0]),
+		.filter = filter,
+	};
+
+	CHECK(syscall(SYS_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog));
+}
+
+FN_TEST(status_reflects_seccomp_state)
+{
+	pid_t pid;
+	int status;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK_WITH(read_status_field("Seccomp"), _ret == 0);
+		CHECK_WITH(read_status_field("NoNewPrivs"), _ret == 0);
+		CHECK_WITH(read_status_field("Seccomp_filters"), _ret == 0);
+
+		CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+		CHECK_WITH(read_status_field("NoNewPrivs"), _ret == 1);
+
+		install_allow_filter();
+		CHECK_WITH(read_status_field("Seccomp"),
+			   _ret == SECCOMP_MODE_FILTER);
+		CHECK_WITH(read_status_field("Seccomp_filters"), _ret == 1);
+
+		install_allow_filter();
+		CHECK_WITH(read_status_field("Seccomp_filters"), _ret == 2);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/seccomp/whitelist.c
+++ b/test/initramfs/src/regression/security/seccomp/whitelist.c
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/*
+ * A runc/Docker-style seccomp whitelist demonstration and regression test.
+ *
+ * Container runtimes such as runc, Docker, and Podman confine workloads with a
+ * seccomp profile whose default action denies every system call and which then
+ * allow-lists the (few hundred) calls a normal program is expected to make.
+ * This program builds the same shape of classic-BPF filter that libseccomp
+ * emits for such a profile:
+ *
+ *   1. Reject calls issued from a foreign architecture, so that the syscall
+ *      numbers checked below cannot be confused with another ABI's numbering.
+ *      This mirrors the architecture guard that libseccomp prepends.
+ *   2. ALLOW every white-listed syscall number.
+ *   3. Apply the profile's default action to anything else. We demonstrate two
+ *      representative default-action styles:
+ *        - SECCOMP_RET_ERRNO with EPERM, the historical Docker default that
+ *          lets a blocked program keep running but fail the call, and
+ *        - SECCOMP_RET_KILL_PROCESS, the hard-deny action used when a sandbox
+ *          must terminate a workload that steps outside its allowance.
+ *
+ * As a regression test it proves that white-listed syscalls run normally while
+ * syscalls outside the allowance are blocked. getppid(2) is used as the blocked
+ * probe because it never fails on its own, so an EPERM (or a SIGSYS kill) can
+ * only have come from the seccomp filter; mount(2) is used as a representative
+ * "dangerous" syscall a container profile would refuse.
+ *
+ * References:
+ *   - seccomp(2); Documentation/userspace-api/seccomp_filter.rst
+ *   - Documentation/networking/filter.rst (classic BPF)
+ *   - moby/moby profiles/seccomp/default.json (Docker default profile)
+ */
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__x86_64__)
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_X86_64
+#elif defined(__riscv) && __riscv_xlen == 64
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_RISCV64
+#elif defined(__loongarch64)
+#define AUDIT_ARCH_NATIVE AUDIT_ARCH_LOONGARCH64
+#else
+#error "unsupported seccomp test architecture"
+#endif
+
+/* Generous upper bound: the filter is `arch guard (3) + load nr (1) + one JEQ
+ * per allowed syscall + default action (1) + allow (1)`. */
+#define MAX_FILTER_INSNS 64
+
+static int seccomp_syscall(unsigned int operation, unsigned int flags,
+			   void *args)
+{
+	return syscall(SYS_seccomp, operation, flags, args);
+}
+
+/*
+ * Installs a libseccomp-style whitelist filter: allow every syscall in
+ * `allowed`, and apply `default_action` to all others.
+ */
+static void install_whitelist(uint32_t default_action, const long *allowed,
+			      size_t allowed_len)
+{
+	struct sock_filter filter[MAX_FILTER_INSNS];
+	size_t pos = 0;
+
+	/* Reject foreign-architecture syscalls before trusting the number. */
+	filter[pos++] = (struct sock_filter)BPF_STMT(
+		BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, arch));
+	filter[pos++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+						     AUDIT_ARCH_NATIVE, 1, 0);
+	filter[pos++] = (struct sock_filter)BPF_STMT(BPF_RET | BPF_K,
+						     SECCOMP_RET_KILL_PROCESS);
+
+	/* Load the syscall number for the allow-list comparisons. */
+	filter[pos++] = (struct sock_filter)BPF_STMT(
+		BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr));
+
+	/*
+	 * Each comparison either jumps to the trailing ALLOW instruction or
+	 * falls through to the next comparison. The jump distance shrinks by one
+	 * per comparison, so the final comparison jumps over the default action.
+	 */
+	for (size_t i = 0; i < allowed_len; i++) {
+		uint8_t jt = (uint8_t)(allowed_len - i);
+
+		filter[pos++] = (struct sock_filter)BPF_JUMP(
+			BPF_JMP | BPF_JEQ | BPF_K, (uint32_t)allowed[i], jt, 0);
+	}
+	filter[pos++] =
+		(struct sock_filter)BPF_STMT(BPF_RET | BPF_K, default_action);
+	filter[pos++] = (struct sock_filter)BPF_STMT(BPF_RET | BPF_K,
+						     SECCOMP_RET_ALLOW);
+
+	struct sock_fprog prog = {
+		.len = (unsigned short)pos,
+		.filter = filter,
+	};
+
+	CHECK(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+	CHECK(seccomp_syscall(SECCOMP_SET_MODE_FILTER, 0, &prog));
+}
+
+static void wait_for_success(pid_t pid)
+{
+	int status;
+
+	CHECK_WITH(waitpid(pid, &status, 0),
+		   _ret == pid && WIFEXITED(status) &&
+			   WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+
+static void wait_for_signal(pid_t pid, int signal)
+{
+	int status;
+
+	CHECK_WITH(waitpid(pid, &status, 0),
+		   _ret == pid && WIFSIGNALED(status) &&
+			   WTERMSIG(status) == signal);
+}
+
+/*
+ * The Docker-style default: a blocked syscall returns EPERM and the workload
+ * keeps running. White-listed syscalls are unaffected.
+ */
+FN_TEST(runc_errno_profile_allows_whitelist_and_denies_rest)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		static const long allowed[] = {
+			SYS_read, SYS_write,	  SYS_getpid,
+			SYS_exit, SYS_exit_group, SYS_rt_sigreturn,
+		};
+
+		install_whitelist(SECCOMP_RET_ERRNO | EPERM, allowed,
+				  sizeof(allowed) / sizeof(allowed[0]));
+
+		/* A white-listed syscall still works. */
+		CHECK_WITH(syscall(SYS_getpid), _ret > 0);
+
+		/* getppid() never fails on its own: EPERM proves the filter. */
+		errno = 0;
+		CHECK_WITH(syscall(SYS_getppid), _ret == -1 && errno == EPERM);
+
+		/* A dangerous syscall a container would refuse is blocked. */
+		errno = 0;
+		CHECK_WITH(syscall(SYS_mount, NULL, NULL, NULL, 0UL, NULL),
+			   _ret == -1 && errno == EPERM);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	wait_for_success(pid);
+}
+END_TEST()
+
+/*
+ * The hard-deny profile: a blocked syscall terminates the whole process with
+ * SIGSYS, while white-listed syscalls run normally up to that point.
+ */
+FN_TEST(runc_kill_profile_terminates_on_denied_syscall)
+{
+	pid_t pid;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		static const long allowed[] = {
+			SYS_write,	SYS_getpid,	  SYS_exit,
+			SYS_exit_group, SYS_rt_sigreturn,
+		};
+
+		install_whitelist(SECCOMP_RET_KILL_PROCESS, allowed,
+				  sizeof(allowed) / sizeof(allowed[0]));
+
+		/* Allowed up to here. */
+		syscall(SYS_getpid);
+		/* Not white-listed: the process must be killed with SIGSYS. */
+		syscall(SYS_getppid);
+
+		_exit(EXIT_FAILURE);
+	}
+
+	wait_for_signal(pid, SIGSYS);
+}
+END_TEST()


### PR DESCRIPTION
## Summary

Add secure computing (seccomp) support so a thread can irreversibly restrict the system calls it may issue, the primitive that sandboxes and container runtimes (runc, Docker, Podman via libseccomp) build on. Both Linux modes are implemented: strict mode and classic-BPF filter mode. State lives in a new `SeccompState` on the POSIX thread, is entered through both `seccomp(2)` and `prctl(2)`, is inherited across `clone`/`fork`, and is preserved across `execve`. See [`seccomp(2)`](https://man7.org/linux/man-pages/man2/seccomp.2.html) and [`prctl(2)`](https://man7.org/linux/man-pages/man2/prctl.2.html).

The dispatch hook is added in `handle_syscall` (`kernel/src/syscall/mod.rs`): before `arch::syscall_dispatch`, `seccomp::check` inspects the thread's mode and may short-circuit the call.

## Modes

### Strict (`SECCOMP_SET_MODE_STRICT`)

A strict thread may only call `read`, `write`, `_exit`, and `rt_sigreturn` (`is_strict_allowed_syscall`); any other syscall terminates the thread with `SIGKILL` via `do_exit(TermStatus::Killed(SIGKILL))`. Note `exit_group` is deliberately not on the allowlist, matching Linux. Enabling is a one-way `compare_exchange` from `Disabled` to `Strict`; re-enabling or attempting to add a filter afterward returns `EINVAL`.

### Filter (`SECCOMP_SET_MODE_FILTER`)

Each install builds a `SeccompData { nr, arch, instruction_pointer, args[6] }` descriptor and evaluates the thread's filter chain against it. Actions supported: `SECCOMP_RET_ALLOW`, `SECCOMP_RET_LOG`, `SECCOMP_RET_ERRNO(data)`, `SECCOMP_RET_TRAP(data)`, `SECCOMP_RET_KILL_THREAD`, and `SECCOMP_RET_KILL_PROCESS`. `ERRNO` returns `-min(data, 4095)`; `KILL_THREAD` and `KILL_PROCESS` exit with `SIGSYS` (the latter via `do_exit_group`). `TRACE`/`USER_NOTIF` are accepted by the validator but currently degrade to `-ENOSYS` (no ptrace/notify-fd backend yet).

## Filter chain and evaluation

A chain is an append-only, singly linked `SeccompFilterChain` held behind an `Arc`, newest-first. Installing a filter prepends a node; a node is never mutated after creation. `evaluate_with_metadata` runs *every* filter in the chain and selects the numerically smallest (most restrictive) action via `SeccompAction::precedence` — `KillProcess < KillThread < Trap < Errno < UserNotif < Trace < Log < Allow` — mirroring `seccomp_run_filters`. On equal precedence the newest filter's data wins, so the walk does not replace on ties. Because the chain is immutable and shared through `Arc`, a forked child inherits its parent's filters for free: `SeccompState::fork_from` clones the head `Arc` (verified by `Arc::ptr_eq` in the ktests). Cumulative program length is bounded at `MAX_INSNS_PER_PATH` (32768) plus a 4-instruction `SECCOMP_FILTER_PENALTY` per installed filter, returning `ENOMEM` past the limit, so an unprivileged thread cannot stack filters to make every syscall arbitrarily expensive.

## Classic BPF

`kernel/src/process/seccomp/bpf.rs` contains a self-contained cBPF interpreter (`run_filter`) and a validator (`validate_filter`) run at install time. The validator rejects empty programs and anything over `BPF_MAXINSNS` (4096), permits only the read-only opcode subset (`LD/LDX/ST/STX`, ALU imm/x, cond/`JA` jumps, `RET`, `TAX`/`TXA`), keeps every jump target, scratch slot, and `seccomp_data` load offset in range, and requires a trailing `BPF_RET`. `check_load_and_stores` propagates a per-instruction initialized-slot mask across the forward-only jumps and rejects a load from a possibly-uninitialized scratch slot, mirroring the kernel. Validating statically lets `run_filter` stay branch-light and fail closed (`SECCOMP_RET_KILL_PROCESS`) on any state a validated program cannot reach, including division/modulo by zero.

## Fast path

`SeccompState::mode` is an `AtomicU32` read with `Ordering::Relaxed`. A thread that never touched seccomp pays exactly one relaxed atomic load per syscall, returns `SeccompMode::Disabled`, and takes no locks. Only a filter-mode thread acquires the chain `RwLock` long enough to clone the head `Arc`, then evaluates outside the lock.

## Syscall and prctl surface

| Interface | Operation | Behavior |
|---|---|---|
| `seccomp(2)` (x86-64 nr 317, generic nr 277) | `SECCOMP_SET_MODE_STRICT` | enter strict; `flags`/`args` must be 0 |
| | `SECCOMP_SET_MODE_FILTER` | install a `sock_fprog` filter |
| | `SECCOMP_GET_ACTION_AVAIL` | probe an action, `EOPNOTSUPP` if unknown |
| `prctl(2)` | `PR_SET_SECCOMP` (22) | mode 1 strict / mode 2 filter |
| | `PR_GET_SECCOMP` (21) | return current mode |
| | `PR_SET_NO_NEW_PRIVS` (38) | require `arg2 == 1` |
| | `PR_GET_NO_NEW_PRIVS` (39) | return the flag |

Filter flags `SECCOMP_FILTER_FLAG_LOG` and `SECCOMP_FILTER_FLAG_SPEC_ALLOW` are accepted; unknown flags are `EINVAL`. Installing a filter requires either `no_new_privs` or `CAP_SYS_ADMIN` (checked through the LSM `on_capable` hook), else `EACCES`.

## Signals

A `TRAP` action fills `siginfo_t` for `SIGSYS` with `si_code = SYS_SECCOMP`, `si_errno` from the filter data, and the `si_call_addr`/`si_syscall`/`si_arch` fields via the new `set_sigsys` on `siginfo_sigsys_t`, then enqueues the signal on the offending thread.

## procfs

`/proc/[pid]/status` now emits `Seccomp:` (0/1/2) and `Seccomp_filters:` (chain length), alongside the existing `NoNewPrivs:`, matching the fields systemd and container introspection tools read.

## no_new_privs

`no_new_privs` is a field of `SeccompState` (Linux keeps the two coupled). It is required before installing a filter, cannot be cleared once set, and is preserved across `execve`: `apply_caps_from_exec` threads `no_new_privs` into `set_uid_from_elf`/`set_gid_from_elf` so a set-uid/set-gid binary does not gain privileges when `no_new_privs` is active.

## Testing

Regression tests under `test/initramfs/src/regression/security/seccomp/`:

- `basic.c` — strict-mode kill, and filter actions ALLOW/ERRNO/TRAP/KILL including the `SIGSYS` payload.
- `whitelist.c` — a runc/Docker-shaped default-deny allowlist filter with the foreign-architecture guard.
- `exec.c` / `exec_child.c` — a `getppid`-denying filter and `no_new_privs` survive `execve`.
- `status.c` — `/proc/[pid]/status` reports `NoNewPrivs`, `Seccomp`, and `Seccomp_filters`.

In-kernel `#[ktest]`s cover precedence selection, newest-data-on-tie, one-way mode transitions, fork sharing, the instruction-count bound, the `sock_fprog` layout offset, and the errno clamp.
