### PR TITLE
Improve setns conformance for supported namespaces

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
@@ -73,8 +73,6 @@ Supported functionality in SCML:
 ```
 
 Unsupported flags:
-* `CLONE_NEWCGROUP`
-* `CLONE_NEWIPC`
 * `CLONE_NEWNET`
 * `CLONE_NEWPID`
 * `CLONE_NEWTIME`
@@ -95,8 +93,6 @@ Supported functionality in SCML:
 ```
 
 Unsupported flags:
-* `CLONE_NEWCGROUP`
-* `CLONE_NEWIPC`
 * `CLONE_NEWNET`
 * `CLONE_NEWPID`
 * `CLONE_NEWTIME`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/setns.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/setns.scml
@@ -1,2 +1,2 @@
 // Reassociate thread with a namespace
-setns(fd, ns_type = CLONE_NEWNS | CLONE_NEWUTS);
+setns(fd, ns_type = CLONE_NEWCGROUP | CLONE_NEWIPC | CLONE_NEWNS | CLONE_NEWUTS);

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/unshare.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/unshare.scml
@@ -1,2 +1,6 @@
 // Disassociate parts of the process execution context
-unshare(flags = CLONE_FILES | CLONE_FS | CLONE_NEWNS | CLONE_NEWUTS | CLONE_THREAD | CLONE_SIGHAND | CLONE_VM);
+unshare(
+    flags = CLONE_FILES | CLONE_FS | CLONE_NEWCGROUP | CLONE_NEWIPC |
+            CLONE_NEWNS | CLONE_NEWUTS | CLONE_THREAD | CLONE_SIGHAND |
+            CLONE_VM
+);

--- a/kernel/src/syscall/setns.rs
+++ b/kernel/src/syscall/setns.rs
@@ -204,14 +204,14 @@ fn set_mnt_ns(
 ) -> Result<()> {
     check_set_ns_perms(target_ns, ctx)?;
 
+    check_current_user_ns_cap(ctx, CapSet::SYS_CHROOT)?;
+
     if ctx.thread_local.is_fs_shared() {
         return_errno_with_message!(
             Errno::EINVAL,
             "setting a mount namespace is not allowed with shared filesystem information"
         );
     }
-
-    // TODO: Are the checks above sufficient?
 
     builder.mnt_ns(target_ns.clone());
 
@@ -231,8 +231,8 @@ fn set_uts_ns(
 }
 
 fn check_set_ns_perms<T: NsCommonOps>(target_ns: &Arc<T>, ctx: &Context) -> Result<()> {
-    // Verify the thread has SYS_ADMIN capability in the target namespace's owner
-    // and the current user namespace.
+    // Verify the thread has `SYS_ADMIN` capability in the target namespace's
+    // owner and in its current user namespace.
     lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
         target_ns.owner_user_ns().unwrap().as_ref(),
         ctx.posix_thread,
@@ -244,7 +244,13 @@ fn check_set_ns_perms<T: NsCommonOps>(target_ns: &Arc<T>, ctx: &Context) -> Resu
         CapSet::SYS_ADMIN,
     ))?;
 
-    // TODO: Are the checks above sufficient?
-
     Ok(())
+}
+
+fn check_current_user_ns_cap(ctx: &Context, cap: CapSet) -> Result<()> {
+    lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+        ctx.thread_local.borrow_user_ns().as_ref(),
+        ctx.posix_thread,
+        cap,
+    ))
 }

