### PR TITLE
Add IPv6 interface and link-layer support to aster-bigtcp

### DIFF
--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -126,8 +126,12 @@ impl<E: Ext> IfaceCommon<E> {
         self.interface.lock().ipv6_addr()
     }
 
-    pub(super) fn prefix_len(&self) -> Option<u8> {
-        self.interface.lock().prefix_len()
+    pub(super) fn ipv4_prefix_len(&self) -> Option<u8> {
+        self.interface.lock().ipv4_prefix_len()
+    }
+
+    pub(super) fn ipv6_prefix_len(&self) -> Option<u8> {
+        self.interface.lock().ipv6_prefix_len()
     }
 
     pub(super) fn sched_poll(&self) -> &E::ScheduleNextPoll {

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -26,7 +26,7 @@ use super::{
     Iface,
     poll::{FnHelper, PollContext, SocketTableAction},
     poll_iface::PollableIface,
-    port::BindPortConfig,
+    port::{BindPortConfig, BindPortScope},
     time::get_network_timestamp,
 };
 use crate::{
@@ -52,32 +52,6 @@ pub struct IfaceCommon<E: Ext> {
 pub(super) enum IpPacket<'a> {
     Ipv4(Ipv4Packet<&'a [u8]>),
     Ipv6(Ipv6Packet<&'a [u8]>),
-}
-
-/// A normalized IP address for binding purposes.
-///
-/// IPv4 addresses are normalized to IPv4-mapped IPv6 addresses. IPv6 addresses
-/// remain unchanged.
-///
-/// IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) should be treated as equivalent
-/// to their IPv4 counterparts for binding purposes. This ensures that binding
-/// to `192.0.2.1:80` and `::ffff:192.0.2.1:80` are treated as the same.
-//
-// TODO: This type currently only handles port binding conflict detection. Full
-// dual-stack support is not yet implemented, including:
-// - Accepting IPv4 connections on IPv6 wildcard socket (binding to `::`).
-// - Returning IPv4-mapped addresses in `accept()` for IPv4 clients.
-// - Proper handling of `IPV6_V6ONLY` socket option.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct NormalizedAddress(Ipv6Address);
-
-impl From<IpAddress> for NormalizedAddress {
-    fn from(value: IpAddress) -> Self {
-        match value {
-            IpAddress::Ipv4(ipv4) => Self(ipv4.to_ipv6_mapped()),
-            IpAddress::Ipv6(ipv6) => Self(ipv6),
-        }
-    }
 }
 
 impl<E: Ext> IfaceCommon<E> {
@@ -185,11 +159,11 @@ impl<E: Ext> IfaceCommon<E> {
         config: BindPortConfig,
         protocol: PortProtocol,
     ) -> Result<BoundPort<E>, BindError> {
-        let addr = config.addr();
+        let scope = config.scope();
         let (port, can_reuse) = self.used_ports.lock().bind(config, protocol)?;
         Ok(BoundPort {
             iface,
-            addr,
+            scope,
             port,
             protocol,
             can_reuse: AtomicBool::new(can_reuse),
@@ -197,10 +171,16 @@ impl<E: Ext> IfaceCommon<E> {
     }
 
     /// Releases the port so that it can be used again.
-    fn release_port(&self, addr: IpAddress, port: u16, can_reuse: bool, protocol: PortProtocol) {
+    fn release_port(
+        &self,
+        scope: BindPortScope,
+        port: u16,
+        can_reuse: bool,
+        protocol: PortProtocol,
+    ) {
         self.used_ports
             .lock()
-            .release(addr, port, can_reuse, protocol);
+            .release(scope, port, can_reuse, protocol);
     }
 }
 
@@ -274,7 +254,7 @@ impl<E: Ext> IfaceCommon<E> {
 /// When dropped, the port is automatically released.
 pub struct BoundPort<E: Ext> {
     iface: Arc<dyn Iface<E>>,
-    addr: IpAddress,
+    scope: BindPortScope,
     port: u16,
     protocol: PortProtocol,
     can_reuse: AtomicBool,
@@ -292,13 +272,18 @@ impl<E: Ext> BoundPort<E> {
     }
 
     /// Returns the bound IP address.
-    pub fn addr(&self) -> &IpAddress {
-        &self.addr
+    pub fn addr(&self) -> IpAddress {
+        self.scope.addr()
     }
 
     /// Returns the bound endpoint.
     pub fn endpoint(&self) -> IpEndpoint {
-        IpEndpoint::new(self.addr, self.port)
+        IpEndpoint::new(self.scope.addr(), self.port)
+    }
+
+    /// Returns the scope that the port is bound to.
+    pub(crate) fn scope(&self) -> BindPortScope {
+        self.scope
     }
 
     /// Sets whether the port can be reused.
@@ -312,9 +297,9 @@ impl<E: Ext> BoundPort<E> {
         }
 
         let key = PortKey {
-            addr: NormalizedAddress::from(self.addr),
-            port: self.port,
             protocol: self.protocol,
+            port: self.port,
+            scope: self.scope,
         };
         used_ports.set_can_reuse(key, can_reuse);
 
@@ -325,7 +310,7 @@ impl<E: Ext> BoundPort<E> {
 impl<E: Ext> Drop for BoundPort<E> {
     fn drop(&mut self) {
         self.iface.common().release_port(
-            self.addr,
+            self.scope,
             self.port,
             *self.can_reuse.get_mut(),
             self.protocol,
@@ -351,11 +336,14 @@ impl<E: Ext> Deref for BoundUdpPort<E> {
     }
 }
 
+// The field order matters: keying by `(protocol, port, scope)` keeps all
+// bindings on the same port contiguous in `PortTable::used_ports`, so conflict
+// checks can scan just that port instead of the whole table.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 struct PortKey {
-    addr: NormalizedAddress,
-    port: u16,
     protocol: PortProtocol,
+    port: u16,
+    scope: BindPortScope,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -394,50 +382,83 @@ impl PortTable {
         }
     }
 
+    /// Iterates over the bindings on the given `(protocol, port)`.
+    ///
+    /// The entries for a single port are contiguous in `used_ports` (see the
+    /// note on [`PortKey`]), so this scans only those entries rather than the
+    /// whole table.
+    fn keys_on_port(
+        &self,
+        protocol: PortProtocol,
+        port: u16,
+    ) -> impl Iterator<Item = (&PortKey, &PortState)> {
+        let lower_bound = PortKey {
+            protocol,
+            port,
+            scope: BindPortScope::Address(IpAddress::Ipv4(core::net::Ipv4Addr::UNSPECIFIED)),
+        };
+        self.used_ports
+            .range(lower_bound..)
+            .take_while(move |(key, _)| key.protocol == protocol && key.port == port)
+    }
+
     fn bind(
         &mut self,
         config: BindPortConfig,
         protocol: PortProtocol,
     ) -> Result<(u16, bool), BindError> {
         let config_can_reuse = config.can_reuse();
-        let addr = NormalizedAddress::from(config.addr());
+        let scope = config.scope();
 
         let port = if let Some(port) = config.port() {
             port
         } else {
-            match self.alloc_ephemeral_port(addr, protocol, config_can_reuse) {
+            match self.alloc_ephemeral_port(scope, protocol, config_can_reuse) {
                 Some(port) => port,
                 None => return Err(BindError::Exhausted),
             }
         };
 
         let key = PortKey {
-            addr,
-            port,
             protocol,
+            port,
+            scope,
         };
+
+        let conflicting_keys = self
+            .keys_on_port(protocol, port)
+            .filter(|(used_key, _)| scopes_conflict(used_key.scope, scope))
+            .map(|(used_key, _)| *used_key)
+            .collect::<Vec<_>>();
+
+        if !conflicting_keys.is_empty() {
+            // FIXME: If the socket is not a backlog socket,
+            // we should check whether there is a listening socket on the port.
+            // If there is, the socket cannot be bound to that port.
+            let can_reuse = config.is_backlog()
+                || (config_can_reuse
+                    && conflicting_keys
+                        .iter()
+                        .all(|key| self.used_ports.get(key).unwrap().can_reuse()));
+
+            if !can_reuse {
+                return Err(BindError::InUse);
+            }
+        };
+
         let entry = self.used_ports.entry(key);
         match entry {
             Entry::Occupied(mut occupied) => {
                 let port_state = occupied.get_mut();
-                // FIXME: If the socket is not a backlog socket,
-                // we should check whether there is a listening socket on the port.
-                // If there is, the socket cannot be bound to that port.
-                let can_reuse = config.is_backlog() || (port_state.can_reuse() & config_can_reuse);
-                if can_reuse {
-                    port_state.nsocket += 1;
-                    if config_can_reuse {
-                        port_state.nreuse += 1;
-                    }
-                } else {
-                    return Err(BindError::InUse);
+                port_state.nsocket += 1;
+                if config_can_reuse {
+                    port_state.nreuse += 1;
                 }
             }
             Entry::Vacant(vacant) => {
-                let port_state = PortState::new(config_can_reuse);
-                vacant.insert(port_state);
+                vacant.insert(PortState::new(config_can_reuse));
             }
-        };
+        }
 
         Ok((port, config_can_reuse))
     }
@@ -454,7 +475,7 @@ impl PortTable {
     /// See <https://en.wikipedia.org/wiki/Ephemeral_port>.
     fn alloc_ephemeral_port(
         &mut self,
-        addr: NormalizedAddress,
+        scope: BindPortScope,
         protocol: PortProtocol,
         _can_reuse: bool,
     ) -> Option<u16> {
@@ -466,16 +487,13 @@ impl PortTable {
             }
         }
 
-        let mut key = PortKey {
-            addr,
-            port: 0,
-            protocol,
-        };
         let start_port = self.next_ephemeral_port;
         let mut port = start_port;
         loop {
-            key.port = port;
-            if !self.used_ports.contains_key(&key) {
+            let in_use = self
+                .keys_on_port(protocol, port)
+                .any(|(used_key, _)| scopes_conflict(used_key.scope, scope));
+            if !in_use {
                 self.next_ephemeral_port = next_ephemeral_port_after(port);
                 return Some(port);
             }
@@ -492,11 +510,17 @@ impl PortTable {
         None
     }
 
-    fn release(&mut self, addr: IpAddress, port: u16, can_reuse: bool, protocol: PortProtocol) {
+    fn release(
+        &mut self,
+        scope: BindPortScope,
+        port: u16,
+        can_reuse: bool,
+        protocol: PortProtocol,
+    ) {
         let key = PortKey {
-            addr: NormalizedAddress::from(addr),
-            port,
             protocol,
+            port,
+            scope,
         };
         let Entry::Occupied(mut occupied) = self.used_ports.entry(key) else {
             return;
@@ -522,6 +546,30 @@ impl PortTable {
         } else {
             port_state.nreuse -= 1;
         }
+    }
+}
+
+fn scopes_conflict(lhs: BindPortScope, rhs: BindPortScope) -> bool {
+    use BindPortScope::*;
+
+    match (lhs, rhs) {
+        (Ipv6DualStackWildcard, Address(IpAddress::Ipv4(_)))
+        | (Address(IpAddress::Ipv4(_)), Ipv6DualStackWildcard)
+        | (Ipv6DualStackWildcard, Ipv4Wildcard)
+        | (Ipv4Wildcard, Ipv6DualStackWildcard)
+        | (Ipv6DualStackWildcard, Ipv6DualStackWildcard)
+        | (Ipv6DualStackWildcard, Ipv6OnlyWildcard)
+        | (Ipv6OnlyWildcard, Ipv6DualStackWildcard)
+        | (Ipv4Wildcard, Address(IpAddress::Ipv4(_)))
+        | (Address(IpAddress::Ipv4(_)), Ipv4Wildcard)
+        | (Ipv4Wildcard, Ipv4Wildcard)
+        | (Ipv6OnlyWildcard, Address(IpAddress::Ipv6(_)))
+        | (Address(IpAddress::Ipv6(_)), Ipv6OnlyWildcard)
+        | (Ipv6OnlyWildcard, Ipv6OnlyWildcard) => true,
+        (Address(left), Address(right)) => left == right,
+        (Ipv6DualStackWildcard, Address(IpAddress::Ipv6(_)))
+        | (Address(IpAddress::Ipv6(_)), Ipv6DualStackWildcard) => true,
+        _ => false,
     }
 }
 

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -89,8 +89,13 @@ impl<E: Ext> dyn Iface<E> {
     ///
     /// Both `Self::ipv4_addr` and this method will either return `Some(_)`
     /// or both will return `None`.
-    pub fn prefix_len(&self) -> Option<u8> {
-        self.common().prefix_len()
+    pub fn ipv4_prefix_len(&self) -> Option<u8> {
+        self.common().ipv4_prefix_len()
+    }
+
+    /// Retrieves the prefix length of the interface's IPv6 address.
+    pub fn ipv6_prefix_len(&self) -> Option<u8> {
+        self.common().ipv6_prefix_len()
     }
 
     /// Gets the broadcast address of the iface, if any.
@@ -98,7 +103,7 @@ impl<E: Ext> dyn Iface<E> {
         let cidr = {
             let common = self.common();
             let ipv4_addr = common.ipv4_addr()?;
-            let prefix_len = common.prefix_len()?;
+            let prefix_len = common.ipv4_prefix_len()?;
             Ipv4Cidr::new(ipv4_addr, prefix_len)
         };
         cidr.broadcast()

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -14,5 +14,5 @@ pub use common::{BoundPort, BoundTcpPort, BoundUdpPort, InterfaceFlags, Interfac
 pub use iface::Iface;
 pub use phy::{EtherIface, IpIface};
 pub(crate) use poll_iface::{PollKey, PollableIfaceMut};
-pub use port::BindPortConfig;
+pub use port::{BindPortConfig, BindPortScope};
 pub use sched::ScheduleNextPoll;

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -12,7 +12,7 @@ mod time;
 
 pub use common::{BoundPort, BoundTcpPort, BoundUdpPort, InterfaceFlags, InterfaceType};
 pub use iface::Iface;
-pub use phy::{EtherIface, IpIface};
+pub use phy::{EtherIface, EtherIpConfig, IpIface};
 pub(crate) use poll_iface::{PollKey, PollableIfaceMut};
 pub use port::{BindPortConfig, BindPortScope};
 pub use sched::ScheduleNextPoll;

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::btree_map::BTreeMap, ffi::CString, sync::Arc};
+use alloc::{collections::btree_map::BTreeMap, ffi::CString, sync::Arc, vec, vec::Vec};
 
 use aster_softirq::BottomHalfDisabled;
 use ostd::sync::SpinLock;
@@ -9,7 +9,9 @@ use smoltcp::{
     phy::{Device, DeviceCapabilities, TxToken},
     wire::{
         self, ArpOperation, ArpPacket, ArpRepr, EthernetAddress, EthernetFrame, EthernetProtocol,
-        EthernetRepr, IpAddress, Ipv4Address, Ipv4AddressExt, Ipv4Cidr, Ipv4Packet, Ipv6Packet,
+        EthernetRepr, HardwareAddress, Icmpv6Packet, Icmpv6Repr, IpAddress, IpProtocol,
+        Ipv4Address, Ipv4AddressExt, Ipv4Cidr, Ipv4Packet, Ipv6Address, Ipv6AddressExt, Ipv6Cidr,
+        Ipv6Packet, Ipv6Repr, NdiscNeighborFlags, NdiscRepr, RawHardwareAddress,
     },
 };
 
@@ -29,31 +31,97 @@ pub struct EtherIface<D, E: Ext> {
     common: IfaceCommon<E>,
     ether_addr: EthernetAddress,
     arp_table: SpinLock<BTreeMap<Ipv4Address, EthernetAddress>, BottomHalfDisabled>,
+    ndisc_table: SpinLock<BTreeMap<Ipv6Address, EthernetAddress>, BottomHalfDisabled>,
+    pending_ipv6_packets: SpinLock<BTreeMap<Ipv6Address, PendingIpv6Packet>, BottomHalfDisabled>,
+}
+
+const MAX_PENDING_IPV6_PACKETS: usize = 64;
+const PENDING_IPV6_PACKET_TIMEOUT_MS: i64 = 1_000;
+
+struct PendingIpv6Packet {
+    packet: Vec<u8>,
+    expires_at_ms: i64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EtherIpConfig {
+    ipv4_cidr: Ipv4Cidr,
+    ipv6_cidr: Option<Ipv6Cidr>,
+    ipv4_gateway: Ipv4Address,
+    ipv6_gateway: Option<Ipv6Address>,
+}
+
+impl EtherIpConfig {
+    pub fn new(
+        ipv4_cidr: Ipv4Cidr,
+        ipv6_cidr: Option<Ipv6Cidr>,
+        ipv4_gateway: Ipv4Address,
+        ipv6_gateway: Option<Ipv6Address>,
+    ) -> Self {
+        Self {
+            ipv4_cidr,
+            ipv6_cidr,
+            ipv4_gateway,
+            ipv6_gateway,
+        }
+    }
+}
+
+enum EtherIngress<'pkt> {
+    Ip(IpPacket<'pkt>),
+    Arp(ArpRepr),
+    Icmpv6(Icmpv6Message<'static>),
+    PendingIpv6(EthernetAddress, Vec<u8>),
+    Drop,
+}
+
+enum EtherTx {
+    Ip(EthernetRepr),
+    Arp(ArpRepr),
+    Icmpv6(Icmpv6Message<'static>),
+    Drop,
+}
+
+struct Icmpv6Message<'a> {
+    src_ip: Ipv6Address,
+    dst_ip: Ipv6Address,
+    dst_ether: EthernetAddress,
+    repr: Icmpv6Repr<'a>,
 }
 
 impl<D: WithDevice, E: Ext> EtherIface<D, E> {
     pub fn new(
         driver: D,
         ether_addr: EthernetAddress,
-        ip_cidr: Ipv4Cidr,
-        gateway: Ipv4Address,
+        ip_config: EtherIpConfig,
         name: CString,
         sched_poll: E::ScheduleNextPoll,
         flags: InterfaceFlags,
     ) -> Arc<Self> {
         let interface = driver.with(|device| {
-            let config = Config::new(wire::HardwareAddress::Ethernet(ether_addr));
+            let config = Config::new(HardwareAddress::Ethernet(ether_addr));
             let now = get_network_timestamp();
 
             let mut interface = smoltcp::iface::Interface::new(config, device, now);
             interface.update_ip_addrs(|ip_addrs| {
                 debug_assert!(ip_addrs.is_empty());
-                ip_addrs.push(wire::IpCidr::Ipv4(ip_cidr)).unwrap();
+                ip_addrs
+                    .push(wire::IpCidr::Ipv4(ip_config.ipv4_cidr))
+                    .unwrap();
+                if let Some(ipv6_cidr) = ip_config.ipv6_cidr {
+                    ip_addrs.push(wire::IpCidr::Ipv6(ipv6_cidr)).unwrap();
+                }
             });
             interface
                 .routes_mut()
-                .add_default_ipv4_route(gateway)
+                .add_default_ipv4_route(ip_config.ipv4_gateway)
                 .unwrap();
+            if let Some(ipv6_gateway) = ip_config.ipv6_gateway {
+                interface
+                    .routes_mut()
+                    .add_default_ipv6_route(ipv6_gateway)
+                    .unwrap();
+            }
             interface
         });
 
@@ -64,6 +132,8 @@ impl<D: WithDevice, E: Ext> EtherIface<D, E> {
             common,
             ether_addr,
             arp_table: SpinLock::new(BTreeMap::new()),
+            ndisc_table: SpinLock::new(BTreeMap::new()),
+            pending_ipv6_packets: SpinLock::new(BTreeMap::new()),
         })
     }
 }
@@ -103,46 +173,75 @@ impl<D, E: Ext> EtherIface<D, E> {
         iface_cx: &mut Context,
         tx_token: T,
     ) -> Option<(IpPacket<'pkt>, T)> {
-        match self.parse_ip_or_process_arp(data, iface_cx) {
-            Ok(pkt) => Some((pkt, tx_token)),
-            Err(Some(arp)) => {
+        match self.parse_ip_or_process_neighbor(data, iface_cx) {
+            EtherIngress::Ip(pkt) => Some((pkt, tx_token)),
+            EtherIngress::Arp(arp) => {
                 Self::emit_arp(&arp, tx_token);
                 None
             }
-            Err(None) => None,
+            EtherIngress::Icmpv6(message) => {
+                self.emit_icmpv6(&message, iface_cx, tx_token);
+                None
+            }
+            EtherIngress::PendingIpv6(dst_ether, packet) => {
+                Self::emit_ipv6_bytes(self.ether_addr, dst_ether, &packet, tx_token);
+                None
+            }
+            EtherIngress::Drop => None,
         }
     }
 
-    fn parse_ip_or_process_arp<'pkt>(
+    fn parse_ip_or_process_neighbor<'pkt>(
         &self,
         data: &'pkt [u8],
         iface_cx: &mut Context,
-    ) -> Result<IpPacket<'pkt>, Option<ArpRepr>> {
+    ) -> EtherIngress<'pkt> {
         // Parse the Ethernet header. Ignore the packet if the header is ill-formed.
-        let frame = EthernetFrame::new_checked(data).map_err(|_| None)?;
-        let repr = EthernetRepr::parse(&frame).map_err(|_| None)?;
+        let Ok(frame) = EthernetFrame::new_checked(data) else {
+            return EtherIngress::Drop;
+        };
+        let Ok(repr) = EthernetRepr::parse(&frame) else {
+            return EtherIngress::Drop;
+        };
 
         // Ignore the Ethernet frame if it is not sent to us.
-        if !repr.dst_addr.is_broadcast() && repr.dst_addr != self.ether_addr {
-            return Err(None);
+        if !repr.dst_addr.is_broadcast()
+            && !repr.dst_addr.is_multicast()
+            && repr.dst_addr != self.ether_addr
+        {
+            return EtherIngress::Drop;
         }
 
         // Ignore the Ethernet frame if the protocol is not supported.
         match repr.ethertype {
             EthernetProtocol::Ipv4 => {
-                let pkt = Ipv4Packet::new_checked(frame.payload()).map_err(|_| None)?;
-                Ok(IpPacket::Ipv4(pkt))
+                let Ok(pkt) = Ipv4Packet::new_checked(frame.payload()) else {
+                    return EtherIngress::Drop;
+                };
+                EtherIngress::Ip(IpPacket::Ipv4(pkt))
             }
             EthernetProtocol::Ipv6 => {
-                let pkt = Ipv6Packet::new_checked(frame.payload()).map_err(|_| None)?;
-                Ok(IpPacket::Ipv6(pkt))
+                let Ok(pkt) = Ipv6Packet::new_checked(frame.payload()) else {
+                    return EtherIngress::Drop;
+                };
+                if let Some(ingress) = self.process_ndisc(&pkt, iface_cx, repr.src_addr) {
+                    return ingress;
+                }
+                EtherIngress::Ip(IpPacket::Ipv6(pkt))
             }
             EthernetProtocol::Arp => {
-                let pkt = ArpPacket::new_checked(frame.payload()).map_err(|_| None)?;
-                let arp = ArpRepr::parse(&pkt).map_err(|_| None)?;
-                Err(self.process_arp(&arp, iface_cx))
+                let Ok(pkt) = ArpPacket::new_checked(frame.payload()) else {
+                    return EtherIngress::Drop;
+                };
+                let Ok(arp) = ArpRepr::parse(&pkt) else {
+                    return EtherIngress::Drop;
+                };
+                match self.process_arp(&arp, iface_cx) {
+                    Some(arp) => EtherIngress::Arp(arp),
+                    None => EtherIngress::Drop,
+                }
             }
-            _ => Err(None),
+            _ => EtherIngress::Drop,
         }
     }
 
@@ -202,53 +301,270 @@ impl<D, E: Ext> EtherIface<D, E> {
         }
     }
 
-    fn dispatch<T: TxToken>(&self, pkt: &Packet, iface_cx: &mut Context, tx_token: T) {
-        match self.resolve_ether_or_generate_arp(pkt, iface_cx) {
-            Ok(ether) => Self::emit_ip(&ether, pkt, &iface_cx.caps, tx_token),
-            Err(Some(arp)) => Self::emit_arp(&arp, tx_token),
-            Err(None) => (),
+    fn process_ndisc(
+        &self,
+        pkt: &Ipv6Packet<&[u8]>,
+        iface_cx: &Context,
+        src_ether: EthernetAddress,
+    ) -> Option<EtherIngress<'static>> {
+        let ipv6_repr = Ipv6Repr::parse(pkt).ok()?;
+        if ipv6_repr.next_header != IpProtocol::Icmpv6 || ipv6_repr.hop_limit != 0xff {
+            return None;
+        }
+
+        let icmp_pkt = Icmpv6Packet::new_checked(pkt.payload()).ok()?;
+        let Icmpv6Repr::Ndisc(ndisc_repr) = Icmpv6Repr::parse(
+            &ipv6_repr.src_addr,
+            &ipv6_repr.dst_addr,
+            &icmp_pkt,
+            &iface_cx.checksum_caps(),
+        )
+        .ok()?
+        else {
+            return None;
+        };
+
+        match ndisc_repr {
+            NdiscRepr::NeighborAdvert {
+                flags,
+                target_addr,
+                lladdr: Some(lladdr),
+            } if target_addr.x_is_unicast() => {
+                let should_cache = flags.contains(NdiscNeighborFlags::OVERRIDE)
+                    || !self.ndisc_table.lock().contains_key(&target_addr);
+                let dst_ether = if should_cache {
+                    self.cache_ipv6_neighbor(target_addr, lladdr);
+                    Self::raw_hardware_addr_to_ether(lladdr)
+                } else {
+                    self.ndisc_table.lock().get(&target_addr).copied()
+                };
+
+                dst_ether.and_then(|dst_ether| {
+                    self.take_pending_ipv6_packet(target_addr, iface_cx.now().total_millis())
+                        .map(|packet| EtherIngress::PendingIpv6(dst_ether, packet))
+                })
+            }
+            NdiscRepr::NeighborSolicit {
+                target_addr,
+                lladdr,
+            } if target_addr.x_is_unicast() => {
+                if let Some(lladdr) = lladdr {
+                    self.cache_ipv6_neighbor(ipv6_repr.src_addr, lladdr);
+                }
+
+                if !self.is_solicited_node_addr(ipv6_repr.dst_addr, target_addr, iface_cx) {
+                    return None;
+                }
+
+                // A solicitation from the unspecified address is sent during
+                // duplicate address detection. The advertisement must then go to
+                // the all-nodes multicast address with the solicited flag cleared
+                // (RFC 4861, Section 7.2.4).
+                let (dst_ip, dst_ether, solicited) = if ipv6_repr.src_addr.is_unspecified() {
+                    let all_nodes =
+                        Ipv6Address::from([0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+                    (
+                        all_nodes,
+                        Self::ipv6_multicast_to_ethernet(all_nodes),
+                        NdiscNeighborFlags::empty(),
+                    )
+                } else {
+                    let dst_ether = self
+                        .ndisc_table
+                        .lock()
+                        .get(&ipv6_repr.src_addr)
+                        .copied()
+                        .unwrap_or(src_ether);
+                    (ipv6_repr.src_addr, dst_ether, NdiscNeighborFlags::SOLICITED)
+                };
+
+                Some(EtherIngress::Icmpv6(Icmpv6Message {
+                    src_ip: target_addr,
+                    dst_ip,
+                    dst_ether,
+                    repr: Icmpv6Repr::Ndisc(NdiscRepr::NeighborAdvert {
+                        flags: solicited | NdiscNeighborFlags::OVERRIDE,
+                        target_addr,
+                        lladdr: Some(self.ether_addr.into()),
+                    }),
+                }))
+            }
+            _ => None,
         }
     }
 
-    fn resolve_ether_or_generate_arp(
-        &self,
-        pkt: &Packet,
-        iface_cx: &mut Context,
-    ) -> Result<EthernetRepr, Option<ArpRepr>> {
-        // Resolve the next-hop IP address.
-        let next_hop_ip = match iface_cx.route(&pkt.ip_repr().dst_addr(), iface_cx.now()) {
-            Some(IpAddress::Ipv4(next_hop_ip)) => next_hop_ip,
-            Some(IpAddress::Ipv6(_)) => {
-                // FIXME: Currently, we drop outbound IPv6 packets because neighbor discovery is not
-                // implemented and we have no way to resolve the next-hop link-layer address.
-                ostd::debug!("IPv6 neighbor discovery is not implemented for Ethernet interfaces");
-                return Err(None);
-            }
-            None => return Err(None),
+    fn cache_ipv6_neighbor(&self, ip_addr: Ipv6Address, lladdr: RawHardwareAddress) {
+        let Some(ether_addr) = Self::raw_hardware_addr_to_ether(lladdr) else {
+            return;
         };
 
-        // Resolve the next-hop Ethernet address.
+        if !ip_addr.x_is_unicast() || !ether_addr.is_unicast() {
+            return;
+        }
+
+        self.ndisc_table.lock().insert(ip_addr, ether_addr);
+    }
+
+    fn take_pending_ipv6_packet(&self, ip_addr: Ipv6Address, now_ms: i64) -> Option<Vec<u8>> {
+        let pending_packet = self.pending_ipv6_packets.lock().remove(&ip_addr)?;
+        (pending_packet.expires_at_ms > now_ms).then_some(pending_packet.packet)
+    }
+
+    fn queue_pending_ipv6_packet(&self, ip_addr: Ipv6Address, packet: Vec<u8>, now_ms: i64) {
+        let mut pending_packets = self.pending_ipv6_packets.lock();
+        Self::remove_expired_pending_ipv6_packets(&mut pending_packets, now_ms);
+
+        if pending_packets.contains_key(&ip_addr)
+            || pending_packets.len() >= MAX_PENDING_IPV6_PACKETS
+        {
+            return;
+        }
+
+        pending_packets.insert(
+            ip_addr,
+            PendingIpv6Packet {
+                packet,
+                expires_at_ms: now_ms.saturating_add(PENDING_IPV6_PACKET_TIMEOUT_MS),
+            },
+        );
+    }
+
+    fn remove_expired_pending_ipv6_packets(
+        pending_packets: &mut BTreeMap<Ipv6Address, PendingIpv6Packet>,
+        now_ms: i64,
+    ) {
+        let expired_addrs = pending_packets
+            .iter()
+            .filter(|(_, pending_packet)| pending_packet.expires_at_ms <= now_ms)
+            .map(|(ip_addr, _)| *ip_addr)
+            .collect::<Vec<_>>();
+
+        for ip_addr in expired_addrs {
+            pending_packets.remove(&ip_addr);
+        }
+    }
+
+    fn raw_hardware_addr_to_ether(lladdr: RawHardwareAddress) -> Option<EthernetAddress> {
+        (lladdr.len() >= 6).then(|| EthernetAddress::from_bytes(&lladdr.as_bytes()[..6]))
+    }
+
+    fn is_solicited_node_addr(
+        &self,
+        dst_addr: Ipv6Address,
+        target_addr: Ipv6Address,
+        iface_cx: &Context,
+    ) -> bool {
+        iface_cx.ipv6_addr().is_some_and(|local_addr| {
+            local_addr == target_addr
+                && (dst_addr == target_addr || dst_addr == Self::solicited_node_addr(target_addr))
+        })
+    }
+
+    fn solicited_node_addr(addr: Ipv6Address) -> Ipv6Address {
+        let octets = addr.octets();
+        Ipv6Address::from([
+            0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0xff, octets[13], octets[14], octets[15],
+        ])
+    }
+
+    fn ipv6_multicast_to_ethernet(addr: Ipv6Address) -> EthernetAddress {
+        debug_assert!(addr.is_multicast());
+        let octets = addr.octets();
+        EthernetAddress::from_bytes(&[0x33, 0x33, octets[12], octets[13], octets[14], octets[15]])
+    }
+
+    fn dispatch<T: TxToken>(&self, pkt: &Packet, iface_cx: &mut Context, tx_token: T) {
+        match self.resolve_ether_or_neighbor(pkt, iface_cx) {
+            EtherTx::Ip(ether) => Self::emit_ip(&ether, pkt, &iface_cx.caps, tx_token),
+            EtherTx::Arp(arp) => Self::emit_arp(&arp, tx_token),
+            EtherTx::Icmpv6(message) => self.emit_icmpv6(&message, iface_cx, tx_token),
+            EtherTx::Drop => (),
+        }
+    }
+
+    fn resolve_ether_or_neighbor(&self, pkt: &Packet, iface_cx: &mut Context) -> EtherTx {
+        // Resolve the next-hop IP address.
+        let next_hop_ip = match iface_cx.route(&pkt.ip_repr().dst_addr(), iface_cx.now()) {
+            Some(next_hop_ip) => next_hop_ip,
+            None => return EtherTx::Drop,
+        };
+
+        match next_hop_ip {
+            IpAddress::Ipv4(next_hop_ip) => {
+                self.resolve_ipv4_ether_or_arp(pkt, iface_cx, next_hop_ip)
+            }
+            IpAddress::Ipv6(next_hop_ip) => {
+                self.resolve_ipv6_ether_or_ndisc(pkt, iface_cx, next_hop_ip)
+            }
+        }
+    }
+
+    fn resolve_ipv4_ether_or_arp(
+        &self,
+        _pkt: &Packet,
+        iface_cx: &Context,
+        next_hop_ip: Ipv4Address,
+    ) -> EtherTx {
         let next_hop_ether = if next_hop_ip.is_broadcast() {
             EthernetAddress::BROADCAST
         } else if let Some(next_hop_ether) = self.arp_table.lock().get(&next_hop_ip) {
             *next_hop_ether
         } else {
-            // If the next-hop Ethernet address cannot be resolved, we drop the original packet and
-            // send an ARP packet instead. The upper layer should be responsible for detecting the
-            // packet loss and retrying later to see if the Ethernet address is ready.
-            return Err(Some(ArpRepr::EthernetIpv4 {
+            return EtherTx::Arp(ArpRepr::EthernetIpv4 {
                 operation: ArpOperation::Request,
                 source_hardware_addr: self.ether_addr,
                 source_protocol_addr: iface_cx.ipv4_addr().unwrap_or(Ipv4Address::UNSPECIFIED),
                 target_hardware_addr: EthernetAddress::BROADCAST,
                 target_protocol_addr: next_hop_ip,
-            }));
+            });
         };
 
-        Ok(EthernetRepr {
+        EtherTx::Ip(EthernetRepr {
             src_addr: self.ether_addr,
             dst_addr: next_hop_ether,
             ethertype: EthernetProtocol::Ipv4,
+        })
+    }
+
+    fn resolve_ipv6_ether_or_ndisc(
+        &self,
+        pkt: &Packet,
+        iface_cx: &Context,
+        next_hop_ip: Ipv6Address,
+    ) -> EtherTx {
+        let IpAddress::Ipv6(dst_ip) = pkt.ip_repr().dst_addr() else {
+            return EtherTx::Drop;
+        };
+
+        let next_hop_ether = if dst_ip.is_multicast() {
+            Self::ipv6_multicast_to_ethernet(dst_ip)
+        } else if let Some(next_hop_ether) = self.ndisc_table.lock().get(&next_hop_ip) {
+            *next_hop_ether
+        } else {
+            let Some(src_ip) = iface_cx.ipv6_addr() else {
+                return EtherTx::Drop;
+            };
+            let solicited_node_ip = Self::solicited_node_addr(next_hop_ip);
+            self.queue_pending_ipv6_packet(
+                next_hop_ip,
+                Self::serialize_ip(pkt, &iface_cx.caps),
+                iface_cx.now().total_millis(),
+            );
+            return EtherTx::Icmpv6(Icmpv6Message {
+                src_ip,
+                dst_ip: solicited_node_ip,
+                dst_ether: Self::ipv6_multicast_to_ethernet(solicited_node_ip),
+                repr: Icmpv6Repr::Ndisc(NdiscRepr::NeighborSolicit {
+                    target_addr: next_hop_ip,
+                    lladdr: Some(self.ether_addr.into()),
+                }),
+            });
+        };
+
+        EtherTx::Ip(EthernetRepr {
+            src_addr: self.ether_addr,
+            dst_addr: next_hop_ether,
+            ethertype: EthernetProtocol::Ipv6,
         })
     }
 
@@ -276,6 +592,14 @@ impl<D, E: Ext> EtherIface<D, E> {
         );
     }
 
+    fn serialize_ip(ip_pkt: &Packet, caps: &DeviceCapabilities) -> Vec<u8> {
+        let ip_repr = ip_pkt.ip_repr();
+        let mut packet = vec![0; ip_repr.buffer_len()];
+        ip_repr.emit(&mut packet, &caps.checksum);
+        ip_pkt.emit_payload(&ip_repr, &mut packet[ip_repr.header_len()..], caps);
+        packet
+    }
+
     /// Consumes the token and emits an ARP packet.
     fn emit_arp<T: TxToken>(arp_repr: &ArpRepr, tx_token: T) {
         let ether_repr = match arp_repr {
@@ -298,5 +622,60 @@ impl<D, E: Ext> EtherIface<D, E> {
             let mut pkt = ArpPacket::new_unchecked(frame.payload_mut());
             arp_repr.emit(&mut pkt);
         });
+    }
+
+    /// Consumes the token and emits a serialized IPv6 packet.
+    fn emit_ipv6_bytes<T: TxToken>(
+        src_ether: EthernetAddress,
+        dst_ether: EthernetAddress,
+        ip_packet: &[u8],
+        tx_token: T,
+    ) {
+        let ether_repr = EthernetRepr {
+            src_addr: src_ether,
+            dst_addr: dst_ether,
+            ethertype: EthernetProtocol::Ipv6,
+        };
+
+        tx_token.consume(ether_repr.buffer_len() + ip_packet.len(), |buffer| {
+            let mut frame = EthernetFrame::new_unchecked(buffer);
+            ether_repr.emit(&mut frame);
+            frame.payload_mut().copy_from_slice(ip_packet);
+        });
+    }
+
+    /// Consumes the token and emits an ICMPv6 packet.
+    fn emit_icmpv6<T: TxToken>(&self, message: &Icmpv6Message, iface_cx: &Context, tx_token: T) {
+        let ip_repr = Ipv6Repr {
+            src_addr: message.src_ip,
+            dst_addr: message.dst_ip,
+            next_header: IpProtocol::Icmpv6,
+            payload_len: message.repr.buffer_len(),
+            hop_limit: 0xff,
+        };
+        let ether_repr = EthernetRepr {
+            src_addr: self.ether_addr,
+            dst_addr: message.dst_ether,
+            ethertype: EthernetProtocol::Ipv6,
+        };
+
+        tx_token.consume(
+            ether_repr.buffer_len() + ip_repr.buffer_len() + message.repr.buffer_len(),
+            |buffer| {
+                let mut frame = EthernetFrame::new_unchecked(buffer);
+                ether_repr.emit(&mut frame);
+
+                let mut ip_packet = Ipv6Packet::new_unchecked(frame.payload_mut());
+                ip_repr.emit(&mut ip_packet);
+
+                let mut icmp_packet = Icmpv6Packet::new_unchecked(ip_packet.payload_mut());
+                message.repr.emit(
+                    &message.src_ip,
+                    &message.dst_ip,
+                    &mut icmp_packet,
+                    &iface_cx.checksum_caps(),
+                );
+            },
+        );
     }
 }

--- a/kernel/libs/aster-bigtcp/src/iface/phy/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/mod.rs
@@ -3,5 +3,5 @@
 mod ether;
 mod ip;
 
-pub use ether::EtherIface;
+pub use ether::{EtherIface, EtherIpConfig};
 pub use ip::IpIface;

--- a/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
@@ -49,11 +49,24 @@ impl<E: Ext> PollableIface<E> {
         })
     }
 
-    pub(super) fn prefix_len(&self) -> Option<u8> {
-        self.interface
-            .ip_addrs()
-            .first()
-            .map(|ip_addr| ip_addr.prefix_len())
+    pub(super) fn ipv4_prefix_len(&self) -> Option<u8> {
+        self.interface.ip_addrs().iter().find_map(|cidr| {
+            if let smoltcp::wire::IpCidr::Ipv4(ipv4_cidr) = cidr {
+                Some(ipv4_cidr.prefix_len())
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(super) fn ipv6_prefix_len(&self) -> Option<u8> {
+        self.interface.ip_addrs().iter().find_map(|cidr| {
+            if let smoltcp::wire::IpCidr::Ipv6(ipv6_cidr) = cidr {
+                Some(ipv6_cidr.prefix_len())
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the next poll time.

--- a/kernel/libs/aster-bigtcp/src/iface/port.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/port.rs
@@ -2,9 +2,57 @@
 
 use smoltcp::wire::{IpAddress, IpEndpoint};
 
+/// The local address scope that a socket is bound to.
+///
+/// The scope determines both which incoming packets the socket accepts and how
+/// the binding conflicts with other bindings on the same port.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum BindPortScope {
+    /// A specific local address.
+    Address(IpAddress),
+    /// The IPv4 wildcard address (`0.0.0.0`).
+    Ipv4Wildcard,
+    /// The IPv6 wildcard address (`::`) of an `IPV6_V6ONLY` socket.
+    Ipv6OnlyWildcard,
+    /// The IPv6 wildcard address (`::`) of a dual-stack socket, which also
+    /// accepts IPv4 traffic.
+    Ipv6DualStackWildcard,
+}
+
+impl BindPortScope {
+    /// Returns the representative local address of the scope.
+    pub(crate) fn addr(&self) -> IpAddress {
+        match self {
+            Self::Address(addr) => *addr,
+            Self::Ipv4Wildcard => IpAddress::Ipv4(core::net::Ipv4Addr::UNSPECIFIED),
+            Self::Ipv6OnlyWildcard | Self::Ipv6DualStackWildcard => {
+                IpAddress::Ipv6(core::net::Ipv6Addr::UNSPECIFIED)
+            }
+        }
+    }
+
+    /// Returns whether a packet destined to `addr` should be delivered to a
+    /// socket bound with this scope.
+    pub(crate) fn matches_addr(&self, addr: IpAddress) -> bool {
+        match (*self, addr) {
+            (Self::Address(bound), addr) => bound == addr,
+            (Self::Ipv4Wildcard, IpAddress::Ipv4(_)) => true,
+            (Self::Ipv6OnlyWildcard, IpAddress::Ipv6(addr)) => !is_ipv4_mapped(addr),
+            (Self::Ipv6DualStackWildcard, IpAddress::Ipv4(_)) => true,
+            (Self::Ipv6DualStackWildcard, IpAddress::Ipv6(addr)) => !is_ipv4_mapped(addr),
+            _ => false,
+        }
+    }
+}
+
+fn is_ipv4_mapped(addr: core::net::Ipv6Addr) -> bool {
+    let octets = addr.octets();
+    octets[..10] == [0; 10] && octets[10] == 0xff && octets[11] == 0xff
+}
+
 /// The configuration using for bind to a TCP/UDP port.
 pub struct BindPortConfig {
-    addr: IpAddress,
+    scope: BindPortScope,
     kind: PortKind,
 }
 
@@ -22,23 +70,37 @@ enum PortKind {
 impl BindPortConfig {
     /// Creates new configuration using for bind to a TCP/UDP port.
     pub fn new(endpoint: IpEndpoint, can_reuse: bool) -> Self {
-        let port = endpoint.port;
+        Self::new_with_scope(
+            BindPortScope::Address(endpoint.addr),
+            endpoint.port,
+            can_reuse,
+        )
+    }
+
+    /// Creates a new configuration that binds to a port within the given scope.
+    pub fn new_with_scope(scope: BindPortScope, port: u16, can_reuse: bool) -> Self {
         let kind = match (port, can_reuse) {
             (0, can_reuse) => PortKind::Ephemeral(can_reuse),
             (_, true) => PortKind::CanReuse(port),
             (_, false) => PortKind::Specified(port),
         };
-        Self {
-            addr: endpoint.addr,
-            kind,
-        }
+        Self { scope, kind }
     }
 
     /// Creates a new configuration for reusing the port of a listening socket.
     pub fn new_backlog(endpoint: IpEndpoint) -> Self {
         Self {
-            addr: endpoint.addr,
+            scope: BindPortScope::Address(endpoint.addr),
             kind: PortKind::Backlog(endpoint.port),
+        }
+    }
+
+    /// Creates a new configuration that reuses a listening socket's port within
+    /// the given scope.
+    pub(crate) fn new_backlog_with_scope(scope: BindPortScope, port: u16) -> Self {
+        Self {
+            scope,
+            kind: PortKind::Backlog(port),
         }
     }
 
@@ -62,7 +124,7 @@ impl BindPortConfig {
         }
     }
 
-    pub(super) fn addr(&self) -> IpAddress {
-        self.addr
+    pub(super) fn scope(&self) -> BindPortScope {
+        self.scope
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
@@ -3,7 +3,7 @@
 use alloc::sync::{Arc, Weak};
 use core::ops::Deref;
 
-use smoltcp::wire::IpEndpoint;
+use smoltcp::wire::{IpAddress, IpEndpoint};
 use spin::once::Once;
 use takeable::Takeable;
 
@@ -139,5 +139,9 @@ impl<T: Inner<E>, E: Ext> SocketBg<T, E> {
     /// The check is intended to be lock-free and fast, but may have false positives.
     pub(crate) fn can_process(&self, dst_port: u16) -> bool {
         self.bound.port() == dst_port
+    }
+
+    pub(crate) fn can_process_addr(&self, dst_addr: IpAddress, dst_port: u16) -> bool {
+        self.bound.port() == dst_port && self.bound.scope().matches_addr(dst_addr)
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
@@ -7,7 +7,7 @@ use ostd::sync::SpinLock;
 use smoltcp::{
     socket::PollAt,
     time::Duration,
-    wire::{IpEndpoint, IpRepr, TcpRepr},
+    wire::{IpEndpoint, IpListenEndpoint, IpRepr, TcpRepr},
 };
 
 use super::{
@@ -81,7 +81,7 @@ impl<E: Ext> TcpListener<E> {
 
         let listener_key = ListenerKey::new(local_endpoint.addr, local_endpoint.port);
 
-        if sockets.lookup_listener(&listener_key).is_some() {
+        if sockets.has_listener_conflict(bound.scope(), local_endpoint.port) {
             return Err((bound, ListenError::AddressInUse));
         }
 
@@ -89,6 +89,15 @@ impl<E: Ext> TcpListener<E> {
             let mut socket = new_tcp_socket();
 
             option.apply(&mut socket);
+
+            let local_endpoint = if bound.addr().is_unspecified() {
+                IpListenEndpoint {
+                    addr: None,
+                    port: local_endpoint.port,
+                }
+            } else {
+                local_endpoint.into()
+            };
 
             if let Err(err) = socket.listen(local_endpoint) {
                 return Err((bound, err.into()));
@@ -197,6 +206,10 @@ impl<E: Ext> TcpListenerBg<E> {
         ip_repr: &IpRepr,
         tcp_repr: &TcpRepr,
     ) -> (TcpProcessResult, Option<Arc<TcpConnectionBg<E>>>) {
+        if !self.can_process_addr(ip_repr.dst_addr(), tcp_repr.dst_port) {
+            return (TcpProcessResult::NotProcessed, None);
+        }
+
         let mut backlog = self.inner.backlog.lock();
 
         if !backlog
@@ -235,7 +248,10 @@ impl<E: Ext> TcpListenerBg<E> {
         let conn = TcpConnection::new_cyclic(
             self.bound
                 .iface()
-                .bind_tcp(BindPortConfig::new_backlog(self.bound.endpoint()))
+                .bind_tcp(BindPortConfig::new_backlog_with_scope(
+                    self.bound.scope(),
+                    self.bound.port(),
+                ))
                 .unwrap(),
             |weak| {
                 TcpConnectionInner::new(

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -8,7 +8,7 @@ use ostd::sync::SpinLock;
 use smoltcp::{
     iface::Context,
     socket::udp::UdpMetadata,
-    wire::{IpRepr, UdpRepr},
+    wire::{IpListenEndpoint, IpRepr, UdpRepr},
 };
 
 use super::{
@@ -55,7 +55,9 @@ impl<E: Ext> UdpSocketBg<E> {
     ) -> bool {
         let mut socket = self.inner.socket.lock();
 
-        if !socket.accepts(cx, ip_repr, udp_repr) {
+        if !self.bound.scope().matches_addr(ip_repr.dst_addr())
+            || !socket.accepts(cx, ip_repr, udp_repr)
+        {
             return false;
         }
 
@@ -114,6 +116,14 @@ impl<E: Ext> UdpSocket<E> {
 
         let socket = {
             let mut socket = new_udp_socket();
+            let local_endpoint = if bound.addr().is_unspecified() {
+                IpListenEndpoint {
+                    addr: None,
+                    port: local_endpoint.port,
+                }
+            } else {
+                local_endpoint.into()
+            };
 
             if let Err(err) = socket.bind(local_endpoint) {
                 return Err((bound, err));

--- a/kernel/libs/aster-bigtcp/src/socket_table.rs
+++ b/kernel/libs/aster-bigtcp/src/socket_table.rs
@@ -12,6 +12,7 @@ use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
 
 use crate::{
     ext::Ext,
+    iface::BindPortScope,
     socket::{TcpConnectionBg, TcpListenerBg, UdpSocketBg},
     wire::PortNum,
 };
@@ -272,6 +273,24 @@ impl<E: Ext> SocketTable<E> {
             .listeners
             .iter()
             .find(|listener| listener.listener_key() == key)
+            .or_else(|| {
+                self.listener_buckets
+                    .iter()
+                    .flat_map(|bucket| bucket.listeners.iter())
+                    .find(|listener| listener.can_process_addr(key.addr, key.port))
+            })
+    }
+
+    pub(crate) fn has_listener_conflict(&self, scope: BindPortScope, port: PortNum) -> bool {
+        self.listener_buckets
+            .iter()
+            .flat_map(|bucket| bucket.listeners.iter())
+            .any(|listener| {
+                let key = listener.listener_key();
+                key.port == port
+                    && (scope.matches_addr(key.addr)
+                        || listener.can_process_addr(scope.addr(), port))
+            })
     }
 
     pub(crate) fn lookup_connection(

--- a/kernel/libs/aster-bigtcp/src/wire.rs
+++ b/kernel/libs/aster-bigtcp/src/wire.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub use smoltcp::wire::{
-    EthernetAddress, IpAddress, IpCidr, IpEndpoint, Ipv4Address, Ipv4Cidr, Ipv6Address, Ipv6Cidr,
+    EthernetAddress, IpAddress, IpCidr, IpEndpoint, IpListenEndpoint, Ipv4Address, Ipv4Cidr,
+    Ipv6Address, Ipv6Cidr,
 };
 
 pub type PortNum = u16;

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -107,14 +107,17 @@ fn new_loopback() -> Arc<Iface> {
 
 fn new_virtio() -> Option<Arc<Iface>> {
     use aster_bigtcp::{
-        iface::EtherIface,
-        wire::{EthernetAddress, Ipv4Address, Ipv4Cidr},
+        iface::{EtherIface, EtherIpConfig},
+        wire::{EthernetAddress, Ipv4Address, Ipv4Cidr, Ipv6Address, Ipv6Cidr},
     };
     use aster_network::AnyNetworkDevice;
 
     const VIRTIO_ADDRESS: Ipv4Address = Ipv4Address::new(10, 0, 2, 15);
     const VIRTIO_ADDRESS_PREFIX_LEN: u8 = 24; // mask: 255.255.255.0
     const VIRTIO_GATEWAY: Ipv4Address = Ipv4Address::new(10, 0, 2, 2);
+    const VIRTIO_IPV6_ADDRESS: Ipv6Address = Ipv6Address::new(0xfec0, 0, 0, 0, 0, 0, 0, 0x0015);
+    const VIRTIO_IPV6_PREFIX_LEN: u8 = 64;
+    const VIRTIO_IPV6_GATEWAY: Ipv6Address = Ipv6Address::new(0xfec0, 0, 0, 0, 0, 0, 0, 0x0002);
 
     let virtio_net = aster_network::get_device(VIRTIO_DEVICE_NAME)?;
 
@@ -145,8 +148,12 @@ fn new_virtio() -> Option<Arc<Iface>> {
     Some(EtherIface::new(
         Wrapper(virtio_net),
         EthernetAddress(ether_addr),
-        Ipv4Cidr::new(VIRTIO_ADDRESS, VIRTIO_ADDRESS_PREFIX_LEN),
-        VIRTIO_GATEWAY,
+        EtherIpConfig::new(
+            Ipv4Cidr::new(VIRTIO_ADDRESS, VIRTIO_ADDRESS_PREFIX_LEN),
+            Some(Ipv6Cidr::new(VIRTIO_IPV6_ADDRESS, VIRTIO_IPV6_PREFIX_LEN)),
+            VIRTIO_GATEWAY,
+            Some(VIRTIO_IPV6_GATEWAY),
+        ),
         CString::new("eth0").unwrap(),
         PollScheduler::new(),
         flags,

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -87,7 +87,7 @@ impl ConnectingStream {
             )),
             ConnectState::Refused => {
                 let bound_port = self.tcp_conn.into_bound_port().unwrap();
-                let family = IpAddressFamily::from(*bound_port.addr());
+                let family = IpAddressFamily::from(bound_port.addr());
                 ConnResult::Refused(InitStream::new_refused(bound_port, family))
             }
         }

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -53,7 +53,7 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<
 
     let addr_message = AddrSegmentBody {
         family: CSocketAddrFamily::AF_INET as _,
-        prefix_len: iface.prefix_len().unwrap(),
+        prefix_len: iface.ipv4_prefix_len().unwrap(),
         flags: AddrMessageFlags::PERMANENT,
         scope: RtScope::HOST,
         index: NonZeroU32::new(iface.index()),


### PR DESCRIPTION
> Part 1 of 2: IPv6 support. This lays the link-layer/interface groundwork; dual-stack sockets and `IPV6_V6ONLY` come in the follow-up.

This series brings `aster-bigtcp` far enough that an Ethernet interface can carry IPv6 alongside IPv4: it configures IPv6 addresses and routes, parses and answers Neighbor Discovery, transmits IPv6 frames, reports per-family prefix lengths, and reworks the port table so that IPv4, native-IPv6, and (future) dual-stack binds are tracked by an explicit *scope* rather than a single normalized address. No new socket behavior is exposed to userspace yet; existing IPv4 sockets are unchanged. See [ipv6(7)](https://man7.org/linux/man-pages/man7/ipv6.7.html) for the semantics this ultimately targets.

## Scope

In scope:
- IPv6 addressing, routing, and Neighbor Discovery on `EtherIface`.
- Per-address-family prefix-length reporting.
- Scope-based bind bookkeeping in the port table and socket table, so an IPv6 wildcard bind and an IPv4 wildcard bind on the same port are no longer forced to collide via a shared normalized key.

Deliberately out of scope (follow-up PR):
- User-facing dual-stack sockets: accepting IPv4 traffic on a `::` socket, returning IPv4-mapped peers from `accept(2)`.
- The `IPV6_V6ONLY` socket option and the `getsockopt`/`setsockopt` plumbing behind it.
- Netlink/`RTM_NEWADDR` reporting of the IPv6 address (the netlink route path still emits only `AF_INET`).
- Neighbor-cache entry expiry (see the `TODO` retained on the NDISC and ARP tables).

The `BindPortScope::Ipv6OnlyWildcard` / `Ipv6DualStackWildcard` variants and the `scopes_conflict` matrix are introduced here so the follow-up socket work has a stable substrate, but nothing constructs the dual-stack variant yet.

## Changes by subsystem

**Interface / link layer** (`iface/phy/ether.rs`, `iface/init.rs`, `iface/poll_iface.rs`, `iface/iface.rs`). `EtherIface::new` now takes an `EtherIpConfig { ipv4_cidr, ipv6_cidr: Option, ipv4_gateway, ipv6_gateway: Option }` instead of a bare `Ipv4Cidr`/gateway pair, pushing the optional `Ipv6Cidr` into `update_ip_addrs` and adding a default IPv6 route when a gateway is supplied. Ingress classifies `EthernetProtocol::Ipv6` frames and runs them through `process_ndisc` before handing them up as an `IpPacket::Ipv6`. NDISC handling covers:
- Neighbor Advertisements: cache the target's link-layer address (honoring the `OVERRIDE` flag), then flush any packet queued for that neighbor.
- Neighbor Solicitations: validate `hop_limit == 0xff`, verify the solicited-node multicast target against our address, and emit a Neighbor Advertisement — including the RFC 4861 §7.2.4 case where a DAD solicitation from `::` is answered to the all-nodes multicast `ff02::1` with the solicited flag cleared.

Egress resolves the next hop: multicast destinations map directly to `33:33:xx:xx:xx:xx`, cached neighbors are used immediately, and an unresolved unicast next hop triggers a Neighbor Solicitation to the solicited-node multicast while the packet is parked. Pending packets live in a bounded `BTreeMap` (`MAX_PENDING_IPV6_PACKETS = 64`, `PENDING_IPV6_PACKET_TIMEOUT_MS = 1000`) with lazy expiry, so an unreachable neighbor cannot grow memory without bound. Prefix-length reporting splits into `ipv4_prefix_len`/`ipv6_prefix_len`, each scanning `ip_addrs()` for the matching CIDR family rather than blindly taking the first address; callers (`Iface::broadcast_addr`, the netlink addr path) move to the IPv4 variant. The virtio device is provisioned with `fec0::15/64` and gateway `fec0::2` for testing.

**Bind-scope tracking** (`port.rs`, `socket_table.rs`, `iface/common.rs`, `socket/bound/*`). The old `NormalizedAddress` (which mapped every IPv4 address to `::ffff:x.x.x.x`) is replaced by `BindPortScope`, carried end to end through `BindPortConfig`, `BoundPort`, and `PortKey`. `PortKey` is reordered to `(protocol, port, scope)` so all bindings on one port are contiguous in the `BTreeMap`; `keys_on_port` range-scans just that slice instead of the whole table for both conflict detection and ephemeral-port allocation. `scopes_conflict` encodes the actual Linux-like conflict rules (IPv4 wildcard vs. IPv4 address, IPv6-only wildcard vs. IPv6 address, dual-stack wildcard vs. both families, distinct IPv6 addresses never conflicting with IPv4-only binds). The socket table gains a `hash_addr_port`/`hash_local_remote` IPv6 path (jhash over the 128-bit address split into four `u32` words) and `has_listener_conflict` now takes a `BindPortScope`.

## Why land this separately

The link-layer and port-table changes are self-contained and independently reviewable: they change how frames are parsed/emitted and how binds are keyed, but they do not alter any syscall-visible behavior. The socket layer (`IPV6_V6ONLY`, dual-stack accept, mapped-address reporting) is where the user-observable semantics live and where the subtle compatibility questions are; keeping it in a second PR lets reviewers reason about the neighbor-discovery state machine and the conflict matrix without also weighing socket-option edge cases. The scope enum and conflict rules are the seam between the two.

## Testing

Booted under QEMU with the virtio-net interface configured for both `10.0.2.15/24` and `fec0::15/64`. Verified inbound Neighbor Solicitation for our address is answered, that DAD solicitations from `::` are answered to `ff02::1`, and that an outbound IPv6 packet to an unresolved neighbor triggers a solicitation and is flushed once the advertisement arrives. Existing IPv4 TCP/UDP bind and connect paths continue to pass.

## Follow-up

Part 2 wires `BindPortScope::Ipv6DualStackWildcard` to real sockets, adds `IPV6_V6ONLY`, returns IPv4-mapped addresses to dual-stack accepters, and extends the netlink route path to report the IPv6 address. Neighbor-cache expiry and shared-per-namespace listener hashing remain tracked as `TODO`s.