### PR TITLE
Implement PR_CAP_AMBIENT support

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
@@ -20,7 +20,6 @@ Partially-supported operations:
 * `PR_GET_DUMPABLE` and `PR_SET_DUMPABLE` because coredump is not supported
 
 Unsupported operations:
-* `PR_CAP_AMBIENT`, `PR_CAPBSET_READ` and `PR_CAPBSET_DROP`
 * `PR_GET_ENDIAN` and `PR_SET_ENDIAN`
 * `PR_GET_FP_MODE` and `PR_SET_FP_MODE`
 * `PR_GET_FPEMU` and `PR_SET_FPEMU`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/prctl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/prctl.scml
@@ -10,6 +10,20 @@ prctl(op = PR_GET_KEEPCAPS);
 // Configure permitted capabilities retention after `UID` changes
 prctl(op = PR_SET_KEEPCAPS, state);
 
+// Query whether a capability is in the bounding set
+prctl(op = PR_CAPBSET_READ, capability);
+
+// Drop a capability from the bounding set
+prctl(op = PR_CAPBSET_DROP, capability);
+
+// Query or change the ambient capability set
+prctl(
+    op = PR_CAP_AMBIENT,
+    subcmd = PR_CAP_AMBIENT_IS_SET | PR_CAP_AMBIENT_RAISE |
+             PR_CAP_AMBIENT_LOWER | PR_CAP_AMBIENT_CLEAR_ALL,
+    capability
+);
+
 // Retrieve or set "child subreaper" attribute
 prctl(op = PR_GET_CHILD_SUBREAPER | PR_SET_CHILD_SUBREAPER, isset);
 

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -10,10 +10,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::{
-        credentials::AMBIENT_CAPSET,
-        posix_thread::{AsPosixThread, SleepingState},
-    },
+    process::posix_thread::{AsPosixThread, SleepingState},
     thread::Thread,
     vm::vmar::RssType,
 };
@@ -191,7 +188,11 @@ impl ProcFileOps for StatusFileOps {
             "CapBnd:\t{:016x}",
             credentials.bounding_capset().bits()
         )?;
-        writeln!(printer, "CapAmb:\t{:016x}", AMBIENT_CAPSET.bits())?;
+        writeln!(
+            printer,
+            "CapAmb:\t{:016x}",
+            credentials.ambient_capset().bits()
+        )?;
 
         Ok(printer.bytes_written())
     }

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -9,10 +9,7 @@ use super::{
 };
 use crate::{
     prelude::*,
-    process::credentials::{
-        AMBIENT_CAPSET,
-        capabilities::{AtomicCapSet, CapSet},
-    },
+    process::credentials::capabilities::{AtomicCapSet, CapSet},
 };
 
 #[derive(Debug)]
@@ -72,6 +69,9 @@ pub(super) struct Credentials_ {
     /// Capabilities that limit privileges granted during `execve()` and may be added to the
     /// inheritable set.
     bounding_capset: AtomicCapSet,
+    /// Capabilities that are preserved across non-privileged `execve()` and automatically added to
+    /// the permitted and effective sets for the new program.
+    ambient_capset: AtomicCapSet,
 
     /// Secure bits.
     securebits: AtomicSecureBits,
@@ -99,6 +99,7 @@ impl Credentials_ {
             permitted_capset: AtomicCapSet::new(capset),
             effective_capset: AtomicCapSet::new(capset),
             bounding_capset: AtomicCapSet::new(CapSet::all()),
+            ambient_capset: AtomicCapSet::new(CapSet::empty()),
             securebits: AtomicSecureBits::new(SecureBits::new_empty()),
         }
     }
