### PR TITLE
Support IPv6 dual-stack sockets and IPV6_V6ONLY

### DIFF
--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -126,8 +126,12 @@ impl<E: Ext> IfaceCommon<E> {
         self.interface.lock().ipv6_addr()
     }
 
-    pub(super) fn prefix_len(&self) -> Option<u8> {
-        self.interface.lock().prefix_len()
+    pub(super) fn ipv4_prefix_len(&self) -> Option<u8> {
+        self.interface.lock().ipv4_prefix_len()
+    }
+
+    pub(super) fn ipv6_prefix_len(&self) -> Option<u8> {
+        self.interface.lock().ipv6_prefix_len()
     }
 
     pub(super) fn sched_poll(&self) -> &E::ScheduleNextPoll {

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -26,7 +26,7 @@ use super::{
     Iface,
     poll::{FnHelper, PollContext, SocketTableAction},
     poll_iface::PollableIface,
-    port::BindPortConfig,
+    port::{BindPortConfig, BindPortScope},
     time::get_network_timestamp,
 };
 use crate::{
@@ -52,32 +52,6 @@ pub struct IfaceCommon<E: Ext> {
 pub(super) enum IpPacket<'a> {
     Ipv4(Ipv4Packet<&'a [u8]>),
     Ipv6(Ipv6Packet<&'a [u8]>),
-}
-
-/// A normalized IP address for binding purposes.
-///
-/// IPv4 addresses are normalized to IPv4-mapped IPv6 addresses. IPv6 addresses
-/// remain unchanged.
-///
-/// IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) should be treated as equivalent
-/// to their IPv4 counterparts for binding purposes. This ensures that binding
-/// to `192.0.2.1:80` and `::ffff:192.0.2.1:80` are treated as the same.
-//
-// TODO: This type currently only handles port binding conflict detection. Full
-// dual-stack support is not yet implemented, including:
-// - Accepting IPv4 connections on IPv6 wildcard socket (binding to `::`).
-// - Returning IPv4-mapped addresses in `accept()` for IPv4 clients.
-// - Proper handling of `IPV6_V6ONLY` socket option.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct NormalizedAddress(Ipv6Address);
-
-impl From<IpAddress> for NormalizedAddress {
-    fn from(value: IpAddress) -> Self {
-        match value {
-            IpAddress::Ipv4(ipv4) => Self(ipv4.to_ipv6_mapped()),
-            IpAddress::Ipv6(ipv6) => Self(ipv6),
-        }
-    }
 }
 
 impl<E: Ext> IfaceCommon<E> {
@@ -185,11 +159,11 @@ impl<E: Ext> IfaceCommon<E> {
         config: BindPortConfig,
         protocol: PortProtocol,
     ) -> Result<BoundPort<E>, BindError> {
-        let addr = config.addr();
+        let scope = config.scope();
         let (port, can_reuse) = self.used_ports.lock().bind(config, protocol)?;
         Ok(BoundPort {
             iface,
-            addr,
+            scope,
             port,
             protocol,
             can_reuse: AtomicBool::new(can_reuse),
@@ -197,10 +171,16 @@ impl<E: Ext> IfaceCommon<E> {
     }
 
     /// Releases the port so that it can be used again.
-    fn release_port(&self, addr: IpAddress, port: u16, can_reuse: bool, protocol: PortProtocol) {
+    fn release_port(
+        &self,
+        scope: BindPortScope,
+        port: u16,
+        can_reuse: bool,
+        protocol: PortProtocol,
+    ) {
         self.used_ports
             .lock()
-            .release(addr, port, can_reuse, protocol);
+            .release(scope, port, can_reuse, protocol);
     }
 }
 
@@ -274,7 +254,7 @@ impl<E: Ext> IfaceCommon<E> {
 /// When dropped, the port is automatically released.
 pub struct BoundPort<E: Ext> {
     iface: Arc<dyn Iface<E>>,
-    addr: IpAddress,
+    scope: BindPortScope,
     port: u16,
     protocol: PortProtocol,
     can_reuse: AtomicBool,
@@ -292,13 +272,18 @@ impl<E: Ext> BoundPort<E> {
     }
 
     /// Returns the bound IP address.
-    pub fn addr(&self) -> &IpAddress {
-        &self.addr
+    pub fn addr(&self) -> IpAddress {
+        self.scope.addr()
     }
 
     /// Returns the bound endpoint.
     pub fn endpoint(&self) -> IpEndpoint {
-        IpEndpoint::new(self.addr, self.port)
+        IpEndpoint::new(self.scope.addr(), self.port)
+    }
+
+    /// Returns the scope that the port is bound to.
+    pub(crate) fn scope(&self) -> BindPortScope {
+        self.scope
     }
 
     /// Sets whether the port can be reused.
@@ -312,9 +297,9 @@ impl<E: Ext> BoundPort<E> {
         }
 
         let key = PortKey {
-            addr: NormalizedAddress::from(self.addr),
-            port: self.port,
             protocol: self.protocol,
+            port: self.port,
+            scope: self.scope,
         };
         used_ports.set_can_reuse(key, can_reuse);
 
@@ -325,7 +310,7 @@ impl<E: Ext> BoundPort<E> {
 impl<E: Ext> Drop for BoundPort<E> {
     fn drop(&mut self) {
         self.iface.common().release_port(
-            self.addr,
+            self.scope,
             self.port,
             *self.can_reuse.get_mut(),
             self.protocol,
@@ -351,11 +336,14 @@ impl<E: Ext> Deref for BoundUdpPort<E> {
     }
 }
 
+// The field order matters: keying by `(protocol, port, scope)` keeps all
+// bindings on the same port contiguous in `PortTable::used_ports`, so conflict
+// checks can scan just that port instead of the whole table.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 struct PortKey {
-    addr: NormalizedAddress,
-    port: u16,
     protocol: PortProtocol,
+    port: u16,
+    scope: BindPortScope,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -394,50 +382,83 @@ impl PortTable {
         }
     }
 
+    /// Iterates over the bindings on the given `(protocol, port)`.
+    ///
+    /// The entries for a single port are contiguous in `used_ports` (see the
+    /// note on [`PortKey`]), so this scans only those entries rather than the
+    /// whole table.
+    fn keys_on_port(
+        &self,
+        protocol: PortProtocol,
+        port: u16,
+    ) -> impl Iterator<Item = (&PortKey, &PortState)> {
+        let lower_bound = PortKey {
+            protocol,
+            port,
+            scope: BindPortScope::Address(IpAddress::Ipv4(core::net::Ipv4Addr::UNSPECIFIED)),
+        };
+        self.used_ports
+            .range(lower_bound..)
+            .take_while(move |(key, _)| key.protocol == protocol && key.port == port)
+    }
+
     fn bind(
         &mut self,
         config: BindPortConfig,
         protocol: PortProtocol,
     ) -> Result<(u16, bool), BindError> {
         let config_can_reuse = config.can_reuse();
-        let addr = NormalizedAddress::from(config.addr());
+        let scope = config.scope();
 
         let port = if let Some(port) = config.port() {
             port
         } else {
-            match self.alloc_ephemeral_port(addr, protocol, config_can_reuse) {
+            match self.alloc_ephemeral_port(scope, protocol, config_can_reuse) {
                 Some(port) => port,
                 None => return Err(BindError::Exhausted),
             }
         };
 
         let key = PortKey {
-            addr,
-            port,
             protocol,
+            port,
+            scope,
         };
+
+        let conflicting_keys = self
+            .keys_on_port(protocol, port)
+            .filter(|(used_key, _)| scopes_conflict(used_key.scope, scope))
+            .map(|(used_key, _)| *used_key)
+            .collect::<Vec<_>>();
+
+        if !conflicting_keys.is_empty() {
+            // FIXME: If the socket is not a backlog socket,
+            // we should check whether there is a listening socket on the port.
+            // If there is, the socket cannot be bound to that port.
+            let can_reuse = config.is_backlog()
+                || (config_can_reuse
+                    && conflicting_keys
+                        .iter()
+                        .all(|key| self.used_ports.get(key).unwrap().can_reuse()));
+
+            if !can_reuse {
+                return Err(BindError::InUse);
+            }
+        };
+
         let entry = self.used_ports.entry(key);
         match entry {
             Entry::Occupied(mut occupied) => {
                 let port_state = occupied.get_mut();
-                // FIXME: If the socket is not a backlog socket,
-                // we should check whether there is a listening socket on the port.
-                // If there is, the socket cannot be bound to that port.
-                let can_reuse = config.is_backlog() || (port_state.can_reuse() & config_can_reuse);
-                if can_reuse {
-                    port_state.nsocket += 1;
-                    if config_can_reuse {
-                        port_state.nreuse += 1;
-                    }
-                } else {
-                    return Err(BindError::InUse);
+                port_state.nsocket += 1;
+                if config_can_reuse {
+                    port_state.nreuse += 1;
                 }
             }
             Entry::Vacant(vacant) => {
-                let port_state = PortState::new(config_can_reuse);
-                vacant.insert(port_state);
+                vacant.insert(PortState::new(config_can_reuse));
             }
-        };
+        }
 
         Ok((port, config_can_reuse))
     }
@@ -454,7 +475,7 @@ impl PortTable {
     /// See <https://en.wikipedia.org/wiki/Ephemeral_port>.
     fn alloc_ephemeral_port(
         &mut self,
-        addr: NormalizedAddress,
+        scope: BindPortScope,
         protocol: PortProtocol,
         _can_reuse: bool,
     ) -> Option<u16> {
@@ -466,16 +487,13 @@ impl PortTable {
             }
         }
 
-        let mut key = PortKey {
-            addr,
-            port: 0,
-            protocol,
-        };
         let start_port = self.next_ephemeral_port;
         let mut port = start_port;
         loop {
-            key.port = port;
-            if !self.used_ports.contains_key(&key) {
+            let in_use = self
+                .keys_on_port(protocol, port)
+                .any(|(used_key, _)| scopes_conflict(used_key.scope, scope));
+            if !in_use {
                 self.next_ephemeral_port = next_ephemeral_port_after(port);
                 return Some(port);
             }
@@ -492,11 +510,17 @@ impl PortTable {
         None
     }
 
-    fn release(&mut self, addr: IpAddress, port: u16, can_reuse: bool, protocol: PortProtocol) {
+    fn release(
+        &mut self,
+        scope: BindPortScope,
+        port: u16,
+        can_reuse: bool,
+        protocol: PortProtocol,
+    ) {
         let key = PortKey {
-            addr: NormalizedAddress::from(addr),
-            port,
             protocol,
+            port,
+            scope,
         };
         let Entry::Occupied(mut occupied) = self.used_ports.entry(key) else {
             return;
@@ -522,6 +546,30 @@ impl PortTable {
         } else {
             port_state.nreuse -= 1;
         }
+    }
+}
+
+fn scopes_conflict(lhs: BindPortScope, rhs: BindPortScope) -> bool {
+    use BindPortScope::*;
+
+    match (lhs, rhs) {
+        (Ipv6DualStackWildcard, Address(IpAddress::Ipv4(_)))
+        | (Address(IpAddress::Ipv4(_)), Ipv6DualStackWildcard)
+        | (Ipv6DualStackWildcard, Ipv4Wildcard)
+        | (Ipv4Wildcard, Ipv6DualStackWildcard)
+        | (Ipv6DualStackWildcard, Ipv6DualStackWildcard)
+        | (Ipv6DualStackWildcard, Ipv6OnlyWildcard)
+        | (Ipv6OnlyWildcard, Ipv6DualStackWildcard)
+        | (Ipv4Wildcard, Address(IpAddress::Ipv4(_)))
+        | (Address(IpAddress::Ipv4(_)), Ipv4Wildcard)
+        | (Ipv4Wildcard, Ipv4Wildcard)
+        | (Ipv6OnlyWildcard, Address(IpAddress::Ipv6(_)))
+        | (Address(IpAddress::Ipv6(_)), Ipv6OnlyWildcard)
+        | (Ipv6OnlyWildcard, Ipv6OnlyWildcard) => true,
+        (Address(left), Address(right)) => left == right,
+        (Ipv6DualStackWildcard, Address(IpAddress::Ipv6(_)))
+        | (Address(IpAddress::Ipv6(_)), Ipv6DualStackWildcard) => true,
+        _ => false,
     }
 }
 

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -89,8 +89,13 @@ impl<E: Ext> dyn Iface<E> {
     ///
     /// Both `Self::ipv4_addr` and this method will either return `Some(_)`
     /// or both will return `None`.
-    pub fn prefix_len(&self) -> Option<u8> {
-        self.common().prefix_len()
+    pub fn ipv4_prefix_len(&self) -> Option<u8> {
+        self.common().ipv4_prefix_len()
+    }
+
+    /// Retrieves the prefix length of the interface's IPv6 address.
+    pub fn ipv6_prefix_len(&self) -> Option<u8> {
+        self.common().ipv6_prefix_len()
     }
 
     /// Gets the broadcast address of the iface, if any.
@@ -98,7 +103,7 @@ impl<E: Ext> dyn Iface<E> {
         let cidr = {
             let common = self.common();
             let ipv4_addr = common.ipv4_addr()?;
-            let prefix_len = common.prefix_len()?;
+            let prefix_len = common.ipv4_prefix_len()?;
             Ipv4Cidr::new(ipv4_addr, prefix_len)
         };
         cidr.broadcast()

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -14,5 +14,5 @@ pub use common::{BoundPort, BoundTcpPort, BoundUdpPort, InterfaceFlags, Interfac
 pub use iface::Iface;
 pub use phy::{EtherIface, IpIface};
 pub(crate) use poll_iface::{PollKey, PollableIfaceMut};
-pub use port::BindPortConfig;
+pub use port::{BindPortConfig, BindPortScope};
 pub use sched::ScheduleNextPoll;

--- a/kernel/libs/aster-bigtcp/src/iface/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/mod.rs
@@ -12,7 +12,7 @@ mod time;
 
 pub use common::{BoundPort, BoundTcpPort, BoundUdpPort, InterfaceFlags, InterfaceType};
 pub use iface::Iface;
-pub use phy::{EtherIface, IpIface};
+pub use phy::{EtherIface, EtherIpConfig, IpIface};
 pub(crate) use poll_iface::{PollKey, PollableIfaceMut};
 pub use port::{BindPortConfig, BindPortScope};
 pub use sched::ScheduleNextPoll;

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{collections::btree_map::BTreeMap, ffi::CString, sync::Arc};
+use alloc::{collections::btree_map::BTreeMap, ffi::CString, sync::Arc, vec, vec::Vec};
 
 use aster_softirq::BottomHalfDisabled;
 use ostd::sync::SpinLock;
@@ -9,7 +9,9 @@ use smoltcp::{
     phy::{Device, DeviceCapabilities, TxToken},
     wire::{
         self, ArpOperation, ArpPacket, ArpRepr, EthernetAddress, EthernetFrame, EthernetProtocol,
-        EthernetRepr, IpAddress, Ipv4Address, Ipv4AddressExt, Ipv4Cidr, Ipv4Packet, Ipv6Packet,
+        EthernetRepr, HardwareAddress, Icmpv6Packet, Icmpv6Repr, IpAddress, IpProtocol,
+        Ipv4Address, Ipv4AddressExt, Ipv4Cidr, Ipv4Packet, Ipv6Address, Ipv6AddressExt, Ipv6Cidr,
+        Ipv6Packet, Ipv6Repr, NdiscNeighborFlags, NdiscRepr, RawHardwareAddress,
     },
 };
 
@@ -29,31 +31,97 @@ pub struct EtherIface<D, E: Ext> {
     common: IfaceCommon<E>,
     ether_addr: EthernetAddress,
     arp_table: SpinLock<BTreeMap<Ipv4Address, EthernetAddress>, BottomHalfDisabled>,
+    ndisc_table: SpinLock<BTreeMap<Ipv6Address, EthernetAddress>, BottomHalfDisabled>,
+    pending_ipv6_packets: SpinLock<BTreeMap<Ipv6Address, PendingIpv6Packet>, BottomHalfDisabled>,
+}
+
+const MAX_PENDING_IPV6_PACKETS: usize = 64;
+const PENDING_IPV6_PACKET_TIMEOUT_MS: i64 = 1_000;
+
+struct PendingIpv6Packet {
+    packet: Vec<u8>,
+    expires_at_ms: i64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EtherIpConfig {
+    ipv4_cidr: Ipv4Cidr,
+    ipv6_cidr: Option<Ipv6Cidr>,
+    ipv4_gateway: Ipv4Address,
+    ipv6_gateway: Option<Ipv6Address>,
+}
+
+impl EtherIpConfig {
+    pub fn new(
+        ipv4_cidr: Ipv4Cidr,
+        ipv6_cidr: Option<Ipv6Cidr>,
+        ipv4_gateway: Ipv4Address,
+        ipv6_gateway: Option<Ipv6Address>,
+    ) -> Self {
+        Self {
+            ipv4_cidr,
+            ipv6_cidr,
+            ipv4_gateway,
+            ipv6_gateway,
+        }
+    }
+}
+
+enum EtherIngress<'pkt> {
+    Ip(IpPacket<'pkt>),
+    Arp(ArpRepr),
+    Icmpv6(Icmpv6Message<'static>),
+    PendingIpv6(EthernetAddress, Vec<u8>),
+    Drop,
+}
+
+enum EtherTx {
+    Ip(EthernetRepr),
+    Arp(ArpRepr),
+    Icmpv6(Icmpv6Message<'static>),
+    Drop,
+}
+
+struct Icmpv6Message<'a> {
+    src_ip: Ipv6Address,
+    dst_ip: Ipv6Address,
+    dst_ether: EthernetAddress,
+    repr: Icmpv6Repr<'a>,
 }
 
 impl<D: WithDevice, E: Ext> EtherIface<D, E> {
     pub fn new(
         driver: D,
         ether_addr: EthernetAddress,
-        ip_cidr: Ipv4Cidr,
-        gateway: Ipv4Address,
+        ip_config: EtherIpConfig,
         name: CString,
         sched_poll: E::ScheduleNextPoll,
         flags: InterfaceFlags,
     ) -> Arc<Self> {
         let interface = driver.with(|device| {
-            let config = Config::new(wire::HardwareAddress::Ethernet(ether_addr));
+            let config = Config::new(HardwareAddress::Ethernet(ether_addr));
             let now = get_network_timestamp();
 
             let mut interface = smoltcp::iface::Interface::new(config, device, now);
             interface.update_ip_addrs(|ip_addrs| {
                 debug_assert!(ip_addrs.is_empty());
-                ip_addrs.push(wire::IpCidr::Ipv4(ip_cidr)).unwrap();
+                ip_addrs
+                    .push(wire::IpCidr::Ipv4(ip_config.ipv4_cidr))
+                    .unwrap();
+                if let Some(ipv6_cidr) = ip_config.ipv6_cidr {
+                    ip_addrs.push(wire::IpCidr::Ipv6(ipv6_cidr)).unwrap();
+                }
             });
             interface
                 .routes_mut()
-                .add_default_ipv4_route(gateway)
+                .add_default_ipv4_route(ip_config.ipv4_gateway)
                 .unwrap();
+            if let Some(ipv6_gateway) = ip_config.ipv6_gateway {
+                interface
+                    .routes_mut()
+                    .add_default_ipv6_route(ipv6_gateway)
+                    .unwrap();
+            }
             interface
         });
 
@@ -64,6 +132,8 @@ impl<D: WithDevice, E: Ext> EtherIface<D, E> {
             common,
             ether_addr,
             arp_table: SpinLock::new(BTreeMap::new()),
+            ndisc_table: SpinLock::new(BTreeMap::new()),
+            pending_ipv6_packets: SpinLock::new(BTreeMap::new()),
         })
     }
 }
@@ -103,46 +173,75 @@ impl<D, E: Ext> EtherIface<D, E> {
         iface_cx: &mut Context,
         tx_token: T,
     ) -> Option<(IpPacket<'pkt>, T)> {
-        match self.parse_ip_or_process_arp(data, iface_cx) {
-            Ok(pkt) => Some((pkt, tx_token)),
-            Err(Some(arp)) => {
+        match self.parse_ip_or_process_neighbor(data, iface_cx) {
+            EtherIngress::Ip(pkt) => Some((pkt, tx_token)),
+            EtherIngress::Arp(arp) => {
                 Self::emit_arp(&arp, tx_token);
                 None
             }
-            Err(None) => None,
+            EtherIngress::Icmpv6(message) => {
+                self.emit_icmpv6(&message, iface_cx, tx_token);
+                None
+            }
+            EtherIngress::PendingIpv6(dst_ether, packet) => {
+                Self::emit_ipv6_bytes(self.ether_addr, dst_ether, &packet, tx_token);
+                None
+            }
+            EtherIngress::Drop => None,
         }
     }
 
-    fn parse_ip_or_process_arp<'pkt>(
+    fn parse_ip_or_process_neighbor<'pkt>(
         &self,
         data: &'pkt [u8],
         iface_cx: &mut Context,
-    ) -> Result<IpPacket<'pkt>, Option<ArpRepr>> {
+    ) -> EtherIngress<'pkt> {
         // Parse the Ethernet header. Ignore the packet if the header is ill-formed.
-        let frame = EthernetFrame::new_checked(data).map_err(|_| None)?;
-        let repr = EthernetRepr::parse(&frame).map_err(|_| None)?;
+        let Ok(frame) = EthernetFrame::new_checked(data) else {
+            return EtherIngress::Drop;
+        };
+        let Ok(repr) = EthernetRepr::parse(&frame) else {
+            return EtherIngress::Drop;
+        };
 
         // Ignore the Ethernet frame if it is not sent to us.
-        if !repr.dst_addr.is_broadcast() && repr.dst_addr != self.ether_addr {
-            return Err(None);
+        if !repr.dst_addr.is_broadcast()
+            && !repr.dst_addr.is_multicast()
+            && repr.dst_addr != self.ether_addr
+        {
+            return EtherIngress::Drop;
         }
 
         // Ignore the Ethernet frame if the protocol is not supported.
         match repr.ethertype {
             EthernetProtocol::Ipv4 => {
-                let pkt = Ipv4Packet::new_checked(frame.payload()).map_err(|_| None)?;
-                Ok(IpPacket::Ipv4(pkt))
+                let Ok(pkt) = Ipv4Packet::new_checked(frame.payload()) else {
+                    return EtherIngress::Drop;
+                };
+                EtherIngress::Ip(IpPacket::Ipv4(pkt))
             }
             EthernetProtocol::Ipv6 => {
-                let pkt = Ipv6Packet::new_checked(frame.payload()).map_err(|_| None)?;
-                Ok(IpPacket::Ipv6(pkt))
+                let Ok(pkt) = Ipv6Packet::new_checked(frame.payload()) else {
+                    return EtherIngress::Drop;
+                };
+                if let Some(ingress) = self.process_ndisc(&pkt, iface_cx, repr.src_addr) {
+                    return ingress;
+                }
+                EtherIngress::Ip(IpPacket::Ipv6(pkt))
             }
             EthernetProtocol::Arp => {
-                let pkt = ArpPacket::new_checked(frame.payload()).map_err(|_| None)?;
-                let arp = ArpRepr::parse(&pkt).map_err(|_| None)?;
-                Err(self.process_arp(&arp, iface_cx))
+                let Ok(pkt) = ArpPacket::new_checked(frame.payload()) else {
+                    return EtherIngress::Drop;
+                };
+                let Ok(arp) = ArpRepr::parse(&pkt) else {
+                    return EtherIngress::Drop;
+                };
+                match self.process_arp(&arp, iface_cx) {
+                    Some(arp) => EtherIngress::Arp(arp),
+                    None => EtherIngress::Drop,
+                }
             }
-            _ => Err(None),
+            _ => EtherIngress::Drop,
         }
     }
 
@@ -202,53 +301,270 @@ impl<D, E: Ext> EtherIface<D, E> {
         }
     }
 
-    fn dispatch<T: TxToken>(&self, pkt: &Packet, iface_cx: &mut Context, tx_token: T) {
-        match self.resolve_ether_or_generate_arp(pkt, iface_cx) {
-            Ok(ether) => Self::emit_ip(&ether, pkt, &iface_cx.caps, tx_token),
-            Err(Some(arp)) => Self::emit_arp(&arp, tx_token),
-            Err(None) => (),
+    fn process_ndisc(
+        &self,
+        pkt: &Ipv6Packet<&[u8]>,
+        iface_cx: &Context,
+        src_ether: EthernetAddress,
+    ) -> Option<EtherIngress<'static>> {
+        let ipv6_repr = Ipv6Repr::parse(pkt).ok()?;
+        if ipv6_repr.next_header != IpProtocol::Icmpv6 || ipv6_repr.hop_limit != 0xff {
+            return None;
+        }
+
+        let icmp_pkt = Icmpv6Packet::new_checked(pkt.payload()).ok()?;
+        let Icmpv6Repr::Ndisc(ndisc_repr) = Icmpv6Repr::parse(
+            &ipv6_repr.src_addr,
+            &ipv6_repr.dst_addr,
+            &icmp_pkt,
+            &iface_cx.checksum_caps(),
+        )
+        .ok()?
+        else {
+            return None;
+        };
+
+        match ndisc_repr {
+            NdiscRepr::NeighborAdvert {
+                flags,
+                target_addr,
+                lladdr: Some(lladdr),
+            } if target_addr.x_is_unicast() => {
+                let should_cache = flags.contains(NdiscNeighborFlags::OVERRIDE)
+                    || !self.ndisc_table.lock().contains_key(&target_addr);
+                let dst_ether = if should_cache {
+                    self.cache_ipv6_neighbor(target_addr, lladdr);
+                    Self::raw_hardware_addr_to_ether(lladdr)
+                } else {
+                    self.ndisc_table.lock().get(&target_addr).copied()
+                };
+
+                dst_ether.and_then(|dst_ether| {
+                    self.take_pending_ipv6_packet(target_addr, iface_cx.now().total_millis())
+                        .map(|packet| EtherIngress::PendingIpv6(dst_ether, packet))
+                })
+            }
+            NdiscRepr::NeighborSolicit {
+                target_addr,
+                lladdr,
+            } if target_addr.x_is_unicast() => {
+                if let Some(lladdr) = lladdr {
+                    self.cache_ipv6_neighbor(ipv6_repr.src_addr, lladdr);
+                }
+
+                if !self.is_solicited_node_addr(ipv6_repr.dst_addr, target_addr, iface_cx) {
+                    return None;
+                }
+
+                // A solicitation from the unspecified address is sent during
+                // duplicate address detection. The advertisement must then go to
+                // the all-nodes multicast address with the solicited flag cleared
+                // (RFC 4861, Section 7.2.4).
+                let (dst_ip, dst_ether, solicited) = if ipv6_repr.src_addr.is_unspecified() {
+                    let all_nodes =
+                        Ipv6Address::from([0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+                    (
+                        all_nodes,
+                        Self::ipv6_multicast_to_ethernet(all_nodes),
+                        NdiscNeighborFlags::empty(),
+                    )
+                } else {
+                    let dst_ether = self
+                        .ndisc_table
+                        .lock()
+                        .get(&ipv6_repr.src_addr)
+                        .copied()
+                        .unwrap_or(src_ether);
+                    (ipv6_repr.src_addr, dst_ether, NdiscNeighborFlags::SOLICITED)
+                };
+
+                Some(EtherIngress::Icmpv6(Icmpv6Message {
+                    src_ip: target_addr,
+                    dst_ip,
+                    dst_ether,
+                    repr: Icmpv6Repr::Ndisc(NdiscRepr::NeighborAdvert {
+                        flags: solicited | NdiscNeighborFlags::OVERRIDE,
+                        target_addr,
+                        lladdr: Some(self.ether_addr.into()),
+                    }),
+                }))
+            }
+            _ => None,
         }
     }
 
-    fn resolve_ether_or_generate_arp(
-        &self,
-        pkt: &Packet,
-        iface_cx: &mut Context,
-    ) -> Result<EthernetRepr, Option<ArpRepr>> {
-        // Resolve the next-hop IP address.
-        let next_hop_ip = match iface_cx.route(&pkt.ip_repr().dst_addr(), iface_cx.now()) {
-            Some(IpAddress::Ipv4(next_hop_ip)) => next_hop_ip,
-            Some(IpAddress::Ipv6(_)) => {
-                // FIXME: Currently, we drop outbound IPv6 packets because neighbor discovery is not
-                // implemented and we have no way to resolve the next-hop link-layer address.
-                ostd::debug!("IPv6 neighbor discovery is not implemented for Ethernet interfaces");
-                return Err(None);
-            }
-            None => return Err(None),
+    fn cache_ipv6_neighbor(&self, ip_addr: Ipv6Address, lladdr: RawHardwareAddress) {
+        let Some(ether_addr) = Self::raw_hardware_addr_to_ether(lladdr) else {
+            return;
         };
 
-        // Resolve the next-hop Ethernet address.
+        if !ip_addr.x_is_unicast() || !ether_addr.is_unicast() {
+            return;
+        }
+
+        self.ndisc_table.lock().insert(ip_addr, ether_addr);
+    }
+
+    fn take_pending_ipv6_packet(&self, ip_addr: Ipv6Address, now_ms: i64) -> Option<Vec<u8>> {
+        let pending_packet = self.pending_ipv6_packets.lock().remove(&ip_addr)?;
+        (pending_packet.expires_at_ms > now_ms).then_some(pending_packet.packet)
+    }
+
+    fn queue_pending_ipv6_packet(&self, ip_addr: Ipv6Address, packet: Vec<u8>, now_ms: i64) {
+        let mut pending_packets = self.pending_ipv6_packets.lock();
+        Self::remove_expired_pending_ipv6_packets(&mut pending_packets, now_ms);
+
+        if pending_packets.contains_key(&ip_addr)
+            || pending_packets.len() >= MAX_PENDING_IPV6_PACKETS
+        {
+            return;
+        }
+
+        pending_packets.insert(
+            ip_addr,
+            PendingIpv6Packet {
+                packet,
+                expires_at_ms: now_ms.saturating_add(PENDING_IPV6_PACKET_TIMEOUT_MS),
+            },
+        );
+    }
+
+    fn remove_expired_pending_ipv6_packets(
+        pending_packets: &mut BTreeMap<Ipv6Address, PendingIpv6Packet>,
+        now_ms: i64,
+    ) {
+        let expired_addrs = pending_packets
+            .iter()
+            .filter(|(_, pending_packet)| pending_packet.expires_at_ms <= now_ms)
+            .map(|(ip_addr, _)| *ip_addr)
+            .collect::<Vec<_>>();
+
+        for ip_addr in expired_addrs {
+            pending_packets.remove(&ip_addr);
+        }
+    }
+
+    fn raw_hardware_addr_to_ether(lladdr: RawHardwareAddress) -> Option<EthernetAddress> {
+        (lladdr.len() >= 6).then(|| EthernetAddress::from_bytes(&lladdr.as_bytes()[..6]))
+    }
+
+    fn is_solicited_node_addr(
+        &self,
+        dst_addr: Ipv6Address,
+        target_addr: Ipv6Address,
+        iface_cx: &Context,
+    ) -> bool {
+        iface_cx.ipv6_addr().is_some_and(|local_addr| {
+            local_addr == target_addr
+                && (dst_addr == target_addr || dst_addr == Self::solicited_node_addr(target_addr))
+        })
+    }
+
+    fn solicited_node_addr(addr: Ipv6Address) -> Ipv6Address {
+        let octets = addr.octets();
+        Ipv6Address::from([
+            0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0xff, octets[13], octets[14], octets[15],
+        ])
+    }
+
+    fn ipv6_multicast_to_ethernet(addr: Ipv6Address) -> EthernetAddress {
+        debug_assert!(addr.is_multicast());
+        let octets = addr.octets();
+        EthernetAddress::from_bytes(&[0x33, 0x33, octets[12], octets[13], octets[14], octets[15]])
+    }
+
+    fn dispatch<T: TxToken>(&self, pkt: &Packet, iface_cx: &mut Context, tx_token: T) {
+        match self.resolve_ether_or_neighbor(pkt, iface_cx) {
+            EtherTx::Ip(ether) => Self::emit_ip(&ether, pkt, &iface_cx.caps, tx_token),
+            EtherTx::Arp(arp) => Self::emit_arp(&arp, tx_token),
+            EtherTx::Icmpv6(message) => self.emit_icmpv6(&message, iface_cx, tx_token),
+            EtherTx::Drop => (),
+        }
+    }
+
+    fn resolve_ether_or_neighbor(&self, pkt: &Packet, iface_cx: &mut Context) -> EtherTx {
+        // Resolve the next-hop IP address.
+        let next_hop_ip = match iface_cx.route(&pkt.ip_repr().dst_addr(), iface_cx.now()) {
+            Some(next_hop_ip) => next_hop_ip,
+            None => return EtherTx::Drop,
+        };
+
+        match next_hop_ip {
+            IpAddress::Ipv4(next_hop_ip) => {
+                self.resolve_ipv4_ether_or_arp(pkt, iface_cx, next_hop_ip)
+            }
+            IpAddress::Ipv6(next_hop_ip) => {
+                self.resolve_ipv6_ether_or_ndisc(pkt, iface_cx, next_hop_ip)
+            }
+        }
+    }
+
+    fn resolve_ipv4_ether_or_arp(
+        &self,
+        _pkt: &Packet,
+        iface_cx: &Context,
+        next_hop_ip: Ipv4Address,
+    ) -> EtherTx {
         let next_hop_ether = if next_hop_ip.is_broadcast() {
             EthernetAddress::BROADCAST
         } else if let Some(next_hop_ether) = self.arp_table.lock().get(&next_hop_ip) {
             *next_hop_ether
         } else {
-            // If the next-hop Ethernet address cannot be resolved, we drop the original packet and
-            // send an ARP packet instead. The upper layer should be responsible for detecting the
-            // packet loss and retrying later to see if the Ethernet address is ready.
-            return Err(Some(ArpRepr::EthernetIpv4 {
+            return EtherTx::Arp(ArpRepr::EthernetIpv4 {
                 operation: ArpOperation::Request,
                 source_hardware_addr: self.ether_addr,
                 source_protocol_addr: iface_cx.ipv4_addr().unwrap_or(Ipv4Address::UNSPECIFIED),
                 target_hardware_addr: EthernetAddress::BROADCAST,
                 target_protocol_addr: next_hop_ip,
-            }));
+            });
         };
 
-        Ok(EthernetRepr {
+        EtherTx::Ip(EthernetRepr {
             src_addr: self.ether_addr,
             dst_addr: next_hop_ether,
             ethertype: EthernetProtocol::Ipv4,
+        })
+    }
+
+    fn resolve_ipv6_ether_or_ndisc(
+        &self,
+        pkt: &Packet,
+        iface_cx: &Context,
+        next_hop_ip: Ipv6Address,
+    ) -> EtherTx {
+        let IpAddress::Ipv6(dst_ip) = pkt.ip_repr().dst_addr() else {
+            return EtherTx::Drop;
+        };
+
+        let next_hop_ether = if dst_ip.is_multicast() {
+            Self::ipv6_multicast_to_ethernet(dst_ip)
+        } else if let Some(next_hop_ether) = self.ndisc_table.lock().get(&next_hop_ip) {
+            *next_hop_ether
+        } else {
+            let Some(src_ip) = iface_cx.ipv6_addr() else {
+                return EtherTx::Drop;
+            };
+            let solicited_node_ip = Self::solicited_node_addr(next_hop_ip);
+            self.queue_pending_ipv6_packet(
+                next_hop_ip,
+                Self::serialize_ip(pkt, &iface_cx.caps),
+                iface_cx.now().total_millis(),
+            );
+            return EtherTx::Icmpv6(Icmpv6Message {
+                src_ip,
+                dst_ip: solicited_node_ip,
+                dst_ether: Self::ipv6_multicast_to_ethernet(solicited_node_ip),
+                repr: Icmpv6Repr::Ndisc(NdiscRepr::NeighborSolicit {
+                    target_addr: next_hop_ip,
+                    lladdr: Some(self.ether_addr.into()),
+                }),
+            });
+        };
+
+        EtherTx::Ip(EthernetRepr {
+            src_addr: self.ether_addr,
+            dst_addr: next_hop_ether,
+            ethertype: EthernetProtocol::Ipv6,
         })
     }
 
@@ -276,6 +592,14 @@ impl<D, E: Ext> EtherIface<D, E> {
         );
     }
 
+    fn serialize_ip(ip_pkt: &Packet, caps: &DeviceCapabilities) -> Vec<u8> {
+        let ip_repr = ip_pkt.ip_repr();
+        let mut packet = vec![0; ip_repr.buffer_len()];
+        ip_repr.emit(&mut packet, &caps.checksum);
+        ip_pkt.emit_payload(&ip_repr, &mut packet[ip_repr.header_len()..], caps);
+        packet
+    }
+
     /// Consumes the token and emits an ARP packet.
     fn emit_arp<T: TxToken>(arp_repr: &ArpRepr, tx_token: T) {
         let ether_repr = match arp_repr {
@@ -298,5 +622,60 @@ impl<D, E: Ext> EtherIface<D, E> {
             let mut pkt = ArpPacket::new_unchecked(frame.payload_mut());
             arp_repr.emit(&mut pkt);
         });
+    }
+
+    /// Consumes the token and emits a serialized IPv6 packet.
+    fn emit_ipv6_bytes<T: TxToken>(
+        src_ether: EthernetAddress,
+        dst_ether: EthernetAddress,
+        ip_packet: &[u8],
+        tx_token: T,
+    ) {
+        let ether_repr = EthernetRepr {
+            src_addr: src_ether,
+            dst_addr: dst_ether,
+            ethertype: EthernetProtocol::Ipv6,
+        };
+
+        tx_token.consume(ether_repr.buffer_len() + ip_packet.len(), |buffer| {
+            let mut frame = EthernetFrame::new_unchecked(buffer);
+            ether_repr.emit(&mut frame);
+            frame.payload_mut().copy_from_slice(ip_packet);
+        });
+    }
+
+    /// Consumes the token and emits an ICMPv6 packet.
+    fn emit_icmpv6<T: TxToken>(&self, message: &Icmpv6Message, iface_cx: &Context, tx_token: T) {
+        let ip_repr = Ipv6Repr {
+            src_addr: message.src_ip,
+            dst_addr: message.dst_ip,
+            next_header: IpProtocol::Icmpv6,
+            payload_len: message.repr.buffer_len(),
+            hop_limit: 0xff,
+        };
+        let ether_repr = EthernetRepr {
+            src_addr: self.ether_addr,
+            dst_addr: message.dst_ether,
+            ethertype: EthernetProtocol::Ipv6,
+        };
+
+        tx_token.consume(
+            ether_repr.buffer_len() + ip_repr.buffer_len() + message.repr.buffer_len(),
+            |buffer| {
+                let mut frame = EthernetFrame::new_unchecked(buffer);
+                ether_repr.emit(&mut frame);
+
+                let mut ip_packet = Ipv6Packet::new_unchecked(frame.payload_mut());
+                ip_repr.emit(&mut ip_packet);
+
+                let mut icmp_packet = Icmpv6Packet::new_unchecked(ip_packet.payload_mut());
+                message.repr.emit(
+                    &message.src_ip,
+                    &message.dst_ip,
+                    &mut icmp_packet,
+                    &iface_cx.checksum_caps(),
+                );
+            },
+        );
     }
 }

--- a/kernel/libs/aster-bigtcp/src/iface/phy/mod.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/mod.rs
@@ -3,5 +3,5 @@
 mod ether;
 mod ip;
 
-pub use ether::EtherIface;
+pub use ether::{EtherIface, EtherIpConfig};
 pub use ip::IpIface;

--- a/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
@@ -49,11 +49,24 @@ impl<E: Ext> PollableIface<E> {
         })
     }
 
-    pub(super) fn prefix_len(&self) -> Option<u8> {
-        self.interface
-            .ip_addrs()
-            .first()
-            .map(|ip_addr| ip_addr.prefix_len())
+    pub(super) fn ipv4_prefix_len(&self) -> Option<u8> {
+        self.interface.ip_addrs().iter().find_map(|cidr| {
+            if let smoltcp::wire::IpCidr::Ipv4(ipv4_cidr) = cidr {
+                Some(ipv4_cidr.prefix_len())
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(super) fn ipv6_prefix_len(&self) -> Option<u8> {
+        self.interface.ip_addrs().iter().find_map(|cidr| {
+            if let smoltcp::wire::IpCidr::Ipv6(ipv6_cidr) = cidr {
+                Some(ipv6_cidr.prefix_len())
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the next poll time.

--- a/kernel/libs/aster-bigtcp/src/iface/port.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/port.rs
@@ -2,9 +2,57 @@
 
 use smoltcp::wire::{IpAddress, IpEndpoint};
 
+/// The local address scope that a socket is bound to.
+///
+/// The scope determines both which incoming packets the socket accepts and how
+/// the binding conflicts with other bindings on the same port.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum BindPortScope {
+    /// A specific local address.
+    Address(IpAddress),
+    /// The IPv4 wildcard address (`0.0.0.0`).
+    Ipv4Wildcard,
+    /// The IPv6 wildcard address (`::`) of an `IPV6_V6ONLY` socket.
+    Ipv6OnlyWildcard,
+    /// The IPv6 wildcard address (`::`) of a dual-stack socket, which also
+    /// accepts IPv4 traffic.
+    Ipv6DualStackWildcard,
+}
+
+impl BindPortScope {
+    /// Returns the representative local address of the scope.
+    pub(crate) fn addr(&self) -> IpAddress {
+        match self {
+            Self::Address(addr) => *addr,
+            Self::Ipv4Wildcard => IpAddress::Ipv4(core::net::Ipv4Addr::UNSPECIFIED),
+            Self::Ipv6OnlyWildcard | Self::Ipv6DualStackWildcard => {
+                IpAddress::Ipv6(core::net::Ipv6Addr::UNSPECIFIED)
+            }
+        }
+    }
+
+    /// Returns whether a packet destined to `addr` should be delivered to a
+    /// socket bound with this scope.
+    pub(crate) fn matches_addr(&self, addr: IpAddress) -> bool {
+        match (*self, addr) {
+            (Self::Address(bound), addr) => bound == addr,
+            (Self::Ipv4Wildcard, IpAddress::Ipv4(_)) => true,
+            (Self::Ipv6OnlyWildcard, IpAddress::Ipv6(addr)) => !is_ipv4_mapped(addr),
+            (Self::Ipv6DualStackWildcard, IpAddress::Ipv4(_)) => true,
+            (Self::Ipv6DualStackWildcard, IpAddress::Ipv6(addr)) => !is_ipv4_mapped(addr),
+            _ => false,
+        }
+    }
+}
+
+fn is_ipv4_mapped(addr: core::net::Ipv6Addr) -> bool {
+    let octets = addr.octets();
+    octets[..10] == [0; 10] && octets[10] == 0xff && octets[11] == 0xff
+}
+
 /// The configuration using for bind to a TCP/UDP port.
 pub struct BindPortConfig {
-    addr: IpAddress,
+    scope: BindPortScope,
     kind: PortKind,
 }
 
@@ -22,23 +70,37 @@ enum PortKind {
 impl BindPortConfig {
     /// Creates new configuration using for bind to a TCP/UDP port.
     pub fn new(endpoint: IpEndpoint, can_reuse: bool) -> Self {
-        let port = endpoint.port;
+        Self::new_with_scope(
+            BindPortScope::Address(endpoint.addr),
+            endpoint.port,
+            can_reuse,
+        )
+    }
+
+    /// Creates a new configuration that binds to a port within the given scope.
+    pub fn new_with_scope(scope: BindPortScope, port: u16, can_reuse: bool) -> Self {
         let kind = match (port, can_reuse) {
             (0, can_reuse) => PortKind::Ephemeral(can_reuse),
             (_, true) => PortKind::CanReuse(port),
             (_, false) => PortKind::Specified(port),
         };
-        Self {
-            addr: endpoint.addr,
-            kind,
-        }
+        Self { scope, kind }
     }
 
     /// Creates a new configuration for reusing the port of a listening socket.
     pub fn new_backlog(endpoint: IpEndpoint) -> Self {
         Self {
-            addr: endpoint.addr,
+            scope: BindPortScope::Address(endpoint.addr),
             kind: PortKind::Backlog(endpoint.port),
+        }
+    }
+
+    /// Creates a new configuration that reuses a listening socket's port within
+    /// the given scope.
+    pub(crate) fn new_backlog_with_scope(scope: BindPortScope, port: u16) -> Self {
+        Self {
+            scope,
+            kind: PortKind::Backlog(port),
         }
     }
 
@@ -62,7 +124,7 @@ impl BindPortConfig {
         }
     }
 
-    pub(super) fn addr(&self) -> IpAddress {
-        self.addr
+    pub(super) fn scope(&self) -> BindPortScope {
+        self.scope
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
@@ -3,7 +3,7 @@
 use alloc::sync::{Arc, Weak};
 use core::ops::Deref;
 
-use smoltcp::wire::IpEndpoint;
+use smoltcp::wire::{IpAddress, IpEndpoint};
 use spin::once::Once;
 use takeable::Takeable;
 
@@ -139,5 +139,9 @@ impl<T: Inner<E>, E: Ext> SocketBg<T, E> {
     /// The check is intended to be lock-free and fast, but may have false positives.
     pub(crate) fn can_process(&self, dst_port: u16) -> bool {
         self.bound.port() == dst_port
+    }
+
+    pub(crate) fn can_process_addr(&self, dst_addr: IpAddress, dst_port: u16) -> bool {
+        self.bound.port() == dst_port && self.bound.scope().matches_addr(dst_addr)
     }
 }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
@@ -7,7 +7,7 @@ use ostd::sync::SpinLock;
 use smoltcp::{
     socket::PollAt,
     time::Duration,
-    wire::{IpEndpoint, IpRepr, TcpRepr},
+    wire::{IpEndpoint, IpListenEndpoint, IpRepr, TcpRepr},
 };
 
 use super::{
@@ -81,7 +81,7 @@ impl<E: Ext> TcpListener<E> {
 
         let listener_key = ListenerKey::new(local_endpoint.addr, local_endpoint.port);
 
-        if sockets.lookup_listener(&listener_key).is_some() {
+        if sockets.has_listener_conflict(bound.scope(), local_endpoint.port) {
             return Err((bound, ListenError::AddressInUse));
         }
 
@@ -89,6 +89,15 @@ impl<E: Ext> TcpListener<E> {
             let mut socket = new_tcp_socket();
 
             option.apply(&mut socket);
+
+            let local_endpoint = if bound.addr().is_unspecified() {
+                IpListenEndpoint {
+                    addr: None,
+                    port: local_endpoint.port,
+                }
+            } else {
+                local_endpoint.into()
+            };
 
             if let Err(err) = socket.listen(local_endpoint) {
                 return Err((bound, err.into()));
@@ -197,6 +206,10 @@ impl<E: Ext> TcpListenerBg<E> {
         ip_repr: &IpRepr,
         tcp_repr: &TcpRepr,
     ) -> (TcpProcessResult, Option<Arc<TcpConnectionBg<E>>>) {
+        if !self.can_process_addr(ip_repr.dst_addr(), tcp_repr.dst_port) {
+            return (TcpProcessResult::NotProcessed, None);
+        }
+
         let mut backlog = self.inner.backlog.lock();
 
         if !backlog
@@ -235,7 +248,10 @@ impl<E: Ext> TcpListenerBg<E> {
         let conn = TcpConnection::new_cyclic(
             self.bound
                 .iface()
-                .bind_tcp(BindPortConfig::new_backlog(self.bound.endpoint()))
+                .bind_tcp(BindPortConfig::new_backlog_with_scope(
+                    self.bound.scope(),
+                    self.bound.port(),
+                ))
                 .unwrap(),
             |weak| {
                 TcpConnectionInner::new(

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -8,7 +8,7 @@ use ostd::sync::SpinLock;
 use smoltcp::{
     iface::Context,
     socket::udp::UdpMetadata,
-    wire::{IpRepr, UdpRepr},
+    wire::{IpListenEndpoint, IpRepr, UdpRepr},
 };
 
 use super::{
@@ -55,7 +55,9 @@ impl<E: Ext> UdpSocketBg<E> {
     ) -> bool {
         let mut socket = self.inner.socket.lock();
 
-        if !socket.accepts(cx, ip_repr, udp_repr) {
+        if !self.bound.scope().matches_addr(ip_repr.dst_addr())
+            || !socket.accepts(cx, ip_repr, udp_repr)
+        {
             return false;
         }
 
@@ -114,6 +116,14 @@ impl<E: Ext> UdpSocket<E> {
 
         let socket = {
             let mut socket = new_udp_socket();
+            let local_endpoint = if bound.addr().is_unspecified() {
+                IpListenEndpoint {
+                    addr: None,
+                    port: local_endpoint.port,
+                }
+            } else {
+                local_endpoint.into()
+            };
 
             if let Err(err) = socket.bind(local_endpoint) {
                 return Err((bound, err));

--- a/kernel/libs/aster-bigtcp/src/socket_table.rs
+++ b/kernel/libs/aster-bigtcp/src/socket_table.rs
@@ -12,6 +12,7 @@ use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
 
 use crate::{
     ext::Ext,
+    iface::BindPortScope,
     socket::{TcpConnectionBg, TcpListenerBg, UdpSocketBg},
     wire::PortNum,
 };
@@ -272,6 +273,24 @@ impl<E: Ext> SocketTable<E> {
             .listeners
             .iter()
             .find(|listener| listener.listener_key() == key)
+            .or_else(|| {
+                self.listener_buckets
+                    .iter()
+                    .flat_map(|bucket| bucket.listeners.iter())
+                    .find(|listener| listener.can_process_addr(key.addr, key.port))
+            })
+    }
+
+    pub(crate) fn has_listener_conflict(&self, scope: BindPortScope, port: PortNum) -> bool {
+        self.listener_buckets
+            .iter()
+            .flat_map(|bucket| bucket.listeners.iter())
+            .any(|listener| {
+                let key = listener.listener_key();
+                key.port == port
+                    && (scope.matches_addr(key.addr)
+                        || listener.can_process_addr(scope.addr(), port))
+            })
     }
 
     pub(crate) fn lookup_connection(

--- a/kernel/libs/aster-bigtcp/src/wire.rs
+++ b/kernel/libs/aster-bigtcp/src/wire.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub use smoltcp::wire::{
-    EthernetAddress, IpAddress, IpCidr, IpEndpoint, Ipv4Address, Ipv4Cidr, Ipv6Address, Ipv6Cidr,
+    EthernetAddress, IpAddress, IpCidr, IpEndpoint, IpListenEndpoint, Ipv4Address, Ipv4Cidr,
+    Ipv6Address, Ipv6Cidr,
 };
 
 pub type PortNum = u16;

--- a/kernel/src/net/iface/init.rs
+++ b/kernel/src/net/iface/init.rs
@@ -107,14 +107,17 @@ fn new_loopback() -> Arc<Iface> {
 
 fn new_virtio() -> Option<Arc<Iface>> {
     use aster_bigtcp::{
-        iface::EtherIface,
-        wire::{EthernetAddress, Ipv4Address, Ipv4Cidr},
+        iface::{EtherIface, EtherIpConfig},
+        wire::{EthernetAddress, Ipv4Address, Ipv4Cidr, Ipv6Address, Ipv6Cidr},
     };
     use aster_network::AnyNetworkDevice;
 
     const VIRTIO_ADDRESS: Ipv4Address = Ipv4Address::new(10, 0, 2, 15);
     const VIRTIO_ADDRESS_PREFIX_LEN: u8 = 24; // mask: 255.255.255.0
     const VIRTIO_GATEWAY: Ipv4Address = Ipv4Address::new(10, 0, 2, 2);
+    const VIRTIO_IPV6_ADDRESS: Ipv6Address = Ipv6Address::new(0xfec0, 0, 0, 0, 0, 0, 0, 0x0015);
+    const VIRTIO_IPV6_PREFIX_LEN: u8 = 64;
+    const VIRTIO_IPV6_GATEWAY: Ipv6Address = Ipv6Address::new(0xfec0, 0, 0, 0, 0, 0, 0, 0x0002);
 
     let virtio_net = aster_network::get_device(VIRTIO_DEVICE_NAME)?;
 
@@ -145,8 +148,12 @@ fn new_virtio() -> Option<Arc<Iface>> {
     Some(EtherIface::new(
         Wrapper(virtio_net),
         EthernetAddress(ether_addr),
-        Ipv4Cidr::new(VIRTIO_ADDRESS, VIRTIO_ADDRESS_PREFIX_LEN),
-        VIRTIO_GATEWAY,
+        EtherIpConfig::new(
+            Ipv4Cidr::new(VIRTIO_ADDRESS, VIRTIO_ADDRESS_PREFIX_LEN),
+            Some(Ipv6Cidr::new(VIRTIO_IPV6_ADDRESS, VIRTIO_IPV6_PREFIX_LEN)),
+            VIRTIO_GATEWAY,
+            Some(VIRTIO_IPV6_GATEWAY),
+        ),
         CString::new("eth0").unwrap(),
         PollScheduler::new(),
         flags,

--- a/kernel/src/net/socket/ip/addr.rs
+++ b/kernel/src/net/socket/ip/addr.rs
@@ -19,6 +19,58 @@ impl TryFrom<SocketAddr> for IpEndpoint {
     }
 }
 
+/// The operation that an address is being converted for.
+///
+/// An `IPV6_V6ONLY` socket rejects IPv4-mapped IPv6 addresses, but the error
+/// differs by operation: `bind(2)` reports `EINVAL` while `connect(2)` and
+/// `sendmsg(2)` report `ENETUNREACH`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SocketAddrOp {
+    Bind,
+    Connect,
+}
+
+pub(super) fn socket_addr_to_endpoint(
+    socket_addr: SocketAddr,
+    family: IpAddressFamily,
+    is_ipv6_only: bool,
+    op: SocketAddrOp,
+) -> Result<IpEndpoint> {
+    match socket_addr {
+        SocketAddr::IPv4(addr, port) if family == IpAddressFamily::IPv4 => {
+            Ok(IpEndpoint::new(addr.into(), port))
+        }
+        SocketAddr::IPv6(addr, port) if family == IpAddressFamily::IPv6 => {
+            if let Some(ipv4_addr) = ipv4_mapped_ipv6_to_ipv4(addr) {
+                if is_ipv6_only {
+                    match op {
+                        SocketAddrOp::Bind => return_errno_with_message!(
+                            Errno::EINVAL,
+                            "an IPv4-mapped IPv6 address cannot be bound on an IPV6_V6ONLY socket"
+                        ),
+                        SocketAddrOp::Connect => return_errno_with_message!(
+                            Errno::ENETUNREACH,
+                            "an IPv4-mapped IPv6 address is unreachable from an IPV6_V6ONLY socket"
+                        ),
+                    }
+                }
+
+                Ok(IpEndpoint::new(ipv4_addr.into(), port))
+            } else {
+                Ok(IpEndpoint::new(addr.into(), port))
+            }
+        }
+        SocketAddr::IPv4(..) | SocketAddr::IPv6(..) => return_errno_with_message!(
+            Errno::EAFNOSUPPORT,
+            "the protocol family does not match the address family"
+        ),
+        _ => return_errno_with_message!(
+            Errno::EAFNOSUPPORT,
+            "the address is in an unsupported address family"
+        ),
+    }
+}
+
 impl From<IpEndpoint> for SocketAddr {
     fn from(endpoint: IpEndpoint) -> Self {
         let port = endpoint.port;
@@ -26,6 +78,28 @@ impl From<IpEndpoint> for SocketAddr {
             IpAddress::Ipv4(addr) => SocketAddr::IPv4(addr, port),
             IpAddress::Ipv6(addr) => SocketAddr::IPv6(addr, port),
         }
+    }
+}
+
+pub(super) fn endpoint_to_socket_addr(endpoint: IpEndpoint, family: IpAddressFamily) -> SocketAddr {
+    let port = endpoint.port;
+    match (endpoint.addr, family) {
+        (IpAddress::Ipv4(addr), IpAddressFamily::IPv6) => {
+            SocketAddr::IPv6(addr.to_ipv6_mapped(), port)
+        }
+        (IpAddress::Ipv4(addr), IpAddressFamily::IPv4) => SocketAddr::IPv4(addr, port),
+        (IpAddress::Ipv6(addr), _) => SocketAddr::IPv6(addr, port),
+    }
+}
+
+fn ipv4_mapped_ipv6_to_ipv4(addr: Ipv6Address) -> Option<Ipv4Address> {
+    let octets = addr.octets();
+    if octets[..10] == [0; 10] && octets[10] == 0xff && octets[11] == 0xff {
+        Some(Ipv4Address::from([
+            octets[12], octets[13], octets[14], octets[15],
+        ]))
+    } else {
+        None
     }
 }
 

--- a/kernel/src/net/socket/ip/common.rs
+++ b/kernel/src/net/socket/ip/common.rs
@@ -2,7 +2,7 @@
 
 use aster_bigtcp::{
     errors::BindError,
-    iface::BindPortConfig,
+    iface::{BindPortConfig, BindPortScope},
     wire::{IpAddress, IpEndpoint},
 };
 
@@ -14,14 +14,17 @@ use crate::{
     prelude::*,
 };
 
-fn get_iface_to_bind(ip_addr: &IpAddress) -> Option<Arc<Iface>> {
-    match *ip_addr {
-        IpAddress::Ipv4(ipv4_addr) => iter_all_ifaces()
+fn get_iface_to_bind(scope: BindPortScope) -> Option<Arc<Iface>> {
+    match scope {
+        BindPortScope::Address(IpAddress::Ipv4(ipv4_addr)) => iter_all_ifaces()
             .find(|iface| iface.ipv4_addr().is_some_and(|addr| addr == ipv4_addr))
             .map(Clone::clone),
-        IpAddress::Ipv6(ipv6_addr) => iter_all_ifaces()
+        BindPortScope::Address(IpAddress::Ipv6(ipv6_addr)) => iter_all_ifaces()
             .find(|iface| iface.ipv6_addr().is_some_and(|addr| addr == ipv6_addr))
             .map(Clone::clone),
+        BindPortScope::Ipv4Wildcard
+        | BindPortScope::Ipv6OnlyWildcard
+        | BindPortScope::Ipv6DualStackWildcard => Some(loopback_iface().clone()),
     }
 }
 
@@ -72,10 +75,12 @@ fn get_ephemeral_iface(remote_ip_addr: &IpAddress) -> Arc<Iface> {
 pub(super) fn resolve_bind_iface_and_config(
     endpoint: &IpEndpoint,
     can_reuse: bool,
+    is_ipv6_only: bool,
 ) -> Result<(Arc<Iface>, BindPortConfig)> {
     check_port_privilege(endpoint.port)?;
 
-    let iface = match get_iface_to_bind(&endpoint.addr) {
+    let scope = bind_scope(endpoint, is_ipv6_only);
+    let iface = match get_iface_to_bind(scope) {
         Some(iface) => iface,
         None => {
             return_errno_with_message!(
@@ -85,9 +90,20 @@ pub(super) fn resolve_bind_iface_and_config(
         }
     };
 
-    let bind_port_config = BindPortConfig::new(*endpoint, can_reuse);
+    let bind_port_config = BindPortConfig::new_with_scope(scope, endpoint.port, can_reuse);
 
     Ok((iface, bind_port_config))
+}
+
+fn bind_scope(endpoint: &IpEndpoint, is_ipv6_only: bool) -> BindPortScope {
+    match endpoint.addr {
+        IpAddress::Ipv4(addr) if addr.is_unspecified() => BindPortScope::Ipv4Wildcard,
+        IpAddress::Ipv6(addr) if addr.is_unspecified() && is_ipv6_only => {
+            BindPortScope::Ipv6OnlyWildcard
+        }
+        IpAddress::Ipv6(addr) if addr.is_unspecified() => BindPortScope::Ipv6DualStackWildcard,
+        _ => BindPortScope::Address(endpoint.addr),
+    }
 }
 
 impl From<BindError> for Error {

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -6,7 +6,9 @@ use aster_bigtcp::wire::IpEndpoint;
 use bound::BoundDatagram;
 use unbound::{BindOptions, UnboundDatagram};
 
-use super::addr::UNSPECIFIED_LOCAL_ENDPOINT;
+use super::addr::{
+    IpAddressFamily, SocketAddrOp, endpoint_to_socket_addr, socket_addr_to_endpoint,
+};
 use crate::{
     events::IoEvents,
     fs::{pseudofs::SockFs, vfs::path::Path},
@@ -37,6 +39,7 @@ pub struct DatagramSocket {
     // Lock order: `inner` first, `options` second
     inner: RwMutex<Inner<UnboundDatagram, BoundDatagram>>,
     options: RwLock<OptionSet>,
+    family: IpAddressFamily,
 
     is_nonblocking: AtomicBool,
     pollee: Pollee,
@@ -59,11 +62,12 @@ impl OptionSet {
 }
 
 impl DatagramSocket {
-    pub fn new(is_nonblocking: bool) -> Arc<Self> {
-        let unbound_datagram = UnboundDatagram::new();
+    pub fn new(is_nonblocking: bool, family: IpAddressFamily) -> Arc<Self> {
+        let unbound_datagram = UnboundDatagram::new(family);
         Arc::new(Self {
             inner: RwMutex::new(Inner::Unbound(unbound_datagram)),
             options: RwLock::new(OptionSet::new()),
+            family,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
             pseudo_path: SockFs::new_path(),
@@ -75,11 +79,16 @@ impl DatagramSocket {
         writer: &mut dyn MultiWrite,
         flags: SendRecvFlags,
     ) -> Result<(usize, SocketAddr)> {
-        let recv_bytes = self
-            .inner
-            .read()
-            .try_recv(writer, flags)
-            .map(|(recv_bytes, remote_endpoint)| (recv_bytes, remote_endpoint.into()))?;
+        let recv_bytes =
+            self.inner
+                .read()
+                .try_recv(writer, flags)
+                .map(|(recv_bytes, remote_endpoint)| {
+                    (
+                        recv_bytes,
+                        endpoint_to_socket_addr(remote_endpoint, self.family),
+                    )
+                })?;
         self.pollee.invalidate();
 
         Ok(recv_bytes)
@@ -138,16 +147,25 @@ impl SocketPrivate for DatagramSocket {
 
 impl Socket for DatagramSocket {
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
-        let endpoint = socket_addr.try_into()?;
-        let can_reuse = self.options.read().socket.reuse_addr();
+        let endpoint = self.socket_addr_to_endpoint(socket_addr, SocketAddrOp::Bind)?;
+        self.check_endpoint_family(&endpoint)?;
+        let options = self.options.read();
+        let can_reuse = options.socket.reuse_addr();
+        let is_ipv6_only = options.ip.ipv6_only();
 
-        self.inner
-            .write()
-            .bind(&endpoint, &self.pollee, BindOptions { can_reuse })
+        self.inner.write().bind(
+            &endpoint,
+            &self.pollee,
+            BindOptions {
+                can_reuse,
+                is_ipv6_only,
+            },
+        )
     }
 
     fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
-        let endpoint = socket_addr.try_into()?;
+        let endpoint = self.socket_addr_to_endpoint(socket_addr, SocketAddrOp::Connect)?;
+        self.check_endpoint_family(&endpoint)?;
         let can_broadcast = self.options.read().socket.broadcast();
         if !can_broadcast && is_broadcast_endpoint(&endpoint) {
             return_errno_with_message!(
@@ -164,9 +182,9 @@ impl Socket for DatagramSocket {
             .inner
             .read()
             .addr()
-            .unwrap_or(UNSPECIFIED_LOCAL_ENDPOINT);
+            .unwrap_or(self.family.unspecified_endpoint());
 
-        Ok(endpoint.into())
+        Ok(endpoint_to_socket_addr(endpoint, self.family))
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
@@ -175,7 +193,7 @@ impl Socket for DatagramSocket {
                 Error::with_message(Errno::ENOTCONN, "the socket is not connected")
             })?;
 
-        Ok(endpoint.into())
+        Ok(endpoint_to_socket_addr(endpoint, self.family))
     }
 
     fn sendmsg(
@@ -195,11 +213,12 @@ impl Socket for DatagramSocket {
         } = message_header;
 
         let endpoint = match addr {
-            Some(addr) => Some(addr.try_into()?),
+            Some(addr) => Some(self.socket_addr_to_endpoint(addr, SocketAddrOp::Connect)?),
             None => None,
         };
 
         if let Some(endpoint) = endpoint.as_ref() {
+            self.check_endpoint_family(endpoint)?;
             let can_broadcast = self.options.read().socket.broadcast();
             if !can_broadcast && is_broadcast_endpoint(endpoint) {
                 return_errno_with_message!(
@@ -258,7 +277,7 @@ impl Socket for DatagramSocket {
         }
 
         // Deal with IP-level options
-        options.ip.get_option(option)
+        options.ip.get_option(option, self.family)
     }
 
     fn set_option(&self, option: &dyn SocketOption) -> Result<()> {
@@ -269,7 +288,7 @@ impl Socket for DatagramSocket {
         let need_iface_poll = match options.socket.set_option(option, &*inner) {
             Err(err) if err.error() == Errno::ENOPROTOOPT => {
                 // Deal with IP-level options
-                options.ip.set_option(option, &*inner)?
+                options.ip.set_option(option, &*inner, self.family)?
             }
             Err(err) => return Err(err),
             Ok(need_iface_poll) => need_iface_poll,
@@ -297,6 +316,31 @@ impl Socket for DatagramSocket {
     }
 }
 
+impl DatagramSocket {
+    fn socket_addr_to_endpoint(
+        &self,
+        socket_addr: SocketAddr,
+        op: SocketAddrOp,
+    ) -> Result<IpEndpoint> {
+        let is_ipv6_only = self.options.read().ip.ipv6_only();
+        socket_addr_to_endpoint(socket_addr, self.family, is_ipv6_only, op)
+    }
+
+    fn check_endpoint_family(&self, endpoint: &IpEndpoint) -> Result<()> {
+        let endpoint_family = IpAddressFamily::from(endpoint.addr);
+        if endpoint_family != self.family
+            && !(self.family == IpAddressFamily::IPv6 && endpoint_family == IpAddressFamily::IPv4)
+        {
+            return_errno_with_message!(
+                Errno::EAFNOSUPPORT,
+                "the protocol family does not match the address family"
+            );
+        }
+
+        Ok(())
+    }
+}
+
 impl GetSocketLevelOption for Inner<UnboundDatagram, BoundDatagram> {
     fn is_listening(&self) -> bool {
         false
@@ -319,5 +363,16 @@ impl SetIpLevelOption for Inner<UnboundDatagram, BoundDatagram> {
             Errno::ENOPROTOOPT,
             "IP_HDRINCL cannot be set on UDP sockets"
         );
+    }
+
+    fn check_set_ipv6_only(&self) -> Result<()> {
+        if matches!(self, Inner::Unbound(_)) {
+            Ok(())
+        } else {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "IPV6_V6ONLY cannot be changed after the socket is bound"
+            );
+        }
     }
 }

--- a/kernel/src/net/socket/ip/datagram/unbound.rs
+++ b/kernel/src/net/socket/ip/datagram/unbound.rs
@@ -8,7 +8,10 @@ use crate::{
     net::{
         iface::BoundUdpPort,
         socket::{
-            ip::common::{get_ephemeral_endpoint, resolve_bind_iface_and_config},
+            ip::{
+                addr::IpAddressFamily,
+                common::{get_ephemeral_endpoint, resolve_bind_iface_and_config},
+            },
             util::datagram_common,
         },
     },
@@ -17,17 +20,18 @@ use crate::{
 };
 
 pub(super) struct UnboundDatagram {
-    _private: (),
+    family: IpAddressFamily,
 }
 
 impl UnboundDatagram {
-    pub(super) fn new() -> Self {
-        Self { _private: () }
+    pub(super) fn new(family: IpAddressFamily) -> Self {
+        Self { family }
     }
 }
 
 pub(super) struct BindOptions {
     pub(super) can_reuse: bool,
+    pub(super) is_ipv6_only: bool,
 }
 
 impl datagram_common::Unbound for UnboundDatagram {
@@ -42,7 +46,8 @@ impl datagram_common::Unbound for UnboundDatagram {
         pollee: &Pollee,
         options: BindOptions,
     ) -> Result<Self::Bound> {
-        let bound_port = bind_port(endpoint, options.can_reuse)?;
+        self.check_endpoint_family(endpoint)?;
+        let bound_port = bind_port(endpoint, options.can_reuse, options.is_ipv6_only)?;
 
         let bound_socket =
             match UdpSocket::new_bind(bound_port, DatagramObserver::new(pollee.clone())) {
@@ -60,13 +65,21 @@ impl datagram_common::Unbound for UnboundDatagram {
         remote_endpoint: &Self::Endpoint,
         pollee: &Pollee,
     ) -> Result<Self::Bound> {
+        self.check_endpoint_family(remote_endpoint)?;
         let endpoint = get_ephemeral_endpoint(remote_endpoint).ok_or_else(|| {
             Error::with_message(
                 Errno::EADDRNOTAVAIL,
                 "no interface has an address for the specified family",
             )
         })?;
-        self.bind(&endpoint, pollee, BindOptions { can_reuse: false })
+        self.bind(
+            &endpoint,
+            pollee,
+            BindOptions {
+                can_reuse: false,
+                is_ipv6_only: false,
+            },
+        )
     }
 
     fn check_io_events(&self) -> IoEvents {
@@ -74,7 +87,23 @@ impl datagram_common::Unbound for UnboundDatagram {
     }
 }
 
-fn bind_port(endpoint: &IpEndpoint, can_reuse: bool) -> Result<BoundUdpPort> {
-    let (iface, config) = resolve_bind_iface_and_config(endpoint, can_reuse)?;
+impl UnboundDatagram {
+    fn check_endpoint_family(&self, endpoint: &IpEndpoint) -> Result<()> {
+        let endpoint_family = IpAddressFamily::from(endpoint.addr);
+        if endpoint_family != self.family
+            && !(self.family == IpAddressFamily::IPv6 && endpoint_family == IpAddressFamily::IPv4)
+        {
+            return_errno_with_message!(
+                Errno::EAFNOSUPPORT,
+                "the protocol family does not match the address family"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+fn bind_port(endpoint: &IpEndpoint, can_reuse: bool, is_ipv6_only: bool) -> Result<BoundUdpPort> {
+    let (iface, config) = resolve_bind_iface_and_config(endpoint, can_reuse, is_ipv6_only)?;
     Ok(iface.bind_udp(config)?)
 }

--- a/kernel/src/net/socket/ip/options.rs
+++ b/kernel/src/net/socket/ip/options.rs
@@ -4,6 +4,7 @@ use core::num::NonZeroU8;
 
 use aster_bigtcp::socket::NeedIfacePoll;
 
+use super::addr::IpAddressFamily;
 use crate::{
     net::socket::options::{
         SocketOption,
@@ -21,6 +22,7 @@ pub(super) struct IpOptionSet {
     ttl: IpTtl,
     hdrincl: bool,
     recverr: bool,
+    ipv6_only: bool,
 }
 
 const DEFAULT_TTL: u8 = 64;
@@ -33,6 +35,7 @@ impl IpOptionSet {
             ttl: IpTtl(None),
             hdrincl: false,
             recverr: false,
+            ipv6_only: false,
         }
     }
 
@@ -42,10 +45,15 @@ impl IpOptionSet {
             ttl: IpTtl(None),
             hdrincl: false,
             recverr: false,
+            ipv6_only: false,
         }
     }
 
-    pub(super) fn get_option(&self, option: &mut dyn SocketOption) -> Result<()> {
+    pub(super) fn get_option(
+        &self,
+        option: &mut dyn SocketOption,
+        family: IpAddressFamily,
+    ) -> Result<()> {
         sock_option_mut!(match option {
             ip_tos @ Tos => {
                 let tos = self.tos();
@@ -63,6 +71,16 @@ impl IpOptionSet {
                 let recverr = self.recverr();
                 ip_recverr.set(recverr);
             }
+            ipv6_only @ Ipv6Only => {
+                if family != IpAddressFamily::IPv6 {
+                    return_errno_with_message!(
+                        Errno::EOPNOTSUPP,
+                        "IPV6_V6ONLY is unsupported on IPv4 sockets"
+                    );
+                }
+                let is_ipv6_only = self.ipv6_only();
+                ipv6_only.set(is_ipv6_only);
+            }
             _ => return_errno_with_message!(Errno::ENOPROTOOPT, "the socket option is unknown"),
         });
 
@@ -73,6 +91,7 @@ impl IpOptionSet {
         &mut self,
         option: &dyn SocketOption,
         socket: &dyn SetIpLevelOption,
+        family: IpAddressFamily,
     ) -> Result<NeedIfacePoll> {
         sock_option_ref!(match option {
             ip_tos @ Tos => {
@@ -95,6 +114,17 @@ impl IpOptionSet {
                 let recverr = ip_recverr.get().unwrap();
                 self.set_recverr(*recverr);
             }
+            ipv6_only @ Ipv6Only => {
+                if family != IpAddressFamily::IPv6 {
+                    return_errno_with_message!(
+                        Errno::ENOPROTOOPT,
+                        "IPV6_V6ONLY is unsupported on IPv4 sockets"
+                    );
+                }
+                socket.check_set_ipv6_only()?;
+                let is_ipv6_only = ipv6_only.get().unwrap();
+                self.set_ipv6_only(*is_ipv6_only);
+            }
             _ => return_errno_with_message!(
                 Errno::ENOPROTOOPT,
                 "the socket option to be set is unknown"
@@ -110,6 +140,7 @@ impl_socket_options!(
     pub struct Ttl(IpTtl);
     pub struct Hdrincl(bool);
     pub struct Recverr(bool);
+    pub struct Ipv6Only(bool);
 );
 
 #[derive(Clone, Copy, Debug)]
@@ -131,4 +162,8 @@ impl IpTtl {
 
 pub(super) trait SetIpLevelOption {
     fn set_hdrincl(&self, _hdrincl: bool) -> Result<()>;
+
+    fn check_set_ipv6_only(&self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -87,7 +87,7 @@ impl ConnectingStream {
             )),
             ConnectState::Refused => {
                 let bound_port = self.tcp_conn.into_bound_port().unwrap();
-                let family = IpAddressFamily::from(*bound_port.addr());
+                let family = IpAddressFamily::from(bound_port.addr());
                 ConnResult::Refused(InitStream::new_refused(bound_port, family))
             }
         }

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -19,6 +19,7 @@ use crate::{
 pub(super) struct ConnectingStream {
     tcp_conn: TcpConnection,
     remote_endpoint: IpEndpoint,
+    family: IpAddressFamily,
 }
 
 pub(super) enum ConnResult {
@@ -33,6 +34,7 @@ impl ConnectingStream {
         remote_endpoint: IpEndpoint,
         option: &RawTcpOption,
         observer: StreamObserver,
+        family: IpAddressFamily,
     ) -> Result<Self, (Error, BoundTcpPort)> {
         let tcp_conn =
             match TcpConnection::new_connect(bound_port, remote_endpoint, option, observer) {
@@ -64,6 +66,7 @@ impl ConnectingStream {
         Ok(Self {
             tcp_conn,
             remote_endpoint,
+            family,
         })
     }
 
@@ -87,8 +90,7 @@ impl ConnectingStream {
             )),
             ConnectState::Refused => {
                 let bound_port = self.tcp_conn.into_bound_port().unwrap();
-                let family = IpAddressFamily::from(bound_port.addr());
-                ConnResult::Refused(InitStream::new_refused(bound_port, family))
+                ConnResult::Refused(InitStream::new_refused(bound_port, self.family))
             }
         }
     }

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -85,21 +85,24 @@ impl InitStream {
         self.family
     }
 
-    pub(super) fn bind(&mut self, endpoint: &IpEndpoint, can_reuse: bool) -> Result<()> {
+    pub(super) fn bind(
+        &mut self,
+        endpoint: &IpEndpoint,
+        can_reuse: bool,
+        is_ipv6_only: bool,
+    ) -> Result<()> {
         if self.bound_port.is_some() {
             return_errno_with_message!(Errno::EINVAL, "the socket is already bound to an address");
         }
 
-        // When we support `IPV6_V6ONLY` and if it is set, we should also reject IPv4-mapped
-        // IPv6 addresses.
-        if IpAddressFamily::from(endpoint.addr) != self.family {
+        if !self.is_endpoint_family_supported(endpoint) {
             return_errno_with_message!(
                 Errno::EAFNOSUPPORT,
                 "the protocol family does not match the address family"
             );
         }
 
-        self.bound_port = Some(bind_port(endpoint, can_reuse)?);
+        self.bound_port = Some(bind_port(endpoint, can_reuse, is_ipv6_only)?);
 
         Ok(())
     }
@@ -120,9 +123,7 @@ impl InitStream {
             "`finish_last_connect()` should be called before calling `connect()`"
         );
 
-        // When we support `IPV6_V6ONLY` and if it is set, we should also reject IPv4-mapped
-        // IPv6 addresses.
-        if IpAddressFamily::from(remote_endpoint.addr) != self.family {
+        if !self.is_endpoint_family_supported(remote_endpoint) {
             return Err((
                 Error::with_message(
                     Errno::EAFNOSUPPORT,
@@ -147,13 +148,13 @@ impl InitStream {
                     ));
                 }
             };
-            match bind_port(&endpoint, can_reuse) {
+            match bind_port(&endpoint, can_reuse, false) {
                 Ok(bound_port) => bound_port,
                 Err(err) => return Err((err, self)),
             }
         };
 
-        ConnectingStream::new(bound_port, *remote_endpoint, option, observer).map_err(
+        ConnectingStream::new(bound_port, *remote_endpoint, option, observer, self.family).map_err(
             |(err, bound_port)| {
                 if err.error() == Errno::ECONNREFUSED {
                     (err, InitStream::new_refused(bound_port, self.family))
@@ -273,7 +274,15 @@ impl InitStream {
     }
 }
 
-fn bind_port(endpoint: &IpEndpoint, can_reuse: bool) -> Result<BoundTcpPort> {
-    let (iface, config) = resolve_bind_iface_and_config(endpoint, can_reuse)?;
+impl InitStream {
+    fn is_endpoint_family_supported(&self, endpoint: &IpEndpoint) -> bool {
+        let endpoint_family = IpAddressFamily::from(endpoint.addr);
+        endpoint_family == self.family
+            || (self.family == IpAddressFamily::IPv6 && endpoint_family == IpAddressFamily::IPv4)
+    }
+}
+
+fn bind_port(endpoint: &IpEndpoint, can_reuse: bool, is_ipv6_only: bool) -> Result<BoundTcpPort> {
+    let (iface, config) = resolve_bind_iface_and_config(endpoint, can_reuse, is_ipv6_only)?;
     Ok(iface.bind_tcp(config)?)
 }

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -21,7 +21,7 @@ use takeable::Takeable;
 use util::{Retrans, TcpOptionSet};
 
 use super::{
-    addr::IpAddressFamily,
+    addr::{IpAddressFamily, SocketAddrOp, endpoint_to_socket_addr, socket_addr_to_endpoint},
     options::{IpOptionSet, SetIpLevelOption},
 };
 use crate::{
@@ -61,6 +61,7 @@ pub struct StreamSocket {
     // and other locks in `aster-bigtcp`), which will break the atomic mode.
     state: RwLock<Takeable<State>>,
     options: RwLock<OptionSet>,
+    family: IpAddressFamily,
 
     is_nonblocking: AtomicBool,
     pollee: Pollee,
@@ -109,13 +110,27 @@ impl StreamSocket {
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Init(init_stream))),
             options: RwLock::new(OptionSet::new()),
+            family,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
             pseudo_path: SockFs::new_path(),
         })
     }
 
-    fn new_accepted(connected_stream: ConnectedStream, listener_options: &OptionSet) -> Arc<Self> {
+    fn socket_addr_to_endpoint(
+        &self,
+        socket_addr: SocketAddr,
+        op: SocketAddrOp,
+    ) -> Result<IpEndpoint> {
+        let is_ipv6_only = self.options.read().ip.ipv6_only();
+        socket_addr_to_endpoint(socket_addr, self.family, is_ipv6_only, op)
+    }
+
+    fn new_accepted(
+        connected_stream: ConnectedStream,
+        listener_options: &OptionSet,
+        family: IpAddressFamily,
+    ) -> Arc<Self> {
         let options = connected_stream.raw_with(|raw_tcp_socket| {
             let mut options = OptionSet::new();
 
@@ -153,6 +168,7 @@ impl StreamSocket {
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
             options: RwLock::new(options),
+            family,
             is_nonblocking: AtomicBool::new(false),
             pollee,
             pseudo_path: SockFs::new_path(),
@@ -322,8 +338,12 @@ impl StreamSocket {
         let accepted = listen_stream.try_accept().map(|connected_stream| {
             let remote_endpoint = connected_stream.remote_endpoint();
             let listener_options = self.options.read();
-            let accepted_socket = Self::new_accepted(connected_stream, &listener_options);
-            (accepted_socket as _, remote_endpoint.into())
+            let accepted_socket =
+                Self::new_accepted(connected_stream, &listener_options, self.family);
+            (
+                accepted_socket as _,
+                endpoint_to_socket_addr(remote_endpoint, self.family),
+            )
         });
         let iface_to_poll = listen_stream.iface().clone();
 
@@ -368,7 +388,10 @@ impl StreamSocket {
             iface.poll();
         }
 
-        Ok((recv_bytes, remote_endpoint.into()))
+        Ok((
+            recv_bytes,
+            endpoint_to_socket_addr(remote_endpoint, self.family),
+        ))
     }
 
     fn try_send(&self, reader: &mut dyn MultiRead, flags: SendRecvFlags) -> Result<usize> {
@@ -448,19 +471,22 @@ impl SocketPrivate for StreamSocket {
 
 impl Socket for StreamSocket {
     fn bind(&self, socket_addr: SocketAddr) -> Result<()> {
-        let endpoint = socket_addr.try_into()?;
+        let endpoint = self.socket_addr_to_endpoint(socket_addr, SocketAddrOp::Bind)?;
+        let options = self.options.read();
+        let can_reuse = options.socket.reuse_addr();
+        let is_ipv6_only = options.ip.ipv6_only();
+        drop(options);
 
         let mut state = self.write_updated_state();
         let State::Init(init_stream) = state.as_mut() else {
             return_errno_with_message!(Errno::EINVAL, "the socket is already bound to an address");
         };
 
-        let can_reuse = self.options.read().socket.reuse_addr();
-        init_stream.bind(&endpoint, can_reuse)
+        init_stream.bind(&endpoint, can_reuse, is_ipv6_only)
     }
 
     fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
-        let remote_endpoint = socket_addr.try_into()?;
+        let remote_endpoint = self.socket_addr_to_endpoint(socket_addr, SocketAddrOp::Connect)?;
 
         if let Some(result) = self.start_connect(&remote_endpoint) {
             return result;
@@ -542,7 +568,7 @@ impl Socket for StreamSocket {
             State::Listen(listen_stream) => listen_stream.local_endpoint(),
             State::Connected(connected_stream) => connected_stream.local_endpoint(),
         };
-        Ok(local_endpoint.into())
+        Ok(endpoint_to_socket_addr(local_endpoint, self.family))
     }
 
     fn peer_addr(&self) -> Result<SocketAddr> {
@@ -554,7 +580,7 @@ impl Socket for StreamSocket {
             State::Connecting(connecting_stream) => connecting_stream.remote_endpoint(),
             State::Connected(connected_stream) => connected_stream.remote_endpoint(),
         };
-        Ok(remote_endpoint.into())
+        Ok(endpoint_to_socket_addr(remote_endpoint, self.family))
     }
 
     fn sendmsg(
@@ -626,7 +652,7 @@ impl Socket for StreamSocket {
         }
 
         // Deal with IP-level options
-        match options.ip.get_option(option) {
+        match options.ip.get_option(option, self.family) {
             Err(err) if err.error() == Errno::ENOPROTOOPT => (),
             res => return res,
         }
@@ -713,7 +739,7 @@ impl Socket for StreamSocket {
         let need_iface_poll = match socket_option_result {
             Err(err) if err.error() == Errno::ENOPROTOOPT => {
                 // Deal with IP-level options
-                match options.ip.set_option(option, state.as_ref()) {
+                match options.ip.set_option(option, state.as_ref(), self.family) {
                     Err(err) if err.error() == Errno::ENOPROTOOPT => {
                         // Deal with TCP-level options
                         do_tcp_setsockopt(option, &mut options, state.as_mut())?
@@ -934,6 +960,16 @@ impl SetIpLevelOption for State {
             Errno::ENOPROTOOPT,
             "IP_HDRINCL cannot be set on TCP sockets"
         );
+    }
+
+    fn check_set_ipv6_only(&self) -> Result<()> {
+        match self {
+            State::Init(init_stream) if init_stream.local_endpoint().is_none() => Ok(()),
+            _ => return_errno_with_message!(
+                Errno::EINVAL,
+                "IPV6_V6ONLY cannot be changed after the socket is bound"
+            ),
+        }
     }
 }
 

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -31,7 +31,7 @@ pub(super) fn do_get_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegme
 
     let mut response_segments: Vec<RtnlSegment> = iter_all_ifaces()
         // GETADDR only supports dump mode, so we're going to report all addresses.
-        .filter_map(|iface| iface_to_new_addr(request_segment.header(), iface))
+        .flat_map(|iface| iface_to_new_addr(request_segment.header(), iface))
         .map(RtnlSegment::NewAddr)
         .collect();
 
@@ -40,9 +40,41 @@ pub(super) fn do_get_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegme
     Ok(response_segments)
 }
 
-fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<AddrSegment> {
-    let ipv4_addr = iface.ipv4_addr()?;
+fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Vec<AddrSegment> {
+    let mut segments = Vec::new();
 
+    if let Some(ipv4_addr) = iface.ipv4_addr() {
+        let prefix_len = iface.ipv4_prefix_len().unwrap();
+        segments.push(new_addr_segment(
+            request_header,
+            iface,
+            CSocketAddrFamily::AF_INET,
+            prefix_len,
+            ipv4_addr.octets().to_vec(),
+        ));
+    }
+
+    if let Some(ipv6_addr) = iface.ipv6_addr() {
+        let prefix_len = iface.ipv6_prefix_len().unwrap();
+        segments.push(new_addr_segment(
+            request_header,
+            iface,
+            CSocketAddrFamily::AF_INET6,
+            prefix_len,
+            ipv6_addr.octets().to_vec(),
+        ));
+    }
+
+    segments
+}
+
+fn new_addr_segment(
+    request_header: &CMsgSegHdr,
+    iface: &Arc<Iface>,
+    family: CSocketAddrFamily,
+    prefix_len: u8,
+    address: Vec<u8>,
+) -> AddrSegment {
     let header = CMsgSegHdr {
         len: 0,
         type_: CSegmentType::NEWADDR as _,
@@ -52,18 +84,24 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<
     };
 
     let addr_message = AddrSegmentBody {
-        family: CSocketAddrFamily::AF_INET as _,
-        prefix_len: iface.ipv4_prefix_len().unwrap(),
+        family: family as _,
+        prefix_len,
         flags: AddrMessageFlags::PERMANENT,
         scope: RtScope::HOST,
         index: NonZeroU32::new(iface.index()),
     };
 
-    let attrs = vec![
-        AddrAttr::Address(ipv4_addr.octets()),
-        AddrAttr::Label(iface.name().to_owned()),
-        AddrAttr::Local(ipv4_addr.octets()),
-    ];
+    // Linux reports `IFA_ADDRESS`, `IFA_LOCAL` and `IFA_LABEL` for IPv4 addresses
+    // (`inet_fill_ifaddr`) but only `IFA_ADDRESS` for IPv6 addresses
+    // (`inet6_fill_ifaddr`).
+    let attrs = match family {
+        CSocketAddrFamily::AF_INET6 => vec![AddrAttr::Address(address)],
+        _ => vec![
+            AddrAttr::Address(address.clone()),
+            AddrAttr::Label(iface.name().to_owned()),
+            AddrAttr::Local(address),
+        ],
+    };
 
-    Some(AddrSegment::new(header, addr_message, attrs))
+    AddrSegment::new(header, addr_message, attrs)
 }

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -53,7 +53,7 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<
 
     let addr_message = AddrSegmentBody {
         family: CSocketAddrFamily::AF_INET as _,
-        prefix_len: iface.prefix_len().unwrap(),
+        prefix_len: iface.ipv4_prefix_len().unwrap(),
         flags: AddrMessageFlags::PERMANENT,
         scope: RtScope::HOST,
         index: NonZeroU32::new(iface.index()),

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -29,8 +29,8 @@ enum AddrAttrClass {
 
 #[derive(Debug)]
 pub enum AddrAttr {
-    Address([u8; 4]),
-    Local([u8; 4]),
+    Address(Vec<u8>),
+    Local(Vec<u8>),
     Label(CString),
 }
 

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -50,12 +50,17 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
                 _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported protocol"),
             }
         }
-        (CSocketAddrFamily::AF_INET, SockType::SOCK_DGRAM) => {
+        (CSocketAddrFamily::AF_INET | CSocketAddrFamily::AF_INET6, SockType::SOCK_DGRAM) => {
             let protocol = Protocol::try_from(protocol)?;
             debug!("protocol = {:?}", protocol);
             match protocol {
                 Protocol::IPPROTO_IP | Protocol::IPPROTO_UDP => {
-                    DatagramSocket::new(is_nonblocking) as Arc<dyn FileLike>
+                    let family = match domain {
+                        CSocketAddrFamily::AF_INET => IpAddressFamily::IPv4,
+                        CSocketAddrFamily::AF_INET6 => IpAddressFamily::IPv6,
+                        _ => unreachable!(),
+                    };
+                    DatagramSocket::new(is_nonblocking, family) as Arc<dyn FileLike>
                 }
                 _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported protocol"),
             }

--- a/kernel/src/util/net/options/ipv6.rs
+++ b/kernel/src/util/net/options/ipv6.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use int_to_c_enum::TryFromInt;
+
+use super::{RawSocketOption, SocketOption, impl_raw_socket_option};
+use crate::{net::socket::ip::options::Ipv6Only, prelude::*};
+
+/// Socket options for IPv6 sockets.
+///
+/// The raw definitions can be found at:
+/// <https://elixir.bootlin.com/linux/v6.0.19/source/include/uapi/linux/in6.h#L178>.
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, TryFromInt)]
+pub enum CIpv6OptionName {
+    V6ONLY = 26,
+}
+
+pub fn new_ipv6_option(name: i32) -> Result<Box<dyn RawSocketOption>> {
+    let name = CIpv6OptionName::try_from(name).map_err(|_| Errno::ENOPROTOOPT)?;
+    match name {
+        CIpv6OptionName::V6ONLY => Ok(Box::new(Ipv6Only::new())),
+    }
+}
+
+impl_raw_socket_option!(Ipv6Only);

--- a/kernel/src/util/net/options/mod.rs
+++ b/kernel/src/util/net/options/mod.rs
@@ -52,11 +52,13 @@
 //!
 
 use ip::new_ip_option;
+use ipv6::new_ipv6_option;
 use netlink::new_netlink_option;
 
 use crate::{net::socket::options::SocketOption, prelude::*};
 
 mod ip;
+mod ipv6;
 mod netlink;
 mod socket;
 mod tcp;
@@ -169,6 +171,7 @@ pub fn new_raw_socket_option(
     match level {
         CSocketOptionLevel::SOL_SOCKET => new_socket_option(name),
         CSocketOptionLevel::SOL_IP => new_ip_option(name),
+        CSocketOptionLevel::SOL_IPV6 => new_ipv6_option(name),
         CSocketOptionLevel::SOL_TCP => new_tcp_option(name),
         CSocketOptionLevel::SOL_NETLINK => new_netlink_option(name),
         _ => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported option level"),

--- a/test/initramfs/src/regression/network/netlink_route.c
+++ b/test/initramfs/src/regression/network/netlink_route.c
@@ -128,6 +128,57 @@ FN_TEST(get_loopback_address)
 }
 END_TEST()
 
+void find_eth0_ipv6_address(struct nl_object *obj, void *arg)
+{
+	int *found_eth0_ipv6 = (int *)arg;
+	struct rtnl_addr *addr = (struct rtnl_addr *)obj;
+	struct nl_addr *local;
+	char buf[INET6_ADDRSTRLEN + 4];
+
+	int family = rtnl_addr_get_family(addr);
+	if (family != AF_INET6) {
+		return;
+	}
+
+	// IPv6 addresses are reported via IFA_ADDRESS only (as on Linux); libnl
+	// exposes it through rtnl_addr_get_local() when IFA_LOCAL is absent.
+	local = rtnl_addr_get_local(addr);
+	if (local) {
+		nl_addr2str(local, buf, sizeof(buf));
+		if (strcmp(buf, "fec0::15/64") == 0) {
+			*found_eth0_ipv6 = 1;
+		}
+	}
+}
+
+FN_TEST(get_eth0_ipv6_address)
+{
+#ifndef __asterinas__
+	SKIP_TEST_IF(1);
+#endif
+	struct nl_sock *sock;
+	struct nl_cache *addr_cache;
+
+	// 1. Create netlink socket and connect
+	sock = nl_socket_alloc();
+	TEST_RES(nl_connect(sock, NETLINK_ROUTE), _ret >= 0);
+
+	// 2. Allocate and retrieve address cache
+	TEST_RES(rtnl_addr_alloc_cache(sock, &addr_cache), _ret >= 0);
+
+	// 3. Iterate over all addresses to find eth0 IPv6 address
+	int found_eth0_ipv6 = 0;
+	TEST_RES(SUCC(nl_cache_foreach(addr_cache, find_eth0_ipv6_address,
+				       &found_eth0_ipv6)),
+		 found_eth0_ipv6 == 1);
+
+	// 4. Cleanup
+	nl_cache_free(addr_cache);
+	nl_close(sock);
+	nl_socket_free(sock);
+}
+END_TEST()
+
 int find_new_addr_until_done(char *buffer, size_t len, int *found_new_addr)
 {
 	struct nlmsghdr *nlh = (struct nlmsghdr *)buffer;

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -122,6 +122,41 @@ FN_TEST(socket_error)
 }
 END_TEST()
 
+FN_TEST(ipv6_v6only)
+{
+	// `IPV6_V6ONLY` is a per-socket switch on an `AF_INET6` socket that
+	// selects between dual-stack (also accepts IPv4-mapped traffic) and
+	// IPv6-only operation. It is carried as a 4-byte integer.
+	int sk = TEST_SUCC(socket(AF_INET6, SOCK_DGRAM, 0));
+	int val;
+	socklen_t len = sizeof(val);
+
+	// Enabling restricts the socket to IPv6.
+	val = 1;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)));
+	val = 0;
+	TEST_RES(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, &len),
+		 val == 1 && len == sizeof(int));
+
+	// Clearing it restores dual-stack behavior.
+	val = 0;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val)));
+	TEST_RES(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &val, &len),
+		 val == 0 && len == sizeof(int));
+
+	TEST_SUCC(close(sk));
+
+	// The option is meaningless on an `AF_INET` socket and is rejected.
+	val = 0;
+	len = sizeof(val);
+	TEST_ERRNO(getsockopt(sk_udp, IPPROTO_IPV6, IPV6_V6ONLY, &val, &len),
+		   EOPNOTSUPP);
+	TEST_ERRNO(setsockopt(sk_udp, IPPROTO_IPV6, IPV6_V6ONLY, &val,
+			      sizeof(val)),
+		   ENOPROTOOPT);
+}
+END_TEST()
+
 FN_TEST(nagle)
 {
 	int option = 1;

--- a/test/initramfs/src/regression/network/tcp_err.c
+++ b/test/initramfs/src/regression/network/tcp_err.c
@@ -621,6 +621,201 @@ FN_TEST(self_connect)
 }
 END_TEST()
 
+FN_TEST(ipv6_send_and_recv)
+{
+	int listen_fd = TEST_SUCC(socket(PF_INET6, SOCK_STREAM, 0));
+	int client_fd = TEST_SUCC(socket(PF_INET6, SOCK_STREAM, 0));
+	struct sockaddr_in6 listen_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8892),
+		.sin6_addr = IN6ADDR_LOOPBACK_INIT,
+	};
+	struct sockaddr_in6 peer_addr = { 0 };
+	socklen_t peer_len = sizeof(peer_addr);
+	char buf[3] = { 0 };
+
+	TEST_SUCC(bind(listen_fd, (struct sockaddr *)&listen_addr,
+		       sizeof(listen_addr)));
+	TEST_SUCC(listen(listen_fd, 3));
+	TEST_SUCC(connect(client_fd, (struct sockaddr *)&listen_addr,
+			  sizeof(listen_addr)));
+
+	int accepted_fd = TEST_SUCC(
+		accept(listen_fd, (struct sockaddr *)&peer_addr, &peer_len));
+	TEST_RES(write(client_fd, "v6", 2), _ret == 2);
+	TEST_RES(read(accepted_fd, buf, 2),
+		 _ret == 2 && memcmp(buf, "v6", 2) == 0 &&
+			 peer_len == sizeof(peer_addr) &&
+			 peer_addr.sin6_family == AF_INET6);
+
+	TEST_SUCC(close(accepted_fd));
+	TEST_SUCC(close(client_fd));
+	TEST_SUCC(close(listen_fd));
+}
+END_TEST()
+
+FN_TEST(ipv6_mapped_ipv4_connect)
+{
+	int listen_fd = TEST_SUCC(socket(PF_INET, SOCK_STREAM, 0));
+	int client_fd = TEST_SUCC(socket(PF_INET6, SOCK_STREAM, 0));
+	struct sockaddr_in listen_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8893),
+	};
+	struct sockaddr_in6 mapped_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8893),
+		.sin6_addr = { .s6_addr = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff,
+					    0xff, 127, 0, 0, 1 } },
+	};
+	struct sockaddr_in6 client_addr = { 0 };
+	socklen_t client_len = sizeof(client_addr);
+	char buf[7] = { 0 };
+
+	TEST_SUCC(inet_aton("127.0.0.1", &listen_addr.sin_addr));
+	TEST_SUCC(bind(listen_fd, (struct sockaddr *)&listen_addr,
+		       sizeof(listen_addr)));
+	TEST_SUCC(listen(listen_fd, 3));
+	TEST_SUCC(connect(client_fd, (struct sockaddr *)&mapped_addr,
+			  sizeof(mapped_addr)));
+
+	int accepted_fd = TEST_SUCC(accept(listen_fd, NULL, NULL));
+	TEST_RES(getsockname(client_fd, (struct sockaddr *)&client_addr,
+			     &client_len),
+		 client_len == sizeof(client_addr) &&
+			 client_addr.sin6_family == AF_INET6 &&
+			 IN6_IS_ADDR_V4MAPPED(&client_addr.sin6_addr));
+	TEST_RES(write(client_fd, "mapped", 6), _ret == 6);
+	TEST_RES(read(accepted_fd, buf, 6),
+		 _ret == 6 && memcmp(buf, "mapped", 6) == 0);
+
+	TEST_SUCC(close(accepted_fd));
+	TEST_SUCC(close(client_fd));
+	TEST_SUCC(close(listen_fd));
+}
+END_TEST()
+
+FN_TEST(ipv6_v6only_connect_unreachable)
+{
+	int client_fd = TEST_SUCC(socket(PF_INET6, SOCK_STREAM, 0));
+	int v6only = 1;
+	struct sockaddr_in6 mapped_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8894),
+		.sin6_addr = { .s6_addr = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff,
+					    0xff, 127, 0, 0, 1 } },
+	};
+
+	TEST_SUCC(setsockopt(client_fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+
+	// A v6only socket cannot reach an IPv4-mapped address, so the connection
+	// attempt fails immediately with ENETUNREACH.
+	TEST_ERRNO(connect(client_fd, (struct sockaddr *)&mapped_addr,
+			   sizeof(mapped_addr)),
+		   ENETUNREACH);
+
+	TEST_SUCC(close(client_fd));
+}
+END_TEST()
+
+FN_TEST(ipv6_wildcard_accepts_ipv4)
+{
+	int listen_fd = TEST_SUCC(socket(PF_INET6, SOCK_STREAM, 0));
+	int client_fd = TEST_SUCC(socket(PF_INET, SOCK_STREAM, 0));
+	struct sockaddr_in6 listen_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8894),
+		.sin6_addr = IN6ADDR_ANY_INIT,
+	};
+	struct sockaddr_in connect_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8894),
+	};
+	struct sockaddr_in6 peer_addr = { 0 };
+	socklen_t peer_len = sizeof(peer_addr);
+
+	TEST_SUCC(inet_aton("127.0.0.1", &connect_addr.sin_addr));
+	TEST_SUCC(bind(listen_fd, (struct sockaddr *)&listen_addr,
+		       sizeof(listen_addr)));
+	TEST_SUCC(listen(listen_fd, 3));
+	TEST_SUCC(connect(client_fd, (struct sockaddr *)&connect_addr,
+			  sizeof(connect_addr)));
+
+	int accepted_fd = TEST_SUCC(
+		accept(listen_fd, (struct sockaddr *)&peer_addr, &peer_len));
+	TEST_RES(0, peer_len == sizeof(peer_addr) &&
+			    peer_addr.sin6_family == AF_INET6 &&
+			    IN6_IS_ADDR_V4MAPPED(&peer_addr.sin6_addr));
+
+	TEST_SUCC(close(accepted_fd));
+	TEST_SUCC(close(client_fd));
+	TEST_SUCC(close(listen_fd));
+}
+END_TEST()
+
+FN_TEST(ipv6_v6only_wildcard_port_isolated)
+{
+	int ipv6_fd = TEST_SUCC(socket(PF_INET6, SOCK_STREAM, 0));
+	int ipv4_fd = TEST_SUCC(socket(PF_INET, SOCK_STREAM, 0));
+	struct sockaddr_in6 ipv6_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8895),
+		.sin6_addr = IN6ADDR_ANY_INIT,
+	};
+	struct sockaddr_in ipv4_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8895),
+	};
+	int v6only = 1;
+
+	TEST_SUCC(inet_aton("127.0.0.1", &ipv4_addr.sin_addr));
+	TEST_SUCC(setsockopt(ipv6_fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+	TEST_SUCC(bind(ipv6_fd, (struct sockaddr *)&ipv6_addr,
+		       sizeof(ipv6_addr)));
+	TEST_SUCC(bind(ipv4_fd, (struct sockaddr *)&ipv4_addr,
+		       sizeof(ipv4_addr)));
+	TEST_SUCC(listen(ipv6_fd, 3));
+	TEST_SUCC(listen(ipv4_fd, 3));
+
+	TEST_SUCC(close(ipv4_fd));
+	TEST_SUCC(close(ipv6_fd));
+}
+END_TEST()
+
+FN_TEST(ipv6_dual_stack_listener_conflict)
+{
+	int ipv4_fd = TEST_SUCC(socket(PF_INET, SOCK_STREAM, 0));
+	int ipv6_fd = TEST_SUCC(socket(PF_INET6, SOCK_STREAM, 0));
+	struct sockaddr_in ipv4_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8896),
+	};
+	struct sockaddr_in6 ipv6_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8896),
+		.sin6_addr = IN6ADDR_ANY_INIT,
+	};
+	int reuse = 1;
+
+	TEST_SUCC(inet_aton("127.0.0.1", &ipv4_addr.sin_addr));
+	TEST_SUCC(setsockopt(ipv4_fd, SOL_SOCKET, SO_REUSEADDR, &reuse,
+			     sizeof(reuse)));
+	TEST_SUCC(setsockopt(ipv6_fd, SOL_SOCKET, SO_REUSEADDR, &reuse,
+			     sizeof(reuse)));
+	TEST_SUCC(bind(ipv4_fd, (struct sockaddr *)&ipv4_addr,
+		       sizeof(ipv4_addr)));
+	TEST_SUCC(bind(ipv6_fd, (struct sockaddr *)&ipv6_addr,
+		       sizeof(ipv6_addr)));
+	TEST_SUCC(listen(ipv4_fd, 3));
+	TEST_ERRNO(listen(ipv6_fd, 3), EADDRINUSE);
+
+	TEST_SUCC(close(ipv6_fd));
+	TEST_SUCC(close(ipv4_fd));
+}
+END_TEST()
+
 FN_TEST(listen_at_the_same_address)
 {
 	int sk_listen1;

--- a/test/initramfs/src/regression/network/udp_err.c
+++ b/test/initramfs/src/regression/network/udp_err.c
@@ -6,6 +6,7 @@
 #include <sys/poll.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <net/if.h>
 #include <fcntl.h>
 
 #include "../common/test.h"
@@ -70,6 +71,309 @@ FN_TEST(getsockname)
 
 	TEST_RES(getsockname(sk_connected, psaddr, &addrlen),
 		 addrlen == sizeof(saddr) && saddr.sin_port != C_PORT);
+}
+END_TEST()
+
+FN_TEST(ipv6_getsockname)
+{
+	int sk = TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in6 saddr = { .sin6_port = 0xbeef };
+	struct sockaddr *psaddr = (struct sockaddr *)&saddr;
+	socklen_t addrlen = sizeof(saddr);
+
+	TEST_RES(getsockname(sk, psaddr, &addrlen),
+		 addrlen == sizeof(saddr) && saddr.sin6_family == AF_INET6 &&
+			 saddr.sin6_port == 0 &&
+			 memcmp(&saddr.sin6_addr, &in6addr_any,
+				sizeof(in6addr_any)) == 0);
+
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+FN_TEST(ipv6_send_and_recv)
+{
+	int receiver =
+		TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int sender = TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in6 receiver_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8084),
+		.sin6_addr = IN6ADDR_LOOPBACK_INIT,
+	};
+	struct sockaddr_in6 peer_addr = { 0 };
+	socklen_t peer_len = sizeof(peer_addr);
+	char send_buf[] = "v6";
+	char recv_buf[sizeof(send_buf)] = { 0 };
+
+	TEST_SUCC(bind(receiver, (struct sockaddr *)&receiver_addr,
+		       sizeof(receiver_addr)));
+	TEST_RES(sendto(sender, send_buf, sizeof(send_buf), 0,
+			(struct sockaddr *)&receiver_addr,
+			sizeof(receiver_addr)),
+		 _ret == sizeof(send_buf));
+	TEST_RES(recvfrom(receiver, recv_buf, sizeof(recv_buf), 0,
+			  (struct sockaddr *)&peer_addr, &peer_len),
+		 _ret == sizeof(send_buf) && peer_len == sizeof(peer_addr) &&
+			 peer_addr.sin6_family == AF_INET6 &&
+			 memcmp(recv_buf, send_buf, sizeof(send_buf)) == 0);
+
+	TEST_SUCC(close(sender));
+	TEST_SUCC(close(receiver));
+}
+END_TEST()
+
+FN_TEST(ipv6_eth0_send_and_recv)
+{
+#ifndef __asterinas__
+	SKIP_TEST_IF(1);
+#endif
+	int receiver =
+		TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int sender = TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	unsigned int eth0_index = if_nametoindex("eth0");
+	struct sockaddr_in6 receiver_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8086),
+	};
+	struct sockaddr_in6 peer_addr = { 0 };
+	socklen_t peer_len = sizeof(peer_addr);
+	char send_buf[] = "eth0-v6";
+	char recv_buf[sizeof(send_buf)] = { 0 };
+
+	TEST_RES(0, eth0_index != 0);
+	TEST_SUCC(inet_pton(AF_INET6, "fec0::15", &receiver_addr.sin6_addr));
+	TEST_SUCC(bind(receiver, (struct sockaddr *)&receiver_addr,
+		       sizeof(receiver_addr)));
+	TEST_RES(sendto(sender, send_buf, sizeof(send_buf), 0,
+			(struct sockaddr *)&receiver_addr,
+			sizeof(receiver_addr)),
+		 _ret == sizeof(send_buf));
+	TEST_RES(recvfrom(receiver, recv_buf, sizeof(recv_buf), 0,
+			  (struct sockaddr *)&peer_addr, &peer_len),
+		 _ret == sizeof(send_buf) && peer_len == sizeof(peer_addr) &&
+			 peer_addr.sin6_family == AF_INET6 &&
+			 memcmp(recv_buf, send_buf, sizeof(send_buf)) == 0);
+
+	TEST_SUCC(close(sender));
+	TEST_SUCC(close(receiver));
+}
+END_TEST()
+
+FN_TEST(ipv6_v6only)
+{
+	int sk = TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int bound_sk =
+		TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in6 mapped_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8091),
+		.sin6_addr = { .s6_addr = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff,
+					    0xff, 127, 0, 0, 1 } },
+	};
+	struct sockaddr_in6 bound_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = 0,
+		.sin6_addr = IN6ADDR_LOOPBACK_INIT,
+	};
+	int v6only = -1;
+	socklen_t optlen = sizeof(v6only);
+
+	TEST_RES(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &optlen),
+		 optlen == sizeof(v6only) && v6only == 0);
+
+	v6only = 1;
+	TEST_SUCC(setsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+	TEST_RES(getsockopt(sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &optlen),
+		 optlen == sizeof(v6only) && v6only == 1);
+
+	TEST_ERRNO(bind(sk, (struct sockaddr *)&mapped_addr,
+			sizeof(mapped_addr)),
+		   EINVAL);
+
+	TEST_SUCC(bind(bound_sk, (struct sockaddr *)&bound_addr,
+		       sizeof(bound_addr)));
+	TEST_ERRNO(setsockopt(bound_sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			      sizeof(v6only)),
+		   EINVAL);
+
+	// Reaching an IPv4-mapped address from a v6only socket fails with
+	// ENETUNREACH on connect() and sendto(), unlike bind() which uses EINVAL.
+	char send_buf[] = "mapped";
+	TEST_ERRNO(connect(sk, (struct sockaddr *)&mapped_addr,
+			   sizeof(mapped_addr)),
+		   ENETUNREACH);
+	TEST_ERRNO(sendto(sk, send_buf, sizeof(send_buf), 0,
+			  (struct sockaddr *)&mapped_addr, sizeof(mapped_addr)),
+		   ENETUNREACH);
+
+	TEST_SUCC(close(bound_sk));
+	TEST_SUCC(close(sk));
+}
+END_TEST()
+
+FN_TEST(ipv6_mapped_ipv4_send_and_recv)
+{
+	int receiver =
+		TEST_SUCC(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int sender = TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in receiver_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8087),
+	};
+	struct sockaddr_in6 mapped_receiver_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8087),
+		.sin6_addr = { .s6_addr = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff,
+					    0xff, 127, 0, 0, 1 } },
+	};
+	struct sockaddr_in peer_addr = { 0 };
+	socklen_t peer_len = sizeof(peer_addr);
+	struct sockaddr_in6 sender_addr = { 0 };
+	socklen_t sender_len = sizeof(sender_addr);
+	char send_buf[] = "mapped";
+	char recv_buf[sizeof(send_buf)] = { 0 };
+
+	TEST_SUCC(inet_aton("127.0.0.1", &receiver_addr.sin_addr));
+	TEST_SUCC(bind(receiver, (struct sockaddr *)&receiver_addr,
+		       sizeof(receiver_addr)));
+	TEST_RES(sendto(sender, send_buf, sizeof(send_buf), 0,
+			(struct sockaddr *)&mapped_receiver_addr,
+			sizeof(mapped_receiver_addr)),
+		 _ret == sizeof(send_buf));
+	TEST_RES(recvfrom(receiver, recv_buf, sizeof(recv_buf), 0,
+			  (struct sockaddr *)&peer_addr, &peer_len),
+		 _ret == sizeof(send_buf) && peer_len == sizeof(peer_addr) &&
+			 peer_addr.sin_family == AF_INET &&
+			 memcmp(recv_buf, send_buf, sizeof(send_buf)) == 0);
+	// After `sendto()` on an unconnected socket, the local address is left
+	// unspecified (only an ephemeral port is auto-assigned), so we check that
+	// the reported address is an IPv6 endpoint with a non-zero port rather than
+	// asserting a specific local address.
+	TEST_RES(getsockname(sender, (struct sockaddr *)&sender_addr,
+			     &sender_len),
+		 sender_len == sizeof(sender_addr) &&
+			 sender_addr.sin6_family == AF_INET6 &&
+			 sender_addr.sin6_port != 0);
+
+	TEST_SUCC(close(sender));
+	TEST_SUCC(close(receiver));
+}
+END_TEST()
+
+FN_TEST(ipv6_wildcard_receives_ipv4)
+{
+	int receiver =
+		TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int sender = TEST_SUCC(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in6 receiver_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8088),
+		.sin6_addr = IN6ADDR_ANY_INIT,
+	};
+	struct sockaddr_in send_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8088),
+	};
+	struct sockaddr_in6 peer_addr = { 0 };
+	socklen_t peer_len = sizeof(peer_addr);
+	char send_buf[] = "dual";
+	char recv_buf[sizeof(send_buf)] = { 0 };
+
+	TEST_SUCC(inet_aton("127.0.0.1", &send_addr.sin_addr));
+	TEST_SUCC(bind(receiver, (struct sockaddr *)&receiver_addr,
+		       sizeof(receiver_addr)));
+	TEST_RES(sendto(sender, send_buf, sizeof(send_buf), 0,
+			(struct sockaddr *)&send_addr, sizeof(send_addr)),
+		 _ret == sizeof(send_buf));
+	TEST_RES(recvfrom(receiver, recv_buf, sizeof(recv_buf), 0,
+			  (struct sockaddr *)&peer_addr, &peer_len),
+		 _ret == sizeof(send_buf) && peer_len == sizeof(peer_addr) &&
+			 peer_addr.sin6_family == AF_INET6 &&
+			 IN6_IS_ADDR_V4MAPPED(&peer_addr.sin6_addr) &&
+			 memcmp(recv_buf, send_buf, sizeof(send_buf)) == 0);
+
+	TEST_SUCC(close(sender));
+	TEST_SUCC(close(receiver));
+}
+END_TEST()
+
+FN_TEST(ipv6_wildcard_port_conflict)
+{
+	int ipv6_sk =
+		TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int ipv4_sk = TEST_SUCC(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in6 ipv6_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8089),
+		.sin6_addr = IN6ADDR_ANY_INIT,
+	};
+	struct sockaddr_in ipv4_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8089),
+	};
+
+	TEST_SUCC(inet_aton("127.0.0.1", &ipv4_addr.sin_addr));
+	TEST_SUCC(bind(ipv6_sk, (struct sockaddr *)&ipv6_addr,
+		       sizeof(ipv6_addr)));
+	TEST_ERRNO(bind(ipv4_sk, (struct sockaddr *)&ipv4_addr,
+			sizeof(ipv4_addr)),
+		   EADDRINUSE);
+
+	TEST_SUCC(close(ipv4_sk));
+	TEST_SUCC(close(ipv6_sk));
+}
+END_TEST()
+
+FN_TEST(ipv6_v6only_wildcard_port_isolated)
+{
+	int ipv6_sk =
+		TEST_SUCC(socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	int ipv4_sk = TEST_SUCC(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in6 ipv6_addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8090),
+		.sin6_addr = IN6ADDR_ANY_INIT,
+	};
+	struct sockaddr_in ipv4_addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(8090),
+	};
+	int v6only = 1;
+
+	TEST_SUCC(inet_aton("127.0.0.1", &ipv4_addr.sin_addr));
+	TEST_SUCC(setsockopt(ipv6_sk, IPPROTO_IPV6, IPV6_V6ONLY, &v6only,
+			     sizeof(v6only)));
+	TEST_SUCC(bind(ipv6_sk, (struct sockaddr *)&ipv6_addr,
+		       sizeof(ipv6_addr)));
+	TEST_SUCC(bind(ipv4_sk, (struct sockaddr *)&ipv4_addr,
+		       sizeof(ipv4_addr)));
+
+	TEST_SUCC(close(ipv4_sk));
+	TEST_SUCC(close(ipv6_sk));
+}
+END_TEST()
+
+FN_TEST(address_family_mismatch)
+{
+	int sk = TEST_SUCC(socket(PF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0));
+	struct sockaddr_in6 addr = {
+		.sin6_family = AF_INET6,
+		.sin6_port = htons(8085),
+		.sin6_addr = IN6ADDR_LOOPBACK_INIT,
+	};
+	char buf = 'x';
+
+	TEST_ERRNO(bind(sk, (struct sockaddr *)&addr, sizeof(addr)),
+		   EAFNOSUPPORT);
+	TEST_ERRNO(connect(sk, (struct sockaddr *)&addr, sizeof(addr)),
+		   EAFNOSUPPORT);
+	TEST_ERRNO(sendto(sk, &buf, sizeof(buf), 0, (struct sockaddr *)&addr,
+			  sizeof(addr)),
+		   EAFNOSUPPORT);
+
+	TEST_SUCC(close(sk));
 }
 END_TEST()
 


### PR DESCRIPTION
> Part 2 of 2, builds on the IPv6 link-layer PR (base: pr/ipv6-link-layer).

The link-layer PR taught the stack to send and receive IPv6 on the wire. This PR exposes that to userspace: `AF_INET6` TCP and UDP sockets now behave like dual-stack sockets, and the `IPV6_V6ONLY` socket option lets an application opt out of the dual-stack behavior. See the [ipv6(7)](https://man7.org/linux/man-pages/man7/ipv6.7.html) man page for the semantics being modeled.

## What this enables

- A server that does `socket(AF_INET6, SOCK_STREAM, 0)`, binds `in6addr_any` (`::`) and calls `listen()` now accepts IPv4 clients too. The peer shows up through `accept()`/`getpeername()` as an `AF_INET6` address whose `sin6_addr` is the IPv4-mapped form `::ffff:a.b.c.d`. `endpoint_to_socket_addr()` performs this mapping via `Ipv4Address::to_ipv6_mapped()` when the socket family is `IPv6`.
- A client on an `AF_INET6` socket can `connect()` (or `sendto()`, for UDP) to an IPv4-mapped address such as `::ffff:127.0.0.1` and reach a plain IPv4 peer. `socket_addr_to_endpoint()` recognizes the mapped prefix (`ipv4_mapped_ipv6_to_ipv4()`, matching 10 zero bytes followed by `0xff 0xff`) and rewrites the endpoint to native IPv4.
- Flipping `IPV6_V6ONLY` on before bind confines the socket to real IPv6. Two `::`-bound listeners — one v6only, one not — no longer collide on the same port, because bind resolves the wildcard into distinct scopes (`bind_scope()` returns `Ipv6OnlyWildcard`, `Ipv6DualStackWildcard`, or `Ipv4Wildcard`).

## IPV6_V6ONLY semantics

The option is `IPPROTO_IPV6`/`IPV6_V6ONLY` (level `41`, name `26`; `CIpv6OptionName::V6ONLY`), decoded in `util/net/options/ipv6.rs` and carried as the `Ipv6Only(bool)` socket option that maps onto `IpOptionSet::ipv6_only`.

- Default is `false` (dual-stack) for both TCP and UDP — see `IpOptionSet::new_tcp()`/`new_udp()`.
- `getsockopt` returns the current flag as an `int`. On an `AF_INET` socket it fails with `EOPNOTSUPP`; `setsockopt` on an `AF_INET` socket fails with `ENOPROTOOPT`.
- `setsockopt` is only honored while the socket is still unbound. Once bound it fails with `EINVAL`; for TCP this is enforced by `check_set_ipv6_only()` on `State`, which permits the change only in `State::Init` with no local endpoint.
- When the flag is set, IPv4-mapped addresses are rejected, but the errno depends on the operation (`SocketAddrOp`): `bind(2)` yields `EINVAL`, while `connect(2)`/`sendmsg(2)` yield `ENETUNREACH` — matching Linux, where a v6only socket simply has no route to a mapped destination.

## Netlink

`RTM_GETADDR` dumps now include IPv6 interface addresses. `iface_to_new_addr()` emits an additional `AF_INET6` `AddrSegment` (with `ipv6_addr()`/`ipv6_prefix_len()`) alongside the existing `AF_INET` one. Following Linux's `inet6_fill_ifaddr()`, IPv6 entries carry only the `IFA_ADDRESS` attribute, whereas IPv4 entries continue to carry `IFA_ADDRESS`, `IFA_LOCAL`, and `IFA_LABEL`.

## Tests

- `udp_err.c` — adds `ipv6_getsockname`, `ipv6_send_and_recv`, `ipv6_v6only` (default `0`, set/get round-trip, `bind`→`EINVAL`, post-bind `setsockopt`→`EINVAL`, `connect`/`sendto` to a mapped address→`ENETUNREACH`), and `ipv6_mapped_ipv4_send_and_recv` (an `AF_INET6` sender delivers to an `AF_INET` receiver via `::ffff:127.0.0.1`).
- `tcp_err.c` — adds `ipv6_send_and_recv`, `ipv6_mapped_ipv4_connect`, `ipv6_v6only_connect_unreachable` (`ENETUNREACH`), `ipv6_wildcard_accepts_ipv4` (a `::` listener serves an IPv4 client), `ipv6_v6only_wildcard_port_isolated`, and `ipv6_dual_stack_listener_conflict` (a dual-stack and an IPv4 listener on the same port conflict with `EADDRINUSE`). It also reworks the existing `getsockname`/`getpeername` error-path coverage.
- `netlink_route.c` — exercises `RTM_GETADDR` through libnl, checking the loopback address and IPv6 reporting via `rtnl_addr_get_local()` when `IFA_LOCAL` is absent, plus malformed-request error paths.
- `sockoption.c` — adds `ipv6_v6only`, a focused option-level check: set/get round-trip of `IPV6_V6ONLY` on an unbound `AF_INET6` socket, and rejection of the option on an `AF_INET` socket (`EOPNOTSUPP`/`ENOPROTOOPT`).

## Compatibility notes

- Behavior tracks Linux's default `net.ipv6.bindv6only = 0` (dual-stack by default).
- `ipv4_mapped_ipv6_to_ipv4()` only matches the canonical `::ffff:0:0/96` mapped range; deprecated IPv4-compatible (`::a.b.c.d`) addresses are not treated as mapped, consistent with modern Linux.
- The `From<IpAddress> for IpAddressFamily` conversion deliberately ignores mapped addresses; scope decisions go through the explicit `is_ipv6_only` plumbing instead.