--- a/test/initramfs/src/regression/security/namespace/cgroup_ns.c
+++ b/test/initramfs/src/regression/security/namespace/cgroup_ns.c
@@ -323,6 +323,37 @@ FN_TEST(setns_revirtualizes_proc_cgroup)
 END_TEST()
 
 /*
+ * Joining a cgroup namespace through its nsfs fd should have the same
+ * re-virtualization effect as joining through a pidfd.
+ */
+FN_TEST(setns_nsfs_revirtualizes_proc_cgroup)
+{
+	char ns_path[64];
+	ino_t child_ns;
+	ino_t joined_ns;
+	pid_t child;
+	int nsfd;
+
+	TEST_SUCC(move_pid_to_cgroup(TEST_BASE_CGROUP, getpid()));
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/cgns-base\n"));
+
+	child = spawn_paused_process(TEST_BASE_CGROUP, MOVE_TO_NEW_CGROUP_NS);
+	TEST_SUCC(read_process_cgroup_ns_inode(child, &child_ns));
+
+	snprintf(ns_path, sizeof(ns_path), "/proc/%d/ns/cgroup", child);
+	nsfd = TEST_SUCC(open(ns_path, O_RDONLY));
+	TEST_SUCC(setns(nsfd, CLONE_NEWCGROUP));
+
+	TEST_RES(read_self_cgroup_ns_inode(&joined_ns), joined_ns == child_ns);
+	TEST_SUCC(check_proc_cgroup(getpid(), "0::/\n"));
+
+	TEST_SUCC(reset_self());
+	TEST_SUCC(close(nsfd));
+	kill_paused_process(child);
+}
+END_TEST()
+
+/*
  * A fresh `cgroup2` mount inside a cgroup namespace starts at the namespace
  * root, so descendants below that root stay visible and siblings above it do
  * not appear in the mount tree.

--- a/test/initramfs/src/regression/security/namespace/ipc_ns_sem.c
+++ b/test/initramfs/src/regression/security/namespace/ipc_ns_sem.c
@@ -20,6 +20,10 @@
 
 // A unique key for semaphore creation.
 #define SEM_KEY_BASE 0x1234
+#define SETNS_PARENT_SEM_KEY (SEM_KEY_BASE + 100)
+#define SETNS_CHILD_SEM_KEY (SEM_KEY_BASE + 101)
+#define SETNS_NSFS_PARENT_SEM_KEY (SEM_KEY_BASE + 102)
+#define SETNS_NSFS_CHILD_SEM_KEY (SEM_KEY_BASE + 103)
 
 union semun {
 	int val;
@@ -247,6 +251,112 @@ FN_TEST(sem_same_key_across_namespaces)
 
 	free(stack1);
 	free(stack2);
+}
+END_TEST()
+
+FN_TEST(sem_setns_via_pidfd)
+{
+	int initial_ipc_ns_fd = TEST_SUCC(open("/proc/self/ns/ipc", O_RDONLY));
+
+	int parent_semid = TEST_SUCC(create_sem(SETNS_PARENT_SEM_KEY));
+	TEST_SUCC(set_sem_val(parent_semid, 33));
+
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(close(pipefd[0]));
+		CHECK(unshare(CLONE_NEWIPC));
+
+		int child_semid = CHECK(create_sem(SETNS_CHILD_SEM_KEY));
+		CHECK(set_sem_val(child_semid, 88));
+
+		char ok = 'K';
+		CHECK(write(pipefd[1], &ok, 1));
+		CHECK(close(pipefd[1]));
+
+		pause();
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+	char ok;
+	TEST_RES(read(pipefd[0], &ok, 1), _ret == 1 && ok == 'K');
+	TEST_SUCC(close(pipefd[0]));
+
+	TEST_ERRNO(get_sem(SETNS_CHILD_SEM_KEY), ENOENT);
+
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_SUCC(setns(pidfd, CLONE_NEWIPC));
+
+	TEST_ERRNO(get_sem(SETNS_PARENT_SEM_KEY), ENOENT);
+	int joined_child_semid = TEST_SUCC(get_sem(SETNS_CHILD_SEM_KEY));
+	TEST_RES(get_sem_val(joined_child_semid), _ret == 88);
+	TEST_SUCC(remove_sem(joined_child_semid));
+
+	TEST_SUCC(setns(initial_ipc_ns_fd, CLONE_NEWIPC));
+	TEST_RES(get_sem_val(parent_semid), _ret == 33);
+
+	TEST_SUCC(remove_sem(parent_semid));
+	TEST_SUCC(close(pidfd));
+	TEST_SUCC(close(initial_ipc_ns_fd));
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_SUCC(waitpid(pid, NULL, 0));
+}
+END_TEST()
+
+FN_TEST(sem_setns_via_nsfs)
+{
+	int initial_ipc_ns_fd = TEST_SUCC(open("/proc/self/ns/ipc", O_RDONLY));
+
+	int parent_semid = TEST_SUCC(create_sem(SETNS_NSFS_PARENT_SEM_KEY));
+	TEST_SUCC(set_sem_val(parent_semid, 44));
+
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(close(pipefd[0]));
+		CHECK(unshare(CLONE_NEWIPC));
+
+		int child_semid = CHECK(create_sem(SETNS_NSFS_CHILD_SEM_KEY));
+		CHECK(set_sem_val(child_semid, 99));
+
+		char ok = 'K';
+		CHECK(write(pipefd[1], &ok, 1));
+		CHECK(close(pipefd[1]));
+
+		pause();
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+	char ok;
+	TEST_RES(read(pipefd[0], &ok, 1), _ret == 1 && ok == 'K');
+	TEST_SUCC(close(pipefd[0]));
+
+	TEST_ERRNO(get_sem(SETNS_NSFS_CHILD_SEM_KEY), ENOENT);
+
+	char ns_path[64];
+	snprintf(ns_path, sizeof(ns_path), "/proc/%d/ns/ipc", pid);
+	int child_ipc_ns_fd = TEST_SUCC(open(ns_path, O_RDONLY));
+	TEST_SUCC(setns(child_ipc_ns_fd, CLONE_NEWIPC));
+
+	TEST_ERRNO(get_sem(SETNS_NSFS_PARENT_SEM_KEY), ENOENT);
+	int joined_child_semid = TEST_SUCC(get_sem(SETNS_NSFS_CHILD_SEM_KEY));
+	TEST_RES(get_sem_val(joined_child_semid), _ret == 99);
+	TEST_SUCC(remove_sem(joined_child_semid));
+
+	TEST_SUCC(setns(initial_ipc_ns_fd, CLONE_NEWIPC));
+	TEST_RES(get_sem_val(parent_semid), _ret == 44);
+
+	TEST_SUCC(remove_sem(parent_semid));
+	TEST_SUCC(close(child_ipc_ns_fd));
+	TEST_SUCC(close(initial_ipc_ns_fd));
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_SUCC(waitpid(pid, NULL, 0));
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/security/namespace/mnt_ns.c
+++ b/test/initramfs/src/regression/security/namespace/mnt_ns.c
@@ -3,14 +3,26 @@
 #define _GNU_SOURCE
 #include <fcntl.h>
 #include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/mount.h>
-#include <sys/wait.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 
+#include "../../common/capability.h"
 #include "../../common/test.h"
 
 #define STACK_SIZE (1024 * 1024)
+
+static int mkdir_if_absent(const char *pathname, mode_t mode)
+{
+	if (mkdir(pathname, mode) < 0 && errno != EEXIST)
+		return -1;
+
+	errno = 0;
+	return 0;
+}
 
 // --- Test for unshare(CLONE_NEWNS) ---
 
@@ -38,8 +50,8 @@ static int unshare_child_fn(void)
 FN_TEST(unshare_newns)
 {
 	// Setup
-	CHECK_WITH(mkdir("/mnt", 0755), _ret >= 0 || errno == EEXIST);
-	CHECK_WITH(mkdir(UNSHARE_MNT, 0755), _ret >= 0 || errno == EEXIST);
+	TEST_SUCC(mkdir_if_absent("/mnt", 0755));
+	TEST_SUCC(mkdir_if_absent(UNSHARE_MNT, 0755));
 
 	TEST_ERRNO(access(UNSHARE_FILE, F_OK), ENOENT);
 
@@ -89,9 +101,9 @@ static int clone_child_fn(void *arg)
 FN_TEST(clone_newns)
 {
 	// Setup
-	CHECK_WITH(mkdir("/mnt", 0755), _ret >= 0 || errno == EEXIST);
-	CHECK_WITH(mkdir(CLONE_PARENT_MNT, 0755), _ret >= 0 || errno == EEXIST);
-	CHECK_WITH(mkdir(CLONE_CHILD_MNT, 0755), _ret >= 0 || errno == EEXIST);
+	TEST_SUCC(mkdir_if_absent("/mnt", 0755));
+	TEST_SUCC(mkdir_if_absent(CLONE_PARENT_MNT, 0755));
+	TEST_SUCC(mkdir_if_absent(CLONE_CHILD_MNT, 0755));
 
 	TEST_SUCC(mount("ramfs_parent", CLONE_PARENT_MNT, "ramfs", 0, ""));
 	int fd = TEST_SUCC(open(PARENT_FILE, O_CREAT | O_WRONLY, 0644));
@@ -145,11 +157,20 @@ static int setns_target_fn(int pipe_write_fd)
 	return 0;
 }
 
+static int setns_shared_fs_child_fn(void *arg)
+{
+	int pid_fd = *(int *)arg;
+
+	CHECK_WITH(setns(pid_fd, CLONE_NEWNS), _ret < 0 && errno == EINVAL);
+
+	return 0;
+}
+
 FN_TEST(setns_newns)
 {
 	// Setup
-	CHECK_WITH(mkdir("/mnt", 0755), _ret >= 0 || errno == EEXIST);
-	CHECK_WITH(mkdir(SETNS_MNT, 0755), _ret >= 0 || errno == EEXIST);
+	TEST_SUCC(mkdir_if_absent("/mnt", 0755));
+	TEST_SUCC(mkdir_if_absent(SETNS_MNT, 0755));
 
 	int pipefd[2];
 	TEST_SUCC(pipe(pipefd));
@@ -157,15 +178,15 @@ FN_TEST(setns_newns)
 	pid_t child_pid = TEST_SUCC(fork());
 
 	if (child_pid == 0) {
-		close(pipefd[0]);
+		CHECK(close(pipefd[0]));
 		exit(setns_target_fn(pipefd[1]));
 	}
 
-	close(pipefd[1]);
+	TEST_SUCC(close(pipefd[1]));
 
 	char buf[10];
 	TEST_SUCC(read(pipefd[0], &buf, 1));
-	close(pipefd[0]);
+	TEST_SUCC(close(pipefd[0]));
 
 	int pid_fd = TEST_SUCC(syscall(SYS_pidfd_open, child_pid, 0));
 
@@ -192,6 +213,145 @@ FN_TEST(setns_newns)
 }
 END_TEST()
 
+FN_TEST(setns_newns_from_ns_file)
+{
+	// Setup
+	TEST_SUCC(mkdir_if_absent("/mnt", 0755));
+	TEST_SUCC(mkdir_if_absent(SETNS_MNT, 0755));
+	int initial_mnt_ns_fd = TEST_SUCC(open("/proc/self/ns/mnt", O_RDONLY));
+
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t child_pid = TEST_SUCC(fork());
+
+	if (child_pid == 0) {
+		CHECK(close(pipefd[0]));
+		exit(setns_target_fn(pipefd[1]));
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+
+	char ok;
+	TEST_RES(read(pipefd[0], &ok, 1), _ret == 1 && ok == 'K');
+	TEST_SUCC(close(pipefd[0]));
+
+	char buf[64];
+	snprintf(buf, sizeof(buf), "/proc/%d/ns/mnt", child_pid);
+	int ns_fd = TEST_SUCC(open(buf, O_RDONLY));
+
+	TEST_SUCC(chdir("/mnt"));
+	TEST_SUCC(setns(ns_fd, CLONE_NEWNS));
+	TEST_RES(getcwd(buf, sizeof(buf)), strcmp(buf, "/") == 0);
+
+	TEST_SUCC(close(ns_fd));
+
+	// Check if we can see the file created by the child in its namespace.
+	TEST_SUCC(access(SETNS_FILE, F_OK));
+
+	// Teardown
+	TEST_SUCC(kill(child_pid, SIGKILL));
+	TEST_SUCC(waitpid(child_pid, NULL, 0));
+
+	TEST_SUCC(umount(SETNS_MNT));
+	TEST_SUCC(setns(initial_mnt_ns_fd, CLONE_NEWNS));
+	TEST_SUCC(close(initial_mnt_ns_fd));
+	TEST_SUCC(rmdir(SETNS_MNT));
+}
+END_TEST()
+
+FN_TEST(setns_newns_rejects_shared_fs)
+{
+	// Setup
+	TEST_SUCC(mkdir_if_absent("/mnt", 0755));
+	TEST_SUCC(mkdir_if_absent(SETNS_MNT, 0755));
+
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t child_pid = TEST_SUCC(fork());
+
+	if (child_pid == 0) {
+		CHECK(close(pipefd[0]));
+		exit(setns_target_fn(pipefd[1]));
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+
+	char ok;
+	TEST_RES(read(pipefd[0], &ok, 1), _ret == 1 && ok == 'K');
+	TEST_SUCC(close(pipefd[0]));
+
+	int pid_fd = TEST_SUCC(syscall(SYS_pidfd_open, child_pid, 0));
+
+	char *stack = TEST_SUCC(malloc(STACK_SIZE));
+	char *stack_top = stack + STACK_SIZE;
+	pid_t test_pid = TEST_SUCC(clone(setns_shared_fs_child_fn, stack_top,
+					 CLONE_FS | SIGCHLD, &pid_fd));
+
+	int status;
+	TEST_RES(waitpid(test_pid, &status, 0),
+		 _ret == test_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(close(pid_fd));
+
+	// Teardown
+	free(stack);
+	TEST_SUCC(kill(child_pid, SIGKILL));
+	TEST_SUCC(waitpid(child_pid, NULL, 0));
+
+	TEST_SUCC(rmdir(SETNS_MNT));
+}
+END_TEST()
+
+FN_TEST(setns_newns_requires_cap_sys_chroot)
+{
+	// Setup
+	TEST_SUCC(mkdir_if_absent("/mnt", 0755));
+	TEST_SUCC(mkdir_if_absent(SETNS_MNT, 0755));
+
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t child_pid = TEST_SUCC(fork());
+
+	if (child_pid == 0) {
+		CHECK(close(pipefd[0]));
+		exit(setns_target_fn(pipefd[1]));
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+
+	char ok;
+	TEST_RES(read(pipefd[0], &ok, 1), _ret == 1 && ok == 'K');
+	TEST_SUCC(close(pipefd[0]));
+
+	int pid_fd = TEST_SUCC(syscall(SYS_pidfd_open, child_pid, 0));
+
+	pid_t test_pid = TEST_SUCC(fork());
+	if (test_pid == 0) {
+		drop_capability(CAP_SYS_CHROOT);
+		CHECK_WITH(setns(pid_fd, CLONE_NEWNS),
+			   _ret < 0 && errno == EPERM);
+		exit(0);
+	}
+
+	int status;
+	TEST_RES(waitpid(test_pid, &status, 0),
+		 _ret == test_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(close(pid_fd));
+
+	// Teardown
+	TEST_SUCC(kill(child_pid, SIGKILL));
+	TEST_SUCC(waitpid(child_pid, NULL, 0));
+
+	TEST_SUCC(rmdir(SETNS_MNT));
+}
+END_TEST()
+
 #define COMPLEX_BASE "/test0"
 #define COMPLEX_CONTENT "/test0/content"
 #define COMPLEX_FILE "/test0/content/hello.txt"
@@ -199,7 +359,7 @@ END_TEST()
 FN_TEST(complex_mount_tree_unshare)
 {
 	// Setup: Create directory structure
-	CHECK_WITH(mkdir(COMPLEX_BASE, 0755), _ret >= 0 || errno == EEXIST);
+	TEST_SUCC(mkdir_if_absent(COMPLEX_BASE, 0755));
 
 	// Mount tmpfs on test0 (first layer)
 	TEST_SUCC(mount("none", COMPLEX_BASE, "tmpfs", 0, ""));
@@ -225,21 +385,21 @@ FN_TEST(complex_mount_tree_unshare)
 	pid_t pid = TEST_SUCC(fork());
 
 	if (pid == 0) {
-		TEST_SUCC(unshare(CLONE_NEWNS));
+		CHECK(unshare(CLONE_NEWNS));
 
 		// Try to read the file created in the parent's mount tree
 		int fd = CHECK(open(COMPLEX_FILE, O_RDONLY));
 
 		char buf[32] = { 0 };
-		TEST_SUCC(read(fd, buf, sizeof(buf) - 1));
-		TEST_SUCC(close(fd));
+		CHECK(read(fd, buf, sizeof(buf) - 1));
+		CHECK(close(fd));
 
 		// Verify the content
 		CHECK_WITH(strcmp(buf, "hello world\n"), _ret == 0);
 
 		// Verify we can still access the nested mount structure
-		TEST_SUCC(access(COMPLEX_CONTENT, F_OK));
-		TEST_SUCC(access(COMPLEX_BASE, F_OK));
+		CHECK(access(COMPLEX_CONTENT, F_OK));
+		CHECK(access(COMPLEX_BASE, F_OK));
 
 		exit(0);
 	} else {

--- a/test/initramfs/src/regression/security/namespace/proc_nsfs.c
+++ b/test/initramfs/src/regression/security/namespace/proc_nsfs.c
@@ -365,6 +365,7 @@ FN_TEST(lifetime)
 	user_ns_fd = TEST_SUCC(ioctl(nsfd, NS_GET_USERNS));
 	TEST_SUCC(close(user_ns_fd));
 	TEST_SUCC(setns(nsfd, 0));
+	TEST_SUCC(setns(nsfd, CLONE_NEWUTS));
 
 	TEST_SUCC(close(nsfd));
 }

--- a/test/initramfs/src/regression/security/namespace/setns.c
+++ b/test/initramfs/src/regression/security/namespace/setns.c
@@ -2,22 +2,19 @@
 
 #define _GNU_SOURCE
 #include <sched.h>
+#include <signal.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 
 #include "../../common/test.h"
 
 FN_TEST(set_ns_empty_flags)
 {
-	// FIXME: The following test will fail on Asterinas
-	// because it currently does not support ns file.
-#ifndef __asterinas__
-	const char *ns_path = "/proc/self/ns/user";
-	int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	int fd_ns = TEST_SUCC(open("/proc/self/ns/user", O_RDONLY));
 	TEST_ERRNO(setns(fd_ns, 0), EINVAL);
 	TEST_SUCC(close(fd_ns));
-#endif
 
 	pid_t pid = getpid();
 	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
@@ -30,18 +27,100 @@ FN_TEST(set_self_ns)
 {
 	// It is not permitted to use setns() to reenter the caller's
 	// current user namespace. This is different from other namespaces.
-	// FIXME: The following test will fail on Asterinas
-	// because it currently does not support ns file.
-#ifndef __asterinas__
-	const char *ns_path = "/proc/self/ns/user";
-	int fd_ns = TEST_SUCC(open(ns_path, O_RDONLY));
+	int fd_ns = TEST_SUCC(open("/proc/self/ns/user", O_RDONLY));
 	TEST_ERRNO(setns(fd_ns, CLONE_NEWUSER), EINVAL);
 	TEST_SUCC(close(fd_ns));
-#endif
 
 	pid_t pid = getpid();
 	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
 	TEST_ERRNO(setns(pidfd, CLONE_NEWUSER), EINVAL);
 	TEST_SUCC(close(pidfd));
+}
+END_TEST()
+
+FN_TEST(set_pidfd_self_uts)
+{
+	pid_t pid = getpid();
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+
+	TEST_SUCC(setns(pidfd, CLONE_NEWUTS));
+
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()
+
+FN_TEST(set_pidfd_reaped_process)
+{
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0)
+		_exit(0);
+
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	TEST_ERRNO(setns(pidfd, CLONE_NEWUTS), ESRCH);
+
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()
+
+FN_TEST(set_pidfd_exited_process)
+{
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(close(pipefd[0]));
+		char ok = 'K';
+		CHECK_WITH(write(pipefd[1], &ok, 1), _ret == 1);
+		CHECK(close(pipefd[1]));
+		pause();
+		_exit(1);
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+	char buf;
+	TEST_RES(read(pipefd[0], &buf, 1), _ret == 1 && buf == 'K');
+	TEST_SUCC(close(pipefd[0]));
+
+	int pidfd = TEST_SUCC(syscall(SYS_pidfd_open, pid, 0));
+	TEST_SUCC(kill(pid, SIGKILL));
+	TEST_SUCC(waitid(P_PID, pid, NULL, WNOWAIT | WEXITED));
+
+	TEST_ERRNO(setns(pidfd, CLONE_NEWUTS), ESRCH);
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0), _ret == pid && WIFSIGNALED(status) &&
+						   WTERMSIG(status) == SIGKILL);
+
+	TEST_SUCC(close(pidfd));
+}
+END_TEST()
+
+FN_TEST(set_ns_file_flags_mismatch)
+{
+	int fd_ns = TEST_SUCC(open("/proc/self/ns/uts", O_RDONLY));
+
+	TEST_ERRNO(setns(fd_ns, CLONE_NEWIPC), EINVAL);
+	TEST_ERRNO(setns(fd_ns, CLONE_NEWNET), EINVAL);
+
+	TEST_SUCC(close(fd_ns));
+}
+END_TEST()
+
+FN_TEST(set_ns_non_namespace_fd)
+{
+	int pipefd[2];
+	TEST_SUCC(pipe(pipefd));
+
+	TEST_ERRNO(setns(pipefd[0], 0), EINVAL);
+	TEST_ERRNO(setns(pipefd[0], CLONE_NEWUTS), EINVAL);
+
+	TEST_SUCC(close(pipefd[0]));
+	TEST_SUCC(close(pipefd[1]));
 }
 END_TEST()


### PR DESCRIPTION
## Summary

Improve `setns` conformance for namespace types that Asterinas already supports.

This PR makes mount namespace switching follow Linux's permission requirements more closely, expands regression coverage for supported namespace switching paths, and updates the syscall compatibility documentation.

## Changes

- Require `CAP_SYS_CHROOT` when switching mount namespaces with `setns(CLONE_NEWNS)`.
- Add regression coverage for `setns` through pidfds and nsfs files.
- Cover supported namespace types:
  - `CLONE_NEWCGROUP`
  - `CLONE_NEWIPC`
  - `CLONE_NEWNS`
  - `CLONE_NEWUTS`
- Add coverage for error and lifetime cases:
  - empty flags
  - self namespace handling
  - exited and reaped pidfd targets
  - nsfs file after target process reaping
  - namespace flag mismatch
  - non-namespace file descriptors
  - shared `fs_struct` rejection for mount namespace switching
  - missing `CAP_SYS_CHROOT` for mount namespace switching
- Update namespace syscall compatibility docs for `setns` and `unshare`.

## Scope

This PR intentionally focuses on namespace types that Asterinas already supports.

Out of scope:

- `CLONE_NEWNET`
- `CLONE_NEWPID`
- `CLONE_NEWTIME`
- `CLONE_NEWUSER`

The remaining source TODOs for switching additional namespace types are left for future work.

## Commit Structure

- `Require SYS_CHROOT for mount setns`
- `Add setns namespace regression coverage`
- `Update namespace compatibility docs`

Each commit is scoped to one logical change.

## Tests

Run in the Asterinas Docker/QEMU environment:

```text
make run_kernel AUTO_TEST=regression
```

Result:

```text
All regression tests passed.
```

Additional local checks:

```text
git diff --check upstream/main...HEAD
```

Result: passed.

## Review Notes

Local review was performed before PR preparation. No confirmed findings were found.

The repository review skill can be triggered with:

```text
/aster-code-review
```