### PR TITLE
Fix chroot capability check

### DIFF
--- a/kernel/src/syscall/chroot.rs
+++ b/kernel/src/syscall/chroot.rs
@@ -4,6 +4,8 @@ use super::SyscallReturn;
 use crate::{
     fs::{file::InodeType, vfs::path::FsPath},
     prelude::*,
+    process::credentials::capabilities::CapSet,
+    security::lsm::hooks as lsm_hooks,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -25,6 +27,13 @@ pub fn sys_chroot(path_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     if path.type_() != InodeType::Dir {
         return_errno_with_message!(Errno::ENOTDIR, "must be directory");
     }
+
+    lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+        ctx.thread_local.borrow_user_ns().as_ref(),
+        ctx.posix_thread,
+        CapSet::SYS_CHROOT,
+    ))?;
+
     path_resolver.set_root(path);
     Ok(SyscallReturn::Return(0))
 }

--- a/test/initramfs/src/conformance/gvisor/blocklists/chroot_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/chroot_test
@@ -1,1 +1,0 @@
-ChrootTest.WithoutCapability

--- a/test/initramfs/src/regression/fs/isolation/chroot.c
+++ b/test/initramfs/src/regression/fs/isolation/chroot.c
@@ -15,7 +15,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "../../common/test.h"
+#include "../../common/capability.h"
 
 FN_SETUP(create_chroot_env)
 {
@@ -63,6 +63,20 @@ static int file_contains(const char *filepath, const char *substring)
 			 _ret == pid && WIFEXITED(status) && \
 				 WEXITSTATUS(status) == 0);  \
 	} while (0)
+
+FN_TEST(chroot_requires_cap_sys_chroot)
+{
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_SYS_CHROOT);
+		CHECK_WITH(chroot("/foo"), _ret == -1 && errno == EPERM);
+
+		exit(EXIT_SUCCESS);
+	} else {
+		WAIT_AND_CHECK_CHILD(pid);
+	}
+}
+END_TEST()
 
 FN_TEST(chroot_getcwd)
 {


### PR DESCRIPTION
## Summary

Require `CAP_SYS_CHROOT` before allowing `chroot` to update the process root.

## Changes

- Add the missing `CAP_SYS_CHROOT` check in `sys_chroot`.
- Add regression for `chroot()` returning `EPERM` after `CAP_SYS_CHROOT` is dropped.
- Unblock the now-passing gVisor `ChrootTest.WithoutCapability` case.

## Testing

- `make check`

- `make run_kernel AUTO_TEST=regression`

  ```text
  All regression tests passed.
  ```

- `make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor`

  ```text
  79 of 79 test cases passed.
  All conformance tests passed.
  ```