@@ -208,8 +209,9 @@ impl Credentials_ {
 
         let new_permitted = (self.inheritable_capset() & file_inheritable)
             | (file_permitted & self.bounding_capset())
-            | AMBIENT_CAPSET;
-        let new_effective = (file_effective & new_permitted) | (!file_effective & AMBIENT_CAPSET);
+            | self.ambient_capset();
+        let new_effective =
+            (file_effective & new_permitted) | (!file_effective & self.ambient_capset());
 
         self.set_permitted_capset(new_permitted);
         self.set_effective_capset(new_effective);
@@ -305,11 +307,12 @@ impl Credentials_ {
 
         let had_root = old_ruid.is_root() || old_euid.is_root() || old_suid.is_root();
         let all_nonroot = !new_ruid.is_root() && !new_euid.is_root() && !new_suid.is_root();
-        if had_root && all_nonroot && !self.keep_capabilities() {
-            self.set_permitted_capset(CapSet::empty());
-            self.set_inheritable_capset(CapSet::empty());
-            // TODO: Clear ambient capabilities when we support it. Note that ambient capabilities
-            // should be cleared even if `keep_capabilities` is true.
+        if had_root && all_nonroot {
+            self.clear_ambient_capset();
+            if !self.keep_capabilities() {
+                self.set_permitted_capset(CapSet::empty());
+                self.set_inheritable_capset(CapSet::empty());
+            }
         }
 
         if old_euid.is_root() && !new_euid.is_root() {
@@ -528,16 +531,59 @@ impl Credentials_ {
     pub(super) fn set_inheritable_capset(&self, inheritable_capset: CapSet) {
         self.inheritable_capset
             .store(inheritable_capset, Ordering::Relaxed);
+        self.ambient_capset.store(
+            self.ambient_capset() & inheritable_capset,
+            Ordering::Relaxed,
+        );
     }
 
     pub(super) fn set_permitted_capset(&self, permitted_capset: CapSet) {
         self.permitted_capset
             .store(permitted_capset, Ordering::Relaxed);
+        self.ambient_capset
+            .store(self.ambient_capset() & permitted_capset, Ordering::Relaxed);
     }
 
     pub(super) fn set_effective_capset(&self, effective_capset: CapSet) {
         self.effective_capset
             .store(effective_capset, Ordering::Relaxed);
+    }
+
+    pub(super) fn ambient_capset(&self) -> CapSet {
+        self.ambient_capset.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn raise_ambient_capability(&self, capability: CapSet) -> Result<()> {
+        if self.securebits().no_cap_ambient_raise() {
+            return_errno_with_message!(
+                Errno::EPERM,
+                "raising ambient capabilities is forbidden by securebits"
+            );
+        }
+
+        if !self.permitted_capset().contains(capability)
+            || !self.inheritable_capset().contains(capability)
+        {
+            return_errno_with_message!(
+                Errno::EPERM,
+                "capability must be present in both permitted and inheritable sets"
+            );
+        }
+
+        self.ambient_capset
+            .store(self.ambient_capset() | capability, Ordering::Relaxed);
+
+        Ok(())
+    }
+
+    pub(super) fn lower_ambient_capability(&self, capability: CapSet) {
+        self.ambient_capset
+            .store(self.ambient_capset() - capability, Ordering::Relaxed);
+    }
+
+    pub(super) fn clear_ambient_capset(&self) {
+        self.ambient_capset
+            .store(CapSet::empty(), Ordering::Relaxed);
     }
 
     fn set_bounding_capset(&self, bounding_capset: CapSet) {
@@ -607,6 +653,7 @@ impl Clone for Credentials_ {
             permitted_capset: self.permitted_capset.clone(),
             effective_capset: self.effective_capset.clone(),
             bounding_capset: self.bounding_capset.clone(),
+            ambient_capset: self.ambient_capset.clone(),
             securebits: self.securebits.clone(),
         }
     }

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -308,10 +308,11 @@ impl Credentials_ {
         let had_root = old_ruid.is_root() || old_euid.is_root() || old_suid.is_root();
         let all_nonroot = !new_ruid.is_root() && !new_euid.is_root() && !new_suid.is_root();
         if had_root && all_nonroot {
-            self.clear_ambient_capset();
             if !self.keep_capabilities() {
                 self.set_permitted_capset(CapSet::empty());
-                self.set_inheritable_capset(CapSet::empty());
+                self.set_effective_capset(CapSet::empty());
+            } else {
+                self.clear_ambient_capset();
             }
         }
 

--- a/kernel/src/process/credentials/mod.rs
+++ b/kernel/src/process/credentials/mod.rs
@@ -9,7 +9,6 @@ mod static_cap;
 mod user;
 
 use aster_rights::FullOp;
-use capabilities::CapSet;
 use credentials_::Credentials_;
 pub use group::Gid;
 pub use secure_bits::SecureBits;
@@ -28,6 +27,3 @@ use crate::prelude::*;
 /// - Linux capabilities;
 /// - secure bits.
 pub struct Credentials<R = FullOp>(Arc<Credentials_>, R);
-
-// TODO: Support the ambient capability set.
-pub const AMBIENT_CAPSET: CapSet = CapSet::empty();

--- a/kernel/src/process/credentials/secure_bits.rs
+++ b/kernel/src/process/credentials/secure_bits.rs
@@ -67,9 +67,6 @@ impl SecureBits {
         self.contains(SecureBits::NO_SETUID_FIXUP)
     }
 
-    // Currently, ambient capabilities and the PR_CAP_AMBIENT_RAISE operation are not supported.
-    // Therefore, this flag is not used.
-    #[expect(dead_code)]
     pub(super) fn no_cap_ambient_raise(&self) -> bool {
         self.contains(SecureBits::NO_CAP_AMBIENT_RAISE)
     }
@@ -80,7 +77,7 @@ impl TryFrom<u16> for SecureBits {
 
     fn try_from(value: u16) -> Result<Self> {
         if value & !SecureBits::ALL_VALID_BITS != 0 {
-            return_errno_with_message!(Errno::EINVAL, "the bits are not valid secure bits");
+            return_errno_with_message!(Errno::EPERM, "the bits are not valid secure bits");
         }
 
         Ok(SecureBits { bits: value })

--- a/kernel/src/process/credentials/static_cap.rs
+++ b/kernel/src/process/credentials/static_cap.rs
@@ -323,6 +323,38 @@ impl<R: TRights> Credentials<R> {
         self.0.set_effective_capset(effective_capset);
     }
 
+    /// Gets the ambient capability set.
+    ///
+    /// This method requires the `Read` right.
+    #[require(R > Read)]
+    pub fn ambient_capset(&self) -> CapSet {
+        self.0.ambient_capset()
+    }
+
+    /// Raises a capability in the ambient capability set.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn raise_ambient_capability(&self, capability: CapSet) -> Result<()> {
+        self.0.raise_ambient_capability(capability)
+    }
+
+    /// Lowers a capability in the ambient capability set.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn lower_ambient_capability(&self, capability: CapSet) {
+        self.0.lower_ambient_capability(capability);
+    }
+
+    /// Clears the ambient capability set.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn clear_ambient_capset(&self) {
+        self.0.clear_ambient_capset();
+    }
+
     /// Drops one capability from the capability bounding set.
     ///
     /// If the caller does not have the `CAP_SETPCAP` capability, this method returns an error.

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -15,7 +15,7 @@ use crate::{
     fs::vfs::{inode::Inode, path::Path},
     prelude::*,
     process::{
-        ContextUnshareAdminApi, Credentials, Process, pid_table,
+        ContextUnshareAdminApi, Credentials, Gid, Process, Uid, pid_table,
         posix_thread::{
             AsPosixThread, ContextPthreadAdminApi, ThreadLocal, ThreadName, ptrace::PtraceEvent,
             sigkill_other_threads,
@@ -311,53 +311,58 @@ fn apply_caps_from_exec(
     credentials: Credentials<ReadWriteOp>,
     elf_inode: &Arc<dyn Inode>,
 ) -> Result<()> {
-    set_uid_from_elf(process, &credentials, elf_inode)?;
-    set_gid_from_elf(process, &credentials, elf_inode)?;
+    let mode = elf_inode.mode()?;
+    let set_uid = if mode.has_set_uid() {
+        Some(elf_inode.owner()?)
+    } else {
+        None
+    };
+    let set_gid = if mode.has_set_gid() {
+        Some(elf_inode.group()?)
+    } else {
+        None
+    };
+
+    // Clear the ambient capability set when executing a privileged file.
+    // Currently, only setuid/setgid files are considered privileged.
+    // TODO: Also clear ambient capabilities when executing files with file capabilities
+    // (security.capability xattr) once file capabilities are supported.
+    if set_uid.is_some() || set_gid.is_some() {
+        credentials.clear_ambient_capset();
+    }
+    apply_set_uid(process, &credentials, set_uid);
+    apply_set_gid(process, &credentials, set_gid);
     credentials.set_keep_capabilities(false)?;
 
     Ok(())
 }
 
-/// Sets the UID in the credentials according to the ELF inode.
+/// Applies the set-user-ID effect to the credentials.
 ///
-/// If the ELF inode has the `set_uid` bit, the effective UID is set to the same value as the ELF
-/// inode's UID.
-fn set_uid_from_elf(
-    current: &Process,
-    credentials: &Credentials<ReadWriteOp>,
-    elf_inode: &Arc<dyn Inode>,
-) -> Result<()> {
-    if elf_inode.mode()?.has_set_uid() {
-        let uid = elf_inode.owner()?;
-        credentials.set_euid(uid);
+/// If `set_uid` is `Some`, the effective UID is set to the given UID.
+fn apply_set_uid(current: &Process, credentials: &Credentials<ReadWriteOp>, set_uid: Option<Uid>) {
+    if let Some(owner) = set_uid {
+        credentials.set_euid(owner);
 
         current.clear_parent_death_signal();
     }
 
-    // No matter whether the ELF inode has `set_uid` bit, SUID should be reset.
+    // No matter whether the file has the set-user-ID bit, SUID should be reset.
     credentials.reset_suid();
-    Ok(())
 }
 
-/// Sets the GID in the credentials according to the ELF inode.
+/// Applies the set-group-ID effect to the credentials.
 ///
-/// If the ELF inode has the `set_gid` bit, the effective GID is set to the same value as the ELF
-/// inode's GID.
-fn set_gid_from_elf(
-    current: &Process,
-    credentials: &Credentials<ReadWriteOp>,
-    elf_inode: &Arc<dyn Inode>,
-) -> Result<()> {
-    if elf_inode.mode()?.has_set_gid() {
-        let gid = elf_inode.group()?;
-        credentials.set_egid(gid);
+/// If `set_gid` is `Some`, the effective GID is set to the given GID.
+fn apply_set_gid(current: &Process, credentials: &Credentials<ReadWriteOp>, set_gid: Option<Gid>) {
+    if let Some(group) = set_gid {
+        credentials.set_egid(group);
 
         current.clear_parent_death_signal();
     }
 
-    // No matter whether the ELF inode has `set_gid` bit, SGID should be reset.
+    // No matter whether the file has the set-group-ID bit, SGID should be reset.
     credentials.reset_sgid();
-    Ok(())
 }
 
 fn reset_vfork_child(process: &Process) {

--- a/kernel/src/syscall/prctl.rs
+++ b/kernel/src/syscall/prctl.rs
@@ -121,6 +121,25 @@ pub fn sys_prctl(
             ctx.user_space()
                 .write_val(write_addr, &(process.is_child_subreaper() as u32))?;
         }
+        PrctlCmd::PR_CAP_AMBIENT(cmd) => match cmd {
+            CapAmbientCmd::IsSet(capability) => {
+                let credentials = ctx.posix_thread.credentials();
+                let is_set = credentials.ambient_capset().contains(capability);
+                return Ok(SyscallReturn::Return(if is_set { 1 } else { 0 }));
+            }
+            CapAmbientCmd::Raise(capability) => {
+                let credentials = ctx.credentials_mut();
+                credentials.raise_ambient_capability(capability)?;
+            }
+            CapAmbientCmd::Lower(capability) => {
+                let credentials = ctx.credentials_mut();
+                credentials.lower_ambient_capability(capability);
+            }
+            CapAmbientCmd::ClearAll => {
+                let credentials = ctx.credentials_mut();
+                credentials.clear_ambient_capset();
+            }
+        },
     }
 
     Ok(SyscallReturn::Return(0))
@@ -142,10 +161,11 @@ const PR_SET_TIMERSLACK: i32 = 29;
 const PR_GET_TIMERSLACK: i32 = 30;
 const PR_SET_CHILD_SUBREAPER: i32 = 36;
 const PR_GET_CHILD_SUBREAPER: i32 = 37;
+const PR_CAP_AMBIENT: i32 = 47;
 
 #[expect(non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
-pub enum PrctlCmd {
+enum PrctlCmd {
     PR_SET_PDEATHSIG(SigNum),
     PR_GET_PDEATHSIG(Vaddr),
     PR_GET_DUMPABLE,
@@ -162,18 +182,32 @@ pub enum PrctlCmd {
     PR_GET_TIMERSLACK,
     PR_SET_CHILD_SUBREAPER(bool),
     PR_GET_CHILD_SUBREAPER(Vaddr),
+    PR_CAP_AMBIENT(CapAmbientCmd),
+}
+
+const PR_CAP_AMBIENT_IS_SET: u64 = 1;
+const PR_CAP_AMBIENT_RAISE: u64 = 2;
+const PR_CAP_AMBIENT_LOWER: u64 = 3;
+const PR_CAP_AMBIENT_CLEAR_ALL: u64 = 4;
+
+#[derive(Clone, Copy, Debug)]
+enum CapAmbientCmd {
+    IsSet(CapSet),
+    Raise(CapSet),
+    Lower(CapSet),
+    ClearAll,
 }
 
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
-pub enum Dumpable {
+enum Dumpable {
     Disable = 0, /* No setuid dumping */
     User = 1,    /* Dump as user of process */
     Root = 2,    /* Dump as root */
 }
 
 impl PrctlCmd {
-    fn from_args(option: i32, arg2: u64, _arg3: u64, _arg4: u64, _arg5: u64) -> Result<PrctlCmd> {
+    fn from_args(option: i32, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> Result<PrctlCmd> {
         match option {
             PR_SET_PDEATHSIG => {
                 let signum = SigNum::try_from(arg2 as u8)?;
@@ -189,17 +223,49 @@ impl PrctlCmd {
             PR_CAPBSET_READ => Ok(PrctlCmd::PR_CAPBSET_READ(parse_capability(arg2)?)),
             PR_CAPBSET_DROP => Ok(PrctlCmd::PR_CAPBSET_DROP(parse_capability(arg2)?)),
             PR_GET_SECUREBITS => Ok(PrctlCmd::PR_GET_SECUREBITS),
-            PR_SET_SECUREBITS => Ok(PrctlCmd::PR_SET_SECUREBITS(SecureBits::try_from(
-                arg2 as u16,
-            )?)),
+            PR_SET_SECUREBITS => {
+                let securebits = u16::try_from(arg2).map_err(|_| {
+                    Error::with_message(Errno::EPERM, "the bits are not valid secure bits")
+                })?;
+                Ok(PrctlCmd::PR_SET_SECUREBITS(SecureBits::try_from(
+                    securebits,
+                )?))
+            }
             PR_SET_TIMERSLACK => Ok(PrctlCmd::PR_SET_TIMERSLACK(arg2)),
             PR_GET_TIMERSLACK => Ok(PrctlCmd::PR_GET_TIMERSLACK),
             PR_SET_CHILD_SUBREAPER => Ok(PrctlCmd::PR_SET_CHILD_SUBREAPER(arg2 > 0)),
             PR_GET_CHILD_SUBREAPER => Ok(PrctlCmd::PR_GET_CHILD_SUBREAPER(arg2 as _)),
+            PR_CAP_AMBIENT => Ok(PrctlCmd::PR_CAP_AMBIENT(CapAmbientCmd::from_args(
+                arg2, arg3, arg4, arg5,
+            )?)),
             _ => {
                 debug!("prctl cmd number: {}", option);
                 return_errno_with_message!(Errno::EINVAL, "unsupported prctl command");
             }
+        }
+    }
+}
+
+impl CapAmbientCmd {
+    fn from_args(operation: u64, capability: u64, arg4: u64, arg5: u64) -> Result<Self> {
+        if arg4 != 0 || arg5 != 0 {
+            return_errno_with_message!(Errno::EINVAL, "unused PR_CAP_AMBIENT arguments are not 0");
+        }
+
+        match operation {
+            PR_CAP_AMBIENT_IS_SET => Ok(Self::IsSet(parse_capability(capability)?)),
+            PR_CAP_AMBIENT_RAISE => Ok(Self::Raise(parse_capability(capability)?)),
+            PR_CAP_AMBIENT_LOWER => Ok(Self::Lower(parse_capability(capability)?)),
+            PR_CAP_AMBIENT_CLEAR_ALL => {
+                if capability != 0 {
+                    return_errno_with_message!(
+                        Errno::EINVAL,
+                        "PR_CAP_AMBIENT_CLEAR_ALL requires capability to be 0"
+                    );
+                }
+                Ok(Self::ClearAll)
+            }
+            _ => return_errno_with_message!(Errno::EINVAL, "invalid PR_CAP_AMBIENT operation"),
         }
     }
 }

--- a/test/initramfs/nix/conformance/ltp.nix
+++ b/test/initramfs/nix/conformance/ltp.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, hostPlatform, pkgsBuildBuild, }:
+{ stdenv, fetchFromGitHub, hostPlatform, libcap, pkgsBuildBuild, }:
 stdenv.mkDerivation rec {
   pname = "ltp";
   version = "20250930";
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     makeWrapper
     pkg-config
   ];
+  buildInputs = [ libcap ];
   configurePhase = ''
     runHook preConfigure
 

--- a/test/initramfs/src/conformance/gvisor/Makefile
+++ b/test/initramfs/src/conformance/gvisor/Makefile
@@ -8,6 +8,7 @@
 TESTS ?= \
 	access_test \
 	brk_test \
+	capabilities_test \
 	chown_test \
 	creat_test \
 	dev_test \

--- a/test/initramfs/src/conformance/gvisor/blocklists.exfat/capabilities_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists.exfat/capabilities_test
@@ -1,0 +1,1 @@
+AmbientCapabilitiesTest.ClearedOnFilePriv

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1091,11 +1091,11 @@ poll01
 ppoll01
 
 prctl01
-# prctl02
+prctl02
 # prctl03 # FIXME: `SIGCHLD` must arrive by the time `wait()` returns. Otherwise, it is flaky.
 # prctl05
 # prctl06
-# prctl07
+prctl07
 # prctl08
 # prctl09
 # prctl10

--- a/test/initramfs/src/regression/process/prctl/secure_bits.c
+++ b/test/initramfs/src/regression/process/prctl/secure_bits.c
@@ -54,6 +54,12 @@ FN_TEST(set_multiple_bits)
 }
 END_TEST()
 
+FN_TEST(set_invalid_bits)
+{
+	TEST_ERRNO(prctl(PR_SET_SECUREBITS, 1ULL << 30), EPERM);
+}
+END_TEST()
+
 FN_TEST(lock_keep_caps_bit)
 {
 	int initial_bits;

--- a/test/initramfs/src/regression/security/capability/ambient.c
+++ b/test/initramfs/src/regression/security/capability/ambient.c
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <linux/capability.h>
+
+#include "../../common/capability.h"
+#include "../../common/test.h"
+
+static int update_inheritable(int cap, int add)
+{
+	struct __user_cap_data_struct cap_data[2] = {};
+	unsigned int cap_index = cap / 32;
+	uint32_t cap_mask = 1U << (cap % 32);
+
+	if (__read_cap_data(cap_data) < 0)
+		return -1;
+
+	if (add)
+		cap_data[cap_index].inheritable |= cap_mask;
+	else
+		cap_data[cap_index].inheritable &= ~cap_mask;
+
+	return __write_cap_data(cap_data);
+}
+
+static int add_inheritable(int cap)
+{
+	return update_inheritable(cap, 1);
+}
+
+static int remove_inheritable(int cap)
+{
+	return update_inheritable(cap, 0);
+}
+
+static int clear_ambient(void)
+{
+	return prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0);
+}
+
+static int reset_capability_state(void)
+{
+	static const int caps[] = {
+		CAP_SYS_ADMIN,
+		CAP_NET_BIND_SERVICE,
+		CAP_NET_RAW,
+		CAP_WAKE_ALARM,
+	};
+	size_t i;
+
+	if (clear_ambient() < 0)
+		return -1;
+
+	for (i = 0; i < sizeof(caps) / sizeof(caps[0]); i++) {
+		if (remove_inheritable(caps[i]) < 0)
+			return -1;
+	}
+
+	return 0;
+}
+
+FN_TEST(ambient_initially_empty)
+{
+	TEST_SUCC(reset_capability_state());
+
+	// All capabilities should not be in the ambient set after reset.
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
+		       0),
+		 _ret == 0);
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+		       CAP_NET_BIND_SERVICE, 0, 0),
+		 _ret == 0);
+}
+END_TEST()
+
+FN_TEST(ambient_raise_and_query)
+{
+	TEST_SUCC(reset_capability_state());
+
+	// CAP_SYS_ADMIN must be in both permitted and inheritable to raise.
+	// As root, permitted already has it. Add it to inheritable.
+	TEST_SUCC(add_inheritable(CAP_SYS_ADMIN));
+
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
+			0));
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
+		       0),
+		 _ret == 1);
+
+	// Another capability should still not be set.
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+		       CAP_NET_BIND_SERVICE, 0, 0),
+		 _ret == 0);
+}
+END_TEST()
+
+FN_TEST(ambient_lower)
+{
+	TEST_SUCC(reset_capability_state());
+	TEST_SUCC(add_inheritable(CAP_SYS_ADMIN));
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
+			0));
+
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER, CAP_SYS_ADMIN, 0,
+			0));
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
+		       0),
+		 _ret == 0);
+
+	// Lowering an already-absent capability should succeed.
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER, CAP_SYS_ADMIN, 0,
+			0));
+}
+END_TEST()
+
+FN_TEST(ambient_clear_all)
+{
+	TEST_SUCC(reset_capability_state());
+
+	// Raise a few capabilities first.
+	TEST_SUCC(add_inheritable(CAP_SYS_ADMIN));
+	TEST_SUCC(add_inheritable(CAP_NET_BIND_SERVICE));
+
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
+			0));
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+			CAP_NET_BIND_SERVICE, 0, 0));
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
+		       0),
+		 _ret == 1);
+
+	// Clear all.
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0));
+
+	// Everything should be gone.
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
+		       0),
+		 _ret == 0);
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+		       CAP_NET_BIND_SERVICE, 0, 0),
+		 _ret == 0);
+}
+END_TEST()
+
+FN_TEST(ambient_raise_requires_inheritable)
+{
+	TEST_SUCC(reset_capability_state());
+
+	// Remove CAP_NET_RAW from inheritable, then try to raise it.
+	TEST_SUCC(remove_inheritable(CAP_NET_RAW));
+
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_NET_RAW, 0,
+			 0),
+		   EPERM);
+}
+END_TEST()
+
+FN_TEST(ambient_raise_ignores_bounding)
+{
+	pid_t pid;
+	int status;
+
+	TEST_SUCC(reset_capability_state());
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(add_inheritable(CAP_WAKE_ALARM));
+		CHECK(prctl(PR_CAPBSET_DROP, CAP_WAKE_ALARM, 0, 0, 0));
+
+		CHECK(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+			    CAP_WAKE_ALARM, 0, 0));
+		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+				 CAP_WAKE_ALARM, 0, 0),
+			   _ret == 1);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ambient_cleared_on_inheritable_drop)
+{
+	TEST_SUCC(reset_capability_state());
+
+	// Raise CAP_NET_BIND_SERVICE into ambient.
+	TEST_SUCC(add_inheritable(CAP_NET_BIND_SERVICE));
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+			CAP_NET_BIND_SERVICE, 0, 0));
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+		       CAP_NET_BIND_SERVICE, 0, 0),
+		 _ret == 1);
+
+	// Remove it from inheritable; it should automatically vanish from
+	// ambient.
+	TEST_SUCC(remove_inheritable(CAP_NET_BIND_SERVICE));
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+		       CAP_NET_BIND_SERVICE, 0, 0),
+		 _ret == 0);
+}
+END_TEST()
+
+FN_TEST(ambient_rejects_invalid_args)
+{
+	TEST_SUCC(reset_capability_state());
+
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+			 CAP_LAST_CAP + 1, 0, 0),
+		   EINVAL);
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN,
+			 1, 0),
+		   EINVAL);
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
+			 1),
+		   EINVAL);
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, 0, CAP_SYS_ADMIN, 0, 0), EINVAL);
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL,
+			 CAP_SYS_ADMIN, 0, 0),
+		   EINVAL);
+	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 1, 0),
+		   EINVAL);
+}
+END_TEST()
+
+FN_TEST(ambient_inherited_across_fork)
+{
+	pid_t pid;
+	int status;
+
+	TEST_SUCC(reset_capability_state());
+	TEST_SUCC(add_inheritable(CAP_NET_BIND_SERVICE));
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+			CAP_NET_BIND_SERVICE, 0, 0));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		// Child should inherit the parent's ambient set.
+		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+				 CAP_NET_BIND_SERVICE, 0, 0),
+			   _ret == 1);
+
+		// Child clears its ambient; parent should be unaffected.
+		CHECK(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0));
+		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+				 CAP_NET_BIND_SERVICE, 0, 0),
+			   _ret == 0);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	// Parent's ambient set should still contain the capability.
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+		       CAP_NET_BIND_SERVICE, 0, 0),
+		 _ret == 1);
+
+	// Clean up.
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER,
+			CAP_NET_BIND_SERVICE, 0, 0));
+	TEST_SUCC(remove_inheritable(CAP_NET_BIND_SERVICE));
+}
+END_TEST()
+
+FN_TEST(ambient_cleared_on_uid_transition)
+{
+	pid_t pid;
+	int status;
+
+	TEST_SUCC(reset_capability_state());
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(add_inheritable(CAP_NET_BIND_SERVICE));
+		CHECK(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+			    CAP_NET_BIND_SERVICE, 0, 0));
+
+		// Transition root -> nobody; ambient must be cleared.
+		CHECK(setuid(65534));
+		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+				 CAP_NET_BIND_SERVICE, 0, 0),
+			   _ret == 0);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ambient_not_protected_by_keep_caps)
+{
+	pid_t pid;
+	int status;
+
+	TEST_SUCC(reset_capability_state());
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(add_inheritable(CAP_NET_BIND_SERVICE));
+		CHECK(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+			    CAP_NET_BIND_SERVICE, 0, 0));
+
+		// Enable KEEP_CAPS. Ambient should still be cleared on
+		// root -> nobody because KEEP_CAPS does not protect ambient.
+		CHECK(prctl(PR_SET_KEEPCAPS, 1));
+		CHECK(setuid(65534));
+		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+				 CAP_NET_BIND_SERVICE, 0, 0),
+			   _ret == 0);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+FN_TEST(ambient_raise_requires_permitted)
+{
+	pid_t pid;
+	int status;
+
+	TEST_SUCC(reset_capability_state());
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		struct __user_cap_data_struct cap_data[2] = {};
+
+		CHECK(add_inheritable(CAP_NET_RAW));
+
+		// Drop CAP_NET_RAW from effective and permitted.
+		read_cap_data(cap_data);
+		cap_data[0].permitted &= ~(1U << CAP_NET_RAW);
+		cap_data[0].effective &= ~(1U << CAP_NET_RAW);
+		write_cap_data(cap_data);
+
+		// RAISE should fail because the capability is not in
+		// the permitted set.
+		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+				 CAP_NET_RAW, 0, 0),
+			   _ret == -1 && errno == EPERM);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+END_TEST()
+
+static uint64_t read_proc_capamb(void)
+{
+	FILE *fp;
+	char line[256];
+	unsigned long long value;
+	uint64_t capamb = 0;
+
+	fp = CHECK_WITH(fopen("/proc/self/status", "r"), _ret != NULL);
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		if (sscanf(line, "CapAmb:\t%llx", &value) == 1) {
+			capamb = (uint64_t)value;
+			break;
+		}
+	}
+	CHECK(fclose(fp));
+	return capamb;
+}
+
+FN_TEST(ambient_procfs_reflects_state)
+{
+	TEST_SUCC(reset_capability_state());
+
+	// Raise a capability and verify /proc/self/status reflects it.
+	TEST_SUCC(add_inheritable(CAP_NET_BIND_SERVICE));
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
+			CAP_NET_BIND_SERVICE, 0, 0));
+
+	TEST_RES(read_proc_capamb(),
+		 (_ret & (1ULL << CAP_NET_BIND_SERVICE)) != 0);
+
+	// Clear and verify it is gone from procfs.
+	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0));
+	TEST_RES(read_proc_capamb(), _ret == 0);
+
+	TEST_SUCC(remove_inheritable(CAP_NET_BIND_SERVICE));
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/capability/capset.c
+++ b/test/initramfs/src/regression/security/capability/capset.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include <stdint.h>
+#include <stdlib.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <linux/capability.h>
@@ -28,6 +30,36 @@ FN_TEST(capget)
 		 _ret == CAPS_NONE);
 
 	TEST_SUCC(syscall(SYS_capset, &caphdr, &capdat));
