### PR TITLE
fix(net): allow truncated getsockopt reads

### DIFF
--- a/kernel/src/util/net/options/utils.rs
+++ b/kernel/src/util/net/options/utils.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{num::NonZeroU8, time::Duration};
+use core::{cmp::min, num::NonZeroU8, time::Duration};
 
 use ostd::mm::VmIo;
 
@@ -38,6 +38,23 @@ pub trait WriteToUser {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize>;
 }
 
+/// Writes the C counterpart of a socket option to the user space, truncating it
+/// to fit the user-provided buffer length if necessary.
+///
+/// This follows the Linux `getsockopt(2)` semantics: the kernel copies
+/// `min(max_len, real_len)` bytes to `optval` and reports `min(max_len, real_len)`
+/// as the number of bytes that the user's `optlen` should be updated to. In
+/// particular, the value written back to `optlen` is the *truncated* length, not
+/// the real option length (e.g. requesting `optlen == 0` copies nothing and
+/// reports a length of `0`).
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.13/source/net/core/sock.c#L1888>.
+fn write_bytes_partial_to_user(addr: Vaddr, bytes: &[u8], max_len: u32) -> Result<usize> {
+    let write_len = min(max_len as usize, bytes.len());
+    current_userspace!().write_bytes(addr, &bytes[..write_len])?;
+    Ok(write_len)
+}
+
 /// This macro is used to implement `ReadFromUser` and `WriteToUser` for u32 and i32.
 macro_rules! impl_read_write_for_32bit_type {
     ($pod_ty: ty) => {
@@ -52,14 +69,7 @@ macro_rules! impl_read_write_for_32bit_type {
 
         impl WriteToUser for $pod_ty {
             fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-                let write_len = size_of::<$pod_ty>();
-
-                if (max_len as usize) < write_len {
-                    return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-                }
-
-                crate::context::current_userspace!().write_val(addr, self)?;
-                Ok(write_len)
+                write_bytes_partial_to_user(addr, self.as_bytes(), max_len)
             }
         }
     };
@@ -123,19 +133,12 @@ impl WriteToUser for IpTtl {
 
 impl WriteToUser for Option<Error> {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = size_of::<i32>();
-
-        if (max_len as usize) < write_len {
-            return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-        }
-
         let val = match self {
             None => 0i32,
             Some(error) => error.error() as i32,
         };
 
-        current_userspace!().write_val(addr, &val)?;
-        Ok(write_len)
+        val.write_to_user(addr, max_len)
     }
 }
 
@@ -153,15 +156,8 @@ impl ReadFromUser for LingerOption {
 
 impl WriteToUser for LingerOption {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = size_of::<CLinger>();
-
-        if (max_len as usize) < write_len {
-            return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-        }
-
         let linger = CLinger::from(*self);
-        current_userspace!().write_val(addr, &linger)?;
-        Ok(write_len)
+        write_bytes_partial_to_user(addr, linger.as_bytes(), max_len)
     }
 }
 
@@ -192,7 +188,7 @@ impl WriteToUser for CongestionControl {
         let name_len = name_bytes.len();
         bytes[..name_len].copy_from_slice(name_bytes);
 
-        let write_len = TCP_CONGESTION_NAME_MAX.min(max_len) as usize;
+        let write_len = min(max_len as usize, bytes.len());
 
         current_userspace!().write_bytes(addr, &bytes[..write_len])?;
 
@@ -227,14 +223,6 @@ impl From<CLinger> for LingerOption {
 
 impl WriteToUser for CUserCred {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = size_of::<CUserCred>();
-
-        if (max_len as usize) < write_len {
-            return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-        };
-
-        current_userspace!().write_val(addr, self)?;
-
-        Ok(write_len)
+        write_bytes_partial_to_user(addr, self.as_bytes(), max_len)
     }
 }

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -122,6 +122,46 @@ FN_TEST(socket_error)
 }
 END_TEST()
 
+FN_TEST(getsockopt_partial_copy)
+{
+	// Linux `getsockopt(2)` copies `min(optlen, real_len)` bytes into the user
+	// buffer and writes that same (possibly truncated) length back to
+	// `*optlen`, instead of failing with `EINVAL` (see issue #3374).
+	// `SO_REUSEADDR` is reported as a 4-byte integer.
+	unsigned char buf[8];
+	socklen_t len;
+	int val = 0x12345678;
+
+	TEST_SUCC(setsockopt(sk_unbound, SOL_SOCKET, SO_REUSEADDR, &val,
+			     sizeof(val)));
+
+	// A buffer shorter than the option receives only the leading bytes, and
+	// `*optlen` reports the number of bytes actually copied.
+	memset(buf, 0xcc, sizeof(buf));
+	len = 1;
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_REUSEADDR, buf, &len),
+		 len == 1 && buf[0] == 1 && buf[1] == 0xcc);
+
+	// A zero-length buffer copies nothing and reports a length of zero.
+	memset(buf, 0xcc, sizeof(buf));
+	len = 0;
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_REUSEADDR, buf, &len),
+		 len == 0 && buf[0] == 0xcc);
+
+	// A buffer that exactly fits receives the whole option.
+	memset(buf, 0xcc, sizeof(buf));
+	len = sizeof(int);
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_REUSEADDR, buf, &len),
+		 len == sizeof(int) && buf[0] == 1 && buf[4] == 0xcc);
+
+	// A buffer larger than the option has `*optlen` clamped down to the real
+	// length.
+	len = sizeof(buf);
+	TEST_RES(getsockopt(sk_unbound, SOL_SOCKET, SO_REUSEADDR, buf, &len),
+		 len == sizeof(int));
+}
+END_TEST()
+
 FN_TEST(nagle)
 {
 	int option = 1;


### PR DESCRIPTION
### Problem

`getsockopt(2)` rejects any request whose `optlen` is smaller than the option's real size. Linux does not: it copies as many bytes as fit and reports the truncated length. A program that only cares about the first byte of an option, or that probes with a short buffer, currently gets `EINVAL` where it should succeed.

```c
int val = 1;
setsockopt(sk, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));

unsigned char buf[8];
socklen_t len = 1;                                  /* buffer of only 1 byte */
getsockopt(sk, SOL_SOCKET, SO_REUSEADDR, buf, &len);
/* Linux: returns 0, buf[0] == 1, len == 1        */
/* asterinas before this patch: returns -1, EINVAL */
```

The same failure hit `SO_LINGER`, `SO_ERROR`, `SO_PEERCRED`, and the TCP congestion-control name — every option whose value is larger than the buffer a probing caller supplies.

### Root cause

The `WriteToUser` implementations in `kernel/src/util/net/options/utils.rs` all treated `max_len` (the user's `optlen`) as a minimum rather than a cap. Each one started with:

```rust
let write_len = size_of::<$pod_ty>();
if (max_len as usize) < write_len {
    return_errno_with_message!(Errno::EINVAL, "max_len is too short");
}
```

and then wrote the full value via `write_val`. So `optlen < size` was an error, and on success the value written back to `optlen` was always the fixed option size regardless of the buffer. This was duplicated across the `i32`/`u32` macro, `Option<Error>`, `LingerOption`, and `CUserCred`. `CongestionControl` already truncated, but computed `write_len` from `TCP_CONGESTION_NAME_MAX` instead of the actual buffer contents.

### Fix

Introduce one helper, `write_bytes_partial_to_user(addr, bytes, max_len)`, that copies `min(max_len, bytes.len())` bytes to `optval` and returns that same count as the value the caller writes back to `optlen`. This matches the kernel contract in [`getsockopt(2)`](https://man7.org/linux/man-pages/man2/getsockopt.2.html) and `sock_getsockopt` in `net/core/sock.c`: copy `min(optlen, len)` bytes, then store the truncated length back into `*optlen`. Notably `optlen == 0` is legal — it copies nothing and reports `0`.

All the `WriteToUser` impls now route through this helper (using `as_bytes()` on the POD types, `CLinger::from(*self).as_bytes()` for `SO_LINGER`, and delegating `bool`/`u8`/`IpTtl`/`Option<Error>` through the `i32` path). `CongestionControl` now derives `write_len` from `min(max_len, bytes.len())` for consistency. The pre-write `EINVAL` checks are removed; the `ReadFromUser` side is untouched, since `setsockopt` still requires a fully sized value.

### Tests

Extends `test/initramfs/src/regression/network/sockoption.c`:

- `getsockopt_partial_copy`: after setting `SO_REUSEADDR`, reads it with `optlen` of 1 (expects 1 byte copied, `len == 1`, trailing `0xcc` untouched), 0 (nothing copied, `len == 0`), exactly `sizeof(int)`, and a larger buffer (expects `len` clamped down to `sizeof(int)`).

`SO_REUSEADDR` is used because it is a plain 4-byte integer available on any socket, so the truncation contract can be exercised without depending on any other feature.