### PR TITLE
Add support for mmap 32bit flag

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/README.md
@@ -29,7 +29,6 @@ Partially supported flags:
 * `MAP_FIXED_NOREPLACE` is treated as `MAP_FIXED`
 
 Unsupported flags:
-* `MAP_32BIT`
 * `MAP_HUGE_1GB`
 * `MAP_HUGE_2MB`
 * `MAP_UNINITIALIZED`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/mmap_and_munmap.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/mmap_and_munmap.scml
@@ -3,6 +3,7 @@ prot = PROT_NONE |
     PROT_READ |
     PROT_WRITE;
 opt_flags =
+    MAP_32BIT |
     MAP_ANONYMOUS |
     MAP_FIXED |
     MAP_FIXED_NOREPLACE |

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -85,10 +85,14 @@ fn do_sys_mmap(
                 options = options.offset(VmarMapOffset::FixedReplace(addr));
             }
         } else {
+            #[cfg(target_arch = "x86_64")]
             if option.flags().contains(MMapFlags::MAP_32BIT) {
-                // TODO: MAP_32BIT requires the mapping address to be below 2 GiB.
-                warn!("MAP_32BIT is not supported");
+                let addr_hint = if addr != 0 { Some(addr) } else { None };
+                options = options.offset(VmarMapOffset::Map32Bit(addr_hint));
+            } else if addr != 0 {
+                options = options.offset(VmarMapOffset::Hint(addr))
             }
+            #[cfg(not(target_arch = "x86_64"))]
             if addr != 0 {
                 options = options.offset(VmarMapOffset::Hint(addr))
             }
@@ -239,6 +243,7 @@ bitflags! {
     struct MMapFlags : u32 {
         const MAP_FIXED           = 0x10;
         const MAP_ANONYMOUS       = 0x20;
+        #[cfg(target_arch = "x86_64")]
         const MAP_32BIT           = 0x40;
         const MAP_GROWSDOWN       = 0x100;
         const MAP_DENYWRITE       = 0x800;
@@ -253,10 +258,15 @@ bitflags! {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
+const ARCH_LEGACY_MMAP_FLAGS: MMapFlags = MMapFlags::MAP_32BIT;
+
+#[cfg(not(target_arch = "x86_64"))]
+const ARCH_LEGACY_MMAP_FLAGS: MMapFlags = MMapFlags::empty();
+
 // Reference: <https://elixir.bootlin.com/linux/v6.18.1/source/include/linux/mman.h#L35-L59>
 const LEGACY_MMAP_FLAGS: MMapFlags = MMapFlags::MAP_FIXED
     .union(MMapFlags::MAP_ANONYMOUS)
-    .union(MMapFlags::MAP_32BIT)
     .union(MMapFlags::MAP_GROWSDOWN)
     .union(MMapFlags::MAP_DENYWRITE)
     .union(MMapFlags::MAP_EXECUTABLE)
@@ -265,7 +275,8 @@ const LEGACY_MMAP_FLAGS: MMapFlags = MMapFlags::MAP_FIXED
     .union(MMapFlags::MAP_POPULATE)
     .union(MMapFlags::MAP_NONBLOCK)
     .union(MMapFlags::MAP_STACK)
-    .union(MMapFlags::MAP_HUGETLB);
+    .union(MMapFlags::MAP_HUGETLB)
+    .union(ARCH_LEGACY_MMAP_FLAGS);
 
 impl MMapFlags {
     pub(self) fn is_fixed(self) -> bool {

--- a/kernel/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/src/vm/vmar/vmar_impls/map.rs
@@ -90,6 +90,14 @@ pub enum VmarMapOffset {
     /// Otherwise, it can be placed at any available offset where there are no
     /// conflict mappings.
     Hint(usize),
+    /// The new mapping will be placed in the first 2 GiB of the address space.
+    ///
+    /// If the hint is `Some(addr)`, the allocator tries `addr` first, then
+    /// falls back to a constrained search if it fails (provided the region
+    /// `[addr, addr + size)` is within the first 2 GiB; otherwise, an error
+    /// is returned). If `None`, it directly searches below 2 GiB.
+    #[cfg(target_arch = "x86_64")]
+    Map32Bit(Option<usize>),
     /// The new mapping can be placed at any available offset where there are
     /// no conflict mappings.
     Any,
@@ -320,6 +328,20 @@ impl<'a> VmarMapOptions<'a> {
                     inner.alloc_free_region(map_size, align)?.start
                 }
             }
+            #[cfg(target_arch = "x86_64")]
+            VmarMapOffset::Map32Bit(addr_hint) => {
+                use super::{MAP_32BIT_HIGH_LIMIT, VMAR_LOWEST_ADDR};
+
+                if let Some(addr) = addr_hint
+                    && (VMAR_LOWEST_ADDR..MAP_32BIT_HIGH_LIMIT).contains(&addr)
+                    && map_size <= MAP_32BIT_HIGH_LIMIT - addr
+                    && inner.alloc_free_region_exact(addr, map_size).is_ok()
+                {
+                    addr
+                } else {
+                    inner.alloc_free_region_below_2gib(map_size, align)?.start
+                }
+            }
             VmarMapOffset::Any => inner.alloc_free_region(map_size, align)?.start,
         };
 
@@ -399,6 +421,17 @@ impl<'a> VmarMapOptions<'a> {
             VmarMapOffset::FixedReplace(offset)
             | VmarMapOffset::FixedNoReplace(offset)
             | VmarMapOffset::Hint(offset) => {
+                debug_assert!(offset.is_multiple_of(self.align));
+                if !offset.is_multiple_of(self.align) {
+                    return_errno_with_message!(Errno::EINVAL, "invalid offset");
+                }
+            }
+            #[cfg(target_arch = "x86_64")]
+            VmarMapOffset::Map32Bit(offset_opt) => {
+                let Some(offset) = offset_opt else {
+                    return Ok(());
+                };
+
                 debug_assert!(offset.is_multiple_of(self.align));
                 if !offset.is_multiple_of(self.align) {
                     return_errno_with_message!(Errno::EINVAL, "invalid offset");

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -351,7 +351,31 @@ impl VmarInner {
         // exist in `ResourceLimits`.
         let high_limit = VMAR_CAP_ADDR - INIT_STACK_SIZE - PAGE_SIZE * 2048;
         let low_limit = VMAR_LOWEST_ADDR;
+        self.alloc_free_region_in_range(size, align, high_limit, low_limit)
+    }
 
+    /// Allocates a free region for mapping that resides below 2 GiB,
+    /// used for the `MAP_32BIT` mmap flag.
+    fn alloc_free_region_below_2gib(
+        &mut self,
+        size: usize,
+        align: usize,
+    ) -> Result<Range<Vaddr>> {
+        const MAP_32BIT_HIGH_LIMIT: Vaddr = 0x8000_0000;
+        let high_limit = MAP_32BIT_HIGH_LIMIT.min(VMAR_CAP_ADDR);
+        let low_limit = VMAR_LOWEST_ADDR;
+        self.alloc_free_region_in_range(size, align, high_limit, low_limit)
+    }
+
+    /// Core logic for [`alloc_free_region`] and [`alloc_free_region_below_2gib`].
+    /// Searches for a free region in [`low_limit`, `high_limit`), from high to low.
+    fn alloc_free_region_in_range(
+        &mut self,
+        size: usize,
+        align: usize,
+        high_limit: Vaddr,
+        low_limit: Vaddr,
+    ) -> Result<Range<Vaddr>> {
         fn try_alloc_in_hole(
             hole_start: Vaddr,
             hole_end: Vaddr,

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -32,6 +32,10 @@ use crate::{
     vm::vmar::is_userspace_vaddr_range,
 };
 
+/// The upper bound for allocations under the `MAP_32BIT` mmap flag.
+#[cfg(target_arch = "x86_64")]
+const MAP_32BIT_HIGH_LIMIT: Vaddr = 0x8000_0000;
+
 /// The VMAR (used to be Virtual Memory Address Region, but now an orphan
 /// initialism).
 ///
@@ -351,30 +355,28 @@ impl VmarInner {
         // exist in `ResourceLimits`.
         let high_limit = VMAR_CAP_ADDR - INIT_STACK_SIZE - PAGE_SIZE * 2048;
         let low_limit = VMAR_LOWEST_ADDR;
-        self.alloc_free_region_in_range(size, align, high_limit, low_limit)
+        self.alloc_free_region_in_range(size, align, low_limit, high_limit)
     }
 
-    /// Allocates a free region for mapping that resides below 2 GiB,
-    /// used for the `MAP_32BIT` mmap flag.
-    fn alloc_free_region_below_2gib(
-        &mut self,
-        size: usize,
-        align: usize,
-    ) -> Result<Range<Vaddr>> {
-        const MAP_32BIT_HIGH_LIMIT: Vaddr = 0x8000_0000;
+    /// Allocates a free region for mapping that resides below 2 GiB.
+    ///
+    /// This is specifically used for supporting the `MAP_32BIT` mmap flag.
+    #[cfg(target_arch = "x86_64")]
+    fn alloc_free_region_below_2gib(&mut self, size: usize, align: usize) -> Result<Range<Vaddr>> {
         let high_limit = MAP_32BIT_HIGH_LIMIT.min(VMAR_CAP_ADDR);
         let low_limit = VMAR_LOWEST_ADDR;
-        self.alloc_free_region_in_range(size, align, high_limit, low_limit)
+        self.alloc_free_region_in_range(size, align, low_limit, high_limit)
     }
 
-    /// Core logic for [`alloc_free_region`] and [`alloc_free_region_below_2gib`].
-    /// Searches for a free region in [`low_limit`, `high_limit`), from high to low.
+    /// Core logic for `alloc_free_region` and `alloc_free_region_below_2gib`.
+    ///
+    /// Searches for a free region in `[low_limit, high_limit)`, from high to low.
     fn alloc_free_region_in_range(
         &mut self,
         size: usize,
         align: usize,
-        high_limit: Vaddr,
         low_limit: Vaddr,
+        high_limit: Vaddr,
     ) -> Result<Range<Vaddr>> {
         fn try_alloc_in_hole(
             hole_start: Vaddr,

--- a/test/initramfs/src/regression/memory/mmap/Makefile
+++ b/test/initramfs/src/regression/memory/mmap/Makefile
@@ -2,4 +2,11 @@
 
 EXTRA_C_FLAGS := -fPIE -pie
 
+# 'MAP_32BIT' is only supported on x86_64 Linux. Filter out this test on
+# other platforms.
+ifneq ($(HOST_PLATFORM), x86_64-linux)
+C_OBJS_FILTER += \
+    mmap_32bit
+endif
+
 include ../../common/Makefile

--- a/test/initramfs/src/regression/memory/mmap/mmap_32bit.c
+++ b/test/initramfs/src/regression/memory/mmap/mmap_32bit.c
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define PAGE_SIZE 4096
+
+FN_TEST(mmap_32bit)
+{
+	void *addr;
+
+	addr = TEST_RES(mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0),
+			(size_t)_ret < 0x80000000);
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
+
+	addr = TEST_RES(mmap((void *)0x40000000, PAGE_SIZE,
+			     PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0),
+			(size_t)_ret < 0x80000000);
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
+
+	addr = TEST_RES(mmap((void *)0x100000000, PAGE_SIZE,
+			     PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0),
+			(size_t)_ret < 0x80000000);
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
+
+	addr = TEST_RES(mmap(NULL, PAGE_SIZE * 64, PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0),
+			(size_t)_ret < 0x80000000);
+	TEST_SUCC(munmap(addr, PAGE_SIZE * 64));
+
+	// `MAP_FIXED` takes precedence over `MAP_32BIT`; the mapping must be
+	// placed at the fixed address (above 2 GiB) rather than constrained
+	// below 2 GiB.
+	addr = TEST_RES(
+		mmap((void *)0x300000000, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		     MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED | MAP_32BIT, -1,
+		     0),
+		_ret == (void *)0x300000000);
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
+
+	// Hint near the 2 GiB boundary with a size that would overflow past it;
+	// the result must be constrained below 2 GiB.
+	addr = TEST_RES(mmap((void *)0x7FFF0000, PAGE_SIZE * 256,
+			     PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0),
+			(size_t)_ret < 0x80000000);
+	TEST_SUCC(munmap(addr, PAGE_SIZE * 256));
+}
+END_TEST()


### PR DESCRIPTION
### Summary

- **Refactor**: Extract the core logic of `alloc_free_region()` into a
  parameterized `alloc_free_region_in_range(high_limit, low_limit)` to
  support future address-range-constrained allocations without code
  duplication. (No behavioral change.)

- **Feature**: Implement the `MAP_32BIT` mmap flag. When set, the
  mapping address is constrained to the first 2 GiB of the user address
  space (`0x00000000`–`0x7FFFFFFF`), matching Linux semantics. Added
  `VmarMapOffset::Map32Bit` variant and `alloc_free_region_below_2gib()`
  for the constrained address search.

- **Test**: Add 6 regression-test cases exercising `MAP_32BIT` with and
  without address hints, including hint values above the 2 GiB boundary.

- **Docs**: Move `MAP_32BIT` from "Unsupported flags" to the supported
  SCML list in the compatibility documentation.