### PR TITLE
Add `no-magic-number` rule and one review problem

### DIFF
--- a/.agents/skills/aster-code-review/benchmark/problems.yaml
+++ b/.agents/skills/aster-code-review/benchmark/problems.yaml
@@ -272,6 +272,66 @@
         A reviewer should flag the non-imperative, non-descriptive subject and ask
         for a specific imperative summary.
 
+- problem_id: 0009-tmpfs-statfs
+  commit: 3749ab3327d1f065fadd1f384db31c06c6c7f761
+  source: >
+    PR-derived. The reviewed change updates `TmpFs::sb` to override tmpfs-visible
+    superblock fields and adds helper functions for default tmpfs limits.
+    The helpers encode the default capacity policy with an unnamed denominator.
+    The change under review is the reviewed commit itself, fetched by full SHA
+    from upstream `asterinas/asterinas` (no local patch).
+  review_mode:
+    diff:
+      base: HEAD^
+  defects:
+    - target: { kind: file, path: kernel/src/fs/fs_impls/tmpfs/fs.rs }
+      persona: maintainability
+      grounding: no-magic-number
+      severity: minor
+      desc: >
+        The literal `2` encodes the tmpfs default capacity policy in both
+        `default_max_blocks` and `default_max_inodes`, but the policy has no
+        semantic name, making the "50% of memory" rule easy to miss or
+        accidentally change inconsistently.
+      fix: >
+        Introduce a named constant for the policy and use it in both helpers, for
+        example `TMPFS_DEFAULT_CAPACITY_DENOMINATOR`.
+      expectation: >
+        A reviewer should flag the duplicated literal `2` in the tmpfs default
+        block and inode limit helpers as an unnamed capacity policy and ask for a
+        named constant.
+    - target: { kind: file, path: kernel/src/fs/fs_impls/tmpfs/fs.rs }
+      persona: maintainability
+      grounding: backtick-identifiers
+      severity: minor
+      desc: >
+        The new `TmpFs::sb` workaround comment names implementation concepts such
+        as Tmpfs and RamFs as plain prose instead of formatting those identifiers
+        with Markdown backticks, which makes the code-oriented comment
+        inconsistent with the local comment style.
+      fix: >
+        Wrap the code identifiers in backticks in the TODO comment, for example
+        using `TmpFs`/`RamFs` consistently where the comment refers to the Rust
+        types or filesystem implementation names.
+      expectation: >
+        A reviewer should flag that the new tmpfs workaround comment leaves
+        code identifiers such as `RamFs` unformatted and ask for backticks around
+        them.
+    - target: { kind: file, path: kernel/src/fs/vfs/path/mod.rs }
+      persona: maintainability
+      grounding: consistency
+      severity: minor
+      desc: >
+        `Path::fs` is a new public method, but its summary is written as a plain
+        `//` comment, so it will not appear in rustdoc with the rest of the
+        public `Path` API.
+      fix: >
+        Change the summary to a rustdoc comment, for example by replacing the
+        `//` summary with a `///` summary that documents the returned filesystem.
+      expectation: >
+        A reviewer should flag that the public `Path::fs` method uses a plain
+        `//` summary instead of `///` and ask for a rustdoc comment.
+
 - problem_id: 0100-cmdline-maintainability-issues
   commit: 46bb6b9c58fc3236ea66f8f93fa08fe8744457ae
   source: >

--- a/book/src/to-contribute/coding-guidelines/for-maintainability/README.md
+++ b/book/src/to-contribute/coding-guidelines/for-maintainability/README.md
@@ -28,6 +28,7 @@ with a one-line gist so a reader (or a review tool) can grasp the guideline befo
 **[Naming](naming.md)**
 - [`descriptive-names`](naming.md#descriptive-names): Names convey meaning at the point of use; avoid single letters and ambiguous abbreviations.
 - [`accurate-names`](naming.md#accurate-names): Avoid names that mislead about meaning, behavior, or side effects.
+- [`no-magic-number`](naming.md#no-magic-number): Give semantic names to numbers that encode rules, limits, units, masks, or external constants.
 - [`encode-units`](naming.md#encode-units): When the type doesn't carry the unit, put it in the name (`timeout_ns`, `size_pages`).
 - [`bool-names`](naming.md#bool-names): Name booleans as positive assertions (`is_`/`has_`/`can_`/…); avoid negation.
 - [`error-message-format`](naming.md#error-message-format): Lowercase start (unless a proper noun), specific, Linux man-page style for syscall errors.

--- a/book/src/to-contribute/coding-guidelines/for-maintainability/naming.md
+++ b/book/src/to-contribute/coding-guidelines/for-maintainability/naming.md
@@ -78,6 +78,42 @@ Where it cannot, the name must carry the information.
 See also:
 PR [#2796](https://github.com/asterinas/asterinas/pull/2796#discussion_r2646889913).
 
+### No magic number (`no-magic-number`) {#no-magic-number}
+
+Numeric literals must be meaningful at the point of use.
+When a number represents a non-local invariant,
+an external contract,
+or a domain-specific meaning
+beyond its immediate arithmetic value,
+give that meaning a name.
+Use a constant,
+typed value,
+enum variant,
+or helper function,
+whichever best expresses the invariant.
+
+```rust
+// Good — the flag's meaning is explicit.
+const NEEDS_ACK_FLAG: u8 = 0b0000_0100;
+let needs_ack = (packet_flags & NEEDS_ACK_FLAG) != 0;
+
+// Bad — the reader must infer why this bit is special.
+let needs_ack = (packet_flags & 0b0000_0100) != 0;
+```
+
+Prefer deriving related values from the named source
+instead of repeating the same number in multiple places.
+If the name alone does not explain where the value comes from,
+add a short comment or cite the relevant specification.
+
+Do not introduce names for numbers
+whose meaning is already obvious locally,
+such as `0`, `1`, or `2`
+in ordinary arithmetic,
+indexing,
+small ranges,
+or direct comparisons.
+
 ### Use assertion-style boolean names (`bool-names`) {#bool-names}
 
 Boolean variables and functions


### PR DESCRIPTION
This PR add the `no-magic-number` rule to the coding guidelines, and add a problem case with three maintainability defects.