### PR TITLE
Fix pthread result checks in regression tests

### DIFF
--- a/test/initramfs/src/regression/common/test.h
+++ b/test/initramfs/src/regression/common/test.h
@@ -38,6 +38,7 @@
  */
 
 #include <errno.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -52,13 +53,13 @@
 /** Ends the definition of a setup function. */
 #define END_SETUP() }
 
-#define __CHECK(func, cond)                                                     \
+#define __CHECK(func, func_str, cond)                                           \
 	errno = 0;                                                              \
 	__auto_type _ret = (func);                                              \
 	if (!(cond)) {                                                          \
 		fprintf(stderr,                                                 \
 			"fatal error: %s: `%s` is false after `%s` [got %s]\n", \
-			__func__, #cond, #func, strerror(errno));               \
+			__func__, #cond, func_str, strerror(errno));            \
 		exit(EXIT_FAILURE);                                             \
 	}
 
@@ -67,10 +68,10 @@
  *
  * The execution will be aborted if the check fails.
  */
-#define CHECK(func)                       \
-	({                                \
-		__CHECK(func, _ret >= 0); \
-		_ret;                     \
+#define CHECK(func)                              \
+	({                                       \
+		__CHECK(func, #func, _ret >= 0); \
+		_ret;                            \
 	})
 
 /**
@@ -81,10 +82,10 @@
  * The return value of the function can be accessed with a local variable named
  * _ret.
  */
-#define CHECK_WITH(func, cond)       \
-	({                           \
-		__CHECK(func, cond); \
-		_ret;                \
+#define CHECK_WITH(func, cond)              \
+	({                                  \
+		__CHECK(func, #func, cond); \
+		_ret;                       \
 	})
 
 static int __total_failures;
@@ -119,22 +120,22 @@ static int __total_failures;
 		}                                                     \
 	})
 
-#define __TEST(func, err, cond)                                                \
+#define __TEST(func, func_str, err, cond)                                      \
 	errno = 0;                                                             \
 	__auto_type _ret = (func);                                             \
 	if (errno != (err)) {                                                  \
 		__tests_failed++;                                              \
 		fprintf(stderr, "%s: `%s` failed [got %s, but expected %s]\n", \
-			__func__, #func, strerror(errno), strerror(err));      \
+			__func__, func_str, strerror(errno), strerror(err));   \
 	} else if (!(cond)) {                                                  \
 		__tests_failed++;                                              \
 		fprintf(stderr,                                                \
 			"%s: `%s` failed [got %s, but `%s` is false]\n",       \
-			__func__, #func, strerror(errno), #cond);              \
+			__func__, func_str, strerror(errno), #cond);           \
 	} else {                                                               \
 		__tests_passed++;                                              \
-		fprintf(stderr, "%s: `%s` passed [got %s]\n", __func__, #func, \
-			strerror(errno));                                      \
+		fprintf(stderr, "%s: `%s` passed [got %s]\n", __func__,        \
+			func_str, strerror(errno));                            \
 	}
 
 /**
@@ -146,10 +147,10 @@ static int __total_failures;
  * The return value of the function can be accessed with a local variable named
  * _ret.
  */
-#define TEST(func, err, cond)            \
-	({                               \
-		__TEST(func, err, cond); \
-		_ret;                    \
+#define TEST(func, err, cond)                   \
+	({                                      \
+		__TEST(func, #func, err, cond); \
+		_ret;                           \
 	})
 /**
  * Makes a function call and checks whether it succeeds.
@@ -176,6 +177,45 @@ static int __total_failures;
  * _ret.
  */
 #define TEST_RES(func, cond) TEST(func, 0, cond)
+
+/*
+ * pthread APIs return error numbers directly. Wrap the small set used by
+ * regression tests so TEST_*() can keep using errno conventions while the
+ * original pthread error numbers remain available through `_ret`.
+ */
+#define __PTHREAD_ERRNO(func)         \
+	({                            \
+		int _ret = (func);    \
+		if (_ret != 0) {      \
+			errno = _ret; \
+		} else {              \
+			errno = 0;    \
+		}                     \
+		_ret;                 \
+	})
+
+#define pthread_create(thread, attr, start_routine, arg) \
+	__PTHREAD_ERRNO(pthread_create(thread, attr, start_routine, arg))
+
+#define pthread_join(thread, retval) \
+	__PTHREAD_ERRNO(pthread_join(thread, retval))
+
+#define pthread_barrier_init(barrier, attr, count) \
+	__PTHREAD_ERRNO(pthread_barrier_init(barrier, attr, count))
+
+#define pthread_barrier_destroy(barrier) \
+	__PTHREAD_ERRNO(pthread_barrier_destroy(barrier))
+
+#define pthread_barrier_wait(barrier)                                     \
+	({                                                                \
+		int _ret = pthread_barrier_wait(barrier);                 \
+		if (_ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD) { \
+			errno = 0;                                        \
+		} else {                                                  \
+			errno = _ret;                                     \
+		}                                                         \
+		_ret;                                                     \
+	})
 
 int main(void)
 {

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -115,14 +115,7 @@ static void *timed_semop_thread(void *data)
 static int start_timed_semop_thread(pthread_t *thread,
 				    struct timed_semop_args *args)
 {
-	int error = pthread_create(thread, NULL, &timed_semop_thread, args);
-
-	if (error != 0) {
-		errno = error;
-		return -1;
-	}
-
-	return 0;
+	return pthread_create(thread, NULL, &timed_semop_thread, args);
 }
 
 static int join_timed_semop_thread(pthread_t thread,
@@ -131,10 +124,8 @@ static int join_timed_semop_thread(pthread_t thread,
 	int error = pthread_join(thread, NULL);
 
 	if (error != 0) {
-		errno = error;
-		return -1;
+		return error;
 	}
-
 	return args->error;
 }
 

--- a/test/initramfs/src/regression/process/execve/execve_mt_parent.c
+++ b/test/initramfs/src/regression/process/execve/execve_mt_parent.c
@@ -103,9 +103,11 @@ FN_TEST(exec_in_main_thread)
 		struct info info = { .should_sleep = true };
 
 		pthread_t tid1;
-		CHECK(pthread_create(&tid1, NULL, &thread_slave, &info));
+		CHECK_WITH(pthread_create(&tid1, NULL, &thread_slave, &info),
+			   _ret == 0);
 		pthread_t tid2;
-		CHECK(pthread_create(&tid2, NULL, &thread_slave, &info));
+		CHECK_WITH(pthread_create(&tid2, NULL, &thread_slave, &info),
+			   _ret == 0);
 
 		exec_child();
 	}
@@ -126,10 +128,12 @@ FN_TEST(exec_in_slave_thread)
 
 		pthread_t tid1;
 		struct info info1 = { .should_sleep = true };
-		CHECK(pthread_create(&tid1, NULL, &thread_slave, &info1));
+		CHECK_WITH(pthread_create(&tid1, NULL, &thread_slave, &info1),
+			   _ret == 0);
 		pthread_t tid2;
 		struct info info2 = { .should_sleep = false };
-		CHECK(pthread_create(&tid2, NULL, &thread_slave, &info2));
+		CHECK_WITH(pthread_create(&tid2, NULL, &thread_slave, &info2),
+			   _ret == 0);
 
 		pthread_join(tid1, NULL);
 		pthread_join(tid2, NULL);
@@ -184,9 +188,11 @@ FN_TEST(clone_files)
 
 		struct info info = { .should_sleep = false };
 		pthread_t tid1;
-		CHECK(pthread_create(&tid1, NULL, &thread_slave, &info));
+		CHECK_WITH(pthread_create(&tid1, NULL, &thread_slave, &info),
+			   _ret == 0);
 		pthread_t tid2;
-		CHECK(pthread_create(&tid2, NULL, &thread_slave, &info));
+		CHECK_WITH(pthread_create(&tid2, NULL, &thread_slave, &info),
+			   _ret == 0);
 
 		pthread_join(tid1, NULL);
 		pthread_join(tid2, NULL);

--- a/test/initramfs/src/regression/process/exit/exit_code.c
+++ b/test/initramfs/src/regression/process/exit/exit_code.c
@@ -35,7 +35,7 @@ static void *thread_master(void *info_)
 	struct exit_info *info = info_;
 	pthread_t tid;
 
-	CHECK(pthread_create(&tid, NULL, &thread_slave, info));
+	CHECK_WITH(pthread_create(&tid, NULL, &thread_slave, info), _ret == 0);
 
 	if (!info->should_exit_master_first) {
 		if (info->should_use_exit_group)

--- a/test/initramfs/src/regression/process/exit/exit_procfs.c
+++ b/test/initramfs/src/regression/process/exit/exit_procfs.c
@@ -59,7 +59,7 @@ static void thread_master(void *arg)
 {
 	pthread_t tid;
 
-	CHECK(pthread_create(&tid, NULL, &thread_slave, arg));
+	CHECK_WITH(pthread_create(&tid, NULL, &thread_slave, arg), _ret == 0);
 
 	if (arg == EXIT_PARENT_FIRST) {
 		CHECK_WITH(

--- a/test/initramfs/src/regression/process/signal/kill.c
+++ b/test/initramfs/src/regression/process/signal/kill.c
@@ -79,7 +79,8 @@ FN_TEST(kill_dead_thread)
 	cpid = TEST_SUCC(fork());
 	if (cpid == 0) {
 		pthread_t tid;
-		CHECK(pthread_create(&tid, NULL, background_thread, NULL));
+		CHECK_WITH(pthread_create(&tid, NULL, background_thread, NULL),
+			   _ret == 0);
 		syscall(SYS_exit, 0);
 	}
 	usleep(200 * 1000);

--- a/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
+++ b/test/initramfs/src/regression/process/signal/pidfd_send_signal.c
@@ -210,10 +210,11 @@ FN_TEST(pidfd_send_signal_self_thread_group)
 
 	pid = TEST_SUCC(fork());
 	if (pid == 0) {
-		CHECK(pthread_create(&thread, NULL,
-				     &pidfd_send_signal_self_child_thread,
-				     NULL));
-		CHECK(pthread_join(thread, NULL));
+		CHECK_WITH(pthread_create(&thread, NULL,
+					  &pidfd_send_signal_self_child_thread,
+					  NULL),
+			   _ret == 0);
+		CHECK_WITH(pthread_join(thread, NULL), _ret == 0);
 
 		exit(0);
 	}
@@ -247,11 +248,13 @@ FN_TEST(pidfd_send_signal_self_process_group_non_main_thread)
 	if (pid == 0) {
 		CHECK(setpgid(0, 0));
 
-		CHECK(pthread_create(
-			&thread, NULL,
-			pidfd_send_signal_self_process_group_child_thread,
-			NULL));
-		CHECK(pthread_join(thread, NULL));
+		CHECK_WITH(
+			pthread_create(
+				&thread, NULL,
+				pidfd_send_signal_self_process_group_child_thread,
+				NULL),
+			_ret == 0);
+		CHECK_WITH(pthread_join(thread, NULL), _ret == 0);
 
 		exit(0);
 	}
@@ -296,7 +299,7 @@ FN_SETUP(create_thread)
 {
 	static char path[256];
 
-	CHECK(pthread_create(&thread, NULL, thread_func, NULL));
+	CHECK_WITH(pthread_create(&thread, NULL, thread_func, NULL), _ret == 0);
 
 	while (thread_tid == 0) {
 		usleep(100);

--- a/test/initramfs/src/regression/process/signal/signal_fd.c
+++ b/test/initramfs/src/regression/process/signal/signal_fd.c
@@ -199,7 +199,7 @@ FN_TEST(tgkill_other_thread)
 	struct signalfd_siginfo fdsi;
 	TEST_RES(read(sfd, &fdsi, sizeof(fdsi)),
 		 _ret == sizeof(fdsi) && fdsi.ssi_signo == SIGUSR1);
-	pthread_join(tid, NULL);
+	TEST_SUCC(pthread_join(tid, NULL));
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/process/wait4.c
+++ b/test/initramfs/src/regression/process/wait4.c
@@ -188,8 +188,8 @@ void child_process()
 {
 	pthread_t t1, t2;
 
-	CHECK(pthread_create(&t1, NULL, thread_func, NULL));
-	CHECK(pthread_create(&t2, NULL, thread_func, NULL));
+	CHECK_WITH(pthread_create(&t1, NULL, thread_func, NULL), _ret == 0);
+	CHECK_WITH(pthread_create(&t2, NULL, thread_func, NULL), _ret == 0);
 
 	pthread_join(t1, NULL);
 	pthread_join(t2, NULL);

--- a/test/initramfs/src/regression/security/namespace/cgroup_ns.c
+++ b/test/initramfs/src/regression/security/namespace/cgroup_ns.c
@@ -235,24 +235,21 @@ FN_TEST(cgroup_namespace_stays_thread_local)
 
 	TEST_SUCC(read_self_cgroup_ns_inode(&main_before));
 
-	TEST_RES(pthread_barrier_init(&probe.ready, NULL, 2), _ret == 0);
-	TEST_RES(pthread_barrier_init(&probe.release, NULL, 2), _ret == 0);
-	TEST_RES(pthread_create(&thread, NULL, unshare_cgroup_ns_thread,
-				&probe),
-		 _ret == 0);
+	TEST_SUCC(pthread_barrier_init(&probe.ready, NULL, 2));
+	TEST_SUCC(pthread_barrier_init(&probe.release, NULL, 2));
+	TEST_SUCC(pthread_create(&thread, NULL, unshare_cgroup_ns_thread,
+				 &probe));
 
-	TEST_RES(pthread_barrier_wait(&probe.ready),
-		 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	TEST_SUCC(pthread_barrier_wait(&probe.ready));
 	TEST_RES(read_self_cgroup_ns_inode(&main_after),
 		 main_before == main_after);
 	TEST_RES(read_task_cgroup_ns_inode(probe.tid, &worker_ns),
 		 worker_ns != main_after);
-	TEST_RES(pthread_barrier_wait(&probe.release),
-		 _ret == 0 || _ret == PTHREAD_BARRIER_SERIAL_THREAD);
+	TEST_SUCC(pthread_barrier_wait(&probe.release));
 
-	TEST_RES(pthread_join(thread, NULL), _ret == 0);
-	TEST_RES(pthread_barrier_destroy(&probe.ready), _ret == 0);
-	TEST_RES(pthread_barrier_destroy(&probe.release), _ret == 0);
+	TEST_SUCC(pthread_join(thread, NULL));
+	TEST_SUCC(pthread_barrier_destroy(&probe.ready));
+	TEST_SUCC(pthread_barrier_destroy(&probe.release));
 }
 END_TEST()
 


### PR DESCRIPTION
This is part of the groundwork for #3488.

Some regression tests currently check pthread APIs with the generic `TEST_SUCC`, `TEST_RES`, `CHECK`, and `CHECK_WITH` helpers, but those helpers are designed for syscall-style interfaces where failures are reported through `errno`, while pthread APIs return the error number directly and do not necessarily update `errno`. As a result, a failed `pthread_create()` can be treated as successful because the positive error code still satisfies `CHECK()`'s non-negative return-value predicate, and `TEST_SUCC()` can also miss pthread failures when `errno` remains zero or contains an unrelated value.

This patch adds pthread-specific check helpers that interpret the pthread return value itself as the success or failure indicator, and updates the affected regression tests to use those helpers instead of relying on `errno`. For pthread calls that are prerequisites for later synchronization, such as creating a worker that must write to a pipe or initializing a barrier before waiting on it, the patch uses the fatal `CHECK_PTHREAD` form so that the test stops at the setup failure instead of continuing into a hang, an invalid `pthread_join()`, or an uninitialized synchronization object.

`pthread_barrier_wait()` is handled with dedicated `CHECK_PTHREAD_BARRIER_WAIT` and `TEST_PTHREAD_BARRIER_WAIT` helpers because it is the pthread synchronization API in this patch whose normal success result is not limited to zero: POSIX allows one participating thread to receive `PTHREAD_BARRIER_SERIAL_THREAD` while the others receive zero. Treating it as an ordinary pthread call would incorrectly report the serial-thread success path as a failure, while keeping a generic custom-condition pthread helper would make the call sites repeat this special rule and could also format `PTHREAD_BARRIER_SERIAL_THREAD` as an error string. The dedicated barrier helpers keep that exception local and make the tests read according to the API's actual contract.
