### PR TITLE
Fix SymlinkTest.FollowUpdatesATime

### DIFF
--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -131,6 +131,11 @@ impl InodeHandle {
         let mut offset = self.offset.lock();
         let read_cnt = file_ops.readdir_at(*offset, visitor)?;
         *offset += read_cnt;
+
+        if read_cnt > 0 && !self.status_flags().contains(StatusFlags::O_NOATIME) {
+            self.path.touch_atime();
+        }
+
         Ok(read_cnt)
     }
 
@@ -264,13 +269,21 @@ impl FileLike for InodeHandle {
         let status_flags = self.status_flags();
 
         if !is_offset_aware {
-            return file_ops.read_at(0, writer, status_flags);
+            let len = file_ops.read_at(0, writer, status_flags)?;
+            if len > 0 && !status_flags.contains(StatusFlags::O_NOATIME) {
+                self.path.touch_atime();
+            }
+            return Ok(len);
         }
 
         let mut offset = self.offset.lock();
 
         let len = file_ops.read_at(*offset, writer, status_flags)?;
         *offset += len;
+
+        if len > 0 && !status_flags.contains(StatusFlags::O_NOATIME) {
+            self.path.touch_atime();
+        }
 
         Ok(len)
     }
@@ -310,7 +323,11 @@ impl FileLike for InodeHandle {
 
         let status_flags = self.status_flags();
 
-        file_ops.read_at(offset, writer, status_flags)
+        let len = file_ops.read_at(offset, writer, status_flags)?;
+        if len > 0 && !status_flags.contains(StatusFlags::O_NOATIME) {
+            self.path.touch_atime();
+        }
+        Ok(len)
     }
 
     fn write_at(&self, mut offset: usize, reader: &mut VmReader) -> Result<usize> {

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         pseudofs::NsInode,
         vfs::{
             file_system::{FileSystem, FsFlags},
-            inode::{HardLinkability, Inode, Metadata, MknodType, RenameMode},
+            inode::{HardLinkability, Inode, Metadata, MknodType, RenameMode, SymbolicLink},
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -31,7 +31,11 @@ use crate::{
         Gid, Uid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
     },
     security::lsm::hooks as lsm_hooks,
+    time::clocks::RealTimeCoarseClock,
 };
+
+/// One day in seconds, used by the `relatime` atime policy.
+const RELATIME_DAY_SECS: u64 = 86400;
 
 mod dentry;
 mod mount;
@@ -319,6 +323,60 @@ impl Path {
         }
 
         Ok(())
+    }
+
+    /// Updates the access time of the inode if the mount's atime policy requires it.
+    ///
+    /// This is the unified VFS-level atime update entry point.
+    /// It checks the mount's atime policy (`noatime`, `relatime`,
+    /// or `strictatime`) and the inode type, and only performs the actual update
+    /// when necessary.
+    ///
+    /// The check is intentionally performed without holding the inode lock, making
+    /// the fast path (no update needed) completely lock-free. Races on the timestamp
+    /// fields are benign: a stale read may cause a spurious update or a missed one,
+    /// neither of which affects correctness.
+    pub fn touch_atime(&self) {
+        let mount_flags = self.mount.flags();
+
+        // `noatime`: never update atime.
+        if mount_flags.contains(PerMountFlags::NOATIME) {
+            return;
+        }
+
+        // `nodiratime`: skip atime update for directories.
+        if mount_flags.contains(PerMountFlags::NODIRATIME) && self.type_() == InodeType::Dir {
+            return;
+        }
+
+        let now = RealTimeCoarseClock::get().read_time();
+        let current_atime = self.atime();
+
+        // If the atime is already equal to (or newer than) the current time,
+        // no update is needed.
+        if current_atime >= now {
+            return;
+        }
+
+        // `relatime` (default): only update atime if the current atime is earlier
+        // than or equal to the mtime or ctime, or if atime has not been updated
+        // for over a day.
+        // Reference: <https://elixir.bootlin.com/linux/latest/source/fs/inode.c#L2060>
+        if !mount_flags.contains(PerMountFlags::STRICTATIME) {
+            let mtime = self.mtime();
+            let ctime = self.ctime();
+
+            let mtime_younger_or_equal = current_atime <= mtime;
+            let ctime_younger_or_equal = current_atime <= ctime;
+            let atime_is_older_than_a_day =
+                now.as_secs().saturating_sub(current_atime.as_secs()) >= RELATIME_DAY_SECS;
+
+            if !mtime_younger_or_equal && !ctime_younger_or_equal && !atime_is_older_than_a_day {
+                return;
+            }
+        }
+
+        self.set_atime(now);
     }
 }
 
@@ -680,6 +738,12 @@ impl Path {
         list_writer: &mut VmWriter,
     ) -> Result<usize>;
     pub fn remove_xattr(&self, name: XattrName) -> Result<()>;
+
+    /// Reads the symbolic link target and updates the access time.
+    pub fn read_link(&self) -> Result<SymbolicLink> {
+        self.touch_atime();
+        self.inode().read_link()
+    }
 
     /// Resizes the file.
     pub fn resize(&self, size: usize) -> Result<()> {

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -709,7 +709,7 @@ impl PathResolver {
                 if follows >= SYMLINKS_MAX {
                     return_errno_with_message!(Errno::ELOOP, "there are too many symlinks");
                 }
-                let read_link_res = next_path.inode().read_link()?;
+                let read_link_res = next_path.read_link()?;
                 match read_link_res {
                     SymbolicLink::Plain(mut tmp_link_path) => {
                         let link_path_remain = {

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -41,7 +41,7 @@ pub fn sys_readlinkat(
         let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::Allow)?;
         let path = path_resolver.lookup_no_follow(&fs_path)?;
 
-        match path.inode().read_link()? {
+        match path.read_link()? {
             SymbolicLink::Plain(s) => s,
             SymbolicLink::Path(path) => path_resolver.make_abs_path(&path).into_string(),
         }

--- a/test/initramfs/src/conformance/gvisor/blocklists.exfat/symlink_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists.exfat/symlink_test
@@ -17,6 +17,7 @@ SymlinkTest.CanCreateSymlinkWithCachedSourceDirent
 SymlinkTest.CanEvaluateLink
 SymlinkTest.CannotCreateSymlinkInReadOnlyDir
 SymlinkTest.ChmodSymlink
+SymlinkTest.FollowUpdatesATime
 SymlinkTest.OldnameIsDangling
 SymlinkTest.PreadFromSymlink
 SymlinkTest.PwriteToSymlink

--- a/test/initramfs/src/conformance/gvisor/blocklists/symlink_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/symlink_test
@@ -1,1 +1,0 @@
-SymlinkTest.FollowUpdatesATime


### PR DESCRIPTION
Fix SymlinkTest.FollowUpdatesATime

The problem here is that, after a symbolic link is followed, the atime needs to be updated.

`exFAT` does not support symbolic links, so it is added to the `blocklists.exfat` here.

The check has been passed for /aster-code-review
