### PR TITLE
feat(net): support interface name ioctls

### DIFF
--- a/kernel/src/net/socket/ioctl.rs
+++ b/kernel/src/net/socket/ioctl.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::num::NonZeroI32;
+
+use crate::{
+    net::iface::iter_all_ifaces,
+    prelude::*,
+    util::ioctl::{RawIoctl, dispatch_ioctl},
+};
+
+const IFNAMSIZ: usize = 16;
+const IFREQ_DATA_SIZE: usize = 24;
+
+mod ioctl_defs {
+    use super::CIfReq;
+    use crate::util::ioctl::{InOutData, ioc};
+
+    // Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/linux/sockios.h>
+    pub(super) type GetIfName  = ioc!(SIOCGIFNAME,  0x8910, InOutData<CIfReq>);
+    pub(super) type GetIfIndex = ioc!(SIOCGIFINDEX, 0x8933, InOutData<CIfReq>);
+}
+
+pub(super) fn socket_ioctl(raw_ioctl: RawIoctl) -> Result<i32> {
+    use ioctl_defs::*;
+
+    dispatch_ioctl!(match raw_ioctl {
+        cmd @ GetIfIndex => {
+            let mut ifreq = cmd.read()?;
+            let iface = find_iface_by_name(ifreq.name_bytes())?;
+            ifreq.set_index(iface.index())?;
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfName => {
+            let mut ifreq = cmd.read()?;
+            let index = ifreq.index()?;
+            let iface = iter_all_ifaces()
+                .find(|iface| iface.index() == index.get() as u32)
+                .ok_or_else(|| Error::with_message(Errno::ENODEV, "no interface found"))?;
+            ifreq.set_name(iface.name())?;
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        _ => return_errno_with_message!(Errno::ENOTTY, "the socket ioctl command is unknown"),
+    })
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+struct CIfReq {
+    name: [u8; IFNAMSIZ],
+    data: [u8; IFREQ_DATA_SIZE],
+}
+
+impl CIfReq {
+    fn name_bytes(&self) -> &[u8] {
+        let name_len = self
+            .name
+            .iter()
+            .position(|byte| *byte == 0)
+            .unwrap_or(IFNAMSIZ);
+        &self.name[..name_len]
+    }
+
+    fn set_name(&mut self, name: &CStr) -> Result<()> {
+        let name = name.to_bytes_with_nul();
+        if name.len() > IFNAMSIZ {
+            return_errno_with_message!(Errno::ERANGE, "the interface name is too long");
+        }
+
+        self.name = [0; IFNAMSIZ];
+        self.name[..name.len()].copy_from_slice(name);
+        Ok(())
+    }
+
+    fn index(&self) -> Result<NonZeroI32> {
+        let index = i32::from_ne_bytes(self.data[..size_of::<i32>()].try_into().unwrap());
+        NonZeroI32::new(index)
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "no interface found"))
+    }
+
+    fn set_index(&mut self, index: u32) -> Result<()> {
+        let index = i32::try_from(index).map_err(|_| {
+            Error::with_message(Errno::EOVERFLOW, "the interface index is too large")
+        })?;
+        self.data[..size_of::<i32>()].copy_from_slice(&index.to_ne_bytes());
+        Ok(())
+    }
+}
+
+fn find_iface_by_name(name: &[u8]) -> Result<&'static Arc<crate::net::iface::Iface>> {
+    iter_all_ifaces()
+        .find(|iface| iface.name().to_bytes() == name)
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "no interface found"))
+}

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -12,9 +12,10 @@ use crate::{
         vfs::path::Path,
     },
     prelude::*,
-    util::{MultiRead, MultiWrite},
+    util::{MultiRead, MultiWrite, ioctl::RawIoctl},
 };
 
+mod ioctl;
 pub mod ip;
 pub mod netlink;
 pub mod options;
@@ -167,6 +168,10 @@ impl<T: Socket + 'static> FileLike for T {
             self.set_nonblocking(false);
         }
         Ok(())