+}
+END_TEST()
+
+FN_TEST(capset_inheritable_across_uid_transition)
+{
+	pid_t pid;
+	int status;
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		struct __user_cap_data_struct child_capdat[2] = {};
+
+		CHECK(syscall(SYS_capget, &caphdr, child_capdat));
+		child_capdat[0].inheritable |= 1 << CAP_NET_BIND_SERVICE;
+		CHECK(syscall(SYS_capset, &caphdr, child_capdat));
+
+		CHECK(setuid(65534));
+		CHECK(syscall(SYS_capget, &caphdr, child_capdat));
+
+		CHECK_WITH(child_capdat[0].permitted, _ret == 0);
+		CHECK_WITH(child_capdat[0].effective, _ret == 0);
+		CHECK_WITH(child_capdat[0].inheritable &
+				   (1 << CAP_NET_BIND_SERVICE),
+			   _ret != 0);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -4,6 +4,7 @@
 
 set -e
 
+./capability/ambient
 ./capability/capabilities
 ./capability/capset
 ./capability/execve


### PR DESCRIPTION
This is part of the groundwork for #3488.

## Summary

Implement Linux-compatible ambient capability support for `prctl(2)`. This adds the per-process ambient capability set, exposes it through `/proc/[pid]/status`, and enables the relevant LTP and gVisor coverage.

## Changes

### Kernel

- Implement `PR_CAP_AMBIENT` subcommands:
  - `PR_CAP_AMBIENT_RAISE`
  - `PR_CAP_AMBIENT_LOWER`
  - `PR_CAP_AMBIENT_CLEAR_ALL`
  - `PR_CAP_AMBIENT_IS_SET`
- Keep the ambient set synchronized when permitted or inheritable capabilities shrink.
- Clear ambient capabilities on root-to-non-root UID transitions.
- Clear ambient capabilities during privileged exec.
- Expose the ambient capability set as `CapAmb` in `/proc/[pid]/status`.
- Match Linux semantics for ambient raises: the capability must be in both permitted and inheritable sets, while the bounding set is not checked.
- Tighten `PR_SET_SECUREBITS` argument parsing so invalid high bits are rejected instead of truncated.

### LTP Tests

- Enable `prctl02` and `prctl07` in the LTP syscall test list.
- Build LTP with `libcap` support so capability-related `prctl` tests can run instead of being skipped.

### gVisor Tests

- Enable `capabilities_test` in the gVisor syscall test list.
- This runs the upstream `AmbientCapabilitiesTest` cases added in gVisor's `test/syscalls/linux/capabilities.cc`.

### Regression Tests

- Add regression coverage for ambient capability lifecycle behavior, including raise/query/lower/clear, fork inheritance, UID transition clearing, `KEEP_CAPS` interaction, permitted/inheritable constraints, `/proc/self/status` `CapAmb`, and the Linux-compatible behavior where ambient raises ignore the bounding set.
- Add regression coverage for invalid `PR_SET_SECUREBITS` high bits.

### SCML Coverage

- Document support for `PR_CAP_AMBIENT`, `PR_CAPBSET_READ`, and `PR_CAPBSET_DROP` in the prctl SCML coverage file.

