### PR TITLE
Fix lseek on /sys/devices

### DIFF
--- a/kernel/src/fs/fs_impls/sysfs/devices.rs
+++ b/kernel/src/fs/fs_impls/sysfs/devices.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Implementation of the `/sys/devices` sysfs directory.
+
+use alloc::sync::Arc;
+
+use aster_systree::{AttrLessBranchNodeFields, SysObj, SysPerms, SysStr, inherit_sys_branch_node};
+use spin::Once;
+
+pub(super) fn init() {
+    DEVICES_SYS_NODE_ROOT.call_once(|| {
+        let singleton = DevicesSysNodeRoot::new();
+        super::systree_singleton()
+            .root()
+            .add_child(singleton.clone())
+            .unwrap();
+
+        singleton
+    });
+}
+
+static DEVICES_SYS_NODE_ROOT: Once<Arc<DevicesSysNodeRoot>> = Once::new();
+
+/// A systree node representing the `/sys/devices` directory.
+///
+/// This node serves as the top-level directory for device-related sysfs entries.
+/// It corresponds to the `/devices` directory in the sysfs filesystem.
+#[derive(Debug)]
+struct DevicesSysNodeRoot {
+    fields: AttrLessBranchNodeFields<dyn SysObj, Self>,
+}
+
+impl DevicesSysNodeRoot {
+    /// Creates a new `DevicesSysNodeRoot` instance.
+    fn new() -> Arc<Self> {
+        let name = SysStr::from("devices");
+        Arc::new_cyclic(|weak_self| {
+            let fields = AttrLessBranchNodeFields::new(name, weak_self.clone());
+            DevicesSysNodeRoot { fields }
+        })
+    }
+}
+
+inherit_sys_branch_node!(DevicesSysNodeRoot, fields, {
+    fn perms(&self) -> SysPerms {
+        SysPerms::DEFAULT_RO_PERMS
+    }
+});

--- a/kernel/src/fs/fs_impls/sysfs/inode.rs
+++ b/kernel/src/fs/fs_impls/sysfs/inode.rs
@@ -98,4 +98,12 @@ impl Inode for SysFsInode {
             "file creation under sysfs is not allowed",
         ))
     }
+
+    fn seek_end(&self) -> Option<usize> {
+        match self.metadata.type_ {
+            InodeType::Dir => Some(0),
+            InodeType::File => Some(self.metadata.size),
+            _ => None,
+        }
+    }
 }

--- a/kernel/src/fs/fs_impls/sysfs/mod.rs
+++ b/kernel/src/fs/fs_impls/sysfs/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+mod devices;
 mod fs;
 mod inode;
 mod kernel;
@@ -17,6 +18,7 @@ use crate::{fs::vfs::registry, prelude::*};
 pub fn init() {
     registry::register(&SysFsType).unwrap();
 
+    devices::init();
     kernel::init();
 }
 

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -439,6 +439,14 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         self.metadata().size
     }
 
+    default fn seek_end(&self) -> Option<usize> {
+        if self.type_() == InodeType::File {
+            Some(self.size())
+        } else {
+            None
+        }
+    }
+
     default fn resize(&self, _new_size: usize) -> Result<()> {
         // The `resize` operation should be ignored by kernelfs inodes,
         // and should not incur an error.

--- a/test/initramfs/src/conformance/gvisor/blocklists/lseek_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/lseek_test
@@ -1,2 +1,0 @@
-# TODO: Add `/sys/devices` and support `lseek(SEEK_END)`.
-LseekTest.SysDir

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -13,6 +13,7 @@ SUBDIRS := \
 	statx \
 	symlink \
 	sync \
+	sysfs \
 	tmpfile \
 	utimensat \
 

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -149,6 +149,8 @@ echo "All mount bind file test passed."
 
 ./sync/sync
 
+./sysfs/sysfs
+
 ./tmpfile/tmpfile
 
 ./utimensat/utimensat

--- a/test/initramfs/src/regression/fs/sysfs/Makefile
+++ b/test/initramfs/src/regression/fs/sysfs/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/sysfs/sysfs.c
+++ b/test/initramfs/src/regression/fs/sysfs/sysfs.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../../common/test.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+FN_TEST(sysfs_devices_lseek)
+{
+	int fd = TEST_RES(open("/sys/devices", O_RDONLY), _ret >= 0);
+	if (fd < 0)
+		goto out;
+
+	TEST_RES(lseek(fd, 0, SEEK_CUR), _ret == 0);
+	TEST_RES(lseek(fd, 0, SEEK_END), _ret == 0);
+
+	TEST_SUCC(close(fd));
+out:;
+}
+END_TEST()


### PR DESCRIPTION
## Summary

Fix `lseek` on `/sys/devices` by adding the top-level sysfs directory and allowing sysfs directories to handle `SEEK_END`.

## Changes

- Add `/sys/devices` as a read-only sysfs branch node.
- Make the systree inode `seek_end` default explicit so sysfs can override it.
- Add regression for opening and seeking `/sys/devices`.
- Remove the unblocked gVisor `LseekTest.SysDir` blocklist file.

## Testing

- `make check`

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  All conformance tests passed.
  ```