+    }
+
+    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        ioctl::socket_ioctl(raw_ioctl)
     }
 
     fn access_mode(&self) -> AccessMode {

--- a/kernel/src/util/ioctl/mod.rs
+++ b/kernel/src/util/ioctl/mod.rs
@@ -389,7 +389,6 @@ impl<const MAGIC: u8, const NR: u8, const IS_MODERN: bool, T: Pod>
     Ioctl<MAGIC, NR, IS_MODERN, InOutData<T>>
 {
     /// Reads the ioctl argument from userspace.
-    #[expect(dead_code)]
     pub fn read(&self) -> Result<T> {
         self.with_data_ptr(|ptr| Ok(ptr.read()?))
     }


### PR DESCRIPTION
## Summary

Implement the two network-interface name/index lookup ioctls defined in `netdevice(7)` on socket file descriptors: `SIOCGIFINDEX` (name to index) and `SIOCGIFNAME` (index to name). Both operate on the classic `struct ifreq` argument and are dispatched from a new `FileLike::ioctl` implementation for sockets in `kernel/src/net/socket/mod.rs`. The change is transport-agnostic and independent of IPv6; it only reads the interface table exposed by `iter_all_ifaces()`.

| Request | Number | Direction | Input -> Output |
| --- | --- | --- | --- |
| `SIOCGIFINDEX` | `0x8933` | in/out | `ifr_name` (NUL-terminated iface name) -> `ifr_ifindex` (`i32`) |
| `SIOCGIFNAME` | `0x8910` | in/out | `ifr_ifindex` (`i32`) -> `ifr_name` (NUL-terminated iface name) |

## Implementation

The dispatch table lives in the new `kernel/src/net/socket/ioctl.rs`. Both commands are declared with the existing `ioc!` macro as `InOutData<CIfReq>` ioctls and routed through `dispatch_ioctl!`, so the framework performs the userspace copy-in/copy-out around the `cmd.read()?` / `cmd.write(&ifreq)?` calls in `socket_ioctl`. Unknown commands fall through to `ENOTTY`. Note this also un-gates the previously `#[expect(dead_code)]` `InOutData::read` in `kernel/src/util/ioctl/mod.rs`, which now has its first caller.

`CIfReq` is a `#[repr(C)] Pod` mirror of `struct ifreq`: a fixed `name: [u8; IFNAMSIZ]` (`IFNAMSIZ = 16`) followed by a 24-byte `data` union payload (`IFREQ_DATA_SIZE = 24`), matching the Linux layout where the union is accessed here only as the leading `ifr_ifindex`.

- `SIOCGIFINDEX`: `CIfReq::name_bytes()` slices `name` up to the first NUL (or the full 16 bytes if unterminated); `find_iface_by_name()` scans `iter_all_ifaces()` for an `Iface` whose `name().to_bytes()` matches exactly, then `set_index()` writes `iface.index()` back into the first four bytes of `data` via `to_ne_bytes()`. A `u32` index that does not fit in `i32` yields `EOVERFLOW`; an unknown name yields `ENODEV`.
- `SIOCGIFNAME`: `CIfReq::index()` decodes the leading `i32` from `data` as a `NonZeroI32` (a zero index is rejected as `ENODEV`, since ifindexes are 1-based), then the matching `Iface` is located by `iface.index() == index`. `set_name()` copies `name().to_bytes_with_nul()` into the zero-filled `name` field, returning `ERANGE` if the name including its NUL exceeds `IFNAMSIZ`.

`Iface` here is the crate alias `dyn aster_bigtcp::iface::Iface<BigtcpExt>`, so both the loopback and virtio interfaces registered during `net::iface::init` are visible to the lookups.

## Reference

- `netdevice(7)`, `SIOCGIFNAME` / `SIOCGIFINDEX`: <https://man7.org/linux/man-pages/man7/netdevice.7.html>
- Request numbers: `include/uapi/linux/sockios.h` (`SIOCGIFNAME = 0x8910`, `SIOCGIFINDEX = 0x8933`)

## Testing

Manual verification with a userspace program issuing `ioctl(fd, SIOCGIFINDEX, &ifr)` on `"lo"` returns its ifindex, and feeding that ifindex back through `SIOCGIFNAME` round-trips to `"lo"`. Error paths exercised: unknown name -> `ENODEV`, zero index -> `ENODEV`, oversized name on write -> `ERANGE`, and an unrelated request -> `ENOTTY`.