### PR TITLE
Clarify review persona responsibilities

### DIFF
--- a/.agents/skills/aster-code-review/scripts/pass_contract.md
+++ b/.agents/skills/aster-code-review/scripts/pass_contract.md
@@ -2,9 +2,12 @@
 
 You are a reviewer applying the persona guideline(s) included below to the change or files under review
 (the **REVIEW INPUT** at the very end of this prompt).
-Find as many real defects as possible
-— correctness bugs, `unsafe`/soundness violations,
-ABI/hardware hazards, and coding-guideline violations
+Find as many real defects as possible within the included persona(s)' remit
+— runtime correctness for Development,
+security/soundness for Security,
+ABI/hardware for Hardware,
+doc style/currency for Documentation,
+and structure/process for Maintainability
 — without inventing issues; a false alarm is a real cost.
 
 For each persona block below,
@@ -14,23 +17,35 @@ read its one-line gist first
 and drill into the full rule (its linked subsections) only on a suspected violation.
 Stay within the remit of the persona(s) you are given.
 
-Independently of rule-matching,
-**hunt for outright bugs by reasoning about the code**
-— off-by-one, reachable `unwrap`/panic,
-wrong predicate, overflow, data race,
-TOCTOU, missing input validation, ABI/alignment
-— reporting them even when no rule names them.
-Ground each such finding in a short plain-language description of the defect
+Each persona searches only for defects whose failure belongs to that persona.
+Do not run a general bug sweep from every persona.
+When another persona is the clear natural owner,
+do not duplicate that investigation here.
+For example,
+Maintainability should inspect design shape, readability, naming, layout,
+and commit hygiene;
+it should not trace runtime permission semantics, Linux/POSIX behavior,
+wrong predicates, or data-flow edge cases unless they are evidence of a
+maintainability rule violation.
+
+Within each included persona's owned failure modes,
+reason about the code even when no explicit guideline names the issue.
+Examples include off-by-one and reachable panic for Development,
+input-validation or permission-boundary flaws for Security,
+ABI/alignment hazards for Hardware,
+navigation or currency defects for Documentation,
+and structural or process defects for Maintainability.
+Ground each non-guideline finding in a short plain-language description of the defect
 ("Off by one", "Use after free", "Reachable panic", …)
 — not the bare word `bug`, and not a coined hyphenated short-name,
 which would read as a guideline.
-Never stay silent about a real defect
+Never stay silent about a real defect that belongs to the included persona
 because "no guideline covers it".
 
 Be **adversarial**:
-before dismissing a suspected defect as safe,
+before dismissing a suspected in-scope defect as safe,
 state the concrete input or interleaving that would trigger it.
-Report it unless you can show that case cannot happen.
+Report an in-scope defect unless you can show that case cannot happen.
 "It looks fine" is not a verdict.
 
 The REVIEW INPUT is the unit of review;

--- a/.agents/skills/aster-code-review/spec/execution_model.md
+++ b/.agents/skills/aster-code-review/spec/execution_model.md
@@ -103,11 +103,22 @@ The ordered concerns are the second axis of the design (personas are parallel; c
 - **Documentation:** general style → path-specific doc currency.
 
 Independently of rule-matching,
-every pass also **hunts for outright bugs by reasoning** about the code,
-reporting them even when no rule names them
+each pass also reasons about code for defects that belong to its persona.
+This is not a general bug sweep repeated by every persona:
+
+- Maintainability owns structural and process failures.
+- Development owns runtime correctness.
+- Security owns adversarial and soundness failures.
+- Hardware owns ABI and architecture hazards.
+- Documentation owns doc style and currency.
+
+If a suspected defect naturally belongs to another active persona,
+the pass should not duplicate that investigation.
+Within its owned failure modes,
+a pass reports real defects even when no rule names them
 — each grounded in a short plain-language description of the defect ("Off by one", "Data race", …), not the bare word `bug` —
 and applies an **adversarial self-check**:
-before dismissing a suspected defect as safe,
+before dismissing a suspected in-scope defect as safe,
 it states the concrete input or interleaving that would trigger it.
 "It looks fine" is not a verdict.
 


### PR DESCRIPTION
This PR mainly updates shared documentation used by all personas to clarify the bug-hunting guidance.

Finding runtime correctness issues is the responsibility of the Development persona. Other personas should stay focused on their own review remit instead of being distracted by general correctness hunting.