### PR TITLE
Make `inject_user_page_fault_handler` arch-agnostic

### DIFF
--- a/kernel/src/thread/exception.rs
+++ b/kernel/src/thread/exception.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+#[cfg(not(target_arch = "loongarch64"))]
 use ostd::arch::cpu::context::CpuException;
 #[cfg(target_arch = "loongarch64")]
 use ostd::arch::cpu::context::CpuExceptionInfo as CpuException;

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -67,7 +67,7 @@ pub(super) fn init() {
     ostd::task::inject_pre_schedule_handler(pre_schedule_handler);
     ostd::task::inject_post_schedule_handler(post_schedule_handler);
     ostd::task::inject_pre_user_run_handler(pre_user_run_handler);
-    ostd::arch::trap::inject_user_page_fault_handler(exception::page_fault_handler);
+    ostd::mm::fault::inject_user_page_fault_handler(exception::page_fault_handler);
 }
 
 /// A thread is a wrapper on top of task.

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -59,7 +59,7 @@ pub(super) fn init() {
     CONTEXT_SWITCH_COUNTER.call_once(PerCpuCounter::new);
     ostd::task::inject_pre_schedule_handler(pre_schedule_handler);
     ostd::task::inject_post_schedule_handler(post_schedule_handler);
-    ostd::arch::trap::inject_user_page_fault_handler(exception::page_fault_handler);
+    ostd::mm::fault::inject_user_page_fault_handler(exception::page_fault_handler);
 }
 
 /// A thread is a wrapper on top of task.

--- a/ostd/src/arch/loongarch/boot/mod.rs
+++ b/ostd/src/arch/loongarch/boot/mod.rs
@@ -35,6 +35,7 @@ fn parse_initramfs() -> Option<&'static [u8]> {
 
     let base_va = paddr_to_vaddr(start);
     let length = end - start;
+    // SAFETY: The command line is safe to read because of the contract with the loader.
     Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
 }
 
@@ -114,15 +115,19 @@ unsafe extern "C" fn loongarch_boot(
     check_cpu_config();
 
     let systab_ptr = paddr_to_vaddr(systab_paddr) as *const EfiSystemTable;
+    // SAFETY: The caller ensures the correctness of `systab_paddr`.
     let systab = unsafe { &*(systab_ptr) };
     EFI_SYSTEM_TABLE.call_once(|| systab);
 
     let device_tree_ptr =
         paddr_to_vaddr(systab.device_tree().expect("device tree not found")) as *const u8;
+    // SAFETY: The caller ensures the correctness of `systab_paddr`, which then provides a correct
+    // `device_tree_ptr`.
     let fdt = unsafe { Fdt::from_ptr(device_tree_ptr).unwrap() };
     DEVICE_TREE.call_once(|| fdt);
 
     let cmdline_ptr = paddr_to_vaddr(cmdline_paddr) as *const i8;
+    // SAFETY: The caller ensures the correctness of `cmdline_paddr`.
     let cmdline = unsafe { CStr::from_ptr(cmdline_ptr) }.to_str();
 
     use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};

--- a/ostd/src/arch/loongarch/boot/mod.rs
+++ b/ostd/src/arch/loongarch/boot/mod.rs
@@ -35,6 +35,10 @@ fn parse_initramfs() -> Option<&'static [u8]> {
 
     let base_va = paddr_to_vaddr(start);
     let length = end - start;
+    // SAFETY:
+    // 1. The initramfs is safe to read because of the contract with the loader.
+    // 2. We reserve the initramfs region in `parse_memory_regions`, so it will live as an immutable
+    //    reference for `'static`.
     Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
 }
 
@@ -114,15 +118,19 @@ unsafe extern "C" fn loongarch_boot(
     check_cpu_config();
 
     let systab_ptr = paddr_to_vaddr(systab_paddr) as *const EfiSystemTable;
+    // SAFETY: The caller ensures the correctness of `systab_paddr`.
     let systab = unsafe { &*(systab_ptr) };
     EFI_SYSTEM_TABLE.call_once(|| systab);
 
     let device_tree_ptr =
         paddr_to_vaddr(systab.device_tree().expect("device tree not found")) as *const u8;
+    // SAFETY: The caller ensures the correctness of `systab_paddr`, which then provides a correct
+    // `device_tree_ptr`.
     let fdt = unsafe { Fdt::from_ptr(device_tree_ptr).unwrap() };
     DEVICE_TREE.call_once(|| fdt);
 
     let cmdline_ptr = paddr_to_vaddr(cmdline_paddr) as *const i8;
+    // SAFETY: The caller ensures the correctness of `cmdline_paddr`.
     let cmdline = unsafe { CStr::from_ptr(cmdline_ptr) }.to_str();
 
     use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};

