### PR TITLE
 Add `O_DIRECT` support for virtiofs regular-file I/O

### DIFF
--- a/kernel/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/dir.rs
@@ -57,6 +57,9 @@ impl FileOps for VirtioFsDir {
     }
 
     fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        // FIXME: `readdir_at` should pass current status flags to the
+        // server, while `FileOps` interface currently does not expose them,
+        // so `FUSE_READDIR` uses the flags captured at open time.
         self.inode.readdir(
             self.open_handle.fh(),
             offset,

--- a/kernel/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/file.rs
@@ -88,14 +88,16 @@ impl FileOps for VirtioFsFile {
         &self,
         offset: usize,
         writer: &mut VmWriter,
-        _status_flags: StatusFlags,
+        status_flags: StatusFlags,
     ) -> Result<usize> {
         let fh = self.open_handle.fh();
-        let file_flags = self.open_handle.file_flags();
+        let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();
 
-        match self.cache_policy {
-            CachePolicy::Cached => self.inode.cached_read_at(offset, writer, fh, file_flags),
-            CachePolicy::Direct => self.inode.direct_read_at(offset, writer, fh, file_flags),
+        if self.cache_policy == CachePolicy::Cached && !status_flags.contains(StatusFlags::O_DIRECT)
+        {
+            self.inode.cached_read_at(offset, writer, fh, file_flags)
+        } else {
+            self.inode.direct_read_at(offset, writer, fh, file_flags)
         }
     }
 
@@ -105,8 +107,11 @@ impl FileOps for VirtioFsFile {
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize> {
+        let fh = self.open_handle.fh();
+        let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();
+
         let write_offset = if status_flags.contains(StatusFlags::O_APPEND) {
-            self.inode.revalidate_attr(self.open_handle.fh())?;
+            self.inode.revalidate_attr(fh)?;
             WriteOffset::Append
         } else {
             WriteOffset::Absolute(offset)
@@ -117,21 +122,14 @@ impl FileOps for VirtioFsFile {
         // bytes that precede the user write. Keep append writes on the direct
         // path until writeback can issue precise positional ranges without
         // append semantics.
-        if self.cache_policy == CachePolicy::Cached && !status_flags.contains(StatusFlags::O_APPEND)
+        if self.cache_policy == CachePolicy::Cached
+            && !status_flags.intersects(StatusFlags::O_APPEND | StatusFlags::O_DIRECT)
         {
-            self.inode.cached_write_at(
-                write_offset,
-                reader,
-                self.open_handle.fh(),
-                self.open_handle.file_flags(),
-            )
+            self.inode
+                .cached_write_at(write_offset, reader, fh, file_flags)
         } else {
-            self.inode.direct_write_at(
-                write_offset,
-                reader,
-                self.open_handle.fh(),
-                self.open_handle.file_flags(),
-            )
+            self.inode
+                .direct_write_at(write_offset, reader, fh, file_flags)
         }
     }
 }

--- a/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -532,7 +532,7 @@ impl FileOps for VirtioFsInode {
         &self,
         offset: usize,
         writer: &mut VmWriter,
-        _status_flags: StatusFlags,
+        status_flags: StatusFlags,
     ) -> Result<usize> {
         if self.type_ != InodeType::File {
             return_errno_with_message!(
@@ -545,7 +545,8 @@ impl FileOps for VirtioFsInode {
         // normal file-open path. Open a transient handle so FUSE I/O still has
         // a server-provided file handle when this inode has no cached open.
         let handle = self.open_transient_handle(AccessMode::O_RDONLY)?;
-        self.direct_read_at(offset, writer, handle.fh(), handle.file_flags())
+        let file_flags = AccessMode::O_RDONLY as u32 | status_flags.bits();
+        self.direct_read_at(offset, writer, handle.fh(), file_flags)
     }
 
     fn write_at(
@@ -589,6 +590,9 @@ impl FileOps for VirtioFsInode {
 
         // FIXME: `readdir_at` exposes the delta-based interface, while
         // FUSE readdir offsets are opaque continuation cookies.
+        // FIXME: `readdir_at` should pass current status flags to the
+        // filesystem backend. The `FileOps` interface currently does not
+        // expose them, so `FUSE_READDIR` uses the transient handle flags.
         self.readdir(dir_handle.fh(), offset, dir_handle.file_flags(), visitor)
     }
 }

--- a/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -351,6 +351,7 @@ impl VirtioFsInode {
             OpenOperation::new(OpenReq::new((access_mode as u32) | status_flags.bits())),
         )?;
         let cache_policy = if self.inner.read().page_cache().is_some()
+            && !status_flags.contains(StatusFlags::O_DIRECT)
             && !open_out
                 .open_flags()
                 .contains(FuseOpenFlags::FOPEN_DIRECT_IO)

--- a/kernel/src/fs/fs_impls/virtiofs/inode/page_cache.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/page_cache.rs
@@ -28,6 +28,10 @@ impl PageCacheBackend for VirtioFsInode {
         let session = self.fs_ref().session().clone();
         let cache_page = locked_page.deref().clone();
         let data_buf = FuseReplyBuf::new_map(Segment::from(cache_page.clone()).into())?;
+        // FIXME: Page-cache I/O should use the current `InodeHandle` status
+        // flags instead of the flags captured in the cached FUSE handle. The
+        // page-cache backend currently receives only the inode, so it cannot
+        // observe per-open status flag changes.
         let read_req = ReadReq::new(
             handle.fh(),
             page_offset(idx)? as u64,
@@ -111,6 +115,10 @@ impl PageCacheBackend for VirtioFsInode {
         let nodeid = self.nodeid();
         let session = fs.session().clone();
         let complete_page = page.clone();
+        // FIXME: Page-cache I/O should use the current `InodeHandle` status
+        // flags instead of the flags captured in the cached FUSE handle. The
+        // page-cache backend currently receives only the inode, so it cannot
+        // observe per-open status flag changes.
         let write_req = WriteReq::new(
             handle.fh(),
             page_start as u64,

--- a/kernel/src/fs/fs_impls/virtiofs/open_handle.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/open_handle.rs
@@ -71,6 +71,9 @@ impl Drop for VirtioFsOpenHandle {
         let fs = self.fs.clone();
         let nodeid = self.nodeid;
         let fh = self.fh;
+        // FIXME: `FUSE_RELEASE` should use the current status flags from the
+        // owning file description. `VirtioFsOpenHandle` can outlive that
+        // context, so release currently uses the flags captured at open time.
         let file_flags = self.file_flags();
         let release_options = self.release_options;
 

--- a/kernel/src/fs/fs_impls/virtiofs/open_handle.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/open_handle.rs
@@ -55,6 +55,11 @@ impl VirtioFsOpenHandle {
         self.access_mode as u32 | self.status_flags.bits()
     }
 
+    /// Returns the access mode.
+    pub(super) fn access_mode(&self) -> AccessMode {
+        self.access_mode
+    }
+
     /// Returns the `FUSE_OPEN` reply flags.
     pub(super) fn open_flags(&self) -> FuseOpenFlags {
         self.open_flags


### PR DESCRIPTION
## Summary

This change makes virtiofs respect `O_DIRECT` both at open time and during read/write operations. Files opened with `O_DIRECT` use the direct I/O path instead of the page cache, and later read/write requests also bypass cached I/O when the current status flags contain
`O_DIRECT`.

The implementation also passes the current status flags to FUSE read/write requests by combining them with the original access mode, so direct I/O behavior stays aligned with the active file status flags.

## Changes

- Select `CachePolicy::Direct` for virtiofs files opened with `O_DIRECT`.
- Route reads and writes through direct FUSE I/O when `O_DIRECT` is set.
- Add an accessor for the immutable access mode so per-operation file flags can be rebuilt with current status flags.