--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -254,14 +254,6 @@ impl UserContextApiInternal for UserContext {
 }
 
 impl UserContextApi for UserContext {
-    fn trap_number(&self) -> usize {
-        todo!()
-    }
-
-    fn trap_error_code(&self) -> usize {
-        todo!()
-    }
-
     fn instruction_pointer(&self) -> usize {
         self.user_context.era
     }

--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -17,7 +17,7 @@ use crate::{
     user::{ReturnReason, UserContextApi, UserContextApiInternal},
 };
 
-/// General registers
+/// General registers.
 #[expect(missing_docs)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -166,7 +166,6 @@ impl UserContextApiInternal for UserContext {
                     | Exception::PageNonExecutableFault
                     | Exception::PagePrivilegeIllegal => {
                         // Handle page fault
-                        // Disable the badv in TLB.
                         tlb_flush_addr(badv);
                         self.cpu_exception_info = Some(CpuExceptionInfo {
                             code: exception,
@@ -197,7 +196,7 @@ impl UserContextApiInternal for UserContext {
                         crate::debug!(
                             "Floating point unit is not available, badv: {badv:#x?}, badi: {badi:#x?}, era: {era:#x?}"
                         );
-                        // TODO: Add FPU support and enable it when this exception occurs.
+                        // TODO: Add FPU support and enable it at proper time
                         break ReturnReason::UserException;
                     }
                     Exception::TLBRFill => unreachable!(),

--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -17,7 +17,7 @@ use crate::{
     user::{ReturnReason, UserContextApi, UserContextApiInternal, UserModeHooks},
 };
 
-/// General registers
+/// General registers.
 #[expect(missing_docs)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -166,7 +166,6 @@ impl UserContextApiInternal for UserContext {
                     | Exception::PageNonExecutableFault
                     | Exception::PagePrivilegeIllegal => {
                         // Handle page fault
-                        // Disable the badv in TLB.
                         tlb_flush_addr(badv);
                         self.cpu_exception_info = Some(CpuExceptionInfo {
                             code: exception,
@@ -197,7 +196,7 @@ impl UserContextApiInternal for UserContext {
                         crate::debug!(
                             "Floating point unit is not available, badv: {badv:#x?}, badi: {badi:#x?}, era: {era:#x?}"
                         );
-                        // TODO: Add FPU support and enable it when this exception occurs.
+                        // TODO: Add FPU support and enable it at proper time
                         break ReturnReason::UserException;
                     }
                     Exception::TLBRFill => unreachable!(),

--- a/ostd/src/arch/loongarch/cpu/local.rs
+++ b/ostd/src/arch/loongarch/cpu/local.rs
@@ -4,6 +4,7 @@
 
 pub(crate) fn get_base() -> u64 {
     let mut gp;
+    // SAFETY: It is safe to read the register containing the CPU-local base.
     unsafe {
         core::arch::asm!(
             "move {gp}, $r21",

--- a/ostd/src/arch/loongarch/iommu/mod.rs
+++ b/ostd/src/arch/loongarch/iommu/mod.rs
@@ -11,10 +11,11 @@ pub(crate) enum IommuError {
     NoIommu,
 }
 
-///
 /// # Safety
 ///
-/// Mapping an incorrect address may lead to a kernel data leak.
+/// While the physical address is mapped as the device address (i.e. from calling this method to
+/// calling [`unmap`]), it must point to an untyped memory page. Otherwise, the device may corrupt
+/// kernel data, which could lead to memory safety issues.
 pub(crate) unsafe fn map(_daddr: Daddr, _paddr: Paddr) -> Result<(), IommuError> {
     Err(IommuError::NoIommu)
 }

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -117,14 +117,11 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(_range: Range<Vaddr>) {
 
 /// Activates the given root-level page table.
 ///
-/// "pgdl" or "pgdh" register doesn't have a field that encodes the cache policy,
-/// so `_root_pt_cache` is ignored.
-///
 /// # Safety
 ///
 /// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
-pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: CachePolicy) {
+pub(crate) unsafe fn activate_page_table(root_paddr: Paddr) {
     assert!(root_paddr.is_multiple_of(PagingConsts::BASE_PAGE_SIZE));
     loongArch64::register::pgdl::set_base(root_paddr);
     loongArch64::register::pgdh::set_base(root_paddr);

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -19,15 +19,14 @@ impl PagingConstsTrait for PagingConsts {
     const NR_LEVELS: PagingLevel = 4;
     const ADDRESS_WIDTH: usize = 48;
     const VA_SIGN_EXT: bool = true;
-    // TODO: Support huge page
     const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 1;
     const PTE_SIZE: usize = size_of::<PageTableEntry>();
 }
 
 bitflags::bitflags! {
+    /// Possible flags for a page table entry.
     #[repr(C)]
     #[derive(Pod)]
-    /// Possible flags for a page table entry.
     pub(crate) struct PteFlags: usize {
         /// Specifies whether the mapped frame is valid.
         const VALID =           1 << 0;
@@ -75,6 +74,7 @@ bitflags::bitflags! {
 }
 
 pub(crate) fn tlb_flush_addr(vaddr: Vaddr) {
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
     unsafe {
         asm!(
             "invtlb 0, $zero, {}",
@@ -90,15 +90,13 @@ pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
 }
 
 pub(crate) fn tlb_flush_all_excluding_global() {
-    unsafe {
-        asm!("invtlb 3, $zero, $zero");
-    }
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { asm!("invtlb 3, $zero, $zero") };
 }
 
 pub(crate) fn tlb_flush_all_including_global() {
-    unsafe {
-        asm!("invtlb 0, $zero, $zero");
-    }
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { asm!("invtlb 0, $zero, $zero") };
 }
 
 pub(crate) fn can_sync_dma() -> bool {
@@ -191,10 +189,10 @@ impl PageTableEntry {
     }
 
     fn prop(&self) -> PageProperty {
-        let flags = parse_flags!(!(self.0), PteFlags::NOT_READABLE, PageFlags::R)
+        let flags = parse_flags!(!self.0, PteFlags::NOT_READABLE, PageFlags::R)
             | parse_flags!(self.0, PteFlags::WRITABLE, PageFlags::W)
-            | parse_flags!(!(self.0), PteFlags::NOT_EXECUTABLE, PageFlags::X)
-            // TODO: How to get the accessed bit in loongarch?
+            | parse_flags!(!self.0, PteFlags::NOT_EXECUTABLE, PageFlags::X)
+            // TODO: How to get the ACCESSED bit in LoongArch?
             | parse_flags!(self.0, PteFlags::PRESENT, PageFlags::ACCESSED)
             | parse_flags!(self.0, PteFlags::DIRTY, PageFlags::DIRTY)
             | parse_flags!(self.0, PteFlags::RSV2, PageFlags::AVAIL2);
@@ -231,7 +229,7 @@ impl PageTableEntry {
 
     fn new_page(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self {
         let mut flags = PteFlags::VALID.bits()
-            // FIXME: To avoid the PageModifyFault exception,
+            // FIXME: To avoid the Page Modify Exception,
             // we set the DIRTY bit to 1 all the time.
             | PteFlags::DIRTY.bits()
             | parse_flags!(
@@ -246,7 +244,7 @@ impl PageTableEntry {
                 PteFlags::NOT_EXECUTABLE
             )
             | parse_flags!(prop.flags.bits(), PageFlags::DIRTY, PteFlags::DIRTY)
-            // TODO: How to get the accessed bit in loongarch?
+            // TODO: How to get the ACCESSED bit in LoongArch?
             | parse_flags!(prop.flags.bits(), PageFlags::ACCESSED, PteFlags::PRESENT)
             | parse_flags!(prop.flags.bits(), PageFlags::AVAIL2, PteFlags::RSV2);
         flags |= parse_flags!(prop.priv_flags.bits(), PrivFlags::AVAIL1, PteFlags::RSV1);

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -119,14 +119,11 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(_range: Range<Vaddr>) {
 
 /// Activates the given root-level page table.
 ///
-/// "pgdl" or "pgdh" register doesn't have a field that encodes the cache policy,
-/// so `_root_pt_cache` is ignored.
-///
 /// # Safety
 ///
 /// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
-pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: CachePolicy) {
+pub(crate) unsafe fn activate_page_table(root_paddr: Paddr) {
     assert!(root_paddr.is_multiple_of(PagingConsts::BASE_PAGE_SIZE));
     loongArch64::register::pgdl::set_base(root_paddr);
     loongArch64::register::pgdh::set_base(root_paddr);

--- a/ostd/src/arch/loongarch/mm/mod.rs
+++ b/ostd/src/arch/loongarch/mm/mod.rs
@@ -19,15 +19,15 @@ impl PagingConstsTrait for PagingConsts {
     const NR_LEVELS: PagingLevel = 4;
     const ADDRESS_WIDTH: usize = 48;
     const VA_SIGN_EXT: bool = true;
-    // TODO: Support huge page
+    // TODO: Set a correct `HIGHEST_TRANSLATION_LEVEL` to enable huge pages
     const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 1;
     const PTE_SIZE: usize = size_of::<PageTableEntry>();
 }
 
 bitflags::bitflags! {
+    /// Possible flags for a page table entry.
     #[repr(C)]
     #[derive(Pod)]
-    /// Possible flags for a page table entry.
     pub(crate) struct PteFlags: usize {
         /// Specifies whether the mapped frame is valid.
         const VALID =           1 << 0;
@@ -57,11 +57,11 @@ bitflags::bitflags! {
         /// Controls whether writes to the mapped frames are allowed.
         /// This flag does not fill in TLB.
         const WRITABLE =        1 << 8;
-        // Whether this entry is a basic page table entry.
+        /// Whether this entry is a basic page table entry.
         const IS_BASIC =        1 << 9;
-        // First bit ignored by MMU.
+        /// First bit ignored by MMU.
         const RSV1 =            1 << 10;
-        // Second bit ignored by MMU.
+        /// Second bit ignored by MMU.
         const RSV2 =            1 << 11;
         /// If this entry is a huge page table entry, it is `GLOBAL`.
         const GLOBAL_IN_HUGE =  1 << 12;
@@ -69,12 +69,14 @@ bitflags::bitflags! {
         const NOT_READABLE =    1 << 61;
         /// Controls whether execution code in the mapped frames are not allowed.
         const NOT_EXECUTABLE =  1 << 62;
-        /// Whether the `PageTableEntry` can only be accessed by the privileged level `PLV` field inferred
+        /// Whether the `PageTableEntry` can only be accessed by the privileged level specified in
+        /// the `PLV` field.
         const RPLV =            1 << 63;
     }
 }
 
 pub(crate) fn tlb_flush_addr(vaddr: Vaddr) {
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
     unsafe {
         asm!(
             "invtlb 0, $zero, {}",
@@ -90,15 +92,13 @@ pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
 }
 
 pub(crate) fn tlb_flush_all_excluding_global() {
-    unsafe {
-        asm!("invtlb 3, $zero, $zero");
-    }
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { asm!("invtlb 3, $zero, $zero") };
 }
 
 pub(crate) fn tlb_flush_all_including_global() {
-    unsafe {
-        asm!("invtlb 0, $zero, $zero");
-    }
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { asm!("invtlb 0, $zero, $zero") };
 }
 
 pub(crate) fn can_sync_dma() -> bool {
@@ -191,10 +191,10 @@ impl PageTableEntry {
     }
 
     fn prop(&self) -> PageProperty {
-        let flags = parse_flags!(!(self.0), PteFlags::NOT_READABLE, PageFlags::R)
+        let flags = parse_flags!(!self.0, PteFlags::NOT_READABLE, PageFlags::R)
             | parse_flags!(self.0, PteFlags::WRITABLE, PageFlags::W)
-            | parse_flags!(!(self.0), PteFlags::NOT_EXECUTABLE, PageFlags::X)
-            // TODO: How to get the accessed bit in loongarch?
+            | parse_flags!(!self.0, PteFlags::NOT_EXECUTABLE, PageFlags::X)
+            // TODO: How to get the `ACCESSED` bit in LoongArch?
             | parse_flags!(self.0, PteFlags::PRESENT, PageFlags::ACCESSED)
             | parse_flags!(self.0, PteFlags::DIRTY, PageFlags::DIRTY)
             | parse_flags!(self.0, PteFlags::RSV2, PageFlags::AVAIL2);
@@ -231,8 +231,8 @@ impl PageTableEntry {
 
     fn new_page(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self {
         let mut flags = PteFlags::VALID.bits()
-            // FIXME: To avoid the PageModifyFault exception,
-            // we set the DIRTY bit to 1 all the time.
+            // FIXME: To avoid the Page Modify Exception,
+            // we set the `DIRTY` bit to 1 all the time.
             | PteFlags::DIRTY.bits()
             | parse_flags!(
                 !prop.flags.bits(),
@@ -246,7 +246,7 @@ impl PageTableEntry {
                 PteFlags::NOT_EXECUTABLE
             )
             | parse_flags!(prop.flags.bits(), PageFlags::DIRTY, PteFlags::DIRTY)
-            // TODO: How to get the accessed bit in loongarch?
+            // TODO: How to get the `ACCESSED` bit in LoongArch?
             | parse_flags!(prop.flags.bits(), PageFlags::ACCESSED, PteFlags::PRESENT)
             | parse_flags!(prop.flags.bits(), PageFlags::AVAIL2, PteFlags::RSV2);
         flags |= parse_flags!(prop.priv_flags.bits(), PrivFlags::AVAIL1, PteFlags::RSV1);

--- a/ostd/src/arch/loongarch/trap/mod.rs
+++ b/ostd/src/arch/loongarch/trap/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     arch::{cpu::context::CpuExceptionInfo, irq::HwIrqLine, mm::tlb_flush_addr},
     cpu::PrivilegeLevel,
     irq::call_irq_callback_functions,
-    mm::MAX_USERSPACE_VADDR,
 };
 
 /// Initializes trap handling on LoongArch.
@@ -56,26 +55,17 @@ unsafe extern "C" fn trap_handler(f: &mut TrapFrame) {
                 crate::debug!(
                     "Page fault occurred in kernel: {exception:?}, badv: {badv:#x?}, badi: {badi:#x?}, era: {era:#x?}"
                 );
-                let page_fault_addr = badv;
-                // Check if the page fault is caused by user-space address
-                if let Some(handler) = USER_PAGE_FAULT_HANDLER.get()
-                    && (0..MAX_USERSPACE_VADDR).contains(&(page_fault_addr as usize))
-                    && handler(&CpuExceptionInfo {
+                crate::mm::fault::handle_user_page_fault(
+                    f,
+                    &CpuExceptionInfo {
                         code: exception,
-                        page_fault_addr,
+                        page_fault_addr: badv,
                         error_code: 0,
-                    })
-                    .is_ok()
-                {
-                    return;
-                }
-                panic!(
-                    "User page fault handler failed: addr: {page_fault_addr:#x}, err: {exception:?}"
+                    },
+                    badv,
                 );
             }
-            Exception::PageModifyFault => {
-                unimplemented!()
-            }
+            Exception::PageModifyFault => unimplemented!(),
             Exception::FetchInstructionAddressError => todo!(),
             Exception::MemoryAccessAddressError => todo!(),
             Exception::AddressNotAligned => todo!(),

--- a/ostd/src/arch/loongarch/trap/mod.rs
+++ b/ostd/src/arch/loongarch/trap/mod.rs
@@ -6,7 +6,6 @@
 mod trap;
 
 use loongArch64::register::estat::{self, Exception, Interrupt, Trap};
-use spin::Once;
 pub(super) use trap::RawUserContext;
 pub use trap::TrapFrame;
 
@@ -14,7 +13,6 @@ use crate::{
     arch::{cpu::context::CpuExceptionInfo, irq::HwIrqLine, mm::tlb_flush_addr},
     cpu::PrivilegeLevel,
     irq::call_irq_callback_functions,
-    mm::MAX_USERSPACE_VADDR,
 };
 
 /// Initializes trap handling on LoongArch.
@@ -56,26 +54,17 @@ unsafe extern "C" fn trap_handler(f: &mut TrapFrame) {
                 crate::debug!(
                     "Page fault occurred in kernel: {exception:?}, badv: {badv:#x?}, badi: {badi:#x?}, era: {era:#x?}"
                 );
-                let page_fault_addr = badv;
-                // Check if the page fault is caused by user-space address
-                if let Some(handler) = USER_PAGE_FAULT_HANDLER.get()
-                    && (0..MAX_USERSPACE_VADDR).contains(&(page_fault_addr as usize))
-                    && handler(&CpuExceptionInfo {
+                crate::mm::fault::handle_user_page_fault(
+                    f,
+                    &CpuExceptionInfo {
                         code: exception,
-                        page_fault_addr,
+                        page_fault_addr: badv,
                         error_code: 0,
-                    })
-                    .is_ok()
-                {
-                    return;
-                }
-                panic!(
-                    "User page fault handler failed: addr: {page_fault_addr:#x}, err: {exception:?}"
+                    },
+                    badv,
                 );
             }
-            Exception::PageModifyFault => {
-                unimplemented!()
-            }
+            Exception::PageModifyFault => unimplemented!(),
             Exception::FetchInstructionAddressError => todo!(),
             Exception::MemoryAccessAddressError => todo!(),
             Exception::AddressNotAligned => todo!(),
@@ -119,13 +108,4 @@ unsafe extern "C" fn trap_handler(f: &mut TrapFrame) {
         ),
         Trap::Unknown => panic!("Unknown trap, badv: {badv:#x?}, badi: {badi:#x?}, era: {era:#x?}"),
     }
-}
-
-#[expect(clippy::type_complexity)]
-static USER_PAGE_FAULT_HANDLER: Once<fn(&CpuExceptionInfo) -> Result<(), ()>> = Once::new();
-
-/// Injects a custom handler for page faults that occur in the kernel and
-/// are caused by user-space address.
-pub fn inject_user_page_fault_handler(handler: fn(info: &CpuExceptionInfo) -> Result<(), ()>) {
-    USER_PAGE_FAULT_HANDLER.call_once(|| handler);
 }

--- a/ostd/src/arch/loongarch/trap/trap.rs
+++ b/ostd/src/arch/loongarch/trap/trap.rs
@@ -2,7 +2,7 @@
 
 use core::arch::global_asm;
 
-use crate::arch::cpu::context::GeneralRegs;
+use crate::{arch::cpu::context::GeneralRegs, mm::fault::TrapFrameApi};
 
 global_asm!(include_str!("trap.S"));
 
@@ -44,6 +44,16 @@ pub struct TrapFrame {
     pub era: usize,
     /// Extended Unit Enable
     pub euen: usize,
+}
+
+impl TrapFrameApi for TrapFrame {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.era = ip;
+    }
+
+    fn instruction_pointer(&self) -> usize {
+        self.era
+    }
 }
 
 /// Saved registers on a trap.

--- a/ostd/src/arch/loongarch/trap/trap.rs
+++ b/ostd/src/arch/loongarch/trap/trap.rs
@@ -2,7 +2,7 @@
 
 use core::arch::global_asm;
 
-use crate::{arch::cpu::context::GeneralRegs, irq::DisabledLocalIrqGuard};
+use crate::{arch::cpu::context::GeneralRegs, irq::DisabledLocalIrqGuard, mm::fault::TrapFrameApi};
 
 global_asm!(include_str!("trap.S"));
 
@@ -44,6 +44,16 @@ pub struct TrapFrame {
     pub era: usize,
     /// Extended Unit Enable
     pub euen: usize,
+}
+
+impl TrapFrameApi for TrapFrame {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.era = ip;
+    }
+
+    fn instruction_pointer(&self) -> usize {
+        self.era
+    }
 }
 
 /// Saved registers on a trap.

--- a/ostd/src/arch/riscv/boot/bsp_boot.S
+++ b/ostd/src/arch/riscv/boot/bsp_boot.S
@@ -50,7 +50,7 @@ _start:
     beq    t0, t1, bsp_flush_tlb
 
     # Try loading the Sv39 page table.
-    lla     t0, sv39_boot_l3pt
+    lla    t0, sv39_boot_l3pt
     li     t1, SATP_MODE_SV39
     srli   t0, t0, PAGE_SHIFT - SATP_PPN_SHIFT
     or     t0, t0, t1
@@ -83,7 +83,7 @@ sv48_boot_l4pt:
     .zero 255 * PTE_SIZE
     .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWX  # linear 0~512 GiB
     .zero 254 * PTE_SIZE
-    .quad 0                                      # TBA (-> boot_l3pt)
+    .quad 0                                  # TBA (-> boot_l3pt)
 sv48_boot_l3pt:  # 0xffff_ffff_0000_0000 -> 0x0000_0000_0000_0000
     .zero 508 * PTE_SIZE
     .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 0~1 GiB

--- a/ostd/src/arch/riscv/boot/mod.rs
+++ b/ostd/src/arch/riscv/boot/mod.rs
@@ -36,6 +36,7 @@ fn parse_initramfs() -> Option<&'static [u8]> {
 
     let base_va = paddr_to_vaddr(start);
     let length = end - start;
+    // SAFETY: The command line is safe to read because of the contract with the loader.
     Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
 }
 
@@ -125,6 +126,7 @@ unsafe extern "C" fn riscv_boot(hart_id: usize, device_tree_paddr: usize) -> ! {
     unsafe { BOOTSTRAP_HART_ID = hart_id as u32 };
 
     let device_tree_ptr = paddr_to_vaddr(device_tree_paddr) as *const u8;
+    // SAFETY: The caller ensures the correctness of `device_tree_ptr`.
     let fdt = unsafe { Fdt::from_ptr(device_tree_ptr).unwrap() };
     DEVICE_TREE.call_once(|| fdt);
 

--- a/ostd/src/arch/riscv/boot/mod.rs
+++ b/ostd/src/arch/riscv/boot/mod.rs
@@ -36,6 +36,10 @@ fn parse_initramfs() -> Option<&'static [u8]> {
 
     let base_va = paddr_to_vaddr(start);
     let length = end - start;
+    // SAFETY:
+    // 1. The initramfs is safe to read because of the contract with the loader.
+    // 2. We reserve the initramfs region in `parse_memory_regions`, so it will live as an immutable
+    //    reference for `'static`.
     Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
 }
 
@@ -125,6 +129,7 @@ unsafe extern "C" fn riscv_boot(hart_id: usize, device_tree_paddr: usize) -> ! {
     unsafe { BOOTSTRAP_HART_ID = hart_id as u32 };
 
     let device_tree_ptr = paddr_to_vaddr(device_tree_paddr) as *const u8;
+    // SAFETY: The caller ensures the correctness of `device_tree_ptr`.
     let fdt = unsafe { Fdt::from_ptr(device_tree_ptr).unwrap() };
     DEVICE_TREE.call_once(|| fdt);
 

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -185,10 +185,14 @@ impl UserContextApiInternal for UserContext {
             let Ok(cause) = Trap::<Interrupt, Exception>::try_from(scause.cause()) else {
                 match scause.cause() {
                     Trap::Interrupt(i) => {
-                        panic!("Unknown interrupt in user mode: {:?}", i);
+                        panic!(
+                            "Cannot handle unknown interrupt: {:#x?}; trapframe: {:#x?}",
+                            i,
+                            self.as_trap_frame()
+                        );
                     }
                     Trap::Exception(e) => {
-                        crate::info!("Unknown exception in user mode: {:?}", e);
+                        crate::info!("Unknown CPU exception in user mode: {:#x?}", e);
                         self.exception = Some(CpuException::Unknown);
                         break ReturnReason::UserException;
                     }

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -230,14 +230,6 @@ impl UserContextApiInternal for UserContext {
 }
 
 impl UserContextApi for UserContext {
-    fn trap_number(&self) -> usize {
-        todo!()
-    }
-
-    fn trap_error_code(&self) -> usize {
-        todo!()
-    }
-
     fn instruction_pointer(&self) -> usize {
         self.user_context.sepc
     }

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -427,30 +427,39 @@ impl Default for QFpuContext {
 
 impl FFpuContext {
     fn save(&mut self) {
+        // SAFETY: It is safe to save FPU registers.
         unsafe { save_fpu_context_f(self as *mut _) };
     }
 
     fn load(&self) {
+        // SAFETY: It is safe to load FPU registers, as the FPU state does not affect the kernel's
+        // memory safety.
         unsafe { load_fpu_context_f(self as *const _) };
     }
 }
 
 impl DFpuContext {
     fn save(&mut self) {
+        // SAFETY: It is safe to save FPU registers.
         unsafe { save_fpu_context_d(self as *mut _) };
     }
 
     fn load(&self) {
+        // SAFETY: It is safe to load FPU registers, as the FPU state does not affect the kernel's
+        // memory safety.
         unsafe { load_fpu_context_d(self as *const _) };
     }
 }
 
 impl QFpuContext {
     fn save(&mut self) {
+        // SAFETY: It is safe to save FPU registers.
         unsafe { save_fpu_context_q(self as *mut _) };
     }
 
     fn load(&self) {
+        // SAFETY: It is safe to load FPU registers, as the FPU state does not affect the kernel's
+        // memory safety.
         unsafe { load_fpu_context_q(self as *const _) };
     }
 }

--- a/ostd/src/arch/riscv/cpu/local.rs
+++ b/ostd/src/arch/riscv/cpu/local.rs
@@ -4,6 +4,7 @@
 
 pub(crate) fn get_base() -> u64 {
     let mut gp;
+    // SAFETY: It is safe to read the register containing the CPU-local base.
     unsafe {
         core::arch::asm!(
             "mv {gp}, gp",

--- a/ostd/src/arch/riscv/iommu/mod.rs
+++ b/ostd/src/arch/riscv/iommu/mod.rs
@@ -11,10 +11,11 @@ pub(crate) enum IommuError {
     NoIommu,
 }
 
-///
 /// # Safety
 ///
-/// Mapping an incorrect address may lead to a kernel data leak.
+/// While the physical address is mapped as the device address (i.e. from calling this method to
+/// calling [`unmap`]), it must point to an untyped memory page. Otherwise, the device may corrupt
+/// kernel data, which could lead to memory safety issues.
 pub(crate) unsafe fn map(_daddr: Daddr, _paddr: Paddr) -> Result<(), IommuError> {
     Err(IommuError::NoIommu)
 }

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -48,9 +48,9 @@ impl PagingConstsTrait for PagingConsts {
 }
 
 bitflags::bitflags! {
+    /// Possible flags for a page table entry.
     #[repr(C)]
     #[derive(Pod)]
-    /// Possible flags for a page table entry.
     pub(crate) struct PteFlags: usize {
         /// Specifies whether the mapped frame or page table is valid.
         const VALID =           1 << 0;
@@ -95,7 +95,8 @@ pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
 }
 
 pub(crate) fn tlb_flush_all_excluding_global() {
-    // TODO: excluding global?
+    // RISC-V does not provide a way to exclude global pages and flush all
+    // other TLB entries. Therefore, we flush all, including global pages.
     riscv::asm::sfence_vma_all()
 }
 
@@ -169,9 +170,8 @@ pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: Cach
     #[cfg(feature = "riscv_sv39_mode")]
     let mode = riscv::register::satp::Mode::Sv39;
 
-    unsafe {
-        riscv::register::satp::set(mode, 0, ppn);
-    }
+    // SAFETY: The safety is upheld by the caller.
+    unsafe { riscv::register::satp::set(mode, 0, ppn) };
 }
 
 pub(crate) fn current_page_table_paddr() -> Paddr {

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -154,14 +154,11 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(range: Range<Vaddr>) {
 
 /// Activates the given root-level page table.
 ///
-/// "satp" register doesn't have a field that encodes the cache policy,
-/// so `_root_pt_cache` is ignored.
-///
 /// # Safety
 ///
 /// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
-pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: CachePolicy) {
+pub(crate) unsafe fn activate_page_table(root_paddr: Paddr) {
     assert!(root_paddr.is_multiple_of(PagingConsts::BASE_PAGE_SIZE));
     let ppn = root_paddr >> 12;
 

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -48,9 +48,9 @@ impl PagingConstsTrait for PagingConsts {
 }
 
 bitflags::bitflags! {
+    /// Possible flags for a page table entry.
     #[repr(C)]
     #[derive(Pod)]
-    /// Possible flags for a page table entry.
     pub(crate) struct PteFlags: usize {
         /// Specifies whether the mapped frame or page table is valid.
         const VALID =           1 << 0;
@@ -70,16 +70,16 @@ bitflags::bitflags! {
         /// Whether the memory area represented by this entry is modified.
         const DIRTY =           1 << 7;
 
-        // First bit ignored by MMU.
+        /// First bit ignored by MMU.
         const RSV1 =            1 << 8;
-        // Second bit ignored by MMU.
+        /// Second bit ignored by MMU.
         const RSV2 =            1 << 9;
 
-        // PBMT: Non-cacheable, idempotent, weakly-ordered (RVWMO), main memory
+        /// PBMT: Non-cacheable, idempotent, weakly-ordered (RVWMO), main memory.
         const PBMT_NC =         1 << 61;
-        // PBMT: Non-cacheable, non-idempotent, strongly-ordered (I/O ordering), I/O
+        /// PBMT: Non-cacheable, non-idempotent, strongly-ordered (I/O ordering), I/O.
         const PBMT_IO =         1 << 62;
-        /// Naturally aligned power-of-2
+        /// Naturally aligned power-of-2.
         const NAPOT =           1 << 63;
     }
 }

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -161,14 +161,11 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(range: Range<Vaddr>) {
 
 /// Activates the given root-level page table.
 ///
-/// "satp" register doesn't have a field that encodes the cache policy,
-/// so `_root_pt_cache` is ignored.
-///
 /// # Safety
 ///
 /// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
-pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: CachePolicy) {
+pub(crate) unsafe fn activate_page_table(root_paddr: Paddr) {
     assert!(root_paddr.is_multiple_of(PagingConsts::BASE_PAGE_SIZE));
     let ppn = root_paddr >> 12;
 

--- a/ostd/src/arch/riscv/trap/mod.rs
+++ b/ostd/src/arch/riscv/trap/mod.rs
@@ -9,7 +9,6 @@ use riscv::{
     interrupt::supervisor::{Exception, Interrupt},
     register::scause::Trap,
 };
-use spin::Once;
 pub use trap::TrapFrame;
 pub(super) use trap::{RawUserContext, SSTATUS_FS_MASK, SSTATUS_SUM};
 
@@ -20,9 +19,7 @@ use crate::{
         timer::TIMER_IRQ,
     },
     cpu::PrivilegeLevel,
-    ex_table::ExTable,
     irq::call_irq_callback_functions,
-    mm::MAX_USERSPACE_VADDR,
 };
 
 /// Initializes interrupt handling on RISC-V.
@@ -85,14 +82,7 @@ unsafe extern "C" fn trap_handler(f: &mut TrapFrame) {
         CpuException::InstructionPageFault(fault_addr)
         | CpuException::LoadPageFault(fault_addr)
         | CpuException::StorePageFault(fault_addr) => {
-            if (0..MAX_USERSPACE_VADDR).contains(&fault_addr) {
-                handle_user_page_fault(f, &exception);
-            } else {
-                panic!(
-                    "Cannot handle page fault in kernel space, exception: {:#x?}, trapframe: {:#x?}.",
-                    exception, f
-                );
-            }
+            crate::mm::fault::handle_user_page_fault(f, &exception, fault_addr);
         }
         _ => {
             panic!(
@@ -128,37 +118,5 @@ pub(super) fn handle_irq(trap_frame: &TrapFrame, interrupt: Interrupt, priv_leve
                 priv_level,
             );
         }
-    }
-}
-
-#[expect(clippy::type_complexity)]
-static USER_PAGE_FAULT_HANDLER: Once<fn(&CpuException) -> Result<(), ()>> = Once::new();
-
-/// Injects a custom handler for page faults that occur in the kernel and
-/// are caused by user-space address.
-pub fn inject_user_page_fault_handler(handler: fn(info: &CpuException) -> Result<(), ()>) {
-    USER_PAGE_FAULT_HANDLER.call_once(|| handler);
-}
-
-fn handle_user_page_fault(f: &mut TrapFrame, exception: &CpuException) {
-    let handler = USER_PAGE_FAULT_HANDLER
-        .get()
-        .expect("Page fault handler is missing");
-
-    let res = handler(exception);
-    // Copying bytes by bytes can recover directly
-    // if handling the page fault successfully.
-    if res.is_ok() {
-        return;
-    }
-
-    // Use the exception table to recover to normal execution.
-    if let Some(addr) = ExTable::find_recovery_inst_addr(f.sepc) {
-        f.sepc = addr;
-    } else {
-        panic!(
-            "Failed to handle page fault, exception: {:?}, trapframe: {:#x?}.",
-            exception, f
-        )
     }
 }

--- a/ostd/src/arch/riscv/trap/mod.rs
+++ b/ostd/src/arch/riscv/trap/mod.rs
@@ -55,9 +55,8 @@ unsafe extern "C" fn trap_handler(f: &mut TrapFrame) {
     let scause = riscv::register::scause::read();
     let Ok(cause) = Trap::<Interrupt, Exception>::try_from(scause.cause()) else {
         panic!(
-            "Cannot handle unknown trap, scause: {:#x}, trapframe: {:#x?}.",
-            scause.bits(),
-            f
+            "Cannot handle unknown trap: {:#x?}; trapframe: {:#x?}",
+            scause, f
         );
     };
 
@@ -86,7 +85,7 @@ unsafe extern "C" fn trap_handler(f: &mut TrapFrame) {
         }
         _ => {
             panic!(
-                "Cannot handle kernel exception, exception: {:#x?}, trapframe: {:#x?}.",
+                "Cannot handle kernel CPU exception: {:#x?}; trapframe: {:#x?}",
                 exception, f
             );
         }

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -18,9 +18,12 @@
 
 use core::arch::{asm, global_asm};
 
-use crate::arch::cpu::{
-    context::GeneralRegs,
-    extension::{IsaExtensions, has_extensions},
+use crate::{
+    arch::cpu::{
+        context::GeneralRegs,
+        extension::{IsaExtensions, has_extensions},
+    },
+    mm::fault::TrapFrameApi,
 };
 
 /// FPU status bits.
@@ -81,6 +84,16 @@ pub struct TrapFrame {
     pub sstatus: usize,
     /// Supervisor Exception Program Counter
     pub sepc: usize,
+}
+
+impl TrapFrameApi for TrapFrame {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.sepc = ip;
+    }
+
+    fn instruction_pointer(&self) -> usize {
+        self.sepc
+    }
 }
 
 /// Saved registers on a trap.

--- a/ostd/src/arch/riscv/trap/trap.rs
+++ b/ostd/src/arch/riscv/trap/trap.rs
@@ -24,6 +24,7 @@ use crate::{
         extension::{IsaExtensions, has_extensions},
     },
     irq::DisabledLocalIrqGuard,
+    mm::fault::TrapFrameApi,
 };
 
 /// FPU status bits.
@@ -84,6 +85,16 @@ pub struct TrapFrame {
     pub sstatus: usize,
     /// Supervisor Exception Program Counter
     pub sepc: usize,
+}
+
+impl TrapFrameApi for TrapFrame {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.sepc = ip;
+    }
+
+    fn instruction_pointer(&self) -> usize {
+        self.sepc
+    }
 }
 
 /// Saved registers on a trap.

--- a/ostd/src/arch/x86/boot/ap_boot.S
+++ b/ostd/src/arch/x86/boot/ap_boot.S
@@ -152,7 +152,7 @@ __ap_boot_cpu_id_tail:
 .code64
 
 ap_long_mode:
-    // Argument passed to ap_early_entry: rdi = cpu_id
+    // Atomically update the CPU ID tail and load the previous value to RDI.
     mov rdi, 1
     lock xadd [__ap_boot_cpu_id_tail], rdi
 
@@ -171,6 +171,7 @@ ap_long_mode:
     wrmsr
 
     // Go to Rust code.
+    // Pass CPU ID as the first argument.
 .extern ap_early_entry
     xor rbp, rbp
     mov rax, offset ap_early_entry

--- a/ostd/src/arch/x86/boot/linux_boot/mod.rs
+++ b/ostd/src/arch/x86/boot/linux_boot/mod.rs
@@ -79,7 +79,10 @@ fn parse_initramfs(boot_params: &BootParams) -> Option<&[u8]> {
 
     let initramfs_ptr = paddr_to_vaddr(boot_params.hdr.ramdisk_image as usize);
     let initramfs_len = boot_params.hdr.ramdisk_size as usize;
-    // SAFETY: The initramfs is safe to read because of the contract with the loader.
+    // SAFETY:
+    // 1. The initramfs is safe to read because of the contract with the loader.
+    // 2. We reserve the initramfs region in `parse_memory_regions`, so it will live as an immutable
+    //    reference for `'static`.
     let initramfs =
         unsafe { core::slice::from_raw_parts(initramfs_ptr as *const u8, initramfs_len) };
 

--- a/ostd/src/arch/x86/boot/multiboot/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot/mod.rs
@@ -55,7 +55,10 @@ fn parse_initramfs(mb1_info: &MultibootLegacyInfo) -> Option<&[u8]> {
     let ptr = paddr_to_vaddr(start as usize) as *const u8;
     let len = (end - start) as usize;
 
-    // SAFETY: The initramfs is safe to read because of the contract with the loader.
+    // SAFETY:
+    // 1. The initramfs is safe to read because of the contract with the loader.
+    // 2. We reserve the initramfs region in `parse_memory_regions`, so it will live as an immutable
+    //    reference for `'static`.
     Some(unsafe { core::slice::from_raw_parts(ptr, len) })
 }
 

--- a/ostd/src/arch/x86/boot/multiboot2/mod.rs
+++ b/ostd/src/arch/x86/boot/multiboot2/mod.rs
@@ -42,7 +42,10 @@ fn parse_initramfs(mb2_info: &BootInformation) -> Option<&'static [u8]> {
 
     let initramfs_ptr = paddr_to_vaddr(module_tag.start_address() as usize);
     let initramfs_len = module_tag.module_size() as usize;
-    // SAFETY: The initramfs is safe to read because of the contract with the loader.
+    // SAFETY:
+    // 1. The initramfs is safe to read because of the contract with the loader.
+    // 2. We reserve the initramfs region in `parse_memory_regions`, so it will live as an immutable
+    //    reference for `'static`.
     let initramfs =
         unsafe { core::slice::from_raw_parts(initramfs_ptr as *const u8, initramfs_len) };
 

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -337,7 +337,7 @@ impl UserContextApiInternal for UserContext {
                 }
                 Some(exception) => {
                     panic!(
-                        "cannot handle user CPU exception: {:?}, trapframe: {:?}",
+                        "Cannot handle user CPU exception: {:?}; trapframe: {:?}",
                         exception,
                         self.as_trap_frame()
                     );

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -468,14 +468,6 @@ bitflags! {
 }
 
 impl UserContextApi for UserContext {
-    fn trap_number(&self) -> usize {
-        self.user_context.trap_num
-    }
-
-    fn trap_error_code(&self) -> usize {
-        self.user_context.error_code
-    }
-
     fn set_instruction_pointer(&mut self, ip: usize) {
         self.set_rip(ip);
     }

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -467,14 +467,6 @@ bitflags! {
 }
 
 impl UserContextApi for UserContext {
-    fn trap_number(&self) -> usize {
-        self.user_context.trap_num
-    }
-
-    fn trap_error_code(&self) -> usize {
-        self.user_context.error_code
-    }
-
     fn set_instruction_pointer(&mut self, ip: usize) {
         self.set_rip(ip);
     }

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -336,7 +336,7 @@ impl UserContextApiInternal for UserContext {
                 }
                 Some(exception) => {
                     panic!(
-                        "cannot handle user CPU exception: {:?}, trapframe: {:?}",
+                        "Cannot handle user CPU exception: {:?}; trapframe: {:?}",
                         exception,
                         self.as_trap_frame()
                     );

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -16,9 +16,7 @@ use x86_64::{
 use crate::mm::{
     PAGE_SIZE, Paddr, PagingConstsTrait, PagingLevel, PodOnce, Vaddr,
     dma::DmaDirection,
-    page_prop::{
-        CachePolicy, PageFlags, PageProperty, PageTableFlags, PrivilegedPageFlags as PrivFlags,
-    },
+    page_prop::{PageFlags, PageProperty, PageTableFlags, PrivilegedPageFlags as PrivFlags},
     page_table::{PteScalar, PteTrait},
 };
 
@@ -135,26 +133,13 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(_range: Range<Vaddr>) {
 
 /// Activates the given root-level page table.
 ///
-/// The cache policy of the root page table node is controlled by `root_pt_cache`.
-///
 /// # Safety
 ///
 /// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
-pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, root_pt_cache: CachePolicy) {
+pub(crate) unsafe fn activate_page_table(root_paddr: Paddr) {
     let addr = PhysFrame::from_start_address(x86_64::PhysAddr::new(root_paddr as u64)).unwrap();
-    let flags = match root_pt_cache {
-        CachePolicy::Writeback => x86_64::registers::control::Cr3Flags::empty(),
-        CachePolicy::Writethrough => x86_64::registers::control::Cr3Flags::PAGE_LEVEL_WRITETHROUGH,
-        CachePolicy::Uncacheable => x86_64::registers::control::Cr3Flags::PAGE_LEVEL_CACHE_DISABLE,
-        // Write-combining and write-protected are not supported for root page table (CR3)
-        // as CR3 only supports WB, WT, and UC via PCD/PWT bits
-        _ => {
-            panic!(
-                "unsupported cache policy for the root page table (only WB, WT, and UC are allowed)"
-            )
-        }
-    };
+    let flags = x86_64::registers::control::Cr3Flags::empty();
 
     // SAFETY: The safety is upheld by the caller.
     unsafe { x86_64::registers::control::Cr3::write(addr, flags) };

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -40,9 +40,9 @@ impl PagingConstsTrait for PagingConsts {
 }
 
 bitflags::bitflags! {
+    /// Possible flags for a page table entry.
     #[repr(C)]
     #[derive(Pod)]
-    /// Possible flags for a page table entry.
     pub(crate) struct PteFlags: usize {
         /// Specifies whether the mapped frame or page table is loaded in memory.
         const PRESENT =         1 << 0;
@@ -81,7 +81,7 @@ bitflags::bitflags! {
     }
 }
 
-/// Flush any TLB entry that contains the map of the given virtual address.
+/// Flushes any TLB entry that contains the map of the given virtual address.
 ///
 /// This flush performs regardless of the global-page bit. So it can flush both global
 /// and non-global entries.
@@ -89,21 +89,21 @@ pub(crate) fn tlb_flush_addr(vaddr: Vaddr) {
     tlb::flush(VirtAddr::new(vaddr as u64));
 }
 
-/// Flush any TLB entry that intersects with the given address range.
+/// Flushes any TLB entry that intersects with the given address range.
 pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
     for vaddr in range.clone().step_by(PAGE_SIZE) {
         tlb_flush_addr(vaddr);
     }
 }
 
-/// Flush all TLB entries except for the global-page entries.
+/// Flushes all TLB entries, except for the global-page entries.
 pub(crate) fn tlb_flush_all_excluding_global() {
     tlb::flush_all();
 }
 
-/// Flush all TLB entries, including global-page entries.
+/// Flushes all TLB entries, including the global-page entries.
 pub(crate) fn tlb_flush_all_including_global() {
-    // SAFETY: updates to CR4 here only change the global-page bit, the side effect
+    // SAFETY: Updates to CR4 here only change the global-page bit. The side effect
     // is only to invalidate the TLB, which doesn't affect the memory safety.
     unsafe {
         // To invalidate all entries, including global-page
@@ -203,8 +203,8 @@ impl PageTableEntry {
     }
 
     fn is_present(&self) -> bool {
-        // For PT child, `PRESENT` should be set; for huge page, `HUGE` should
-        // be set; for the leaf child page, `PAT`, which is the same bit as
+        // For PT children, `PRESENT` should be set; for huge pages, `HUGE`
+        // should be set; for leaf child pages, `PAT`, which is the same bit as
         // the `HUGE` bit in upper levels, should be set.
         self.0 & PteFlags::PRESENT.bits() != 0 || self.0 & PteFlags::HUGE.bits() != 0
     }

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -39,9 +39,9 @@ impl PagingConstsTrait for PagingConsts {
 }
 
 bitflags::bitflags! {
+    /// Possible flags for a page table entry.
     #[repr(C)]
     #[derive(Pod)]
-    /// Possible flags for a page table entry.
     pub(crate) struct PteFlags: usize {
         /// Specifies whether the mapped frame or page table is loaded in memory.
         const PRESENT =         1 << 0;
@@ -80,7 +80,7 @@ bitflags::bitflags! {
     }
 }
 
-/// Flush any TLB entry that contains the map of the given virtual address.
+/// Flushes any TLB entry that contains the map of the given virtual address.
 ///
 /// This flush performs regardless of the global-page bit. So it can flush both global
 /// and non-global entries.
@@ -88,21 +88,21 @@ pub(crate) fn tlb_flush_addr(vaddr: Vaddr) {
     tlb::flush(VirtAddr::new(vaddr as u64));
 }
 
-/// Flush any TLB entry that intersects with the given address range.
+/// Flushes any TLB entry that intersects with the given address range.
 pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
     for vaddr in range.clone().step_by(PAGE_SIZE) {
         tlb_flush_addr(vaddr);
     }
 }
 
-/// Flush all TLB entries except for the global-page entries.
+/// Flushes all TLB entries, except for the global-page entries.
 pub(crate) fn tlb_flush_all_excluding_global() {
     tlb::flush_all();
 }
 
-/// Flush all TLB entries, including global-page entries.
+/// Flushes all TLB entries, including the global-page entries.
 pub(crate) fn tlb_flush_all_including_global() {
-    // SAFETY: updates to CR4 here only change the global-page bit, the side effect
+    // SAFETY: Updates to CR4 here only change the global-page bit. The side effect
     // is only to invalidate the TLB, which doesn't affect the memory safety.
     unsafe {
         // To invalidate all entries, including global-page
@@ -203,8 +203,8 @@ impl PageTableEntry {
     }
 
     fn is_present(&self) -> bool {
-        // For PT child, `PRESENT` should be set; for huge page, `HUGE` should
-        // be set; for the leaf child page, `PAT`, which is the same bit as
+        // For PT children, `PRESENT` should be set; for huge pages, `HUGE`
+        // should be set; for leaf child pages, `PAT`, which is the same bit as
         // the `HUGE` bit in upper levels, should be set.
         self.0 & PteFlags::PRESENT.bits() != 0 || self.0 & PteFlags::HUGE.bits() != 0
     }

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -15,9 +15,7 @@ use x86_64::{
 use crate::mm::{
     PAGE_SIZE, Paddr, PagingConstsTrait, PagingLevel, PodOnce, Vaddr,
     dma::DmaDirection,
-    page_prop::{
-        CachePolicy, PageFlags, PageProperty, PageTableFlags, PrivilegedPageFlags as PrivFlags,
-    },
+    page_prop::{PageFlags, PageProperty, PageTableFlags, PrivilegedPageFlags as PrivFlags},
     page_table::{PteScalar, PteTrait},
 };
 
@@ -134,26 +132,13 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(_range: Range<Vaddr>) {
 
 /// Activates the given root-level page table.
 ///
-/// The cache policy of the root page table node is controlled by `root_pt_cache`.
-///
 /// # Safety
 ///
 /// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
 /// changing the page mapping.
-pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, root_pt_cache: CachePolicy) {
+pub(crate) unsafe fn activate_page_table(root_paddr: Paddr) {
     let addr = PhysFrame::from_start_address(x86_64::PhysAddr::new(root_paddr as u64)).unwrap();
-    let flags = match root_pt_cache {
-        CachePolicy::Writeback => x86_64::registers::control::Cr3Flags::empty(),
-        CachePolicy::Writethrough => x86_64::registers::control::Cr3Flags::PAGE_LEVEL_WRITETHROUGH,
-        CachePolicy::Uncacheable => x86_64::registers::control::Cr3Flags::PAGE_LEVEL_CACHE_DISABLE,
-        // Write-combining and write-protected are not supported for root page table (CR3)
-        // as CR3 only supports WB, WT, and UC via PCD/PWT bits
-        _ => {
-            panic!(
-                "unsupported cache policy for the root page table (only WB, WT, and UC are allowed)"
-            )
-        }
-    };
+    let flags = x86_64::registers::control::Cr3Flags::empty();
 
     // SAFETY: The safety is upheld by the caller.
     unsafe { x86_64::registers::control::Cr3::write(addr, flags) };

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -21,7 +21,6 @@ mod idt;
 mod syscall;
 
 use cfg_if::cfg_if;
-use spin::Once;
 
 use super::cpu::context::GeneralRegs;
 use crate::{
@@ -30,9 +29,8 @@ use crate::{
         irq::{HwIrqLine, disable_local, enable_local},
     },
     cpu::PrivilegeLevel,
-    ex_table::ExTable,
     irq::call_irq_callback_functions,
-    mm::MAX_USERSPACE_VADDR,
+    mm::fault::TrapFrameApi,
 };
 
 cfg_if! {
@@ -101,6 +99,16 @@ pub struct TrapFrame {
 // to a 16-byte boundary before pushing the stack frame"), so we only need to
 // ensure the size of a `TrapFrame` is also aligned.
 crate::const_assert!(size_of::<TrapFrame>().is_multiple_of(16));
+
+impl TrapFrameApi for TrapFrame {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.rip = ip;
+    }
+
+    fn instruction_pointer(&self) -> usize {
+        self.rip
+    }
+}
 
 /// Initializes interrupt handling on x86_64.
 ///
@@ -173,18 +181,9 @@ unsafe extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
             *f = *trapframe_wrapper.0;
             disable_local_if(was_irq_enabled);
         }
-        Some(CpuException::PageFault(raw_page_fault_info)) => {
+        Some(page_fault @ CpuException::PageFault(raw_page_fault_info)) => {
             enable_local_if(was_irq_enabled);
-            // The actual user space implementation should be responsible
-            // for providing mechanism to treat the 0 virtual address.
-            if (0..MAX_USERSPACE_VADDR).contains(&raw_page_fault_info.addr) {
-                handle_user_page_fault(f, cpu_exception.as_ref().unwrap());
-            } else {
-                panic!(
-                    "Cannot handle kernel page fault: {:#x?}; trapframe: {:#x?}",
-                    raw_page_fault_info, f
-                );
-            }
+            crate::mm::fault::handle_user_page_fault(f, &page_fault, raw_page_fault_info.addr);
             disable_local_if(was_irq_enabled);
         }
         Some(exception) => {
@@ -201,36 +200,6 @@ unsafe extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
                 PrivilegeLevel::Kernel,
             );
         }
-    }
-}
-
-#[expect(clippy::type_complexity)]
-static USER_PAGE_FAULT_HANDLER: Once<fn(&CpuException) -> Result<(), ()>> = Once::new();
-
-/// Injects a custom handler for page faults that occur in the kernel and
-/// are caused by user-space address.
-pub fn inject_user_page_fault_handler(handler: fn(info: &CpuException) -> Result<(), ()>) {
-    USER_PAGE_FAULT_HANDLER.call_once(|| handler);
-}
-
-/// Handles page fault from user space.
-fn handle_user_page_fault(f: &mut TrapFrame, exception: &CpuException) {
-    let handler = USER_PAGE_FAULT_HANDLER
-        .get()
-        .expect("a page fault handler is missing");
-
-    let res = handler(exception);
-    // Copying bytes by bytes can recover directly
-    // if handling the page fault successfully.
-    if res.is_ok() {
-        return;
-    }
-
-    // Use the exception table to recover to normal execution.
-    if let Some(addr) = ExTable::find_recovery_inst_addr(f.rip) {
-        f.rip = addr;
-    } else {
-        panic!("Cannot handle user page fault; trapframe: {:#x?}", f);
     }
 }
 

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -20,8 +20,6 @@ pub(super) mod gdt;
 mod idt;
 mod syscall;
 
-use spin::Once;
-
 use super::cpu::context::GeneralRegs;
 use crate::{
     arch::{
@@ -29,9 +27,8 @@ use crate::{
         irq::{HwIrqLine, disable_local, enable_local},
     },
     cpu::PrivilegeLevel,
-    ex_table::ExTable,
     irq::call_irq_callback_functions,
-    mm::MAX_USERSPACE_VADDR,
+    mm::fault::TrapFrameApi,
 };
 
 cfg_select! {
@@ -100,6 +97,16 @@ pub struct TrapFrame {
 // to a 16-byte boundary before pushing the stack frame"), so we only need to
 // ensure the size of a `TrapFrame` is also aligned.
 crate::const_assert!(size_of::<TrapFrame>().is_multiple_of(16));
+
+impl TrapFrameApi for TrapFrame {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.rip = ip;
+    }
+
+    fn instruction_pointer(&self) -> usize {
+        self.rip
+    }
+}
 
 /// Initializes interrupt handling on x86_64.
 ///
@@ -172,18 +179,9 @@ unsafe extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
             *f = *trapframe_wrapper.0;
             disable_local_if(was_irq_enabled);
         }
-        Some(CpuException::PageFault(raw_page_fault_info)) => {
+        Some(page_fault @ CpuException::PageFault(raw_page_fault_info)) => {
             enable_local_if(was_irq_enabled);
-            // The actual user space implementation should be responsible
-            // for providing mechanism to treat the 0 virtual address.
-            if (0..MAX_USERSPACE_VADDR).contains(&raw_page_fault_info.addr) {
-                handle_user_page_fault(f, cpu_exception.as_ref().unwrap());
-            } else {
-                panic!(
-                    "Cannot handle kernel page fault: {:#x?}; trapframe: {:#x?}",
-                    raw_page_fault_info, f
-                );
-            }
+            crate::mm::fault::handle_user_page_fault(f, &page_fault, raw_page_fault_info.addr);
             disable_local_if(was_irq_enabled);
         }
         Some(exception) => {
@@ -200,36 +198,6 @@ unsafe extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
                 PrivilegeLevel::Kernel,
             );
         }
-    }
-}
-
-#[expect(clippy::type_complexity)]
-static USER_PAGE_FAULT_HANDLER: Once<fn(&CpuException) -> Result<(), ()>> = Once::new();
-
-/// Injects a custom handler for page faults that occur in the kernel and
-/// are caused by user-space address.
-pub fn inject_user_page_fault_handler(handler: fn(info: &CpuException) -> Result<(), ()>) {
-    USER_PAGE_FAULT_HANDLER.call_once(|| handler);
-}
-
-/// Handles page fault from user space.
-fn handle_user_page_fault(f: &mut TrapFrame, exception: &CpuException) {
-    let handler = USER_PAGE_FAULT_HANDLER
-        .get()
-        .expect("a page fault handler is missing");
-
-    let res = handler(exception);
-    // Copying bytes by bytes can recover directly
-    // if handling the page fault successfully.
-    if res.is_ok() {
-        return;
-    }
-
-    // Use the exception table to recover to normal execution.
-    if let Some(addr) = ExTable::find_recovery_inst_addr(f.rip) {
-        f.rip = addr;
-    } else {
-        panic!("Cannot handle user page fault; trapframe: {:#x?}", f);
     }
 }
 

--- a/ostd/src/irq/guard.rs
+++ b/ostd/src/irq/guard.rs
@@ -15,15 +15,18 @@ use crate::{arch::irq as arch_irq, sync::GuardTransfer, task::atomic_mode::InAto
 ///
 /// [`SpinLock`]: crate::sync::SpinLock
 ///
-/// # Example
+/// # Examples
 ///
 /// ```rust
+/// # fn work_with_irq_disabled() {}
+/// #
 /// use ostd::irq;
 ///
-/// {
-///     let _ = irq::disable_local();
-///     todo!("do something when irqs are disabled");
-/// }
+/// let guard = irq::disable_local();
+/// // Do something with IRQs disabled.
+/// work_with_irq_disabled();
+/// // Re-enable IRQs if they were previously enabled.
+/// drop(guard);
 /// ```
 pub fn disable_local() -> DisabledLocalIrqGuard {
     DisabledLocalIrqGuard::new()

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -36,7 +36,6 @@ pub mod bus;
 pub mod console;
 pub mod cpu;
 mod error;
-mod ex_table;
 pub mod io;
 pub mod irq;
 pub mod log;

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -37,7 +37,6 @@ pub mod bus;
 pub mod console;
 pub mod cpu;
 mod error;
-mod ex_table;
 pub mod io;
 pub mod irq;
 pub mod log;

--- a/ostd/src/mm/fault/ex_table.rs
+++ b/ostd/src/mm/fault/ex_table.rs
@@ -53,7 +53,7 @@ unsafe extern "C" {
 ///
 /// After that, we can use the API of `ExTable` to resume execution when handling
 /// exceptions caused by `rep movsb` (which `label1` point to) failing.
-pub(crate) struct ExTable;
+pub(super) struct ExTable;
 
 impl ExTable {
     /// Finds the recovery instruction address for a given instruction address.
@@ -61,8 +61,7 @@ impl ExTable {
     /// This function is generally used when an exception (such as a page fault) occurs.
     /// if the exception handling fails and there is a predefined recovery action,
     /// then the found recovery action will be taken.
-    #[cfg_attr(target_arch = "loongarch64", expect(unused))]
-    pub fn find_recovery_inst_addr(inst_addr: Vaddr) -> Option<Vaddr> {
+    pub(super) fn find_recovery_inst_addr(inst_addr: Vaddr) -> Option<Vaddr> {
         let table_size = (__ex_table_end as *const () as usize - __ex_table as *const () as usize)
             / size_of::<ExTableItem>();
         // SAFETY: `__ex_table` is a static section consisting of `ExTableItem`.

--- a/ostd/src/mm/fault/mod.rs
+++ b/ostd/src/mm/fault/mod.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Page fault handling.
+
+mod ex_table;
+
+use spin::Once;
+
+#[cfg(not(target_arch = "loongarch64"))]
+use crate::arch::cpu::context::CpuException;
+#[cfg(target_arch = "loongarch64")]
+use crate::arch::cpu::context::CpuExceptionInfo as CpuException;
+use crate::{
+    arch::trap::TrapFrame,
+    mm::{MAX_USERSPACE_VADDR, Vaddr, fault::ex_table::ExTable},
+};
+
+#[expect(clippy::type_complexity)]
+static USER_PAGE_FAULT_HANDLER: Once<fn(&CpuException) -> Result<(), ()>> = Once::new();
+
+/// Injects a custom handler for page faults that occur in the kernel and
+/// are caused by user-space address.
+pub fn inject_user_page_fault_handler(handler: fn(info: &CpuException) -> Result<(), ()>) {
+    USER_PAGE_FAULT_HANDLER.call_once(|| handler);
+}
+
+/// The common interface that every CPU architecture-specific [`TrapFrame`] implements.
+pub(crate) trait TrapFrameApi {
+    /// Sets the instruction pointer.
+    fn set_instruction_pointer(&mut self, ip: usize);
+
+    /// Gets the instruction pointer.
+    fn instruction_pointer(&self) -> usize;
+}
+
+/// Handles page fault from user space.
+pub(crate) fn handle_user_page_fault(
+    f: &mut TrapFrame,
+    exception: &CpuException,
+    fault_addr: Vaddr,
+) {
+    // The actual user space implementation should be responsible
+    // for providing mechanism to treat the 0 virtual address.
+    if !(0..MAX_USERSPACE_VADDR).contains(&fault_addr) {
+        panic!(
+            "Cannot handle kernel page fault: {:#x?}; trapframe: {:#x?}",
+            exception, f
+        );
+    }
+
+    let handler = USER_PAGE_FAULT_HANDLER
+        .get()
+        .expect("a page fault handler is missing");
+
+    let res = handler(exception);
+    // Copying bytes by bytes can recover directly
+    // if handling the page fault successfully.
+    if res.is_ok() {
+        return;
+    }
+
+    // Use the exception table to recover to normal execution.
+    let inst_addr = f.instruction_pointer();
+    if let Some(new_addr) = ExTable::find_recovery_inst_addr(inst_addr) {
+        f.set_instruction_pointer(new_addr);
+    } else {
+        panic!("Cannot handle user page fault; trapframe: {:#x?}", f);
+    }
+}

--- a/ostd/src/mm/fault/mod.rs
+++ b/ostd/src/mm/fault/mod.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Page fault handling.
+//!
+//! This module manages a handler that can address page faults occurring in the kernel due to
+//! user-space addresses. For example, this occurs during [`FallibleVmRead::read_fallible`] and
+//! [`FallibleVmWrite::write_fallible`].
+//!
+//! If the page fault is handled successfully, the read/write process continues and the fault
+//! address is retried. Otherwise, those methods will return an error to indicate that the
+//! read/write process cannot be completed.
+//!
+//! [`FallibleVmRead::read_fallible`]: super::FallibleVmRead::read_fallible
+//! [`FallibleVmWrite::write_fallible`]: super::FallibleVmWrite::write_fallible
+
+mod ex_table;
+
+use spin::Once;
+
+#[cfg(not(target_arch = "loongarch64"))]
+use crate::arch::cpu::context::CpuException;
+#[cfg(target_arch = "loongarch64")]
+use crate::arch::cpu::context::CpuExceptionInfo as CpuException;
+use crate::{
+    arch::trap::TrapFrame,
+    mm::{MAX_USERSPACE_VADDR, Vaddr, fault::ex_table::ExTable},
+};
+
+/// A handler that handles page faults caused by user-space addresses.
+///
+/// The page fault is described in [`CpuException`]. If it can be resolved successfully,
+/// this method will return `Ok(())`. Otherwise, it should return `Err(())`.
+pub type UserPageFaultHandler = fn(&CpuException) -> Result<(), ()>;
+
+static USER_PAGE_FAULT_HANDLER: Once<UserPageFaultHandler> = Once::new();
+
+/// Injects a custom handler for page faults that occur in the kernel and
+/// are caused by user-space addresses.
+///
+/// The function may be called only once; subsequent calls take no effect.
+pub fn inject_user_page_fault_handler(handler: UserPageFaultHandler) {
+    USER_PAGE_FAULT_HANDLER.call_once(|| handler);
+}
+
+/// The common interface that every CPU architecture-specific [`TrapFrame`] implements.
+pub(crate) trait TrapFrameApi {
+    /// Sets the instruction pointer.
+    fn set_instruction_pointer(&mut self, ip: usize);
+
+    /// Gets the instruction pointer.
+    fn instruction_pointer(&self) -> usize;
+}
+
+/// Handles page fault from user space.
+pub(crate) fn handle_user_page_fault(
+    f: &mut TrapFrame,
+    exception: &CpuException,
+    fault_addr: Vaddr,
+) {
+    // The actual user space implementation should be responsible
+    // for providing mechanism to treat the 0 virtual address.
+    if !(0..MAX_USERSPACE_VADDR).contains(&fault_addr) {
+        panic!(
+            "Cannot handle kernel page fault: {:#x?}; trapframe: {:#x?}",
+            exception, f
+        );
+    }
+
+    let handler = USER_PAGE_FAULT_HANDLER
+        .get()
+        .expect("a page fault handler is missing");
+
+    let res = handler(exception);
+    // Copying bytes by bytes can recover directly
+    // if handling the page fault successfully.
+    if res.is_ok() {
+        return;
+    }
+
+    // Use the exception table to recover to normal execution.
+    let inst_addr = f.instruction_pointer();
+    if let Some(new_addr) = ExTable::find_recovery_inst_addr(inst_addr) {
+        f.set_instruction_pointer(new_addr);
+    } else {
+        panic!("Cannot handle user page fault; trapframe: {:#x?}", f);
+    }
+}

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -8,6 +8,7 @@
 )]
 
 pub mod dma;
+pub mod fault;
 pub mod frame;
 pub mod heap;
 pub mod io;

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -116,8 +116,3 @@ pub(crate) const fn nr_subpage_per_huge<C: PagingConstsTrait>() -> usize {
 pub(crate) const fn nr_base_per_page<C: PagingConstsTrait>(level: PagingLevel) -> usize {
     page_size::<C>(level) / C::BASE_PAGE_SIZE
 }
-
-/// Checks if the given address is page-aligned.
-pub const fn is_page_aligned(p: usize) -> bool {
-    (p & (PAGE_SIZE - 1)) == 0
-}

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -92,10 +92,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
     ///
     /// Only top-level page tables can be activated using this function.
     pub(super) unsafe fn activate(&self) {
-        use crate::{
-            arch::mm::{activate_page_table, current_page_table_paddr},
-            mm::CachePolicy,
-        };
+        use crate::arch::mm::{activate_page_table, current_page_table_paddr};
 
         assert_eq!(self.level(), C::NR_LEVELS);
 
@@ -105,7 +102,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
         }
 
         // SAFETY: The safety is upheld by the caller.
-        unsafe { activate_page_table(self.clone().into_raw(), CachePolicy::Writeback) };
+        unsafe { activate_page_table(self.clone().into_raw()) };
 
         // Restore and drop the last activated page table.
         // SAFETY: The physical address is valid and points to a forgotten page table node.
@@ -117,10 +114,10 @@ impl<C: PageTableConfig> PageTableNode<C> {
     /// It will not try dropping the last activate page table. It is the same
     /// with [`Self::activate()`] in other senses.
     pub(super) unsafe fn first_activate(&self) {
-        use crate::{arch::mm::activate_page_table, mm::CachePolicy};
+        use crate::arch::mm::activate_page_table;
 
         // SAFETY: The safety is upheld by the caller.
-        unsafe { activate_page_table(self.clone().into_raw(), CachePolicy::Writeback) };
+        unsafe { activate_page_table(self.clone().into_raw()) };
     }
 }
 

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -19,12 +19,6 @@ pub(crate) trait UserContextApiInternal {
 
 /// The common interface that every CPU architecture-specific [`UserContext`] implements.
 pub trait UserContextApi {
-    /// Gets the trap number of this interrupt.
-    fn trap_number(&self) -> usize;
-
-    /// Gets the trap error code of this interrupt.
-    fn trap_error_code(&self) -> usize;
-
     /// Sets the instruction pointer
     fn set_instruction_pointer(&mut self, ip: usize);
 

--- a/ostd/src/user.rs
+++ b/ostd/src/user.rs
@@ -20,12 +20,6 @@ pub(crate) trait UserContextApiInternal {
 
 /// The common interface that every CPU architecture-specific [`UserContext`] implements.
 pub trait UserContextApi {
-    /// Gets the trap number of this interrupt.
-    fn trap_number(&self) -> usize;
-
-    /// Gets the trap error code of this interrupt.
-    fn trap_error_code(&self) -> usize;
-
     /// Sets the instruction pointer
     fn set_instruction_pointer(&mut self, ip: usize);
 


### PR DESCRIPTION
 1. There is no need to implement `inject_user_page_fault_handler` under `ostd::arch`:
    https://github.com/asterinas/asterinas/blob/5b46e566dee52a836b0189082d88e0bb208b549e/ostd/src/arch/riscv/trap/mod.rs#L134-L141
    https://github.com/asterinas/asterinas/blob/5b46e566dee52a836b0189082d88e0bb208b549e/ostd/src/arch/x86/trap/mod.rs#L207-L214

    This PR moves it to `ostd::mm::fault::inject_user_page_fault_handler`.

  2. `activate_page_table` does not need to accept `CachePolicy`, which is really useless and just creates unnecessary complexity.
     https://github.com/asterinas/asterinas/blob/5b46e566dee52a836b0189082d88e0bb208b549e/ostd/src/arch/x86/mm/mod.rs#L144

  3. Some unused APIs are removed in this PR.
  4. Additionally, this PR revises some comments. This will align them more closely with the comment style of the codebase.