### PR TITLE
Improve AppArmor policy semantics and exec transitions

### DIFF
--- a/.github/workflows/test_loongarch.yml
+++ b/.github/workflows/test_loongarch.yml
@@ -23,5 +23,4 @@ jobs:
         uses: ./.github/actions/test
         with:
           auto_test: 'general'
-          runs_on: 'ubuntu-latest'
           arch: 'loongarch64'

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -33,7 +33,6 @@ jobs:
         uses: ./.github/actions/test
         with:
           auto_test: 'general'
-          runs_on: 'ubuntu-latest'
 
   osdk-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ GDB_PROFILE_INTERVAL ?= 0.1
 # mode using the kernel command line.
 # Here are the options for the auto test feature.
 AUTO_TEST ?= none
+APPARMOR_SMOKE_POLICY ?= $(abspath target/apparmor/smoke-profile.bin)
+ENABLE_APPARMOR_SMOKE_TEST ?= false
 # Specify whether to build conformance tests under `test/initramfs/src/conformance`.
 ENABLE_CONFORMANCE_TEST ?= false
 CONFORMANCE_TEST_SUITE ?= ltp
@@ -124,6 +126,10 @@ CARGO_OSDK_BUILD_ARGS += --kcmd-args="INTEL_TDX=$(INTEL_TDX)"
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_regression_test.sh"
 else ifeq ($(AUTO_TEST), boot)
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/boot_hello.sh"
+else ifeq ($(AUTO_TEST), apparmor)
+ENABLE_APPARMOR_SMOKE_TEST := true
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="security=apparmor"
+CARGO_OSDK_BUILD_ARGS += --init-args="/test/apparmor-smoke.sh /test/apparmor-smoke.bin"
 else ifeq ($(AUTO_TEST), vsock)
 ENABLE_REGRESSION_TEST := true
 export VSOCK=on
@@ -259,9 +265,22 @@ check_vdso:
 		exit 1; \
 	fi
 
+.PHONY: apparmor_smoke_policy
+apparmor_smoke_policy:
+	@mkdir -p $(dir $(APPARMOR_SMOKE_POLICY))
+	@sh tools/apparmor/compile-policy.sh \
+		tools/apparmor/smoke-profile.apparmor \
+		$(APPARMOR_SMOKE_POLICY)
+
+ifeq ($(AUTO_TEST), apparmor)
+initramfs: apparmor_smoke_policy
+endif
+
 .PHONY: initramfs
 initramfs: check_vdso
-	@$(MAKE) --no-print-directory -C test/initramfs
+	@$(MAKE) --no-print-directory -C test/initramfs \
+		ENABLE_APPARMOR_SMOKE_TEST=$(ENABLE_APPARMOR_SMOKE_TEST) \
+		APPARMOR_SMOKE_POLICY=$(APPARMOR_SMOKE_POLICY)
 
 # Build the kernel with an initramfs
 .PHONY: kernel
@@ -282,6 +301,9 @@ else ifeq ($(AUTO_TEST), regression)
 else ifeq ($(AUTO_TEST), boot)
 	@tail --lines 100 qemu.log | grep -q "^Successfully booted." \
 		|| (echo "Boot test failed" && exit 1)
+else ifeq ($(AUTO_TEST), apparmor)
+	@tail --lines 100 qemu.log | grep -q "^apparmor smoke: passed" \
+		|| (echo "AppArmor smoke test failed" && exit 1)
 else ifeq ($(AUTO_TEST), vsock)
 	@tail --lines 100 qemu.log | grep -q "^Vsock test passed." \
 		|| (echo "Vsock test failed" && exit 1)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -30,6 +30,7 @@
     * [Intel TDX](kernel/intel-tdx.md)
 * [The Framekernel Architecture](kernel/the-framekernel-architecture.md)
 * [Linux Compatibility](kernel/linux-compatibility/README.md)
+    * [AppArmor](kernel/linux-compatibility/apparmor.md)
     * [Syscall Flag Coverage](kernel/linux-compatibility/syscall-flag-coverage/README.md)
         * [System Call Matching Language (SCML)](kernel/linux-compatibility/syscall-flag-coverage/system-call-matching-language.md)
         * [Process and thread management](kernel/linux-compatibility/syscall-flag-coverage/process-and-thread-management/README.md)

--- a/book/src/kernel/linux-compatibility/apparmor.md
+++ b/book/src/kernel/linux-compatibility/apparmor.md
@@ -1,0 +1,117 @@
+# AppArmor
+
+Asterinas provides an AppArmor-like major Linux Security Module (LSM).
+It can be enabled with either `security=apparmor` or an `lsm=` list that
+contains `apparmor`.
+
+The implementation follows the Linux AppArmor model in the areas that are
+currently supported:
+- AppArmor confinement is attached to task credentials.
+- Tasks run under a current label/profile and inherit that state across
+  fork-like task creation.
+- Policy is loaded from user space instead of being hard-coded in the kernel.
+- File access is mediated by matching resolved paths against profile policy.
+- Capability use is mediated through the kernel capability hook.
+- AppArmor task identity is exposed through procfs.
+
+This is a supported AppArmor subset, not a claim of full Linux AppArmor policy
+ABI coverage.
+
+## Policy management
+
+When AppArmor is enabled, mount securityfs to access the AppArmor policy
+management interface:
+
+```sh
+mount -t securityfs none /sys/kernel/security
+```
+
+The AppArmor directory is then available at:
+
+```text
+/sys/kernel/security/apparmor
+```
+
+Supported policy control files:
+- `.load`: loads policy data.
+- `.replace`: loads or replaces policy data.
+- `.remove`: removes policy data.
+- `profiles`: lists loaded profiles and their modes.
+- `features`: exposes the AppArmor feature ABI supported by Asterinas.
+
+The `.load` and `.replace` files accept binary policy data produced by user
+space. The `.remove` file accepts either a binary remove payload or a profile
+name. Policy control writes require `CAP_MAC_ADMIN` in the initial user
+namespace.
+
+The feature ABI currently exposes:
+- `features/abi`
+- `features/policy/versions/{v5,v6,v7}`
+- `features/policy/set_load`
+- `features/policy/permstable32`
+- `features/policy/permstable32_version`
+- `features/file/mask`
+- `features/caps/mask`
+- `features/domain/change_profile`
+- `features/domain/change_onexec`
+- `features/domain/version`
+
+## Procfs interfaces
+
+AppArmor task identity is exposed through:
+
+```text
+/proc/[pid]/task/[tid]/attr/current
+/proc/[pid]/task/[tid]/attr/exec
+/proc/[pid]/task/[tid]/attr/prev
+```
+
+The files report the current profile, the on-exec profile, and the previous
+profile for the task. The `current` and `exec` files are writable by the
+current task to request profile changes supported by the loaded policy.
+
+Asterinas also exposes compatibility control files under:
+
+```text
+/proc/sys/kernel/apparmor
+```
+
+Supported entries:
+- `profiles`
+- `load`
+- `current`
+
+## Mediation coverage
+
+The current implementation mediates file and capability operations.
+
+File mediation covers path-based operations including:
+- open
+- create
+- delete
+- link
+- rename
+- setattr
+- file permission checks
+- mmap
+- file receive
+- file lock
+- getattr
+- exec
+
+Capability mediation covers capability checks that flow through
+`security::capable`.
+
+Network, mount, ptrace, signal, D-Bus, and rlimit mediation are not covered by
+this AppArmor subset yet.
+
+## Policy behavior
+
+Profiles may run in enforce or complain mode.
+In enforce mode, denied accesses fail.
+In complain mode, denied accesses are recorded through the AppArmor decision
+path but are allowed to continue.
+
+The file policy is conservative: an access is allowed only when the current
+profile grants the requested permissions, and explicit deny rules take
+precedence over allow rules.

--- a/book/src/kernel/linux-compatibility/apparmor.md
+++ b/book/src/kernel/linux-compatibility/apparmor.md
@@ -46,7 +46,7 @@ namespace.
 
 The feature ABI currently exposes:
 - `features/abi`
-- `features/policy/versions/{v5,v6,v7}`
+- `features/policy/versions/{v5,v6,v7,v8,v9}`
 - `features/policy/set_load`
 - `features/policy/permstable32`
 - `features/policy/permstable32_version`
@@ -55,6 +55,10 @@ The feature ABI currently exposes:
 - `features/domain/change_profile`
 - `features/domain/change_onexec`
 - `features/domain/version`
+
+The `features/abi` file reports the supported Asterinas AppArmor ABI subset,
+including the Linux policy ABI range, file audit/quiet support, capability
+audit support, and complain-mode support.
 
 ## Procfs interfaces
 
@@ -109,8 +113,8 @@ this AppArmor subset yet.
 
 Profiles may run in enforce or complain mode.
 In enforce mode, denied accesses fail.
-In complain mode, denied accesses are recorded through the AppArmor decision
-path but are allowed to continue.
+In complain mode, implicit denials are recorded through the AppArmor decision
+path but are allowed to continue. Explicit deny rules remain enforced.
 
 The file policy is conservative: an access is allowed only when the current
 profile grants the requested permissions, and explicit deny rules take

--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -35,6 +35,48 @@ console=ttyS0
 console=ttyS0 console=hvc0
 ```
 
+### `lsm`
+
+Select optional built-in Linux Security Modules in order.
+The mandatory `capability` module is always enabled before modules named in
+this parameter.
+
+Supported module names:
+- `apparmor`
+- `capability`
+- `yama`
+
+Notes:
+- Unknown module names are ignored with a warning.
+- Duplicate module names are ignored after their first selection.
+- `apparmor` is an exclusive major LSM. If multiple exclusive modules are
+  selected, the first selected exclusive module is kept.
+- If `lsm=` is specified, `security=` is ignored.
+
+Examples:
+```text
+lsm=apparmor,yama
+lsm=capability,apparmor,yama
+```
+
+### `security`
+
+Select one legacy major LSM.
+This parameter is provided for Linux compatibility.
+
+Supported value:
+- `apparmor`
+
+Notes:
+- `security=` is ignored when `lsm=` is also specified.
+- The default optional LSM stack is still enabled before the legacy major LSM
+  selected by this parameter.
+
+Example:
+```text
+security=apparmor
+```
+
 ### `virtio_mmio.device`
 
 Register a VirtIO-MMIO device from the kernel command line.

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -196,7 +196,9 @@ impl PerOpenFileOps for PtyMaster {
 
                     let inode_handle = {
                         let open_args = OpenArgs::from_modes(AccessMode::O_RDWR, mkmod!(u+rw));
-                        path_resolver.lookup(&fs_path)?.open(open_args)?
+                        path_resolver
+                            .lookup(&fs_path)?
+                            .open(open_args, &path_resolver)?
                     };
                     Arc::new(inode_handle)
                 };

--- a/kernel/src/fs/file/flock.rs
+++ b/kernel/src/fs/file/flock.rs
@@ -41,6 +41,11 @@ impl FlockItem {
         Weak::upgrade(&self.lock.owner)
     }
 
+    /// Returns the lock type.
+    pub fn type_(&self) -> FlockType {
+        self.lock.type_
+    }
+
     /// Checks if this lock has the same owner as another lock.
     pub fn same_owner_with(&self, other: &Self) -> bool {
         self.lock.owner.ptr_eq(&other.lock.owner)

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
+    security::{self, FilePermission},
     util::ioctl::RawIoctl,
 };
 
@@ -122,6 +123,7 @@ impl InodeHandle {
         if !self.rights.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
+        security::file_permission(&self.path, FilePermission::READ)?;
 
         let file_ops: &dyn FileOps = if let Some(ref open_file) = self.open_file {
             open_file.as_ref()
@@ -160,11 +162,13 @@ impl InodeHandle {
                 if !self.rights.contains(Rights::READ) {
                     return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
                 }
+                security::file_lock(&self.path, FilePermission::READ)?;
             }
             RangeLockType::WriteLock => {
                 if !self.rights.contains(Rights::WRITE) {
                     return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
                 }
+                security::file_lock(&self.path, file_write_permission(self.status_flags()))?;
             }
             RangeLockType::Unlock => {
                 if self.rights.is_empty() {
@@ -209,6 +213,11 @@ impl InodeHandle {
         if self.rights.is_empty() {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
+        let permissions = match lock.type_() {
+            super::flock::FlockType::SharedLock => FilePermission::READ,
+            super::flock::FlockType::ExclusiveLock => file_write_permission(self.status_flags()),
+        };
+        security::file_lock(&self.path, permissions)?;
 
         let flock_list = self.path.inode().fs_lock_context_or_init().flock_list();
         flock_list.set_lock(lock, is_nonblocking)
@@ -259,6 +268,7 @@ impl FileLike for InodeHandle {
         if !self.rights.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
+        security::file_permission(&self.path, FilePermission::READ)?;
 
         let (file_ops, is_offset_aware) = self.file_ops_and_is_offset_aware();
         let status_flags = self.status_flags();
@@ -282,6 +292,7 @@ impl FileLike for InodeHandle {
 
         let (file_ops, is_offset_aware) = self.file_ops_and_is_offset_aware();
         let status_flags = self.status_flags();
+        security::file_permission(&self.path, file_write_permission(status_flags))?;
 
         if !is_offset_aware {
             return file_ops.write_at(0, reader, status_flags);
@@ -307,6 +318,7 @@ impl FileLike for InodeHandle {
         if !self.rights.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
+        security::file_permission(&self.path, FilePermission::READ)?;
 
         let status_flags = self.status_flags();
 
@@ -320,6 +332,7 @@ impl FileLike for InodeHandle {
         }
 
         let status_flags = self.status_flags();
+        security::file_permission(&self.path, file_write_permission(status_flags))?;
 
         // FIXME: How can we deal with the `O_APPEND` flag if `open_file` is set?
         if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
@@ -429,6 +442,7 @@ impl FileLike for InodeHandle {
         if !self.rights.contains(Rights::WRITE) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
         }
+        security::file_permission(&self.path, file_write_permission(self.status_flags()))?;
 
         let inode = self.path.inode().as_ref();
         let inode_type = inode.type_();
@@ -513,6 +527,14 @@ impl Debug for InodeHandle {
             .field("status_flags", &self.status_flags())
             .field("rights", &self.rights)
             .finish_non_exhaustive()
+    }
+}
+
+fn file_write_permission(status_flags: StatusFlags) -> FilePermission {
+    if status_flags.contains(StatusFlags::O_APPEND) {
+        FilePermission::APPEND
+    } else {
+        FilePermission::WRITE
     }
 }
 

--- a/kernel/src/fs/fs_impls/mod.rs
+++ b/kernel/src/fs/fs_impls/mod.rs
@@ -13,6 +13,7 @@ pub mod overlayfs;
 pub mod procfs;
 pub mod pseudofs;
 pub mod ramfs;
+pub mod securityfs;
 pub mod sysfs;
 pub mod tmpfs;
 pub mod virtiofs;
@@ -22,6 +23,7 @@ pub(super) fn init() {
     procfs::init();
     cgroupfs::init();
     configfs::init();
+    securityfs::init();
     ramfs::init();
     tmpfs::init();
     devpts::init();

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -549,6 +549,20 @@ impl OverlayInode {
     pub fn sync_data(&self) -> Result<()> {
         self.upper().map_or(Ok(()), |upper| upper.sync_data())
     }
+
+    pub fn set_xattr(
+        &self,
+        name: XattrName,
+        value_reader: &mut VmReader,
+        flags: XattrSetFlags,
+    ) -> Result<()> {
+        self.build_upper_recursively_if_needed()?
+            .set_xattr(name, value_reader, flags)
+    }
+
+    pub fn remove_xattr(&self, name: XattrName) -> Result<()> {
+        self.build_upper_recursively_if_needed()?.remove_xattr(name)
+    }
 }
 
 #[inherit_methods(from = "self.get_top_valid_inode()")]

--- a/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::{
+            StaticEntryWithOps,
+            template::{
+                ListedEntry, ProcDir, ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry,
+                listed_entries_from_table, lookup_child_from_table, visit_listed_entries,
+            },
+        },
+        vfs::inode::{Inode, RevalidationPolicy},
+    },
+    prelude::*,
+    process::posix_thread::AsPosixThread,
+    security,
+    thread::Thread,
+};
+
+const MAX_PROFILE_NAME_LEN: usize = 4096;
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr`.
+pub(super) struct AttrDirOps(TidDirOps);
+
+impl AttrDirOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L2850>
+        ProcDir::new(Self(dir.clone()), parent, mkmod!(a+rx))
+    }
+
+    const STATIC_ENTRIES: &'static [StaticEntryWithOps<AttrDirOps>] = &[
+        ("current", InodeType::File, CurrentFileOps::new_inode),
+        ("exec", InodeType::File, ExecFileOps::new_inode),
+        ("prev", InodeType::File, PrevFileOps::new_inode),
+    ];
+}
+
+impl ProcDirOps for AttrDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if self.0.thread().is_none() {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
+        }
+
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(self, this_dir.this_weak().clone())
+        }) {
+            return Ok(child);
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the file does not exist");
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        if self.0.thread().is_none() {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
+        }
+
+        visit_listed_entries(offset, self.static_listed_entries(), visit_fn)
+    }
+
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS
+    }
+
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        self.0.thread().is_some()
+    }
+}
+
+impl AttrDirOps {
+    fn static_listed_entries(&self) -> impl Iterator<Item = ListedEntry<'_>> + '_ {
+        listed_entries_from_table(Self::STATIC_ENTRIES)
+    }
+}
+
+fn task_state_of(dir: &TidDirOps) -> Result<security::AppArmorTaskState> {
+    let Some(thread) = dir.thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+    };
+    let posix_thread = thread.as_posix_thread().unwrap();
+    let Some(task_state) = security::apparmor_task_state(posix_thread) else {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    };
+
+    Ok(task_state)
+}
+
+fn ensure_current_thread(thread: &Arc<Thread>) -> Result<()> {
+    let Some(current_thread) = Thread::current() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread does not exist");
+    };
+    if !Arc::ptr_eq(&current_thread, thread) {
+        return_errno_with_message!(
+            Errno::EPERM,
+            "the AppArmor task attribute is only writable by the current thread"
+        );
+    }
+
+    Ok(())
+}
+
+fn read_profile_name_from(reader: &mut VmReader) -> Result<(Option<String>, usize)> {
+    let (profile_name, read_bytes) = reader.read_cstring_until_end(MAX_PROFILE_NAME_LEN)?;
+    if reader.has_remain() {
+        return_errno_with_message!(Errno::E2BIG, "the AppArmor profile name is too large");
+    }
+
+    let profile_name = profile_name
+        .to_str()
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the profile name is not valid UTF-8"))?
+        .trim();
+    let profile_name = (!profile_name.is_empty()).then(|| profile_name.to_string());
+
+    Ok((profile_name, read_bytes))
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/current`.
+struct CurrentFileOps(TidDirOps);
+
+impl CurrentFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L2775>
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for CurrentFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        let task_state = task_state_of(&self.0)?;
+        writeln!(printer, "{}", task_state.current_profile().as_str())?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        ensure_current_thread(&thread)?;
+
+        let (profile_name, read_bytes) = read_profile_name_from(reader)?;
+        let Some(profile_name) = profile_name else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is empty");
+        };
+        security::set_current_apparmor_profile(&profile_name)?;
+
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/exec`.
+struct ExecFileOps(TidDirOps);
+
+impl ExecFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L2775>
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for ExecFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        let task_state = task_state_of(&self.0)?;
+        if let Some(profile_name) = task_state.onexec_profile() {
+            writeln!(printer, "{}", profile_name.as_str())?;
+        }
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        ensure_current_thread(&thread)?;
+
+        let (profile_name, read_bytes) = read_profile_name_from(reader)?;
+        security::set_current_apparmor_onexec_profile(profile_name.as_deref())?;
+
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/prev`.
+struct PrevFileOps(TidDirOps);
+
+impl PrevFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L2775>
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r))
+    }
+}
+
+impl ProcFileOps for PrevFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        let task_state = task_state_of(&self.0)?;
+        if let Some(profile_name) = task_state.previous_profile() {
+            writeln!(printer, "{}", profile_name.as_str())?;
+        }
+
+        Ok(printer.bytes_written())
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -7,12 +7,12 @@ use crate::{
         procfs::{
             StaticEntryWithOps,
             pid::task::{
-                auxv::AuxvFileOps, cgroup::CgroupFileOps, cmdline::CmdlineFileOps,
-                comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
-                gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
-                mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
-                ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
-                status::StatusFileOps, uid_map::UidMapFileOps,
+                attr::AttrDirOps, auxv::AuxvFileOps, cgroup::CgroupFileOps,
+                cmdline::CmdlineFileOps, comm::CommFileOps, environ::EnvironFileOps,
+                exe::ExeSymOps, fd::FdDirOps, gid_map::GidMapFileOps, maps::MapsFileOps,
+                mem::MemFileOps, mountinfo::MountInfoFileOps, mounts::MountsFileOps,
+                mountstats::MountStatsFileOps, ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps,
+                stat::StatFileOps, status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
                 ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, keyed_readdir_entries,
@@ -27,6 +27,7 @@ use crate::{
     thread::{Thread, Tid},
 };
 
+mod attr;
 mod auxv;
 mod cgroup;
 mod cmdline;
@@ -100,6 +101,7 @@ impl TidDirOps {
     }
 
     const STATIC_ENTRIES: &'static [StaticEntryWithOps<TidDirOps>] = &[
+        ("attr", InodeType::Dir, AttrDirOps::new_inode),
         ("auxv", InodeType::File, AuxvFileOps::new_inode),
         ("cgroup", InodeType::File, CgroupFileOps::new_inode),
         ("cmdline", InodeType::File, CmdlineFileOps::new_inode),

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/apparmor.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/apparmor.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::{
+            StaticEntry,
+            template::{
+                ProcDir, ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry,
+                listed_entries_from_table, lookup_child_from_table, visit_listed_entries,
+            },
+        },
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
+    security,
+};
+
+const MAX_POLICY_TEXT_LEN: usize = 64 * 1024;
+const MAX_PROFILE_NAME_LEN: usize = 4096;
+
+/// Represents the inode at `/proc/sys/kernel/apparmor`.
+pub struct AppArmorDirOps;
+
+impl AppArmorDirOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/security/apparmor/lsm.c#L2096>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/proc_sysctl.c#L978>
+        ProcDir::new(Self, parent, mkmod!(a+rx))
+    }
+
+    const STATIC_ENTRIES: &'static [StaticEntry] = &[
+        ("profiles", InodeType::File, ProfilesFileOps::new_inode),
+        ("load", InodeType::File, LoadFileOps::new_inode),
+        ("current", InodeType::File, CurrentFileOps::new_inode),
+    ];
+}
+
+impl ProcDirOps for AppArmorDirOps {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
+            return Ok(child);
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the file does not exist");
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/apparmor/profiles`.
+struct ProfilesFileOps;
+
+impl ProfilesFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r))
+    }
+}
+
+impl ProcFileOps for ProfilesFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        for (profile_name, mode) in security::apparmor_profile_summaries()? {
+            writeln!(printer, "{} {}", profile_name.as_str(), mode.as_str())?;
+        }
+
+        Ok(printer.bytes_written())
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/apparmor/load`.
+struct LoadFileOps;
+
+impl LoadFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(u+w))
+    }
+}
+
+impl ProcFileOps for LoadFileOps {
+    fn read_at(&self, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
+        return_errno_with_message!(Errno::EPERM, "the file is not readable");
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        require_mac_admin()?;
+
+        let (policy_text, read_bytes) = read_text_from(reader, MAX_POLICY_TEXT_LEN)?;
+        security::load_apparmor_policy(&policy_text)?;
+
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/sys/kernel/apparmor/current`.
+struct CurrentFileOps;
+
+impl CurrentFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for CurrentFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        let current_thread = current_thread!();
+        let Some(posix_thread) = current_thread.as_posix_thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+        };
+        let Some(task_state) = security::apparmor_task_state(posix_thread) else {
+            return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+        };
+
+        writeln!(printer, "{}", task_state.current_profile().as_str())?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        require_mac_admin()?;
+
+        let (profile_name, read_bytes) = read_text_from(reader, MAX_PROFILE_NAME_LEN)?;
+        let profile_name = profile_name.trim();
+        if profile_name.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is empty");
+        }
+
+        security::set_current_apparmor_profile(profile_name)?;
+
+        Ok(read_bytes)
+    }
+}
+
+fn require_mac_admin() -> Result<()> {
+    let current_thread = current_thread!();
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+    };
+
+    security::capable(
+        UserNamespace::get_init_singleton().as_ref(),
+        CapSet::MAC_ADMIN,
+        posix_thread,
+    )
+}
+
+fn read_text_from(reader: &mut VmReader, max_len: usize) -> Result<(String, usize)> {
+    let (text, read_bytes) = reader.read_cstring_until_end(max_len)?;
+    if reader.has_remain() {
+        return_errno_with_message!(Errno::E2BIG, "the AppArmor policy text is too large");
+    }
+
+    let text = text
+        .to_str()
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the text is not valid UTF-8"))?;
+
+    Ok((text.to_string(), read_bytes))
+}

--- a/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/kernel/mod.rs
@@ -6,7 +6,8 @@ use crate::{
         procfs::{
             ProcDir, StaticEntry,
             sys::kernel::{
-                cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps, yama::YamaDirOps,
+                apparmor::AppArmorDirOps, cap_last_cap::CapLastCapFileOps, pid_max::PidMaxFileOps,
+                yama::YamaDirOps,
             },
             template::{
                 ListedEntry, ProcDirOps, ReaddirEntry, listed_entries_from_table,
@@ -16,9 +17,10 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    security::lsm::is_yama_enabled,
+    security,
 };
 
+mod apparmor;
 mod cap_last_cap;
 mod pid_max;
 mod yama;
@@ -52,8 +54,12 @@ impl ProcDirOps for KernelDirOps {
             return Ok(child);
         }
 
-        if name == "yama" && is_yama_enabled() {
+        if name == "yama" && security::is_yama_enabled() {
             return Ok(YamaDirOps::new_inode(this_dir.this_weak().clone()));
+        }
+
+        if name == "apparmor" && security::is_apparmor_enabled() {
+            return Ok(AppArmorDirOps::new_inode(this_dir.this_weak().clone()));
         }
 
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
@@ -63,11 +69,16 @@ impl ProcDirOps for KernelDirOps {
     where
         F: FnMut(ReaddirEntry<'a>) -> Result<()>,
     {
-        let yama_entry = is_yama_enabled().then(|| ListedEntry::new("yama", InodeType::Dir));
+        let yama_entry =
+            security::is_yama_enabled().then(|| ListedEntry::new("yama", InodeType::Dir));
+        let apparmor_entry =
+            security::is_apparmor_enabled().then(|| ListedEntry::new("apparmor", InodeType::Dir));
 
         visit_listed_entries(
             offset,
-            listed_entries_from_table(Self::STATIC_ENTRIES).chain(yama_entry),
+            listed_entries_from_table(Self::STATIC_ENTRIES)
+                .chain(yama_entry)
+                .chain(apparmor_entry),
             visit_fn,
         )
     }

--- a/kernel/src/fs/fs_impls/securityfs/mod.rs
+++ b/kernel/src/fs/fs_impls/securityfs/mod.rs
@@ -1,0 +1,713 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::{sync::atomic::AtomicU64, time::Duration};
+
+use aster_systree::EmptyNode;
+use aster_util::printer::VmPrinter;
+use spin::Once;
+
+use crate::{
+    fs::{
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        pseudofs::AnonDeviceId,
+        utils::{DirentVisitor, NAME_MAX},
+        vfs::{
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            inode::{
+                Extension, FileOps, Inode, Metadata, MknodType, RenameMode, RevalidationPolicy,
+                SymbolicLink,
+            },
+            path::{is_dot, is_dotdot},
+            registry::{FsCreationCtx, FsProperties, FsType},
+        },
+    },
+    prelude::*,
+    process::{
+        Gid, Uid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
+    },
+    security::{self, AppArmorPolicyOperation},
+};
+
+const SECURITYFS_MAGIC: u64 = 0x73636673;
+const SECURITYFS_BLOCK_SIZE: usize = 4096;
+const ROOT_INO: u64 = 1;
+const MAX_BINARY_POLICY_LEN: usize = 1024 * 1024;
+const MAX_REMOVE_TEXT_LEN: usize = 4096;
+
+pub(super) fn init() {
+    let security_kernel_sysnode = EmptyNode::new("security".into());
+    super::sysfs::register_kernel_sysnode(security_kernel_sysnode).unwrap();
+
+    crate::fs::vfs::registry::register(&SecurityFsType).unwrap();
+}
+
+struct SecurityFs {
+    _anon_device_id: AnonDeviceId,
+    sb: SuperBlock,
+    root: Arc<dyn Inode>,
+    inode_allocator: AtomicU64,
+    fs_event_subscriber_stats: FsEventSubscriberStats,
+}
+
+impl SecurityFs {
+    fn singleton() -> &'static Arc<Self> {
+        static SINGLETON: Once<Arc<SecurityFs>> = Once::new();
+
+        SINGLETON.call_once(Self::new)
+    }
+
+    fn new() -> Arc<Self> {
+        let anon_device_id =
+            AnonDeviceId::acquire().expect("no device ID is available for securityfs");
+        let sb = SuperBlock::new(
+            SECURITYFS_MAGIC,
+            SECURITYFS_BLOCK_SIZE,
+            NAME_MAX,
+            anon_device_id.id(),
+        );
+
+        Arc::new_cyclic(|weak_fs| Self {
+            _anon_device_id: anon_device_id,
+            sb: sb.clone(),
+            root: SecurityFsInode::new_root(weak_fs.clone(), &sb),
+            inode_allocator: AtomicU64::new(ROOT_INO + 1),
+            fs_event_subscriber_stats: FsEventSubscriberStats::new(),
+        })
+    }
+
+    fn alloc_id(&self) -> u64 {
+        self.inode_allocator
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl FileSystem for SecurityFs {
+    fn name(&self) -> &'static str {
+        "securityfs"
+    }
+
+    fn sync(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.root.clone()
+    }
+
+    fn sb(&self) -> SuperBlock {
+        self.sb.clone()
+    }
+
+    fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+        &self.fs_event_subscriber_stats
+    }
+}
+
+struct SecurityFsType;
+
+impl FsType for SecurityFsType {
+    fn name(&self) -> &'static str {
+        "securityfs"
+    }
+
+    fn properties(&self) -> FsProperties {
+        FsProperties::empty()
+    }
+
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(SecurityFs::singleton().clone())
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
+        None
+    }
+}
+
+struct SecurityFsInode {
+    kind: SecurityFsNodeKind,
+    metadata: RwLock<Metadata>,
+    extension: Extension,
+    fs: Weak<dyn FileSystem>,
+    parent: Option<Weak<dyn Inode>>,
+    this: Weak<SecurityFsInode>,
+}
+
+impl SecurityFsInode {
+    fn new_root(fs: Weak<SecurityFs>, sb: &SuperBlock) -> Arc<dyn Inode> {
+        let fs: Weak<dyn FileSystem> = fs;
+        let metadata = Metadata::new_dir(
+            ROOT_INO,
+            SecurityFsNodeKind::Root.mode(),
+            SECURITYFS_BLOCK_SIZE,
+            sb.container_dev_id,
+        );
+
+        Arc::new_cyclic(|this| Self {
+            kind: SecurityFsNodeKind::Root,
+            metadata: RwLock::new(metadata),
+            extension: Extension::new(),
+            fs: fs.clone(),
+            parent: None,
+            this: this.clone(),
+        })
+    }
+
+    fn new_child(kind: SecurityFsNodeKind, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        let fs = parent.upgrade().unwrap().fs();
+        let securityfs = fs.downcast_ref::<SecurityFs>().unwrap();
+        let metadata = match kind.type_() {
+            InodeType::Dir => Metadata::new_dir(
+                securityfs.alloc_id(),
+                kind.mode(),
+                SECURITYFS_BLOCK_SIZE,
+                securityfs.sb().container_dev_id,
+            ),
+            InodeType::File => Metadata::new_file(
+                securityfs.alloc_id(),
+                kind.mode(),
+                SECURITYFS_BLOCK_SIZE,
+                securityfs.sb().container_dev_id,
+            ),
+            _ => unreachable!("securityfs only creates directories and regular files"),
+        };
+
+        Arc::new_cyclic(|this| Self {
+            kind,
+            metadata: RwLock::new(metadata),
+            extension: Extension::new(),
+            fs: Arc::downgrade(&fs),
+            parent: Some(parent),
+            this: this.clone(),
+        })
+    }
+
+    fn this(&self) -> Arc<dyn Inode> {
+        self.this.upgrade().unwrap()
+    }
+
+    fn parent(&self) -> Option<Arc<dyn Inode>> {
+        self.parent.as_ref().and_then(Weak::upgrade)
+    }
+
+    fn entries(&self) -> Vec<SecurityFsEntry> {
+        match self.kind {
+            SecurityFsNodeKind::Root => {
+                if security::is_apparmor_enabled() {
+                    vec![SecurityFsEntry::new(
+                        "apparmor",
+                        SecurityFsNodeKind::AppArmorDir,
+                    )]
+                } else {
+                    Vec::new()
+                }
+            }
+            SecurityFsNodeKind::AppArmorDir => vec![
+                SecurityFsEntry::new("profiles", SecurityFsNodeKind::Profiles),
+                SecurityFsEntry::new(".load", SecurityFsNodeKind::Load),
+                SecurityFsEntry::new(".replace", SecurityFsNodeKind::Replace),
+                SecurityFsEntry::new(".remove", SecurityFsNodeKind::Remove),
+                SecurityFsEntry::new("features", SecurityFsNodeKind::FeaturesDir),
+            ],
+            SecurityFsNodeKind::FeaturesDir => vec![
+                SecurityFsEntry::new("abi", SecurityFsNodeKind::FeatureAbi),
+                SecurityFsEntry::new("policy", SecurityFsNodeKind::FeaturePolicyDir),
+                SecurityFsEntry::new("file", SecurityFsNodeKind::FeatureFileDir),
+                SecurityFsEntry::new("domain", SecurityFsNodeKind::FeatureDomainDir),
+                SecurityFsEntry::new("caps", SecurityFsNodeKind::FeatureCapsDir),
+            ],
+            SecurityFsNodeKind::FeaturePolicyDir => vec![
+                SecurityFsEntry::new("versions", SecurityFsNodeKind::FeaturePolicyVersionsDir),
+                SecurityFsEntry::new("set_load", SecurityFsNodeKind::FeaturePolicySetLoad),
+                SecurityFsEntry::new(
+                    "permstable32",
+                    SecurityFsNodeKind::FeaturePolicyPermstable32,
+                ),
+                SecurityFsEntry::new(
+                    "permstable32_version",
+                    SecurityFsNodeKind::FeaturePolicyPermstable32Version,
+                ),
+            ],
+            SecurityFsNodeKind::FeaturePolicyVersionsDir => vec![
+                SecurityFsEntry::new("v5", SecurityFsNodeKind::FeaturePolicyVersionV5),
+                SecurityFsEntry::new("v6", SecurityFsNodeKind::FeaturePolicyVersionV6),
+                SecurityFsEntry::new("v7", SecurityFsNodeKind::FeaturePolicyVersionV7),
+            ],
+            SecurityFsNodeKind::FeatureFileDir => {
+                vec![SecurityFsEntry::new(
+                    "mask",
+                    SecurityFsNodeKind::FeatureFileMask,
+                )]
+            }
+            SecurityFsNodeKind::FeatureCapsDir => {
+                vec![SecurityFsEntry::new(
+                    "mask",
+                    SecurityFsNodeKind::FeatureCapsMask,
+                )]
+            }
+            SecurityFsNodeKind::FeatureDomainDir => vec![
+                SecurityFsEntry::new(
+                    "change_profile",
+                    SecurityFsNodeKind::FeatureDomainChangeProfile,
+                ),
+                SecurityFsEntry::new(
+                    "change_onexec",
+                    SecurityFsNodeKind::FeatureDomainChangeOnexec,
+                ),
+                SecurityFsEntry::new("version", SecurityFsNodeKind::FeatureDomainVersion),
+            ],
+            _ => Vec::new(),
+        }
+    }
+
+    fn lookup_entry(&self, name: &str) -> Option<SecurityFsEntry> {
+        self.entries().into_iter().find(|entry| entry.name == name)
+    }
+}
+
+impl FileOps for SecurityFsInode {
+    fn read_at(
+        &self,
+        offset: usize,
+        writer: &mut VmWriter,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        if self.kind.type_() == InodeType::Dir {
+            return_errno_with_message!(Errno::EISDIR, "securityfs directories are not readable");
+        }
+
+        let mut printer = VmPrinter::new_skip(writer, offset);
+        match self.kind {
+            SecurityFsNodeKind::Profiles => {
+                for (profile_name, mode) in security::apparmor_profile_summaries()? {
+                    writeln!(printer, "{} {}", profile_name.as_str(), mode.as_str())?;
+                }
+            }
+            SecurityFsNodeKind::FeatureAbi => {
+                writeln!(printer, "asterinas-apparmor-linux-filedfa-v1")?;
+                writeln!(
+                    printer,
+                    "root_namespace={}",
+                    security::apparmor_root_namespace_name()?
+                )?;
+            }
+            SecurityFsNodeKind::FeaturePolicySetLoad
+            | SecurityFsNodeKind::FeaturePolicyVersionV5
+            | SecurityFsNodeKind::FeaturePolicyVersionV6
+            | SecurityFsNodeKind::FeaturePolicyVersionV7
+            | SecurityFsNodeKind::FeatureDomainChangeProfile
+            | SecurityFsNodeKind::FeatureDomainChangeOnexec => {
+                writeln!(printer, "yes")?;
+            }
+            SecurityFsNodeKind::FeaturePolicyPermstable32 => {
+                writeln!(
+                    printer,
+                    "allow deny subtree cond kill complain prompt audit quiet hide xindex tag label"
+                )?;
+            }
+            SecurityFsNodeKind::FeaturePolicyPermstable32Version => {
+                writeln!(printer, "0x000002")?;
+            }
+            SecurityFsNodeKind::FeatureFileMask => {
+                writeln!(printer, "create read write exec append mmap_exec link")?;
+            }
+            SecurityFsNodeKind::FeatureCapsMask => {
+                writeln!(
+                    printer,
+                    "chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_module sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap mac_override mac_admin syslog wake_alarm block_suspend audit_read perfmon bpf checkpoint_restore"
+                )?;
+            }
+            SecurityFsNodeKind::FeatureDomainVersion => {
+                writeln!(printer, "1.2")?;
+            }
+            SecurityFsNodeKind::Load | SecurityFsNodeKind::Replace | SecurityFsNodeKind::Remove => {
+                return_errno_with_message!(Errno::EPERM, "the securityfs file is not readable");
+            }
+            _ => return_errno_with_message!(Errno::EINVAL, "invalid securityfs read target"),
+        }
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        reader: &mut VmReader,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        if self.kind.type_() == InodeType::Dir {
+            return_errno_with_message!(Errno::EISDIR, "securityfs directories are not writable");
+        }
+
+        match self.kind {
+            SecurityFsNodeKind::Load | SecurityFsNodeKind::Replace => {
+                require_mac_admin()?;
+                let (policy, read_bytes) = read_bytes_from(reader, MAX_BINARY_POLICY_LEN)?;
+                security::load_apparmor_binary_policy(&policy, AppArmorPolicyOperation::Replace)?;
+                Ok(read_bytes)
+            }
+            SecurityFsNodeKind::Remove => {
+                require_mac_admin()?;
+                let (policy, read_bytes) = read_bytes_from(reader, MAX_BINARY_POLICY_LEN)?;
+                if security::has_apparmor_binary_policy_magic(&policy) {
+                    security::load_apparmor_binary_policy(
+                        &policy,
+                        AppArmorPolicyOperation::Remove,
+                    )?;
+                } else {
+                    let profile_name = parse_remove_profile_name(&policy)?;
+                    security::remove_apparmor_profile_by_name(profile_name)?;
+                }
+                Ok(read_bytes)
+            }
+            _ => return_errno_with_message!(Errno::EPERM, "the securityfs file is not writable"),
+        }
+    }
+
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        if self.kind.type_() != InodeType::Dir {
+            return_errno_with_message!(Errno::ENOTDIR, "securityfs inode is not a directory");
+        }
+
+        let try_readdir =
+            |iterate_offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
+                let this_inode = self.this();
+                let parent_inode = self.parent().unwrap_or_else(|| this_inode.clone());
+                for (name, inode, next_offset) in
+                    [(".", this_inode, 1usize), ("..", parent_inode, 2usize)]
+                {
+                    if next_offset <= *iterate_offset {
+                        continue;
+                    }
+
+                    visitor.visit(name, inode.ino(), inode.type_(), next_offset)?;
+                    *iterate_offset = next_offset;
+                }
+
+                for (index, entry) in self.entries().into_iter().enumerate() {
+                    let next_offset = 3 + index;
+                    if next_offset <= *iterate_offset {
+                        continue;
+                    }
+
+                    visitor.visit(entry.name, 2, entry.kind.type_(), next_offset)?;
+                    *iterate_offset = next_offset;
+                }
+
+                Ok(())
+            };
+
+        let mut iterate_offset = offset;
+        match try_readdir(&mut iterate_offset, visitor) {
+            Err(error) if iterate_offset == offset => Err(error),
+            _ => Ok(iterate_offset - offset),
+        }
+    }
+}
+
+impl Inode for SecurityFsInode {
+    fn size(&self) -> usize {
+        self.metadata.read().size
+    }
+
+    fn resize(&self, _new_size: usize) -> Result<()> {
+        Ok(())
+    }
+
+    fn metadata(&self) -> Metadata {
+        *self.metadata.read()
+    }
+
+    fn ino(&self) -> u64 {
+        self.metadata.read().ino
+    }
+
+    fn type_(&self) -> InodeType {
+        self.kind.type_()
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.metadata.read().mode)
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        self.metadata.write().mode = mode;
+        Ok(())
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(self.metadata.read().uid)
+    }
+
+    fn set_owner(&self, uid: Uid) -> Result<()> {
+        self.metadata.write().uid = uid;
+        Ok(())
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(self.metadata.read().gid)
+    }
+
+    fn set_group(&self, gid: Gid) -> Result<()> {
+        self.metadata.write().gid = gid;
+        Ok(())
+    }
+
+    fn atime(&self) -> Duration {
+        self.metadata.read().last_access_at
+    }
+
+    fn set_atime(&self, time: Duration) {
+        self.metadata.write().last_access_at = time;
+    }
+
+    fn mtime(&self) -> Duration {
+        self.metadata.read().last_modify_at
+    }
+
+    fn set_mtime(&self, time: Duration) {
+        self.metadata.write().last_modify_at = time;
+    }
+
+    fn ctime(&self) -> Duration {
+        self.metadata.read().last_meta_change_at
+    }
+
+    fn set_ctime(&self, time: Duration) {
+        self.metadata.write().last_meta_change_at = time;
+    }
+
+    fn open(
+        &self,
+        _access_mode: AccessMode,
+        _status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        None
+    }
+
+    fn create(&self, _name: &str, _type_: InodeType, _mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        return_errno_with_message!(Errno::EPERM, "securityfs does not support create");
+    }
+
+    fn mknod(&self, _name: &str, _mode: InodeMode, _type_: MknodType) -> Result<Arc<dyn Inode>> {
+        return_errno_with_message!(Errno::EPERM, "securityfs does not support mknod");
+    }
+
+    fn link(&self, _old: &Arc<dyn Inode>, _name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EPERM, "securityfs does not support link");
+    }
+
+    fn unlink(&self, _name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EPERM, "securityfs does not support unlink");
+    }
+
+    fn rmdir(&self, _name: &str) -> Result<()> {
+        return_errno_with_message!(Errno::EPERM, "securityfs does not support rmdir");
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        if is_dot(name) {
+            return Ok(self.this());
+        }
+        if is_dotdot(name) {
+            return Ok(self.parent().unwrap_or_else(|| self.this()));
+        }
+
+        let Some(entry) = self.lookup_entry(name) else {
+            return_errno_with_message!(Errno::ENOENT, "the securityfs file does not exist");
+        };
+
+        let this: Arc<dyn Inode> = self.this();
+        Ok(SecurityFsInode::new_child(
+            entry.kind,
+            Arc::downgrade(&this),
+        ))
+    }
+
+    fn rename(
+        &self,
+        _old_name: &str,
+        _target: &Arc<dyn Inode>,
+        _new_name: &str,
+        _mode: RenameMode,
+    ) -> Result<()> {
+        return_errno_with_message!(Errno::EPERM, "securityfs does not support rename");
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        Err(Error::new(Errno::EINVAL))
+    }
+
+    fn write_link(&self, _target: &str) -> Result<()> {
+        Err(Error::new(Errno::EINVAL))
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.fs.upgrade().unwrap()
+    }
+
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        match self.kind {
+            SecurityFsNodeKind::Root => {
+                RevalidationPolicy::REVALIDATE_EXISTS | RevalidationPolicy::REVALIDATE_ABSENT
+            }
+            _ => RevalidationPolicy::empty(),
+        }
+    }
+
+    fn revalidate_exists(&self, name: &str, _child: &dyn Inode) -> bool {
+        self.lookup_entry(name).is_some()
+    }
+
+    fn revalidate_absent(&self, name: &str) -> bool {
+        self.lookup_entry(name).is_none()
+    }
+
+    fn seek_end(&self) -> Option<usize> {
+        (self.kind.type_() == InodeType::Dir).then_some(0)
+    }
+
+    fn extension(&self) -> &Extension {
+        &self.extension
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SecurityFsNodeKind {
+    Root,
+    AppArmorDir,
+    Profiles,
+    Load,
+    Replace,
+    Remove,
+    FeaturesDir,
+    FeatureAbi,
+    FeaturePolicyDir,
+    FeaturePolicyVersionsDir,
+    FeaturePolicySetLoad,
+    FeaturePolicyPermstable32,
+    FeaturePolicyPermstable32Version,
+    FeaturePolicyVersionV5,
+    FeaturePolicyVersionV6,
+    FeaturePolicyVersionV7,
+    FeatureFileDir,
+    FeatureFileMask,
+    FeatureCapsDir,
+    FeatureCapsMask,
+    FeatureDomainDir,
+    FeatureDomainChangeProfile,
+    FeatureDomainChangeOnexec,
+    FeatureDomainVersion,
+}
+
+impl SecurityFsNodeKind {
+    fn type_(self) -> InodeType {
+        match self {
+            Self::Root
+            | Self::AppArmorDir
+            | Self::FeaturesDir
+            | Self::FeaturePolicyDir
+            | Self::FeaturePolicyVersionsDir
+            | Self::FeatureFileDir
+            | Self::FeatureCapsDir
+            | Self::FeatureDomainDir => InodeType::Dir,
+            Self::Profiles
+            | Self::Load
+            | Self::Replace
+            | Self::Remove
+            | Self::FeatureAbi
+            | Self::FeaturePolicySetLoad
+            | Self::FeaturePolicyPermstable32
+            | Self::FeaturePolicyPermstable32Version
+            | Self::FeaturePolicyVersionV5
+            | Self::FeaturePolicyVersionV6
+            | Self::FeaturePolicyVersionV7
+            | Self::FeatureFileMask
+            | Self::FeatureCapsMask
+            | Self::FeatureDomainChangeProfile
+            | Self::FeatureDomainChangeOnexec
+            | Self::FeatureDomainVersion => InodeType::File,
+        }
+    }
+
+    fn mode(self) -> InodeMode {
+        match self {
+            Self::Root
+            | Self::AppArmorDir
+            | Self::FeaturesDir
+            | Self::FeaturePolicyDir
+            | Self::FeaturePolicyVersionsDir
+            | Self::FeatureFileDir
+            | Self::FeatureCapsDir
+            | Self::FeatureDomainDir => mkmod!(a+rx),
+            Self::Profiles
+            | Self::FeatureAbi
+            | Self::FeaturePolicySetLoad
+            | Self::FeaturePolicyPermstable32
+            | Self::FeaturePolicyPermstable32Version
+            | Self::FeaturePolicyVersionV5
+            | Self::FeaturePolicyVersionV6
+            | Self::FeaturePolicyVersionV7
+            | Self::FeatureFileMask
+            | Self::FeatureCapsMask
+            | Self::FeatureDomainChangeProfile
+            | Self::FeatureDomainChangeOnexec
+            | Self::FeatureDomainVersion => mkmod!(a+r),
+            Self::Load | Self::Replace | Self::Remove => mkmod!(u+w),
+        }
+    }
+}
+
+struct SecurityFsEntry {
+    name: &'static str,
+    kind: SecurityFsNodeKind,
+}
+
+impl SecurityFsEntry {
+    fn new(name: &'static str, kind: SecurityFsNodeKind) -> Self {
+        Self { name, kind }
+    }
+}
+
+fn require_mac_admin() -> Result<()> {
+    let current_thread = current_thread!();
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+    };
+
+    security::capable(
+        UserNamespace::get_init_singleton().as_ref(),
+        CapSet::MAC_ADMIN,
+        posix_thread,
+    )
+}
+
+fn read_bytes_from(reader: &mut VmReader, max_len: usize) -> Result<(Vec<u8>, usize)> {
+    let len = reader.remain();
+    if len > max_len {
+        return_errno_with_message!(Errno::E2BIG, "the AppArmor policy payload is too large");
+    }
+
+    let mut bytes = vec![0; len];
+    let mut writer = VmWriter::from(bytes.as_mut_slice()).to_fallible();
+    let read_bytes = reader
+        .read_fallible(&mut writer)
+        .map_err(|(error, _read_bytes)| error)?;
+    bytes.truncate(read_bytes);
+
+    Ok((bytes, read_bytes))
+}
+
+fn parse_remove_profile_name(bytes: &[u8]) -> Result<&str> {
+    if bytes.len() > MAX_REMOVE_TEXT_LEN {
+        return_errno_with_message!(Errno::E2BIG, "the AppArmor profile name is too large");
+    }
+
+    let profile_name = core::str::from_utf8(bytes)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the profile name is not UTF-8"))?
+        .trim();
+    if profile_name.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is empty");
+    }
+
+    Ok(profile_name)
+}

--- a/kernel/src/fs/fs_impls/securityfs/mod.rs
+++ b/kernel/src/fs/fs_impls/securityfs/mod.rs
@@ -231,6 +231,8 @@ impl SecurityFsInode {
                 SecurityFsEntry::new("v5", SecurityFsNodeKind::FeaturePolicyVersionV5),
                 SecurityFsEntry::new("v6", SecurityFsNodeKind::FeaturePolicyVersionV6),
                 SecurityFsEntry::new("v7", SecurityFsNodeKind::FeaturePolicyVersionV7),
+                SecurityFsEntry::new("v8", SecurityFsNodeKind::FeaturePolicyVersionV8),
+                SecurityFsEntry::new("v9", SecurityFsNodeKind::FeaturePolicyVersionV9),
             ],
             SecurityFsNodeKind::FeatureFileDir => {
                 vec![SecurityFsEntry::new(
@@ -289,26 +291,33 @@ impl FileOps for SecurityFsInode {
                     "root_namespace={}",
                     security::apparmor_root_namespace_name()?
                 )?;
+                writeln!(printer, "policy_abi=linux-v5-v9-subset")?;
+                writeln!(printer, "file_audit=yes")?;
+                writeln!(printer, "file_quiet=yes")?;
+                writeln!(printer, "capability_audit=yes")?;
+                writeln!(printer, "complain=yes")?;
             }
             SecurityFsNodeKind::FeaturePolicySetLoad
             | SecurityFsNodeKind::FeaturePolicyVersionV5
             | SecurityFsNodeKind::FeaturePolicyVersionV6
             | SecurityFsNodeKind::FeaturePolicyVersionV7
+            | SecurityFsNodeKind::FeaturePolicyVersionV8
+            | SecurityFsNodeKind::FeaturePolicyVersionV9
             | SecurityFsNodeKind::FeatureDomainChangeProfile
             | SecurityFsNodeKind::FeatureDomainChangeOnexec => {
                 writeln!(printer, "yes")?;
             }
             SecurityFsNodeKind::FeaturePolicyPermstable32 => {
-                writeln!(
-                    printer,
-                    "allow deny subtree cond kill complain prompt audit quiet hide xindex tag label"
-                )?;
+                writeln!(printer, "allow deny audit quiet xindex")?;
             }
             SecurityFsNodeKind::FeaturePolicyPermstable32Version => {
                 writeln!(printer, "0x000002")?;
             }
             SecurityFsNodeKind::FeatureFileMask => {
-                writeln!(printer, "create read write exec append mmap_exec link")?;
+                writeln!(
+                    printer,
+                    "create read write exec append delete rename setattr mmap_exec link"
+                )?;
             }
             SecurityFsNodeKind::FeatureCapsMask => {
                 writeln!(
@@ -589,6 +598,8 @@ enum SecurityFsNodeKind {
     FeaturePolicyVersionV5,
     FeaturePolicyVersionV6,
     FeaturePolicyVersionV7,
+    FeaturePolicyVersionV8,
+    FeaturePolicyVersionV9,
     FeatureFileDir,
     FeatureFileMask,
     FeatureCapsDir,
@@ -621,6 +632,8 @@ impl SecurityFsNodeKind {
             | Self::FeaturePolicyVersionV5
             | Self::FeaturePolicyVersionV6
             | Self::FeaturePolicyVersionV7
+            | Self::FeaturePolicyVersionV8
+            | Self::FeaturePolicyVersionV9
             | Self::FeatureFileMask
             | Self::FeatureCapsMask
             | Self::FeatureDomainChangeProfile
@@ -647,6 +660,8 @@ impl SecurityFsNodeKind {
             | Self::FeaturePolicyVersionV5
             | Self::FeaturePolicyVersionV6
             | Self::FeaturePolicyVersionV7
+            | Self::FeaturePolicyVersionV8
+            | Self::FeaturePolicyVersionV9
             | Self::FeatureFileMask
             | Self::FeatureCapsMask
             | Self::FeatureDomainChangeProfile

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -44,7 +44,7 @@ pub fn init_in_first_process(ctx: &Context) {
         path_resolver
             .lookup(&tty_path)
             .unwrap()
-            .open(open_args)
+            .open(open_args, &path_resolver)
             .unwrap()
     };
     let stdout = {
@@ -52,7 +52,7 @@ pub fn init_in_first_process(ctx: &Context) {
         path_resolver
             .lookup(&tty_path)
             .unwrap()
-            .open(open_args)
+            .open(open_args, &path_resolver)
             .unwrap()
     };
     let stderr = {
@@ -60,7 +60,7 @@ pub fn init_in_first_process(ctx: &Context) {
         path_resolver
             .lookup(&tty_path)
             .unwrap()
-            .open(open_args)
+            .open(open_args, &path_resolver)
             .unwrap()
     };
 

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     process::{
         Gid, Uid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
     },
-    security::lsm::hooks as lsm_hooks,
+    security::{self, lsm::hooks as lsm_hooks},
 };
 
 mod dentry;
@@ -120,7 +120,7 @@ impl Path {
     /// Opens the `Path` with the given `OpenArgs`.
     ///
     /// Returns an `InodeHandle` on success.
-    pub fn open(&self, open_args: OpenArgs) -> Result<InodeHandle> {
+    pub fn open(&self, open_args: OpenArgs, path_resolver: &PathResolver) -> Result<InodeHandle> {
         let inode = self.inode().as_ref();
         let inode_type = inode.type_();
         let creation_flags = &open_args.creation_flags;
@@ -151,14 +151,26 @@ impl Path {
             );
         }
 
+        if !status_flags.contains(StatusFlags::O_PATH) {
+            inode.check_permission(open_args.access_mode.into())?;
+        }
+
+        security::file_open(
+            self,
+            path_resolver,
+            open_args.access_mode,
+            open_args.status_flags,
+        )?;
+
         if inode_type.is_regular_file()
             && creation_flags.contains(CreationFlags::O_TRUNC)
             && !status_flags.contains(StatusFlags::O_PATH)
         {
+            security::file_setattr(self, path_resolver, security::FileSetattrKind::Size)?;
             self.resize(0)?;
         }
 
-        InodeHandle::new(self.clone(), open_args.access_mode, *status_flags)
+        InodeHandle::new_unchecked_access(self.clone(), open_args.access_mode, *status_flags)
     }
 
     /// Gets the parent `Path` within the same mount.
@@ -598,7 +610,7 @@ impl Path {
     }
 
     /// Links a new name for the `Path`.
-    pub fn link(&self, old: &Self, name: &str) -> Result<()> {
+    pub fn link(&self, old: &Self, name: &str, path_resolver: &PathResolver) -> Result<()> {
         if !Arc::ptr_eq(&old.mount, &self.mount) {
             return_errno_with_message!(Errno::EXDEV, "the operation cannot cross mounts");
         }
@@ -606,6 +618,7 @@ impl Path {
         let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
         old.check_hardlink_source()?;
         self.check_dir_entry_mutation()?;
+        security::file_link(old, self, name, path_resolver)?;
         dir_dentry.link(old.inode(), name)
     }
 

--- a/kernel/src/net/socket/unix/ctrl_msg.rs
+++ b/kernel/src/net/socket/unix/ctrl_msg.rs
@@ -15,7 +15,7 @@ use crate::{
     net::socket::util::{CControlHeader, ControlMessage},
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
-    security::lsm::hooks as lsm_hooks,
+    security::{self, FilePermission, lsm::hooks as lsm_hooks},
     util::net::CSocketOptionLevel,
 };
 
@@ -132,6 +132,7 @@ impl FileMessage {
         let current = Task::current().unwrap();
         let file_table = current.as_thread_local().unwrap().borrow_file_table();
         for file in self.files[..nfiles].iter() {
+            security::file_receive(file.path(), file_permissions_for_receive(file.as_ref()))?;
             // TODO: Deal with the `O_CLOEXEC` flag.
             let fd = file_table
                 .unwrap()
@@ -145,6 +146,27 @@ impl FileMessage {
 
         Ok(header)
     }
+}
+
+fn file_permissions_for_receive(file: &dyn FileLike) -> FilePermission {
+    let access_mode = file.access_mode();
+    let mut permissions = FilePermission::empty();
+
+    if access_mode.is_readable() {
+        permissions |= FilePermission::READ;
+    }
+    if access_mode.is_writable() {
+        if file
+            .status_flags()
+            .contains(crate::fs::file::StatusFlags::O_APPEND)
+        {
+            permissions |= FilePermission::APPEND;
+        } else {
+            permissions |= FilePermission::WRITE;
+        }
+    }
+
+    permissions
 }
 
 #[derive(Debug)]

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -10,6 +10,7 @@ use super::{
 use crate::{
     prelude::*,
     process::credentials::capabilities::{AtomicCapSet, CapSet},
+    security::AppArmorTaskState,
 };
 
 #[derive(Debug)]
@@ -75,6 +76,9 @@ pub(super) struct Credentials_ {
 
     /// Secure bits.
     securebits: AtomicSecureBits,
+
+    /// The AppArmor task confinement state.
+    apparmor: RwLock<AppArmorTaskState>,
 }
 
 impl Credentials_ {
@@ -101,6 +105,7 @@ impl Credentials_ {
             bounding_capset: AtomicCapSet::new(CapSet::all()),
             ambient_capset: AtomicCapSet::new(CapSet::empty()),
             securebits: AtomicSecureBits::new(SecureBits::new_empty()),
+            apparmor: RwLock::new(AppArmorTaskState::default()),
         }
     }
 
@@ -636,6 +641,16 @@ impl Credentials_ {
 
         self.securebits.try_store(securebits, Ordering::Relaxed)
     }
+
+    //  ******* AppArmor methods *******
+
+    pub(super) fn apparmor_task_state(&self) -> AppArmorTaskState {
+        self.apparmor.read().clone()
+    }
+
+    pub(super) fn set_apparmor_task_state(&self, task_state: AppArmorTaskState) {
+        *self.apparmor.write() = task_state;
+    }
 }
 
 impl Clone for Credentials_ {
@@ -656,6 +671,7 @@ impl Clone for Credentials_ {
             bounding_capset: self.bounding_capset.clone(),
             ambient_capset: self.ambient_capset.clone(),
             securebits: self.securebits.clone(),
+            apparmor: RwLock::new(self.apparmor.read().clone()),
         }
     }
 }

--- a/kernel/src/process/credentials/static_cap.rs
+++ b/kernel/src/process/credentials/static_cap.rs
@@ -5,7 +5,7 @@ use aster_rights_proc::require;
 use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 
 use super::{Credentials, Gid, SecureBits, Uid, capabilities::CapSet, credentials_::Credentials_};
-use crate::prelude::*;
+use crate::{prelude::*, security::AppArmorTaskState};
 
 impl<R: TRights> Credentials<R> {
     /// Creates a root `Credentials`.
@@ -402,5 +402,23 @@ impl<R: TRights> Credentials<R> {
     #[require(R > Write)]
     pub fn set_securebits(&self, securebits: SecureBits) -> Result<()> {
         self.0.set_securebits(securebits)
+    }
+
+    // *********** AppArmor methods **********
+
+    /// Gets the AppArmor task state.
+    ///
+    /// This method requires the `Read` right.
+    #[require(R > Read)]
+    pub fn apparmor_task_state(&self) -> AppArmorTaskState {
+        self.0.apparmor_task_state()
+    }
+
+    /// Sets the AppArmor task state.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn set_apparmor_task_state(&self, task_state: AppArmorTaskState) {
+        self.0.set_apparmor_task_state(task_state);
     }
 }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -28,6 +28,7 @@ use crate::{
             signals::kernel::KernelSignal,
         },
     },
+    security,
     vm::vmar::VmarHandle,
 };
 
@@ -167,8 +168,12 @@ fn do_execve_no_return(
     // while holding the process VMAR lock.
     // This prevents race conditions when checking access permissions while opening
     // `/proc/[pid]/mem` or `/proc/[pid]/maps`.
+    let fs_ref = thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
     let (vmar_guard, old_vmar) = activate_vmar(ctx, new_vmar);
-    apply_caps_from_exec(process, ctx.credentials_mut(), elf_file.inode())?;
+    let credentials = ctx.credentials_mut();
+    apply_caps_from_exec(process, &credentials, elf_file.inode())?;
+    security::bprm_committed_creds(&elf_file, &path_resolver, &credentials)?;
     drop(vmar_guard);
     drop(old_vmar);
 
@@ -308,7 +313,7 @@ fn set_cpu_context(
 /// The capabilities will be updated accordingly.
 fn apply_caps_from_exec(
     process: &Process,
-    credentials: Credentials<ReadWriteOp>,
+    credentials: &Credentials<ReadWriteOp>,
     elf_inode: &Arc<dyn Inode>,
 ) -> Result<()> {
     let mode = elf_inode.mode()?;
@@ -330,8 +335,8 @@ fn apply_caps_from_exec(
     if set_uid.is_some() || set_gid.is_some() {
         credentials.clear_ambient_capset();
     }
-    apply_set_uid(process, &credentials, set_uid);
-    apply_set_gid(process, &credentials, set_gid);
+    apply_set_uid(process, credentials, set_uid);
+    apply_set_gid(process, credentials, set_gid);
     credentials.set_keep_capabilities(false)?;
 
     Ok(())

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         posix_thread::ptrace::TraceeStatus,
         signal::{PauseReason, PollHandle, sig_mask::SigMask},
     },
+    security::AppArmorTaskState,
     thread::{Thread, Tid},
     time::{Timer, TimerManager, clocks::ProfClock, timer::TimerGuard},
 };
@@ -306,6 +307,11 @@ impl PosixThread {
     /// Gets the duplicatable read-only credentials of the thread.
     pub fn credentials_dup(&self) -> Credentials<ReadDupOp> {
         self.credentials.dup().restrict()
+    }
+
+    /// Sets the AppArmor task state attached to this thread's credentials.
+    pub(crate) fn set_apparmor_task_state(&self, task_state: AppArmorTaskState) {
+        self.credentials.set_apparmor_task_state(task_state);
     }
 
     /// Returns the I/O priority value of the thread.

--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -17,6 +17,7 @@ use crate::{
         process_vm::{AuxKey, AuxVec},
         program_loader::check_executable_inode,
     },
+    security,
     util::random::getrandom,
     vm::{
         perms::VmPerms,
@@ -62,7 +63,7 @@ pub fn load_elf_to_vmar(
         expect(unused_mut)
     )]
     let (elf_mapped_info, entry_point, mut aux_vec) =
-        map_vmos_and_build_aux_vec(vmar, ldso, &elf_headers, &elf_file)?;
+        map_vmos_and_build_aux_vec(vmar, ldso, &elf_headers, &elf_file, path_resolver)?;
     vmar.process_vm()
         .set_code_range(elf_mapped_info.code_range.clone());
     vmar.process_vm()
@@ -142,6 +143,7 @@ fn map_vmos_and_build_aux_vec(
     ldso: Option<(Path, ElfHeaders)>,
     parsed_elf: &ElfHeaders,
     elf_file: &Path,
+    path_resolver: &PathResolver,
 ) -> Result<(ElfMappedInfo, Vaddr, AuxVec)> {
     let ldso_load_info = if let Some((ldso_file, ldso_elf)) = ldso {
         Some(load_ldso(vmar, &ldso_file, &ldso_elf)?)
@@ -160,7 +162,10 @@ fn map_vmos_and_build_aux_vec(
 
     // Set AT_SECURE based on setuid/setgid bits of the executable file.
     let mode = elf_file.inode().mode()?;
-    let secure = if mode.has_set_uid() || mode.has_set_gid() {
+    let secure = if mode.has_set_uid()
+        || mode.has_set_gid()
+        || security::bprm_secureexec(elf_file, path_resolver)?
+    {
         1
     } else {
         0

--- a/kernel/src/process/program_loader/mod.rs
+++ b/kernel/src/process/program_loader/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         },
     },
     prelude::*,
+    security,
     vm::vmar::Vmar,
 };
 
@@ -40,6 +41,7 @@ impl ProgramToLoad {
         envp: Vec<CString>,
     ) -> Result<Self> {
         check_executable_inode(elf_file.inode().as_ref())?;
+        security::bprm_check_security(&elf_file, path_resolver)?;
 
         // A limit to the recursion depth of shebang executables.
         //
@@ -70,6 +72,7 @@ impl ProgramToLoad {
                 path_resolver.lookup(&fs_path)?
             };
             check_executable_inode(interpreter.inode().as_ref())?;
+            security::bprm_check_security(&interpreter, path_resolver)?;
 
             // Update the argument list and the executable inode. Then, try again.
             new_argv.extend(argv);

--- a/kernel/src/security/lsm/hooks/bprm.rs
+++ b/kernel/src/security/lsm/hooks/bprm.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_rights::ReadWriteOp;
+
+use super::super::modules;
+use crate::{
+    fs::vfs::path::{Path, PathResolver},
+    prelude::*,
+    process::Credentials,
+};
+
+/// Runs executable image check hooks in module order.
+pub fn on_bprm_check_security(context: &BprmCheckContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_bprm_check_security(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs post-exec credential hooks in module order.
+pub fn on_bprm_committed_creds(context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_bprm_committed_creds(context)?;
+    }
+
+    Ok(())
+}
+
+/// Returns whether the executable should run in secure-execution mode.
+pub fn on_bprm_secureexec(context: &BprmCheckContext<'_>) -> Result<bool> {
+    let mut secureexec = false;
+    for module in modules::active_modules() {
+        secureexec |= module.on_bprm_secureexec(context)?;
+    }
+
+    Ok(secureexec)
+}
+
+/// The inputs for an executable image security check.
+pub struct BprmCheckContext<'a> {
+    executable: &'a Path,
+    path_resolver: &'a PathResolver,
+}
+
+impl<'a> BprmCheckContext<'a> {
+    /// Creates an executable image check context.
+    pub const fn new(executable: &'a Path, path_resolver: &'a PathResolver) -> Self {
+        Self {
+            executable,
+            path_resolver,
+        }
+    }
+
+    /// Returns the executable path.
+    pub const fn executable(&self) -> &'a Path {
+        self.executable
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+}
+
+/// The inputs for an executable-label transition after credentials are committed.
+pub struct BprmCommittedCredsContext<'a> {
+    executable: &'a Path,
+    path_resolver: &'a PathResolver,
+    credentials: &'a Credentials<ReadWriteOp>,
+}
+
+impl<'a> BprmCommittedCredsContext<'a> {
+    /// Creates a post-exec credential context.
+    pub const fn new(
+        executable: &'a Path,
+        path_resolver: &'a PathResolver,
+        credentials: &'a Credentials<ReadWriteOp>,
+    ) -> Self {
+        Self {
+            executable,
+            path_resolver,
+            credentials,
+        }
+    }
+
+    /// Returns the executable path.
+    pub const fn executable(&self) -> &'a Path {
+        self.executable
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the committed credentials.
+    pub const fn credentials(&self) -> &'a Credentials<ReadWriteOp> {
+        self.credentials
+    }
+}

--- a/kernel/src/security/lsm/hooks/file.rs
+++ b/kernel/src/security/lsm/hooks/file.rs
@@ -1,0 +1,633 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    fs::{
+        file::{AccessMode, StatusFlags},
+        vfs::{
+            inode::RenameMode,
+            path::{Path, PathResolver},
+        },
+    },
+    prelude::*,
+};
+
+/// Runs file open hooks in module order.
+pub fn on_file_open(context: &FileOpenContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_open(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file creation hooks in module order.
+pub fn on_file_create(context: &FileCreateContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_create(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file deletion hooks in module order.
+pub fn on_file_delete(context: &FileDeleteContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_delete(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file link hooks in module order.
+pub fn on_file_link(context: &FileLinkContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_link(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file rename hooks in module order.
+pub fn on_file_rename(context: &FileRenameContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_rename(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file attribute-change hooks in module order.
+pub fn on_file_setattr(context: &FileSetattrContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_setattr(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file permission revalidation hooks in module order.
+pub fn on_file_permission(context: &FilePermissionContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_permission(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file mmap hooks in module order.
+pub fn on_file_mmap(context: &FileMmapContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_mmap(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file receive hooks in module order.
+pub fn on_file_receive(context: &FileReceiveContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_receive(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file lock hooks in module order.
+pub fn on_file_lock(context: &FileLockContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_lock(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs file metadata query hooks in module order.
+pub fn on_file_getattr(context: &FileGetattrContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_getattr(context)?;
+    }
+
+    Ok(())
+}
+
+bitflags! {
+    /// File permissions requested from LSM file hooks.
+    pub struct FilePermission: u32 {
+        /// Reads file contents, directory entries, or file metadata.
+        const READ = 1 << 0;
+        /// Writes file contents.
+        const WRITE = 1 << 1;
+        /// Executes file contents.
+        const EXECUTE = 1 << 2;
+        /// Appends file contents.
+        const APPEND = 1 << 3;
+        /// Creates executable file mappings.
+        const MMAP = 1 << 4;
+    }
+}
+
+/// The inputs for checking a newly opened file.
+pub struct FileOpenContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+    access_mode: AccessMode,
+    status_flags: StatusFlags,
+}
+
+impl<'a> FileOpenContext<'a> {
+    /// Creates a file open context.
+    pub const fn new(
+        path: &'a Path,
+        path_resolver: &'a PathResolver,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Self {
+        Self {
+            path,
+            path_resolver,
+            access_mode,
+            status_flags,
+        }
+    }
+
+    /// Returns the path being opened.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the requested access mode.
+    pub const fn access_mode(&self) -> AccessMode {
+        self.access_mode
+    }
+
+    /// Returns the open status flags.
+    pub const fn status_flags(&self) -> StatusFlags {
+        self.status_flags
+    }
+}
+
+/// The inputs for checking access through an existing opened file.
+pub struct FilePermissionContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+    permissions: FilePermission,
+}
+
+impl<'a> FilePermissionContext<'a> {
+    /// Creates a file permission context.
+    pub const fn new(
+        path: &'a Path,
+        path_resolver: &'a PathResolver,
+        permissions: FilePermission,
+    ) -> Self {
+        Self {
+            path,
+            path_resolver,
+            permissions,
+        }
+    }
+
+    /// Returns the path being accessed.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the requested permissions.
+    pub const fn permissions(&self) -> FilePermission {
+        self.permissions
+    }
+}
+
+/// The inputs for checking a file-backed mapping.
+pub struct FileMmapContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+    permissions: FilePermission,
+}
+
+impl<'a> FileMmapContext<'a> {
+    /// Creates a file mmap context.
+    pub const fn new(
+        path: &'a Path,
+        path_resolver: &'a PathResolver,
+        permissions: FilePermission,
+    ) -> Self {
+        Self {
+            path,
+            path_resolver,
+            permissions,
+        }
+    }
+
+    /// Returns the path being mapped.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the requested permissions.
+    pub const fn permissions(&self) -> FilePermission {
+        self.permissions
+    }
+}
+
+/// The inputs for checking a file descriptor received from another task.
+pub struct FileReceiveContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+    permissions: FilePermission,
+}
+
+impl<'a> FileReceiveContext<'a> {
+    /// Creates a file receive context.
+    pub const fn new(
+        path: &'a Path,
+        path_resolver: &'a PathResolver,
+        permissions: FilePermission,
+    ) -> Self {
+        Self {
+            path,
+            path_resolver,
+            permissions,
+        }
+    }
+
+    /// Returns the received file's path.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the permissions carried by the received file.
+    pub const fn permissions(&self) -> FilePermission {
+        self.permissions
+    }
+}
+
+/// The inputs for checking a file lock operation.
+pub struct FileLockContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+    permissions: FilePermission,
+}
+
+impl<'a> FileLockContext<'a> {
+    /// Creates a file lock context.
+    pub const fn new(
+        path: &'a Path,
+        path_resolver: &'a PathResolver,
+        permissions: FilePermission,
+    ) -> Self {
+        Self {
+            path,
+            path_resolver,
+            permissions,
+        }
+    }
+
+    /// Returns the locked file's path.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the permissions needed for the lock.
+    pub const fn permissions(&self) -> FilePermission {
+        self.permissions
+    }
+}
+
+/// The inputs for checking a file metadata query.
+pub struct FileGetattrContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+}
+
+impl<'a> FileGetattrContext<'a> {
+    /// Creates a file metadata query context.
+    pub const fn new(path: &'a Path, path_resolver: &'a PathResolver) -> Self {
+        Self {
+            path,
+            path_resolver,
+        }
+    }
+
+    /// Returns the queried file's path.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+}
+
+/// The kind of filesystem object being created.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FileCreateKind {
+    /// A regular file.
+    Regular,
+    /// A directory.
+    Directory,
+    /// A device node.
+    Device,
+    /// A named pipe.
+    Fifo,
+    /// A symbolic link.
+    Symlink,
+}
+
+/// The inputs for checking a file that will be created and opened.
+pub struct FileCreateContext<'a> {
+    parent: &'a Path,
+    name: Option<&'a str>,
+    path_resolver: &'a PathResolver,
+    kind: FileCreateKind,
+    access_mode: Option<AccessMode>,
+    status_flags: StatusFlags,
+}
+
+impl<'a> FileCreateContext<'a> {
+    /// Creates a file creation context.
+    pub const fn new(
+        parent: &'a Path,
+        name: Option<&'a str>,
+        path_resolver: &'a PathResolver,
+        kind: FileCreateKind,
+        access_mode: Option<AccessMode>,
+        status_flags: StatusFlags,
+    ) -> Self {
+        Self {
+            parent,
+            name,
+            path_resolver,
+            kind,
+            access_mode,
+            status_flags,
+        }
+    }
+
+    /// Returns the parent directory path.
+    pub const fn parent(&self) -> &'a Path {
+        self.parent
+    }
+
+    /// Returns the basename that will be created, if the object is named.
+    pub const fn name(&self) -> Option<&'a str> {
+        self.name
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the kind of filesystem object being created.
+    pub const fn kind(&self) -> FileCreateKind {
+        self.kind
+    }
+
+    /// Returns the requested access mode for the opened file.
+    pub const fn access_mode(&self) -> Option<AccessMode> {
+        self.access_mode
+    }
+
+    /// Returns the open status flags.
+    pub const fn status_flags(&self) -> StatusFlags {
+        self.status_flags
+    }
+}
+
+/// The kind of filesystem object being deleted.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FileDeleteKind {
+    /// A non-directory name removed by `unlink`.
+    NonDirectory,
+    /// A directory removed by `rmdir`.
+    Directory,
+}
+
+/// The kind of file attribute being changed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FileSetattrKind {
+    /// File mode bits.
+    Mode,
+    /// File owner or group.
+    Owner,
+    /// File size.
+    Size,
+    /// File timestamps.
+    Times,
+}
+
+/// The inputs for checking a file attribute change.
+pub struct FileSetattrContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+    kind: FileSetattrKind,
+}
+
+impl<'a> FileSetattrContext<'a> {
+    /// Creates a file attribute-change context.
+    pub const fn new(
+        path: &'a Path,
+        path_resolver: &'a PathResolver,
+        kind: FileSetattrKind,
+    ) -> Self {
+        Self {
+            path,
+            path_resolver,
+            kind,
+        }
+    }
+
+    /// Returns the path whose attributes will change.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the kind of attribute being changed.
+    pub const fn kind(&self) -> FileSetattrKind {
+        self.kind
+    }
+}
+
+/// The inputs for checking a file deletion.
+pub struct FileDeleteContext<'a> {
+    parent: &'a Path,
+    name: &'a str,
+    path_resolver: &'a PathResolver,
+    kind: FileDeleteKind,
+}
+
+impl<'a> FileDeleteContext<'a> {
+    /// Creates a file deletion context.
+    pub const fn new(
+        parent: &'a Path,
+        name: &'a str,
+        path_resolver: &'a PathResolver,
+        kind: FileDeleteKind,
+    ) -> Self {
+        Self {
+            parent,
+            name,
+            path_resolver,
+            kind,
+        }
+    }
+
+    /// Returns the parent directory path.
+    pub const fn parent(&self) -> &'a Path {
+        self.parent
+    }
+
+    /// Returns the basename that will be deleted.
+    pub const fn name(&self) -> &'a str {
+        self.name
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the kind of filesystem object being deleted.
+    pub const fn kind(&self) -> FileDeleteKind {
+        self.kind
+    }
+}
+
+/// The inputs for checking a hard-link creation.
+pub struct FileLinkContext<'a> {
+    source: &'a Path,
+    target_parent: &'a Path,
+    target_name: &'a str,
+    path_resolver: &'a PathResolver,
+}
+
+impl<'a> FileLinkContext<'a> {
+    /// Creates a file link context.
+    pub const fn new(
+        source: &'a Path,
+        target_parent: &'a Path,
+        target_name: &'a str,
+        path_resolver: &'a PathResolver,
+    ) -> Self {
+        Self {
+            source,
+            target_parent,
+            target_name,
+            path_resolver,
+        }
+    }
+
+    /// Returns the existing source path.
+    pub const fn source(&self) -> &'a Path {
+        self.source
+    }
+
+    /// Returns the target parent directory path.
+    pub const fn target_parent(&self) -> &'a Path {
+        self.target_parent
+    }
+
+    /// Returns the target basename.
+    pub const fn target_name(&self) -> &'a str {
+        self.target_name
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+}
+
+/// The inputs for checking a rename operation.
+pub struct FileRenameContext<'a> {
+    source: &'a Path,
+    new_parent: &'a Path,
+    new_name: &'a str,
+    target: Option<&'a Path>,
+    path_resolver: &'a PathResolver,
+    mode: RenameMode,
+}
+
+impl<'a> FileRenameContext<'a> {
+    /// Creates a file rename context.
+    pub const fn new(
+        source: &'a Path,
+        new_parent: &'a Path,
+        new_name: &'a str,
+        target: Option<&'a Path>,
+        path_resolver: &'a PathResolver,
+        mode: RenameMode,
+    ) -> Self {
+        Self {
+            source,
+            new_parent,
+            new_name,
+            target,
+            path_resolver,
+            mode,
+        }
+    }
+
+    /// Returns the source path.
+    pub const fn source(&self) -> &'a Path {
+        self.source
+    }
+
+    /// Returns the target parent directory path.
+    pub const fn new_parent(&self) -> &'a Path {
+        self.new_parent
+    }
+
+    /// Returns the target basename.
+    pub const fn new_name(&self) -> &'a str {
+        self.new_name
+    }
+
+    /// Returns the existing target path, if the target name already exists.
+    pub const fn target(&self) -> Option<&'a Path> {
+        self.target
+    }
+
+    /// Returns the resolver that defines the caller-visible path namespace.
+    pub const fn path_resolver(&self) -> &'a PathResolver {
+        self.path_resolver
+    }
+
+    /// Returns the requested rename mode.
+    pub const fn mode(&self) -> RenameMode {
+        self.mode
+    }
+}

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -3,11 +3,25 @@
 //! LSM hook points.
 
 mod alien_access;
+mod bprm;
 mod capability;
+mod file;
 
 pub use self::{
     alien_access::{AlienAccessContext, on_alien_access},
+    bprm::{
+        BprmCheckContext, BprmCommittedCredsContext, on_bprm_check_security,
+        on_bprm_committed_creds, on_bprm_secureexec,
+    },
     capability::{CapableContext, on_capable},
+    file::{
+        FileCreateContext, FileCreateKind, FileDeleteContext, FileDeleteKind, FileGetattrContext,
+        FileLinkContext, FileLockContext, FileMmapContext, FileOpenContext, FilePermission,
+        FilePermissionContext, FileReceiveContext, FileRenameContext, FileSetattrContext,
+        FileSetattrKind, on_file_create, on_file_delete, on_file_getattr, on_file_link,
+        on_file_lock, on_file_mmap, on_file_open, on_file_permission, on_file_receive,
+        on_file_rename, on_file_setattr,
+    },
 };
 use crate::prelude::*;
 
@@ -21,6 +35,80 @@ pub(super) trait LsmAlienAccessHook: Sync {
 pub(super) trait LsmCapabilityHook: Sync {
     /// Checks whether a thread holds a capability in a user namespace.
     fn on_capable(&self, _context: &CapableContext) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmBprmHook: Sync {
+    /// Checks whether an executable image may be loaded.
+    fn on_bprm_check_security(&self, _context: &BprmCheckContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Updates security state after executable credentials are committed.
+    fn on_bprm_committed_creds(&self, _context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Returns whether the executable should run in secure-execution mode.
+    fn on_bprm_secureexec(&self, _context: &BprmCheckContext<'_>) -> Result<bool> {
+        Ok(false)
+    }
+}
+
+pub(super) trait LsmFileHook: Sync {
+    /// Checks whether a file may be created and opened.
+    fn on_file_create(&self, _context: &FileCreateContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a filesystem object may be deleted.
+    fn on_file_delete(&self, _context: &FileDeleteContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a hard link may be created.
+    fn on_file_link(&self, _context: &FileLinkContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a new file handle may be opened.
+    fn on_file_open(&self, _context: &FileOpenContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a filesystem object may be renamed.
+    fn on_file_rename(&self, _context: &FileRenameContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether file attributes may be changed.
+    fn on_file_setattr(&self, _context: &FileSetattrContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Revalidates access through an existing opened file.
+    fn on_file_permission(&self, _context: &FilePermissionContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a file may be mapped.
+    fn on_file_mmap(&self, _context: &FileMmapContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a file descriptor may be received.
+    fn on_file_receive(&self, _context: &FileReceiveContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a file may be locked.
+    fn on_file_lock(&self, _context: &FileLockContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether file metadata may be queried.
+    fn on_file_getattr(&self, _context: &FileGetattrContext<'_>) -> Result<()> {
         Ok(())
     }
 }

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -7,8 +7,9 @@
 //! inspect common hook contexts before allowing or rejecting an operation.
 //!
 //! This module defines the common LSM traits and hook contexts shared by
-//! built-in modules such as `capability` and `yama`. Module selection follows
-//! the `lsm=` and legacy `security=` kernel command-line parameters.
+//! built-in modules such as `capability`, `yama`, and `apparmor`. Module
+//! selection follows the `lsm=` and legacy `security=` kernel command-line
+//! parameters.
 
 pub mod hooks;
 mod modules;
@@ -17,8 +18,26 @@ pub mod yama {
     pub use super::modules::yama::{YamaScope, get_scope, set_scope};
 }
 
-use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook};
-use crate::prelude::*;
+pub mod apparmor {
+    pub use super::modules::apparmor::{
+        AppArmorMode, AppArmorPolicyOperation, AppArmorProfileName, AppArmorTaskState,
+        change_onexec_state, change_profile_state, has_binary_policy_magic, load_binary_policy,
+        load_policy, profile_summaries, remove_profile_by_name, root_namespace_name,
+    };
+}
+
+use self::hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook};
+pub use self::{
+    apparmor::{AppArmorMode, AppArmorPolicyOperation, AppArmorProfileName, AppArmorTaskState},
+    hooks::{
+        BprmCheckContext, BprmCommittedCredsContext, CapableContext, FileCreateContext,
+        FileCreateKind, FileDeleteContext, FileDeleteKind, FileGetattrContext, FileLinkContext,
+        FileLockContext, FileMmapContext, FileOpenContext, FilePermission, FilePermissionContext,
+        FileReceiveContext, FileRenameContext, FileSetattrContext, FileSetattrKind,
+    },
+    yama::YamaScope,
+};
+use crate::{prelude::*, process::posix_thread::PosixThread};
 
 bitflags! {
     /// LSM module flags.
@@ -31,7 +50,7 @@ bitflags! {
 }
 
 /// The common interface for built-in LSM modules.
-trait LsmModule: LsmAlienAccessHook + LsmCapabilityHook + Sync {
+trait LsmModule: LsmAlienAccessHook + LsmBprmHook + LsmCapabilityHook + LsmFileHook + Sync {
     /// Returns the module name.
     fn name(&self) -> &'static str;
 
@@ -46,8 +65,144 @@ pub fn is_yama_enabled() -> bool {
         .any(|module| module.name() == "yama")
 }
 
+/// Returns whether the AppArmor LSM is enabled.
+pub fn is_apparmor_enabled() -> bool {
+    modules::active_modules()
+        .iter()
+        .any(|module| module.name() == "apparmor")
+}
+
+/// Returns the AppArmor task state for a POSIX thread if the module is active.
+pub fn apparmor_task_state(posix_thread: &PosixThread) -> Option<AppArmorTaskState> {
+    is_apparmor_enabled().then(|| posix_thread.credentials().apparmor_task_state())
+}
+
+/// Loads, replaces, or removes an AppArmor profile from policy text.
+pub fn load_apparmor_policy(policy_text: &str) -> Result<()> {
+    apparmor::load_policy(policy_text)
+}
+
+/// Loads, replaces, or removes an AppArmor profile from binary policy data.
+pub fn load_apparmor_binary_policy(
+    policy: &[u8],
+    expected_operation: AppArmorPolicyOperation,
+) -> Result<()> {
+    apparmor::load_binary_policy(policy, expected_operation)
+}
+
+/// Returns whether the data starts with the AppArmor binary policy magic.
+pub fn has_apparmor_binary_policy_magic(policy: &[u8]) -> bool {
+    apparmor::has_binary_policy_magic(policy)
+}
+
+/// Removes a loaded AppArmor profile by name.
+pub fn remove_apparmor_profile_by_name(profile_name: &str) -> Result<()> {
+    apparmor::remove_profile_by_name(profile_name)
+}
+
+/// Returns summaries of the implicit and loaded AppArmor profiles.
+pub fn apparmor_profile_summaries() -> Vec<(AppArmorProfileName, AppArmorMode)> {
+    apparmor::profile_summaries()
+}
+
+/// Returns the root AppArmor policy namespace name.
+pub fn apparmor_root_namespace_name() -> &'static str {
+    apparmor::root_namespace_name()
+}
+
+/// Creates task state after a mediated immediate AppArmor profile change.
+pub fn apparmor_change_profile_state(
+    task_state: &AppArmorTaskState,
+    profile_name: &str,
+) -> Result<AppArmorTaskState> {
+    apparmor::change_profile_state(task_state, profile_name)
+}
+
+/// Creates task state after a mediated AppArmor change-on-exec request.
+pub fn apparmor_change_onexec_state(
+    task_state: &AppArmorTaskState,
+    profile_name: Option<&str>,
+) -> Result<AppArmorTaskState> {
+    apparmor::change_onexec_state(task_state, profile_name)
+}
+
 pub(super) fn init() {
     for module in modules::active_modules() {
         info!("[kernel] LSM module enabled: {}", module.name());
     }
+}
+
+/// Runs the LSM stack for a capability check.
+pub fn capable(context: CapableContext<'_>) -> Result<()> {
+    hooks::on_capable(context)
+}
+
+/// Runs the LSM stack for an executable image check.
+pub fn bprm_check_security(context: &BprmCheckContext<'_>) -> Result<()> {
+    hooks::on_bprm_check_security(context)
+}
+
+/// Runs the LSM stack after executable credentials are committed.
+pub fn bprm_committed_creds(context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+    hooks::on_bprm_committed_creds(context)
+}
+
+/// Returns whether the executable should run in secure-execution mode.
+pub fn bprm_secureexec(context: &BprmCheckContext<'_>) -> Result<bool> {
+    hooks::on_bprm_secureexec(context)
+}
+
+/// Runs the LSM stack for a file open check.
+pub fn file_open(context: &FileOpenContext<'_>) -> Result<()> {
+    hooks::on_file_open(context)
+}
+
+/// Runs the LSM stack for a file creation check.
+pub fn file_create(context: &FileCreateContext<'_>) -> Result<()> {
+    hooks::on_file_create(context)
+}
+
+/// Runs the LSM stack for a file deletion check.
+pub fn file_delete(context: &FileDeleteContext<'_>) -> Result<()> {
+    hooks::on_file_delete(context)
+}
+
+/// Runs the LSM stack for a file link check.
+pub fn file_link(context: &FileLinkContext<'_>) -> Result<()> {
+    hooks::on_file_link(context)
+}
+
+/// Runs the LSM stack for a file rename check.
+pub fn file_rename(context: &FileRenameContext<'_>) -> Result<()> {
+    hooks::on_file_rename(context)
+}
+
+/// Runs the LSM stack for a file attribute-change check.
+pub fn file_setattr(context: &FileSetattrContext<'_>) -> Result<()> {
+    hooks::on_file_setattr(context)
+}
+
+/// Runs the LSM stack for a file permission revalidation check.
+pub fn file_permission(context: &FilePermissionContext<'_>) -> Result<()> {
+    hooks::on_file_permission(context)
+}
+
+/// Runs the LSM stack for a file mmap check.
+pub fn file_mmap(context: &FileMmapContext<'_>) -> Result<()> {
+    hooks::on_file_mmap(context)
+}
+
+/// Runs the LSM stack for a file receive check.
+pub fn file_receive(context: &FileReceiveContext<'_>) -> Result<()> {
+    hooks::on_file_receive(context)
+}
+
+/// Runs the LSM stack for a file lock check.
+pub fn file_lock(context: &FileLockContext<'_>) -> Result<()> {
+    hooks::on_file_lock(context)
+}
+
+/// Runs the LSM stack for a file metadata query check.
+pub fn file_getattr(context: &FileGetattrContext<'_>) -> Result<()> {
+    hooks::on_file_getattr(context)
 }

--- a/kernel/src/security/lsm/modules/apparmor/attachment.rs
+++ b/kernel/src/security/lsm/modules/apparmor/attachment.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{
+    dfa::AppArmorDfaFilePolicy,
+    path::{AppArmorPathPattern, AppArmorPathView},
+    profile::AppArmorProfileName,
+};
+use crate::prelude::*;
+
+/// A profile attachment matcher.
+///
+/// Linux AppArmor uses profile attachments to choose a profile when an
+/// executable image is committed. Asterinas keeps the matcher separate from
+/// file mediation so path-based MAC remains independent from exec attachment.
+#[derive(Clone, Debug)]
+pub(super) struct AppArmorAttachment {
+    pattern: Option<AppArmorPathPattern>,
+    policy: Option<AppArmorDfaFilePolicy>,
+}
+
+impl AppArmorAttachment {
+    /// Creates an attachment from optional text and DFA matchers.
+    pub(super) fn new(
+        pattern: Option<AppArmorPathPattern>,
+        policy: Option<AppArmorDfaFilePolicy>,
+    ) -> Self {
+        Self { pattern, policy }
+    }
+
+    /// Creates the attachment implied by Linux profile syntax.
+    pub(super) fn from_profile(
+        profile_name: &AppArmorProfileName,
+        attach: Option<String>,
+        policy: Option<AppArmorDfaFilePolicy>,
+    ) -> Self {
+        let pattern = attach
+            .or_else(|| {
+                profile_name
+                    .as_str()
+                    .starts_with('/')
+                    .then(|| profile_name.as_str().into())
+            })
+            .map(AppArmorPathPattern::new);
+
+        Self::new(pattern, policy)
+    }
+
+    /// Returns whether the attachment selects a profile for `path_view`.
+    pub(super) fn matches(&self, path_view: &AppArmorPathView) -> bool {
+        if !path_view.is_reachable() {
+            return false;
+        }
+
+        if let Some(policy) = &self.policy
+            && policy.matches_path(path_view)
+        {
+            return true;
+        }
+
+        self.pattern
+            .as_ref()
+            .is_some_and(|pattern| pattern.matches(path_view))
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/binary.rs
+++ b/kernel/src/security/lsm/modules/apparmor/binary.rs
@@ -1,0 +1,939 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::str;
+
+use super::{
+    attachment::AppArmorAttachment,
+    capability::AppArmorCapabilityPolicy,
+    dfa::{AppArmorDfa, AppArmorDfaFilePolicy, AppArmorDfaPermissions},
+    path::{
+        AppArmorExecMode, AppArmorExecTransition, AppArmorFilePermission, AppArmorPathPattern,
+        AppArmorPathRule,
+    },
+    policy_update::AppArmorPolicyUpdate,
+    profile::{AppArmorFilePolicy, AppArmorProfile, AppArmorProfileName},
+    state::AppArmorMode,
+};
+use crate::{prelude::*, process::credentials::capabilities::CapSet};
+
+const ASTERINAS_MAGIC: &[u8; 8] = b"AASTAA01";
+const ASTERINAS_OP_REPLACE: u8 = 1;
+const ASTERINAS_OP_REMOVE: u8 = 2;
+const ASTERINAS_MODE_NONE: u8 = 0;
+const ASTERINAS_MODE_ENFORCE: u8 = 1;
+const ASTERINAS_MODE_COMPLAIN: u8 = 2;
+const ASTERINAS_TRANSITION_INHERIT: u8 = 0;
+const ASTERINAS_TRANSITION_UNCONFINED: u8 = 1;
+const ASTERINAS_TRANSITION_PROFILE: u8 = 2;
+const ASTERINAS_RULE_DENY: u8 = 1 << 0;
+const ASTERINAS_RULE_AUDIT: u8 = 1 << 1;
+const LINUX_MIN_ABI_VERSION: u32 = 5;
+const LINUX_MAX_ABI_VERSION: u32 = 9;
+const LINUX_FORCE_COMPLAIN_FLAG: u32 = 1 << 11;
+const LINUX_KERNEL_ABI_MASK: u32 = 0x3ff;
+const LINUX_PACKED_MODE_ENFORCE: u32 = 0;
+const LINUX_PACKED_MODE_COMPLAIN: u32 = 1;
+const LINUX_PACKED_MODE_KILL: u32 = 2;
+const LINUX_PACKED_MODE_UNCONFINED: u32 = 3;
+const LINUX_PACKED_MODE_USER: u32 = 4;
+const LINUX_PACKED_FLAG_HAT: u32 = 1;
+
+/// The expected policy operation for a securityfs policy control file.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AppArmorPolicyOperation {
+    /// Inserts or replaces a profile.
+    Replace,
+    /// Removes a profile.
+    Remove,
+}
+
+impl AppArmorPolicyOperation {
+    fn from_asterinas_opcode(opcode: u8) -> Result<Self> {
+        match opcode {
+            ASTERINAS_OP_REPLACE => Ok(Self::Replace),
+            ASTERINAS_OP_REMOVE => Ok(Self::Remove),
+            _ => return_errno_with_message!(Errno::EINVAL, "the AppArmor policy opcode is invalid"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LinuxCode {
+    U8 = 0,
+    U16 = 1,
+    U32 = 2,
+    U64 = 3,
+    Name = 4,
+    String = 5,
+    Blob = 6,
+    Struct = 7,
+    StructEnd = 8,
+    Array = 11,
+    ArrayEnd = 12,
+}
+
+impl LinuxCode {
+    fn from_byte(byte: u8) -> Result<Self> {
+        match byte {
+            0 => Ok(Self::U8),
+            1 => Ok(Self::U16),
+            2 => Ok(Self::U32),
+            3 => Ok(Self::U64),
+            4 => Ok(Self::Name),
+            5 => Ok(Self::String),
+            6 => Ok(Self::Blob),
+            7 => Ok(Self::Struct),
+            8 => Ok(Self::StructEnd),
+            11 => Ok(Self::Array),
+            12 => Ok(Self::ArrayEnd),
+            _ => return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor policy type code is invalid"
+            ),
+        }
+    }
+}
+
+/// Returns whether a byte slice starts with a legacy Asterinas AppArmor magic.
+pub fn has_binary_policy_magic(policy: &[u8]) -> bool {
+    policy.starts_with(ASTERINAS_MAGIC)
+}
+
+pub(super) fn unpack_binary_policy(
+    policy: &[u8],
+    expected_operation: AppArmorPolicyOperation,
+) -> Result<AppArmorPolicyUpdate> {
+    if policy.starts_with(ASTERINAS_MAGIC) {
+        unpack_asterinas_binary_policy(policy, expected_operation)
+    } else {
+        unpack_linux_binary_policy(policy, expected_operation)
+    }
+}
+
+fn unpack_asterinas_binary_policy(
+    policy: &[u8],
+    expected_operation: AppArmorPolicyOperation,
+) -> Result<AppArmorPolicyUpdate> {
+    let mut reader = BinaryReader::new(policy);
+    let magic = reader.read_bytes(ASTERINAS_MAGIC.len())?;
+    if magic != ASTERINAS_MAGIC {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor binary policy magic is invalid");
+    }
+
+    let operation = AppArmorPolicyOperation::from_asterinas_opcode(reader.read_u8()?)?;
+    if operation != expected_operation {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the AppArmor binary policy operation does not match the target file"
+        );
+    }
+
+    let mode = parse_asterinas_mode(reader.read_u8()?)?;
+    let _reserved = reader.read_u16()?;
+    let name_len = usize::from(reader.read_u16()?);
+    let rule_count = usize::from(reader.read_u16()?);
+    let profile_name = read_profile_name(&mut reader, name_len)?;
+
+    if profile_name.is_unconfined() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the implicit unconfined AppArmor profile cannot be changed"
+        );
+    }
+
+    let update = match operation {
+        AppArmorPolicyOperation::Replace => {
+            let Some(mode) = mode else {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "replacement AppArmor policies require a profile mode"
+                );
+            };
+            let mut rules = Vec::with_capacity(rule_count);
+            for _ in 0..rule_count {
+                rules.push(read_asterinas_rule(&mut reader)?);
+            }
+            AppArmorPolicyUpdate::Replace(Box::new(AppArmorProfile::new(profile_name, mode, rules)))
+        }
+        AppArmorPolicyOperation::Remove => {
+            if mode.is_some() || rule_count != 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "remove AppArmor policies must not carry mode or rules"
+                );
+            }
+            AppArmorPolicyUpdate::Remove(profile_name)
+        }
+    };
+
+    if reader.has_remaining() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the AppArmor binary policy has trailing bytes"
+        );
+    }
+
+    Ok(update)
+}
+
+fn unpack_linux_binary_policy(
+    policy: &[u8],
+    expected_operation: AppArmorPolicyOperation,
+) -> Result<AppArmorPolicyUpdate> {
+    if expected_operation != AppArmorPolicyOperation::Replace {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "Linux AppArmor remove operations are plain profile-name writes"
+        );
+    }
+
+    let mut reader = LinuxPolicyReader::new(policy);
+    let mut namespace: Option<String> = None;
+    let mut profiles = Vec::new();
+    while reader.has_remaining() {
+        let header = reader.read_header(profiles.is_empty(), namespace.as_deref())?;
+        if namespace.is_none() {
+            namespace = header.namespace;
+        }
+
+        profiles.push(reader.read_profile(header.force_complain)?);
+    }
+
+    if profiles.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor policy has no profiles");
+    }
+
+    Ok(AppArmorPolicyUpdate::ReplaceMany(profiles))
+}
+
+fn parse_asterinas_mode(mode: u8) -> Result<Option<AppArmorMode>> {
+    match mode {
+        ASTERINAS_MODE_NONE => Ok(None),
+        ASTERINAS_MODE_ENFORCE => Ok(Some(AppArmorMode::Enforce)),
+        ASTERINAS_MODE_COMPLAIN => Ok(Some(AppArmorMode::Complain)),
+        _ => return_errno_with_message!(Errno::EINVAL, "the AppArmor policy mode is invalid"),
+    }
+}
+
+fn read_profile_name(reader: &mut BinaryReader<'_>, len: usize) -> Result<AppArmorProfileName> {
+    AppArmorProfileName::new(read_string(reader, len)?)
+}
+
+fn read_asterinas_rule(reader: &mut BinaryReader<'_>) -> Result<AppArmorPathRule> {
+    let flags = reader.read_u8()?;
+    let transition = reader.read_u8()?;
+    let permissions = read_permissions(reader.read_u32()?)?;
+    let pattern_len = usize::from(reader.read_u16()?);
+    let target_len = usize::from(reader.read_u16()?);
+    let pattern = AppArmorPathPattern::new(read_string(reader, pattern_len)?);
+    let target = read_string(reader, target_len)?;
+
+    let deny = flags & ASTERINAS_RULE_DENY != 0;
+    let audit = flags & ASTERINAS_RULE_AUDIT != 0;
+    if flags & !(ASTERINAS_RULE_DENY | ASTERINAS_RULE_AUDIT) != 0 {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor rule flags are invalid");
+    }
+
+    let exec_transition = match transition {
+        ASTERINAS_TRANSITION_INHERIT => {
+            if !target.is_empty() {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "inherit AppArmor transitions must not name a target profile"
+                );
+            }
+            AppArmorExecTransition::Inherit
+        }
+        ASTERINAS_TRANSITION_UNCONFINED => {
+            if !target.is_empty() {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "unconfined AppArmor transitions must not name a target profile"
+                );
+            }
+            AppArmorExecTransition::unconfined(AppArmorExecMode::Unsafe)
+        }
+        ASTERINAS_TRANSITION_PROFILE => AppArmorExecTransition::profile(
+            AppArmorProfileName::new(target)?,
+            AppArmorExecMode::Unsafe,
+        ),
+        _ => return_errno_with_message!(Errno::EINVAL, "the AppArmor exec transition is invalid"),
+    };
+
+    if deny && exec_transition != AppArmorExecTransition::Inherit {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "deny rules cannot carry AppArmor exec transitions"
+        );
+    }
+    if exec_transition != AppArmorExecTransition::Inherit
+        && !permissions.contains(AppArmorFilePermission::EXECUTE)
+    {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "AppArmor exec transitions require execute permission"
+        );
+    }
+
+    Ok(AppArmorPathRule::new_with_transition(
+        pattern,
+        permissions,
+        exec_transition,
+        audit,
+        deny,
+    ))
+}
+
+fn read_permissions(bits: u32) -> Result<AppArmorFilePermission> {
+    let Some(permissions) = AppArmorFilePermission::from_bits(bits) else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor permissions are invalid");
+    };
+    if permissions.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor permissions are empty");
+    }
+
+    Ok(permissions)
+}
+
+fn read_capability_mask(low: u32, high: u32) -> Result<CapSet> {
+    let bits = u64::from(low) | (u64::from(high) << 32);
+    CapSet::try_from(bits).map_err(|_| {
+        Error::with_message(
+            Errno::EINVAL,
+            "the AppArmor capability mask contains unsupported capabilities",
+        )
+    })
+}
+
+fn read_string(reader: &mut BinaryReader<'_>, len: usize) -> Result<String> {
+    let bytes = reader.read_bytes(len)?;
+    let text = str::from_utf8(bytes)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the AppArmor string is not UTF-8"))?;
+    if text.bytes().any(|byte| byte == 0) {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor string contains a nul byte");
+    }
+
+    Ok(text.to_string())
+}
+
+struct LinuxHeader {
+    namespace: Option<String>,
+    force_complain: bool,
+}
+
+struct LinuxProfileFlags {
+    mode: AppArmorMode,
+}
+
+struct LinuxPolicyReader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+    abi_version: u32,
+}
+
+impl<'a> LinuxPolicyReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            offset: 0,
+            abi_version: 0,
+        }
+    }
+
+    fn has_remaining(&self) -> bool {
+        self.offset < self.bytes.len()
+    }
+
+    fn read_header(
+        &mut self,
+        required: bool,
+        previous_namespace: Option<&str>,
+    ) -> Result<LinuxHeader> {
+        let Some(version) = self.read_optional_u32("version")? else {
+            if required {
+                return_errno_with_message!(
+                    Errno::EPROTONOSUPPORT,
+                    "the AppArmor policy version is missing"
+                );
+            }
+            return Ok(LinuxHeader {
+                namespace: None,
+                force_complain: false,
+            });
+        };
+
+        let abi_version = decode_linux_abi_version(version);
+        if !(LINUX_MIN_ABI_VERSION..=LINUX_MAX_ABI_VERSION).contains(&abi_version) {
+            return_errno_with_message!(
+                Errno::EPROTONOSUPPORT,
+                "the AppArmor policy ABI version is unsupported"
+            );
+        }
+        self.abi_version = abi_version;
+
+        let namespace = self.read_optional_string("namespace")?;
+        if let Some(namespace) = namespace.as_deref() {
+            if namespace.is_empty() {
+                return_errno_with_message!(Errno::EINVAL, "the AppArmor namespace is empty");
+            }
+            if namespace != "root" {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "only the root AppArmor policy namespace is supported"
+                );
+            }
+        }
+        if let (Some(previous), Some(namespace)) = (previous_namespace, namespace.as_deref())
+            && previous != namespace
+        {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "one AppArmor policy payload cannot change namespaces"
+            );
+        }
+
+        Ok(LinuxHeader {
+            namespace,
+            force_complain: version & LINUX_FORCE_COMPLAIN_FLAG != 0,
+        })
+    }
+
+    fn read_profile(&mut self, force_complain: bool) -> Result<AppArmorProfile> {
+        self.expect_name_code(LinuxCode::Struct, Some("profile"))?;
+        let profile_name = AppArmorProfileName::new(self.read_string(None)?)?;
+        if profile_name.is_unconfined() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the implicit unconfined AppArmor profile cannot be loaded"
+            );
+        }
+
+        if self.read_optional_string("rename")?.is_some() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "renaming AppArmor profiles is not supported"
+            );
+        }
+        let attach = self.read_optional_string("attach")?;
+        let attach_policy = self.read_optional_attach_policy()?;
+        let _disconnected = self.read_optional_string("disconnected")?;
+        let _kill_signal = self.read_optional_u32("kill")?;
+
+        let profile = self.read_profile_flags(force_complain)?;
+        let _path_flags = self.read_optional_u32("path_flags")?;
+        let capability_policy = self.read_capabilities()?;
+        self.read_optional_xattrs()?;
+        self.read_optional_rlimits()?;
+        self.read_optional_secmark()?;
+        let domain_policy = self.read_optional_domain_policy()?;
+        let file_policy = self.read_file_policy()?;
+        self.read_optional_data_table()?;
+        self.expect_name_code(LinuxCode::StructEnd, None)?;
+
+        let attachment = AppArmorAttachment::from_profile(
+            &profile_name,
+            attach,
+            attach_policy.or(domain_policy),
+        );
+
+        Ok(AppArmorProfile::new_with_policies(
+            profile_name,
+            attachment,
+            profile.mode,
+            file_policy,
+            capability_policy,
+        ))
+    }
+
+    fn read_profile_flags(&mut self, force_complain: bool) -> Result<LinuxProfileFlags> {
+        self.expect_name_code(LinuxCode::Struct, Some("flags"))?;
+        let flags = self.read_u32(None)?;
+        if flags & LINUX_PACKED_FLAG_HAT != 0 {
+            return_errno_with_message!(Errno::EINVAL, "AppArmor hats are not supported");
+        }
+        let packed_mode = self.read_u32(None)?;
+        let _audit = self.read_u32(None)?;
+        self.expect_name_code(LinuxCode::StructEnd, None)?;
+
+        let mode = if force_complain || packed_mode == LINUX_PACKED_MODE_COMPLAIN {
+            AppArmorMode::Complain
+        } else if packed_mode == LINUX_PACKED_MODE_ENFORCE {
+            AppArmorMode::Enforce
+        } else if packed_mode == LINUX_PACKED_MODE_KILL
+            || packed_mode == LINUX_PACKED_MODE_UNCONFINED
+            || packed_mode == LINUX_PACKED_MODE_USER
+        {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile mode is not supported");
+        } else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile mode is invalid");
+        };
+
+        Ok(LinuxProfileFlags { mode })
+    }
+
+    fn read_capabilities(&mut self) -> Result<AppArmorCapabilityPolicy> {
+        let low_allow = self.read_u32(None)?;
+        let low_audit = self.read_u32(None)?;
+        let low_quiet = self.read_u32(None)?;
+        let low_reserved = self.read_u32(None)?;
+        let mut high_words = [0; 4];
+        if self.consume_name_code(LinuxCode::Struct, Some("caps64"))? {
+            for word in &mut high_words {
+                *word = self.read_u32(None)?;
+            }
+            self.expect_name_code(LinuxCode::StructEnd, None)?;
+        }
+        if self.consume_name_code(LinuxCode::Struct, Some("capsx"))? {
+            let extended_low = self.read_u32(None)?;
+            let extended_high = self.read_u32(None)?;
+            if extended_low != 0 || extended_high != 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "AppArmor capability mediation is not supported"
+                );
+            }
+            self.expect_name_code(LinuxCode::StructEnd, None)?;
+        }
+
+        if low_reserved != 0 || high_words[3] != 0 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "AppArmor capability kill mode is not supported"
+            );
+        }
+
+        Ok(AppArmorCapabilityPolicy::new(
+            read_capability_mask(low_allow, high_words[0])?,
+            read_capability_mask(low_audit, high_words[1])?,
+            read_capability_mask(low_quiet, high_words[2])?,
+        ))
+    }
+
+    fn read_optional_attach_policy(&mut self) -> Result<Option<AppArmorDfaFilePolicy>> {
+        let position = self.offset;
+        match self.read_policydb(false, false)? {
+            Some(policy) => Ok(Some(policy)),
+            None => {
+                self.offset = position;
+                Ok(None)
+            }
+        }
+    }
+
+    fn read_optional_domain_policy(&mut self) -> Result<Option<AppArmorDfaFilePolicy>> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("policydb"))? {
+            return Ok(None);
+        }
+
+        // Linux emits a profile-domain policydb before the file mediation policy.
+        let domain_policy = self.read_policydb(true, false)?;
+        self.expect_name_code(LinuxCode::StructEnd, None)?;
+        Ok(domain_policy)
+    }
+
+    fn read_file_policy(&mut self) -> Result<AppArmorFilePolicy> {
+        let Some(policy) = self.read_policydb(false, true)? else {
+            return Ok(AppArmorFilePolicy::PathRules(Vec::new()));
+        };
+        Ok(AppArmorFilePolicy::Dfa(Box::new(policy)))
+    }
+
+    fn read_policydb(
+        &mut self,
+        required_dfa: bool,
+        required_transitions: bool,
+    ) -> Result<Option<AppArmorDfaFilePolicy>> {
+        self.skip_optional_tags()?;
+        let permissions = self.read_optional_permissions_table()?;
+        let _perms_version = self.read_optional_u32("permsv")?;
+        let dfa = self.read_optional_dfa()?;
+        let start = self
+            .read_optional_u32("start")?
+            .or(self.read_optional_u32("dfa_start")?)
+            .unwrap_or(1);
+        let transitions = self.read_optional_transition_table()?;
+
+        if dfa.is_none() {
+            if required_dfa {
+                return_errno_with_message!(Errno::EINVAL, "the AppArmor policydb DFA is missing");
+            }
+            if required_transitions && !transitions.is_empty() {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "AppArmor transition tables require a DFA"
+                );
+            }
+            return Ok(None);
+        }
+
+        let dfa = dfa.unwrap();
+        match permissions {
+            Some(permissions) => {
+                AppArmorDfaFilePolicy::new(dfa, start, permissions, transitions).map(Some)
+            }
+            None => AppArmorDfaFilePolicy::new_legacy(dfa, start, transitions).map(Some),
+        }
+    }
+
+    fn skip_optional_tags(&mut self) -> Result<()> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("tags"))? {
+            return Ok(());
+        }
+
+        return_errno_with_message!(Errno::EINVAL, "AppArmor policy tags are not supported")
+    }
+
+    fn read_optional_permissions_table(&mut self) -> Result<Option<Vec<AppArmorDfaPermissions>>> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("perms"))? {
+            return Ok(None);
+        }
+
+        let version = self.read_u32(Some("version"))?;
+        if version != 1 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor permission table version is unsupported"
+            );
+        }
+        let count = usize::from(self.read_array(None)?);
+        let mut permissions = Vec::with_capacity(count);
+        for _ in 0..count {
+            let _reserved = self.read_u32(None)?;
+            let allow = self.read_u32(None)?;
+            let deny = self.read_u32(None)?;
+            let _subtree = self.read_u32(None)?;
+            let _condition = self.read_u32(None)?;
+            let _kill = self.read_u32(None)?;
+            let _complain = self.read_u32(None)?;
+            let _prompt = self.read_u32(None)?;
+            let audit = self.read_u32(None)?;
+            let _quiet = self.read_u32(None)?;
+            let _hide = self.read_u32(None)?;
+            let xindex = self.read_u32(None)?;
+            let tag = self.read_u32(None)?;
+            let label = self.read_u32(None)?;
+            if tag != 0 || label != 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "AppArmor tagged permissions are not supported"
+                );
+            }
+            permissions.push(AppArmorDfaPermissions::new(allow, deny, audit, xindex));
+        }
+        self.expect_name_code(LinuxCode::ArrayEnd, None)?;
+        self.expect_name_code(LinuxCode::StructEnd, None)?;
+
+        Ok(Some(permissions))
+    }
+
+    fn read_optional_dfa(&mut self) -> Result<Option<AppArmorDfa>> {
+        let Some((blob, content_start, content_end)) = self.read_optional_blob("aadfa")? else {
+            return Ok(None);
+        };
+        let dfa_start = aligned_blob_payload_offset(content_start, content_end)?;
+        if dfa_start > blob.len() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA blob is invalid");
+        }
+
+        AppArmorDfa::unpack(&blob[dfa_start..]).map(Some)
+    }
+
+    fn read_optional_transition_table(&mut self) -> Result<Vec<AppArmorExecTransition>> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("xtable"))? {
+            return Ok(Vec::new());
+        }
+
+        let count = usize::from(self.read_array(None)?);
+        let mut transitions = Vec::with_capacity(count);
+        for _ in 0..count {
+            let target = self.read_string(None)?;
+            transitions.push(parse_linux_transition_target(target)?);
+        }
+        self.expect_name_code(LinuxCode::ArrayEnd, None)?;
+        self.expect_name_code(LinuxCode::StructEnd, None)?;
+        Ok(transitions)
+    }
+
+    fn read_optional_xattrs(&mut self) -> Result<()> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("xattrs"))? {
+            return Ok(());
+        }
+
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "AppArmor xattr attachments are not supported"
+        )
+    }
+
+    fn read_optional_rlimits(&mut self) -> Result<()> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("rlimits"))? {
+            return Ok(());
+        }
+
+        return_errno_with_message!(Errno::EINVAL, "AppArmor rlimit mediation is not supported")
+    }
+
+    fn read_optional_secmark(&mut self) -> Result<()> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("secmark"))? {
+            return Ok(());
+        }
+
+        return_errno_with_message!(Errno::EINVAL, "AppArmor secmark mediation is not supported")
+    }
+
+    fn read_optional_data_table(&mut self) -> Result<()> {
+        if !self.consume_name_code(LinuxCode::Struct, Some("data"))? {
+            return Ok(());
+        }
+
+        while let Some(_key) = self.read_optional_string_any_name()? {
+            let _ = self.read_optional_blob_any_name()?;
+        }
+        self.expect_name_code(LinuxCode::StructEnd, None)
+    }
+
+    fn read_optional_string(&mut self, name: &str) -> Result<Option<String>> {
+        if !self.consume_name_code(LinuxCode::String, Some(name))? {
+            return Ok(None);
+        }
+        self.read_string_payload().map(Some)
+    }
+
+    fn read_optional_string_any_name(&mut self) -> Result<Option<String>> {
+        if !self.consume_name_code(LinuxCode::String, None)? {
+            return Ok(None);
+        }
+        self.read_string_payload().map(Some)
+    }
+
+    fn read_string(&mut self, name: Option<&str>) -> Result<String> {
+        self.expect_name_code(LinuxCode::String, name)?;
+        self.read_string_payload()
+    }
+
+    fn read_string_payload(&mut self) -> Result<String> {
+        let len = usize::from(self.read_le_u16_raw()?);
+        let bytes = self.read_bytes(len)?;
+        if bytes.last().copied() != Some(0) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor policy string is not nul-terminated"
+            );
+        }
+        let text = str::from_utf8(&bytes[..bytes.len() - 1]).map_err(|_| {
+            Error::with_message(Errno::EINVAL, "the AppArmor policy string is not UTF-8")
+        })?;
+        if text.bytes().any(|byte| byte == 0) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor policy string contains an embedded nul byte"
+            );
+        }
+
+        Ok(text.to_string())
+    }
+
+    fn read_optional_blob(&mut self, name: &str) -> Result<Option<(&'a [u8], usize, usize)>> {
+        if !self.consume_name_code(LinuxCode::Blob, Some(name))? {
+            return Ok(None);
+        }
+        self.read_blob_payload().map(Some)
+    }
+
+    fn read_optional_blob_any_name(&mut self) -> Result<Option<(&'a [u8], usize, usize)>> {
+        if !self.consume_name_code(LinuxCode::Blob, None)? {
+            return Ok(None);
+        }
+        self.read_blob_payload().map(Some)
+    }
+
+    fn read_blob_payload(&mut self) -> Result<(&'a [u8], usize, usize)> {
+        let len = self.read_le_u32_raw()? as usize;
+        let content_start = self.offset;
+        let bytes = self.read_bytes(len)?;
+        let content_end = self.offset;
+        Ok((bytes, content_start, content_end))
+    }
+
+    fn read_optional_u32(&mut self, name: &str) -> Result<Option<u32>> {
+        if !self.consume_name_code(LinuxCode::U32, Some(name))? {
+            return Ok(None);
+        }
+        self.read_le_u32_raw().map(Some)
+    }
+
+    fn read_u32(&mut self, name: Option<&str>) -> Result<u32> {
+        self.expect_name_code(LinuxCode::U32, name)?;
+        self.read_le_u32_raw()
+    }
+
+    fn read_array(&mut self, name: Option<&str>) -> Result<u16> {
+        self.expect_name_code(LinuxCode::Array, name)?;
+        self.read_le_u16_raw()
+    }
+
+    fn consume_name_code(&mut self, code: LinuxCode, name: Option<&str>) -> Result<bool> {
+        let position = self.offset;
+        match self.expect_name_code(code, name) {
+            Ok(()) => Ok(true),
+            Err(_) => {
+                self.offset = position;
+                Ok(false)
+            }
+        }
+    }
+
+    fn expect_name_code(&mut self, code: LinuxCode, name: Option<&str>) -> Result<()> {
+        let position = self.offset;
+        if self.peek_code()? == Some(LinuxCode::Name) {
+            self.offset += 1;
+            let tag = self.read_tag_name()?;
+            if let Some(expected_name) = name
+                && tag != expected_name
+            {
+                self.offset = position;
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the AppArmor policy field name is invalid"
+                );
+            }
+        } else if name.is_some() {
+            self.offset = position;
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor policy field name is missing");
+        }
+
+        let Some(actual_code) = self.peek_code()? else {
+            self.offset = position;
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor policy is truncated");
+        };
+        if actual_code != code {
+            self.offset = position;
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor policy field type is invalid");
+        }
+        self.offset += 1;
+        Ok(())
+    }
+
+    fn read_tag_name(&mut self) -> Result<String> {
+        let len = usize::from(self.read_le_u16_raw()?);
+        let bytes = self.read_bytes(len)?;
+        if bytes.last().copied() != Some(0) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor policy field name is not nul-terminated"
+            );
+        }
+        let name = str::from_utf8(&bytes[..bytes.len() - 1]).map_err(|_| {
+            Error::with_message(Errno::EINVAL, "the AppArmor field name is not UTF-8")
+        })?;
+        Ok(name.to_string())
+    }
+
+    fn peek_code(&self) -> Result<Option<LinuxCode>> {
+        let Some(byte) = self.bytes.get(self.offset).copied() else {
+            return Ok(None);
+        };
+        LinuxCode::from_byte(byte).map(Some)
+    }
+
+    fn read_le_u16_raw(&mut self) -> Result<u16> {
+        let bytes = self.read_bytes(2)?;
+        Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn read_le_u32_raw(&mut self) -> Result<u32> {
+        let bytes = self.read_bytes(4)?;
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn read_bytes(&mut self, len: usize) -> Result<&'a [u8]> {
+        let Some(end) = self.offset.checked_add(len) else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor binary policy is truncated");
+        };
+        if end > self.bytes.len() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor binary policy is truncated");
+        }
+
+        let bytes = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(bytes)
+    }
+}
+
+fn decode_linux_abi_version(version: u32) -> u32 {
+    if version <= LINUX_MIN_ABI_VERSION {
+        version
+    } else {
+        version & LINUX_KERNEL_ABI_MASK
+    }
+}
+
+fn aligned_blob_payload_offset(content_start: usize, content_end: usize) -> Result<usize> {
+    let Some(unaligned) = content_start.checked_sub(content_end & 7) else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA blob is invalid");
+    };
+    let aligned = align_up(unaligned, 8)?;
+    Ok(aligned - unaligned)
+}
+
+fn align_up(value: usize, align: usize) -> Result<usize> {
+    let Some(value) = value.checked_add(align - 1) else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor binary policy size overflows");
+    };
+    Ok(value & !(align - 1))
+}
+
+fn parse_linux_transition_target(target: String) -> Result<AppArmorExecTransition> {
+    if target.is_empty() {
+        return Ok(AppArmorExecTransition::Inherit);
+    }
+    if target == "unconfined" {
+        return Ok(AppArmorExecTransition::unconfined(AppArmorExecMode::Unsafe));
+    }
+
+    AppArmorProfileName::new(target)
+        .map(|profile_name| AppArmorExecTransition::profile(profile_name, AppArmorExecMode::Unsafe))
+}
+
+struct BinaryReader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> BinaryReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn has_remaining(&self) -> bool {
+        self.offset < self.bytes.len()
+    }
+
+    fn read_u8(&mut self) -> Result<u8> {
+        let bytes = self.read_bytes(1)?;
+        Ok(bytes[0])
+    }
+
+    fn read_u16(&mut self) -> Result<u16> {
+        let bytes = self.read_bytes(2)?;
+        Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn read_u32(&mut self) -> Result<u32> {
+        let bytes = self.read_bytes(4)?;
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn read_bytes(&mut self, len: usize) -> Result<&'a [u8]> {
+        let Some(end) = self.offset.checked_add(len) else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor binary policy is truncated");
+        };
+        if end > self.bytes.len() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor binary policy is truncated");
+        }
+
+        let bytes = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(bytes)
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/binary.rs
+++ b/kernel/src/security/lsm/modules/apparmor/binary.rs
@@ -607,7 +607,7 @@ impl<'a> LinuxPolicyReader<'a> {
             let _complain = self.read_u32(None)?;
             let _prompt = self.read_u32(None)?;
             let audit = self.read_u32(None)?;
-            let _quiet = self.read_u32(None)?;
+            let quiet = self.read_u32(None)?;
             let _hide = self.read_u32(None)?;
             let xindex = self.read_u32(None)?;
             let tag = self.read_u32(None)?;
@@ -618,7 +618,9 @@ impl<'a> LinuxPolicyReader<'a> {
                     "AppArmor tagged permissions are not supported"
                 );
             }
-            permissions.push(AppArmorDfaPermissions::new(allow, deny, audit, xindex));
+            permissions.push(AppArmorDfaPermissions::new(
+                allow, deny, audit, quiet, xindex,
+            ));
         }
         self.expect_name_code(LinuxCode::ArrayEnd, None)?;
         self.expect_name_code(LinuxCode::StructEnd, None)?;

--- a/kernel/src/security/lsm/modules/apparmor/capability.rs
+++ b/kernel/src/security/lsm/modules/apparmor/capability.rs
@@ -26,13 +26,11 @@ impl AppArmorCapabilityPolicy {
     }
 
     /// Returns capability audit mask.
-    #[expect(dead_code, reason = "AppArmor audit logging is not wired yet")]
     pub const fn audit(self) -> CapSet {
         self.audit
     }
 
     /// Returns capability quiet mask.
-    #[expect(dead_code, reason = "AppArmor audit logging is not wired yet")]
     pub const fn quiet(self) -> CapSet {
         self.quiet
     }

--- a/kernel/src/security/lsm/modules/apparmor/capability.rs
+++ b/kernel/src/security/lsm/modules/apparmor/capability.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::process::credentials::capabilities::CapSet;
+
+/// AppArmor capability policy attached to a profile.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct AppArmorCapabilityPolicy {
+    allowed: CapSet,
+    audit: CapSet,
+    quiet: CapSet,
+}
+
+impl AppArmorCapabilityPolicy {
+    /// Creates capability policy from Linux AppArmor capability masks.
+    pub const fn new(allowed: CapSet, audit: CapSet, quiet: CapSet) -> Self {
+        Self {
+            allowed,
+            audit,
+            quiet,
+        }
+    }
+
+    /// Returns whether the requested capabilities are allowed.
+    pub fn allows(self, capabilities: CapSet) -> bool {
+        self.allowed.contains(capabilities)
+    }
+
+    /// Returns capability audit mask.
+    #[expect(dead_code, reason = "AppArmor audit logging is not wired yet")]
+    pub const fn audit(self) -> CapSet {
+        self.audit
+    }
+
+    /// Returns capability quiet mask.
+    #[expect(dead_code, reason = "AppArmor audit logging is not wired yet")]
+    pub const fn quiet(self) -> CapSet {
+        self.quiet
+    }
+}
+
+impl Default for AppArmorCapabilityPolicy {
+    fn default() -> Self {
+        Self::new(CapSet::empty(), CapSet::empty(), CapSet::empty())
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/dfa.rs
+++ b/kernel/src/security/lsm/modules/apparmor/dfa.rs
@@ -109,12 +109,15 @@ impl AppArmorDfaFilePolicy {
         let missing = requested_bits & !permissions.allow;
         let denied_bits = explicitly_denied | missing;
         let denied = AppArmorFilePermission::from_linux_bits(denied_bits);
+        let explicit_denied = AppArmorFilePermission::from_linux_bits(explicitly_denied);
         let exec_transition = self.exec_transition(permissions, path_view)?;
 
         Ok(AppArmorDfaAccessOutcome {
             denied,
+            explicit_denied,
             exec_transition,
             audit: requested_bits & permissions.audit != 0,
+            quiet: denied_bits != 0 && denied_bits & !permissions.quiet == 0,
         })
     }
 
@@ -172,26 +175,34 @@ impl AppArmorDfaFilePolicy {
 pub struct AppArmorDfaAccessOutcome {
     /// Permissions denied by the policy.
     pub denied: AppArmorFilePermission,
+    /// Permissions denied by an explicit `deny` rule.
+    pub explicit_denied: AppArmorFilePermission,
     /// Executable profile transition selected by the matching state.
     pub exec_transition: AppArmorExecTransition,
     /// Whether matching permissions requested auditing.
     pub audit: bool,
+    /// Whether denied permissions should be kept out of routine audit logs.
+    pub quiet: bool,
 }
 
 impl AppArmorDfaAccessOutcome {
     fn allow() -> Self {
         Self {
             denied: AppArmorFilePermission::empty(),
+            explicit_denied: AppArmorFilePermission::empty(),
             exec_transition: AppArmorExecTransition::Inherit,
             audit: false,
+            quiet: false,
         }
     }
 
     fn deny(permissions: AppArmorFilePermission) -> Self {
         Self {
             denied: permissions,
+            explicit_denied: AppArmorFilePermission::empty(),
             exec_transition: AppArmorExecTransition::Inherit,
             audit: false,
+            quiet: false,
         }
     }
 }
@@ -202,16 +213,18 @@ pub(super) struct AppArmorDfaPermissions {
     pub allow: u32,
     pub deny: u32,
     pub audit: u32,
+    pub quiet: u32,
     pub xindex: u32,
 }
 
 impl AppArmorDfaPermissions {
     /// Creates a permission entry from a Linux AppArmor permstable row.
-    pub(super) fn new(allow: u32, deny: u32, audit: u32, xindex: u32) -> Self {
+    pub(super) fn new(allow: u32, deny: u32, audit: u32, quiet: u32, xindex: u32) -> Self {
         Self {
             allow,
             deny,
             audit,
+            quiet,
             xindex,
         }
     }
@@ -418,6 +431,7 @@ impl AppArmorDfa {
                 map_legacy_file_permissions_to_linux_bits(legacy_user_allow(accept)),
                 0,
                 map_legacy_file_permissions_to_linux_bits(legacy_user_audit(accept2)),
+                0,
                 map_legacy_xindex(accept & OLD_PERM_EXEC_MASK),
             ));
         }

--- a/kernel/src/security/lsm/modules/apparmor/dfa.rs
+++ b/kernel/src/security/lsm/modules/apparmor/dfa.rs
@@ -1,0 +1,701 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{
+    path::{AppArmorExecMode, AppArmorExecTransition, AppArmorFilePermission, AppArmorPathView},
+    profile::AppArmorProfileName,
+};
+use crate::prelude::*;
+
+const YYTH_MAGIC: u32 = 0x1b5e_783d;
+const YYTH_FLAG_DIFF_ENCODE: u16 = 1;
+const YYTH_FLAG_OOB_TRANS: u16 = 2;
+const YYTH_FLAGS: u16 = YYTH_FLAG_DIFF_ENCODE | YYTH_FLAG_OOB_TRANS;
+const YYTD_ID_ACCEPT: usize = 0;
+const YYTD_ID_BASE: usize = 1;
+const YYTD_ID_CHK: usize = 2;
+const YYTD_ID_DEF: usize = 3;
+const YYTD_ID_EC: usize = 4;
+const YYTD_ID_ACCEPT2: usize = 6;
+const YYTD_ID_NXT: usize = 7;
+const YYTD_ID_TSIZE: usize = 8;
+const YYTD_ID_MAX: usize = 8;
+const YYTD_DATA8: u16 = 1;
+const YYTD_DATA16: u16 = 2;
+const YYTD_DATA32: u16 = 4;
+const DFA_NOMATCH: u32 = 0;
+const MATCH_FLAG_DIFF_ENCODE: u32 = 0x8000_0000;
+const MATCH_FLAG_OOB_TRANSITION: u32 = 0x2000_0000;
+const MATCH_FLAGS_MASK: u32 = 0xff00_0000;
+const MATCH_FLAGS_VALID: u32 = MATCH_FLAG_DIFF_ENCODE | MATCH_FLAG_OOB_TRANSITION;
+const MATCH_FLAGS_INVALID: u32 = MATCH_FLAGS_MASK & !MATCH_FLAGS_VALID;
+const BASE_INDEX_MASK: u32 = 0x00ff_ffff;
+const AA_X_INDEX_MASK: u32 = 0x00ff_ffff;
+const AA_X_TYPE_MASK: u32 = 0x0c00_0000;
+const AA_X_NAME: u32 = 0x0400_0000;
+const AA_X_TABLE: u32 = 0x0800_0000;
+const AA_X_INHERIT: u32 = 0x4000_0000;
+const AA_X_UNCONFINED: u32 = 0x8000_0000;
+
+/// A DFA-backed file policy decoded from Linux AppArmor binary policy.
+#[derive(Clone, Debug)]
+pub struct AppArmorDfaFilePolicy {
+    dfa: AppArmorDfa,
+    start: u32,
+    permissions: Vec<AppArmorDfaPermissions>,
+    transitions: Vec<AppArmorExecTransition>,
+}
+
+impl AppArmorDfaFilePolicy {
+    /// Creates a DFA-backed file policy.
+    pub(super) fn new(
+        dfa: AppArmorDfa,
+        start: u32,
+        permissions: Vec<AppArmorDfaPermissions>,
+        transitions: Vec<AppArmorExecTransition>,
+    ) -> Result<Self> {
+        dfa.verify_accept_indexes(permissions.len())?;
+        if start as usize >= dfa.state_count() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA start state is invalid");
+        }
+
+        Ok(Self {
+            dfa,
+            start,
+            permissions,
+            transitions,
+        })
+    }
+
+    /// Creates a DFA-backed file policy from the legacy inline permission format.
+    pub(super) fn new_legacy(
+        mut dfa: AppArmorDfa,
+        start: u32,
+        transitions: Vec<AppArmorExecTransition>,
+    ) -> Result<Self> {
+        let permissions = dfa.legacy_permissions()?;
+        for (index, accept) in dfa.accept.iter_mut().enumerate() {
+            *accept = u32::try_from(index)
+                .map_err(|_| Error::with_message(Errno::EINVAL, "too many AppArmor DFA states"))?;
+        }
+
+        Self::new(dfa, start, permissions, transitions)
+    }
+
+    /// Evaluates access to a path.
+    pub fn evaluate_path_access(
+        &self,
+        path_view: &AppArmorPathView,
+        requested_permissions: AppArmorFilePermission,
+    ) -> Result<AppArmorDfaAccessOutcome> {
+        let requested_bits = requested_permissions.to_linux_bits();
+        if requested_bits == 0 {
+            return Ok(AppArmorDfaAccessOutcome::allow());
+        }
+
+        let state = self
+            .dfa
+            .match_bytes(self.start, path_view.as_str().as_bytes());
+        let Some(permission_index) = self.dfa.accept_index(state) else {
+            return Ok(AppArmorDfaAccessOutcome::deny(requested_permissions));
+        };
+        let Some(permissions) = self.permissions.get(permission_index) else {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor DFA permission index is invalid"
+            );
+        };
+
+        let explicitly_denied = requested_bits & permissions.deny;
+        let missing = requested_bits & !permissions.allow;
+        let denied_bits = explicitly_denied | missing;
+        let denied = AppArmorFilePermission::from_linux_bits(denied_bits);
+        let exec_transition = self.exec_transition(permissions, path_view)?;
+
+        Ok(AppArmorDfaAccessOutcome {
+            denied,
+            exec_transition,
+            audit: requested_bits & permissions.audit != 0,
+        })
+    }
+
+    /// Returns whether this policy accepts `path_view` as an attachment.
+    pub(super) fn matches_path(&self, path_view: &AppArmorPathView) -> bool {
+        let state = self
+            .dfa
+            .match_bytes(self.start, path_view.as_str().as_bytes());
+        if state == DFA_NOMATCH {
+            return false;
+        }
+
+        let Some(permission_index) = self.dfa.accept_index(state) else {
+            return false;
+        };
+        self.permissions
+            .get(permission_index)
+            .is_some_and(|permissions| permissions.allow != 0 && permissions.deny == 0)
+    }
+
+    fn exec_transition(
+        &self,
+        permissions: &AppArmorDfaPermissions,
+        path_view: &AppArmorPathView,
+    ) -> Result<AppArmorExecTransition> {
+        let xindex = permissions.xindex;
+        if xindex & AA_X_INHERIT != 0 {
+            return Ok(AppArmorExecTransition::Inherit);
+        }
+        if xindex & AA_X_UNCONFINED != 0 {
+            return Ok(AppArmorExecTransition::unconfined(AppArmorExecMode::Unsafe));
+        }
+
+        match xindex & AA_X_TYPE_MASK {
+            AA_X_NAME => Ok(AppArmorExecTransition::profile(
+                AppArmorProfileName::new(path_view.as_str().to_string())?,
+                AppArmorExecMode::Unsafe,
+            )),
+            AA_X_TABLE => {
+                let index = (xindex & AA_X_INDEX_MASK) as usize;
+                let Some(transition) = self.transitions.get(index) else {
+                    return_errno_with_message!(
+                        Errno::EINVAL,
+                        "the AppArmor exec transition index is invalid"
+                    );
+                };
+                Ok(transition.clone())
+            }
+            _ => Ok(AppArmorExecTransition::Inherit),
+        }
+    }
+}
+
+/// A path-access decision from a DFA-backed policy.
+pub struct AppArmorDfaAccessOutcome {
+    /// Permissions denied by the policy.
+    pub denied: AppArmorFilePermission,
+    /// Executable profile transition selected by the matching state.
+    pub exec_transition: AppArmorExecTransition,
+    /// Whether matching permissions requested auditing.
+    pub audit: bool,
+}
+
+impl AppArmorDfaAccessOutcome {
+    fn allow() -> Self {
+        Self {
+            denied: AppArmorFilePermission::empty(),
+            exec_transition: AppArmorExecTransition::Inherit,
+            audit: false,
+        }
+    }
+
+    fn deny(permissions: AppArmorFilePermission) -> Self {
+        Self {
+            denied: permissions,
+            exec_transition: AppArmorExecTransition::Inherit,
+            audit: false,
+        }
+    }
+}
+
+/// Permissions stored in a Linux AppArmor permstable entry.
+#[derive(Clone, Debug, Default)]
+pub(super) struct AppArmorDfaPermissions {
+    pub allow: u32,
+    pub deny: u32,
+    pub audit: u32,
+    pub xindex: u32,
+}
+
+impl AppArmorDfaPermissions {
+    /// Creates a permission entry from a Linux AppArmor permstable row.
+    pub(super) fn new(allow: u32, deny: u32, audit: u32, xindex: u32) -> Self {
+        Self {
+            allow,
+            deny,
+            audit,
+            xindex,
+        }
+    }
+}
+
+/// A Linux AppArmor serialized DFA.
+#[derive(Clone, Debug)]
+pub(super) struct AppArmorDfa {
+    flags: u16,
+    accept: Vec<u32>,
+    accept2: Option<Vec<u32>>,
+    base: Vec<u32>,
+    default: Vec<u32>,
+    next: Vec<u32>,
+    check: Vec<u32>,
+    equivalence: Option<Vec<u8>>,
+}
+
+impl AppArmorDfa {
+    /// Unpacks a Linux AppArmor DFA blob.
+    pub(super) fn unpack(blob: &[u8]) -> Result<Self> {
+        let mut reader = DfaReader::new(blob);
+        let magic = reader.read_be_u32()?;
+        if magic != YYTH_MAGIC {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA magic is invalid");
+        }
+
+        let header_size = reader.read_be_u32()? as usize;
+        let _serialized_size = reader.read_be_u32()?;
+        let flags = reader.read_be_u16()?;
+        if flags & !YYTH_FLAGS != 0 {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA flags are invalid");
+        }
+        if header_size < reader.offset() || header_size > blob.len() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA header is invalid");
+        }
+        reader.skip_to(header_size)?;
+
+        let mut tables = DfaTables::default();
+        while reader.has_remaining() {
+            let table = reader.read_table()?;
+            tables.insert(table)?;
+        }
+
+        let dfa = tables.into_dfa(flags)?;
+        dfa.verify_tables()?;
+        Ok(dfa)
+    }
+
+    fn state_count(&self) -> usize {
+        self.base.len()
+    }
+
+    fn accept_index(&self, state: u32) -> Option<usize> {
+        self.accept
+            .get(state as usize)
+            .copied()
+            .map(|index| index as usize)
+    }
+
+    fn match_bytes(&self, start: u32, bytes: &[u8]) -> u32 {
+        if start == DFA_NOMATCH {
+            return DFA_NOMATCH;
+        }
+
+        let mut state = start;
+        for byte in bytes {
+            let transition = self
+                .equivalence
+                .as_ref()
+                .map(|equivalence| equivalence[usize::from(*byte)])
+                .unwrap_or(*byte);
+            state = self.next_state(state, u32::from(transition));
+        }
+
+        state
+    }
+
+    fn next_state(&self, mut state: u32, transition: u32) -> u32 {
+        loop {
+            let Some(base) = self.base.get(state as usize).copied() else {
+                return DFA_NOMATCH;
+            };
+            let Some(index) = base_index(base).checked_add(transition) else {
+                return DFA_NOMATCH;
+            };
+            let index = index as usize;
+            if self.check.get(index).copied() == Some(state) {
+                return self.next.get(index).copied().unwrap_or(DFA_NOMATCH);
+            }
+
+            state = self
+                .default
+                .get(state as usize)
+                .copied()
+                .unwrap_or(DFA_NOMATCH);
+            if base & MATCH_FLAG_DIFF_ENCODE == 0 {
+                return state;
+            }
+        }
+    }
+
+    fn verify_tables(&self) -> Result<()> {
+        let state_count = self.state_count();
+        if state_count < 2 || self.default.len() != state_count || self.accept.len() != state_count
+        {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA state tables are invalid");
+        }
+        if let Some(accept2) = &self.accept2
+            && accept2.len() != state_count
+        {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA accept2 table is invalid");
+        }
+        if self.next.len() != self.check.len() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor DFA transition tables are invalid"
+            );
+        }
+        if let Some(equivalence) = &self.equivalence
+            && equivalence.len() != 256
+        {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor DFA equivalence table is invalid"
+            );
+        }
+
+        let transition_count = self.next.len() as u32;
+        for (index, base) in self.base.iter().copied().enumerate() {
+            if self.default[index] as usize >= state_count {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the AppArmor DFA default state is out of bounds"
+                );
+            }
+            if base & MATCH_FLAGS_INVALID != 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the AppArmor DFA state flags are invalid"
+                );
+            }
+            if base & MATCH_FLAG_OOB_TRANSITION != 0 {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "AppArmor DFA out-of-band transitions are not supported"
+                );
+            }
+            let Some(upper_bound) = base_index(base).checked_add(255) else {
+                return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA base index overflows");
+            };
+            if upper_bound >= transition_count {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the AppArmor DFA base index is out of bounds"
+                );
+            }
+        }
+
+        for next_state in &self.next {
+            if *next_state as usize >= state_count {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the AppArmor DFA next state is out of bounds"
+                );
+            }
+        }
+        for check_state in &self.check {
+            if *check_state as usize >= state_count {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the AppArmor DFA check state is out of bounds"
+                );
+            }
+        }
+
+        let _flags = self.flags;
+        Ok(())
+    }
+
+    fn verify_accept_indexes(&self, permission_count: usize) -> Result<()> {
+        for index in &self.accept {
+            if *index as usize >= permission_count {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "the AppArmor DFA accept index is out of bounds"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn legacy_permissions(&self) -> Result<Vec<AppArmorDfaPermissions>> {
+        let mut permissions = Vec::with_capacity(self.accept.len());
+        for (state, accept) in self.accept.iter().copied().enumerate() {
+            let accept2 = self
+                .accept2
+                .as_ref()
+                .and_then(|table| table.get(state))
+                .copied()
+                .unwrap_or(0);
+            permissions.push(AppArmorDfaPermissions::new(
+                map_legacy_file_permissions_to_linux_bits(legacy_user_allow(accept)),
+                0,
+                map_legacy_file_permissions_to_linux_bits(legacy_user_audit(accept2)),
+                map_legacy_xindex(accept & OLD_PERM_EXEC_MASK),
+            ));
+        }
+
+        Ok(permissions)
+    }
+}
+
+fn base_index(base: u32) -> u32 {
+    base & BASE_INDEX_MASK
+}
+
+const OLD_PERM_EXEC_MASK: u32 = 0x3fff;
+const OLD_PERM_USER_MASK: u32 = 0x7f;
+const OLD_PERM_MAY_EXEC: u32 = 0x01;
+const OLD_PERM_MAY_WRITE: u32 = 0x02;
+const OLD_PERM_MAY_READ: u32 = 0x04;
+const OLD_PERM_MAY_APPEND: u32 = 0x08;
+const OLD_PERM_MAY_LINK: u32 = 0x10;
+const OLD_PERM_EXEC_MMAP: u32 = 0x40;
+const LEGACY_PERM_MAY_MMAP_EXEC: u32 = 0x0001_0000;
+const OLD_X_UNCONFINED: u32 = 0x80;
+const OLD_X_UNSAFE: u32 = 0x100;
+const OLD_X_INHERIT: u32 = 0x200;
+const LINUX_PERM_EXECUTE: u32 = 1 << 0;
+const LINUX_PERM_WRITE: u32 = 1 << 1;
+const LINUX_PERM_READ: u32 = 1 << 2;
+const LINUX_PERM_APPEND: u32 = 1 << 3;
+const LINUX_PERM_CREATE: u32 = 0x0010;
+const LINUX_PERM_DELETE: u32 = 0x0020;
+const LINUX_PERM_SETATTR: u32 = 0x0100;
+const LINUX_PERM_MMAP: u32 = 0x0001_0000;
+const LINUX_PERM_LINK: u32 = 0x0004_0000;
+
+fn legacy_user_allow(accept: u32) -> u32 {
+    accept & (OLD_PERM_USER_MASK | LEGACY_PERM_MAY_MMAP_EXEC)
+}
+
+fn legacy_user_audit(accept2: u32) -> u32 {
+    accept2 & (OLD_PERM_USER_MASK | LEGACY_PERM_MAY_MMAP_EXEC)
+}
+
+fn map_legacy_file_permissions_to_linux_bits(old_permissions: u32) -> u32 {
+    let mut permissions = 0;
+
+    if old_permissions & OLD_PERM_MAY_EXEC != 0 {
+        permissions |= LINUX_PERM_EXECUTE;
+    }
+    if old_permissions & OLD_PERM_MAY_WRITE != 0 {
+        permissions |=
+            LINUX_PERM_WRITE | LINUX_PERM_CREATE | LINUX_PERM_DELETE | LINUX_PERM_SETATTR;
+    }
+    if old_permissions & OLD_PERM_MAY_READ != 0 {
+        permissions |= LINUX_PERM_READ;
+    }
+    if old_permissions & OLD_PERM_MAY_APPEND != 0 {
+        permissions |= LINUX_PERM_APPEND;
+    }
+    if old_permissions & OLD_PERM_MAY_LINK != 0 {
+        permissions |= LINUX_PERM_LINK;
+    }
+    if old_permissions & (OLD_PERM_EXEC_MMAP | LEGACY_PERM_MAY_MMAP_EXEC) != 0 {
+        permissions |= LINUX_PERM_MMAP;
+    }
+
+    permissions
+}
+
+fn map_legacy_xindex(mask: u32) -> u32 {
+    let old_index = (mask >> 10) & 0xf;
+    let mut xindex = 0;
+
+    if mask & OLD_X_INHERIT != 0 {
+        xindex |= AA_X_INHERIT;
+    }
+    if mask & OLD_X_UNCONFINED != 0 || old_index == 1 {
+        xindex |= AA_X_UNCONFINED;
+    } else if old_index == 2 || old_index == 3 {
+        xindex |= AA_X_NAME;
+    } else if old_index != 0 {
+        xindex |= AA_X_TABLE | (old_index - 4);
+    }
+
+    let _unsafe_exec = mask & OLD_X_UNSAFE;
+    xindex
+}
+
+#[derive(Default)]
+struct DfaTables {
+    tables: [Option<DfaTable>; YYTD_ID_TSIZE],
+}
+
+impl DfaTables {
+    fn insert(&mut self, table: DfaTable) -> Result<()> {
+        let id = table.id;
+        if id > YYTD_ID_MAX || id == YYTD_ID_TSIZE {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA table id is invalid");
+        }
+        if self.tables[id].is_some() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA table is duplicated");
+        }
+        self.tables[id] = Some(table);
+        Ok(())
+    }
+
+    fn into_dfa(mut self, flags: u16) -> Result<AppArmorDfa> {
+        let accept = self.take_u32_table(YYTD_ID_ACCEPT)?;
+        let base = self.take_u32_table(YYTD_ID_BASE)?;
+        let default = self.take_u32_table(YYTD_ID_DEF)?;
+        let next = self.take_u32_table(YYTD_ID_NXT)?;
+        let check = self.take_u32_table(YYTD_ID_CHK)?;
+        let equivalence = self.take_u8_table(YYTD_ID_EC)?;
+        let accept2 = if self.tables[YYTD_ID_ACCEPT2].is_some() {
+            Some(self.take_u32_table(YYTD_ID_ACCEPT2)?)
+        } else {
+            None
+        };
+
+        Ok(AppArmorDfa {
+            flags,
+            accept,
+            accept2,
+            base,
+            default,
+            next,
+            check,
+            equivalence,
+        })
+    }
+
+    fn take_u8_table(&mut self, id: usize) -> Result<Option<Vec<u8>>> {
+        let Some(table) = self.tables[id].take() else {
+            return Ok(None);
+        };
+        table.into_u8_table()
+    }
+
+    fn take_u32_table(&mut self, id: usize) -> Result<Vec<u32>> {
+        let Some(table) = self.tables[id].take() else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA table is missing");
+        };
+        table.into_u32_table()
+    }
+}
+
+#[derive(Debug)]
+struct DfaTable {
+    id: usize,
+    data: DfaTableData,
+}
+
+impl DfaTable {
+    fn into_u8_table(self) -> Result<Option<Vec<u8>>> {
+        match self.data {
+            DfaTableData::U8(data) => Ok(Some(data)),
+            _ => {
+                return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA table width is invalid")
+            }
+        }
+    }
+
+    fn into_u32_table(self) -> Result<Vec<u32>> {
+        match self.data {
+            DfaTableData::U16(data) => Ok(data.into_iter().map(u32::from).collect()),
+            DfaTableData::U32(data) => Ok(data),
+            _ => {
+                return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA table width is invalid")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum DfaTableData {
+    U8(Vec<u8>),
+    U16(Vec<u16>),
+    U32(Vec<u32>),
+}
+
+struct DfaReader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> DfaReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn has_remaining(&self) -> bool {
+        self.offset < self.bytes.len()
+    }
+
+    fn offset(&self) -> usize {
+        self.offset
+    }
+
+    fn skip_to(&mut self, offset: usize) -> Result<()> {
+        if offset > self.bytes.len() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA is truncated");
+        }
+        self.offset = offset;
+        Ok(())
+    }
+
+    fn read_table(&mut self) -> Result<DfaTable> {
+        let table_start = self.offset;
+        let id = usize::from(self.read_be_u16()?);
+        let flags = self.read_be_u16()?;
+        let _high_len = self.read_be_u32()?;
+        let low_len = self.read_be_u32()? as usize;
+        if id == 0 {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA table id is invalid");
+        }
+        let id = id - 1;
+
+        let data = match flags {
+            YYTD_DATA8 => DfaTableData::U8(self.read_be_u8_array(low_len)?),
+            YYTD_DATA16 => DfaTableData::U16(self.read_be_u16_array(low_len)?),
+            YYTD_DATA32 => DfaTableData::U32(self.read_be_u32_array(low_len)?),
+            _ => return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor DFA table flags are invalid"
+            ),
+        };
+        let table_size = align_up(self.offset - table_start, 8)?;
+        self.skip_to(table_start + table_size)?;
+
+        Ok(DfaTable { id, data })
+    }
+
+    fn read_be_u8_array(&mut self, len: usize) -> Result<Vec<u8>> {
+        Ok(self.read_bytes(len)?.to_vec())
+    }
+
+    fn read_be_u16_array(&mut self, len: usize) -> Result<Vec<u16>> {
+        let mut array = Vec::with_capacity(len);
+        for _ in 0..len {
+            array.push(self.read_be_u16()?);
+        }
+        Ok(array)
+    }
+
+    fn read_be_u32_array(&mut self, len: usize) -> Result<Vec<u32>> {
+        let mut array = Vec::with_capacity(len);
+        for _ in 0..len {
+            array.push(self.read_be_u32()?);
+        }
+        Ok(array)
+    }
+
+    fn read_be_u16(&mut self) -> Result<u16> {
+        let bytes = self.read_bytes(2)?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn read_be_u32(&mut self) -> Result<u32> {
+        let bytes = self.read_bytes(4)?;
+        Ok(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn read_bytes(&mut self, len: usize) -> Result<&'a [u8]> {
+        let Some(end) = self.offset.checked_add(len) else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA is truncated");
+        };
+        if end > self.bytes.len() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA is truncated");
+        }
+
+        let bytes = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(bytes)
+    }
+}
+
+fn align_up(value: usize, align: usize) -> Result<usize> {
+    let Some(value) = value.checked_add(align - 1) else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor DFA size overflows");
+    };
+    Ok(value & !(align - 1))
+}

--- a/kernel/src/security/lsm/modules/apparmor/label.rs
+++ b/kernel/src/security/lsm/modules/apparmor/label.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::profile::AppArmorProfileName;
+use crate::prelude::*;
+
+/// A set of AppArmor profiles attached to a task or object.
+///
+/// Linux AppArmor mediates labels rather than raw profile names. The current
+/// implementation carries one profile per label, but the type is intentionally
+/// shaped as a profile set so profile stacking can be added without changing
+/// the surrounding task state and hook code.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppArmorLabel {
+    profiles: Vec<AppArmorProfileName>,
+}
+
+impl AppArmorLabel {
+    /// Creates an unconfined label.
+    pub fn new_unconfined() -> Self {
+        Self {
+            profiles: vec![AppArmorProfileName::new_unconfined()],
+        }
+    }
+
+    /// Creates a label containing a single profile.
+    pub fn new_single(profile_name: AppArmorProfileName) -> Self {
+        Self {
+            profiles: vec![profile_name],
+        }
+    }
+
+    /// Returns the primary profile in this label.
+    pub fn primary_profile(&self) -> &AppArmorProfileName {
+        self.profiles
+            .first()
+            .expect("AppArmor labels always contain at least one profile")
+    }
+
+    /// Returns whether this is the unconfined label.
+    pub fn is_unconfined(&self) -> bool {
+        self.profiles.len() == 1 && self.primary_profile().is_unconfined()
+    }
+}
+
+impl Default for AppArmorLabel {
+    fn default() -> Self {
+        Self::new_unconfined()
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/loader.rs
+++ b/kernel/src/security/lsm/modules/apparmor/loader.rs
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{
+    attachment::AppArmorAttachment,
+    capability::AppArmorCapabilityPolicy,
+    path::{
+        AppArmorExecMode, AppArmorExecTransition, AppArmorFilePermission, AppArmorPathPattern,
+        AppArmorPathRule,
+    },
+    policy_update::AppArmorPolicyUpdate,
+    profile::{
+        AppArmorFilePolicy, AppArmorProfile, AppArmorProfileName, AppArmorProfileTransitionPolicy,
+    },
+    state::AppArmorMode,
+};
+use crate::{prelude::*, process::credentials::capabilities::CapSet};
+
+pub(super) fn parse_policy_load(policy_text: &str) -> Result<AppArmorPolicyUpdate> {
+    let mut lines = policy_text
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty() && !line.starts_with('#'));
+
+    let Some(header) = lines.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor policy text is empty");
+    };
+
+    if header.starts_with("remove ") {
+        let profile_name = parse_remove_header(header)?;
+        if lines.next().is_some() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "remove commands must not include policy rules"
+            );
+        }
+        return Ok(AppArmorPolicyUpdate::Remove(profile_name));
+    }
+
+    let (profile_name, mode) = parse_profile_header(header)?;
+    let mut file_rules = Vec::new();
+    let mut allowed_capabilities = CapSet::empty();
+    let mut change_profile_targets = Vec::new();
+    let mut change_onexec_targets = Vec::new();
+    for line in lines {
+        match parse_rule(line)? {
+            AppArmorTextRule::File(rule) => file_rules.push(rule),
+            AppArmorTextRule::Capability(capabilities) => allowed_capabilities |= capabilities,
+            AppArmorTextRule::ChangeProfile(profile_name) => {
+                change_profile_targets.push(profile_name);
+            }
+            AppArmorTextRule::ChangeOnexec(profile_name) => {
+                change_onexec_targets.push(profile_name);
+            }
+        }
+    }
+
+    let attachment = AppArmorAttachment::from_profile(&profile_name, None, None);
+    Ok(AppArmorPolicyUpdate::Replace(Box::new(
+        AppArmorProfile::new_with_transition_policy(
+            profile_name,
+            attachment,
+            mode,
+            AppArmorFilePolicy::PathRules(file_rules),
+            AppArmorCapabilityPolicy::new(allowed_capabilities, CapSet::empty(), CapSet::empty()),
+            AppArmorProfileTransitionPolicy::new(change_profile_targets, change_onexec_targets),
+        ),
+    )))
+}
+
+fn parse_remove_header(header: &str) -> Result<AppArmorProfileName> {
+    let mut tokens = header.split_whitespace();
+    if tokens.next() != Some("remove") {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor command is invalid");
+    }
+
+    let Some(profile_name) = tokens.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is missing");
+    };
+
+    if tokens.next().is_some() {
+        return_errno_with_message!(Errno::EINVAL, "the remove command has extra fields");
+    }
+
+    let profile_name = AppArmorProfileName::new(profile_name.to_string())?;
+    if profile_name.is_unconfined() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the implicit unconfined AppArmor profile cannot be removed"
+        );
+    }
+
+    Ok(profile_name)
+}
+
+fn parse_profile_header(header: &str) -> Result<(AppArmorProfileName, AppArmorMode)> {
+    let mut tokens = header.split_whitespace();
+    if tokens.next() != Some("profile") {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor profile header is invalid");
+    }
+
+    let Some(profile_name) = tokens.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is missing");
+    };
+    let profile_name = AppArmorProfileName::new(profile_name.to_string())?;
+    if profile_name.is_unconfined() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the implicit unconfined AppArmor profile cannot be loaded"
+        );
+    }
+
+    let Some(mode) = tokens.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor profile mode is missing");
+    };
+    let mode = AppArmorMode::parse(mode)?;
+
+    if tokens.next().is_some() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the AppArmor profile header has extra fields"
+        );
+    }
+
+    Ok((profile_name, mode))
+}
+
+enum AppArmorTextRule {
+    File(AppArmorPathRule),
+    Capability(CapSet),
+    ChangeProfile(AppArmorProfileName),
+    ChangeOnexec(AppArmorProfileName),
+}
+
+fn parse_rule(line: &str) -> Result<AppArmorTextRule> {
+    let mut tokens = line.split_whitespace();
+    let Some(rule_kind) = tokens.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor rule is empty");
+    };
+    let deny = match rule_kind {
+        "allow" => false,
+        "deny" => true,
+        _ => return_errno_with_message!(Errno::EINVAL, "the AppArmor rule kind is invalid"),
+    };
+
+    if tokens.clone().next() == Some("capability") {
+        return parse_capability_rule(tokens, deny);
+    }
+    if tokens.clone().next() == Some("change_profile") {
+        return parse_profile_transition_rule(tokens, deny, true);
+    }
+    if tokens.clone().next() == Some("change_onexec") {
+        return parse_profile_transition_rule(tokens, deny, false);
+    }
+
+    let Some(pattern) = tokens.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor path pattern is missing");
+    };
+    let pattern = AppArmorPathPattern::new(pattern.to_string());
+
+    let Some(permissions) = tokens.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor permissions are missing");
+    };
+    let permissions = parse_permissions(permissions)?;
+
+    let mut audit = false;
+    let mut exec_transition = AppArmorExecTransition::Inherit;
+    for token in tokens {
+        if token == "audit" {
+            audit = true;
+            continue;
+        }
+
+        let Some(new_transition) = parse_exec_transition(token)? else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor rule option is invalid");
+        };
+
+        if exec_transition != AppArmorExecTransition::Inherit {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor rule has multiple exec transitions"
+            );
+        }
+        exec_transition = new_transition;
+    }
+
+    if deny && exec_transition != AppArmorExecTransition::Inherit {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "deny rules cannot carry AppArmor exec transitions"
+        );
+    }
+
+    if exec_transition != AppArmorExecTransition::Inherit
+        && !permissions.contains(AppArmorFilePermission::EXECUTE)
+    {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "AppArmor exec transitions require execute permission"
+        );
+    }
+
+    Ok(AppArmorTextRule::File(
+        AppArmorPathRule::new_with_transition(pattern, permissions, exec_transition, audit, deny),
+    ))
+}
+
+fn parse_profile_transition_rule<'a>(
+    mut tokens: impl Iterator<Item = &'a str>,
+    deny: bool,
+    immediate: bool,
+) -> Result<AppArmorTextRule> {
+    if deny {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "deny profile transition rules are not supported by the text AppArmor loader"
+        );
+    }
+
+    let expected = if immediate {
+        "change_profile"
+    } else {
+        "change_onexec"
+    };
+    if tokens.next() != Some(expected) {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the AppArmor profile transition rule is invalid"
+        );
+    }
+
+    let Some(profile_name) = tokens.next() else {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the AppArmor profile transition target is missing"
+        );
+    };
+    if tokens.next().is_some() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the AppArmor profile transition rule has extra fields"
+        );
+    }
+
+    let profile_name = AppArmorProfileName::new(profile_name.to_string())?;
+    if immediate {
+        Ok(AppArmorTextRule::ChangeProfile(profile_name))
+    } else {
+        Ok(AppArmorTextRule::ChangeOnexec(profile_name))
+    }
+}
+
+fn parse_capability_rule<'a>(
+    mut tokens: impl Iterator<Item = &'a str>,
+    deny: bool,
+) -> Result<AppArmorTextRule> {
+    if deny {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "deny capability rules are not supported by the text AppArmor loader"
+        );
+    }
+    if tokens.next() != Some("capability") {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor capability rule is invalid");
+    }
+
+    let Some(capabilities) = tokens.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor capability rule is missing");
+    };
+    if tokens.next().is_some() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the AppArmor capability rule has extra fields"
+        );
+    }
+
+    Ok(AppArmorTextRule::Capability(parse_capabilities(
+        capabilities,
+    )?))
+}
+
+fn parse_capabilities(capabilities_text: &str) -> Result<CapSet> {
+    let mut capabilities = CapSet::empty();
+
+    for capability_text in capabilities_text.split(',') {
+        if capability_text.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor capability is empty");
+        }
+        capabilities |= parse_capability_token(capability_text)?;
+    }
+
+    if capabilities.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor capabilities are empty");
+    }
+
+    Ok(capabilities)
+}
+
+fn parse_capability_token(capability_text: &str) -> Result<CapSet> {
+    let capability = match capability_text {
+        "all" => CapSet::all(),
+        "chown" => CapSet::CHOWN,
+        "dac_override" => CapSet::DAC_OVERRIDE,
+        "dac_read_search" => CapSet::DAC_READ_SEARCH,
+        "fowner" => CapSet::FOWNER,
+        "fsetid" => CapSet::FSETID,
+        "kill" => CapSet::KILL,
+        "setgid" => CapSet::SETGID,
+        "setuid" => CapSet::SETUID,
+        "setpcap" => CapSet::SETPCAP,
+        "linux_immutable" => CapSet::LINUX_IMMUTABLE,
+        "net_bind_service" => CapSet::NET_BIND_SERVICE,
+        "net_broadcast" => CapSet::NET_BROADCAST,
+        "net_admin" => CapSet::NET_ADMIN,
+        "net_raw" => CapSet::NET_RAW,
+        "ipc_lock" => CapSet::IPC_LOCK,
+        "ipc_owner" => CapSet::IPC_OWNER,
+        "sys_module" => CapSet::SYS_MODULE,
+        "sys_rawio" => CapSet::SYS_RAWIO,
+        "sys_chroot" => CapSet::SYS_CHROOT,
+        "sys_ptrace" => CapSet::SYS_PTRACE,
+        "sys_pacct" => CapSet::SYS_PACCT,
+        "sys_admin" => CapSet::SYS_ADMIN,
+        "sys_boot" => CapSet::SYS_BOOT,
+        "sys_nice" => CapSet::SYS_NICE,
+        "sys_resource" => CapSet::SYS_RESOURCE,
+        "sys_time" => CapSet::SYS_TIME,
+        "sys_tty_config" => CapSet::SYS_TTY_CONFIG,
+        "mknod" => CapSet::MKNOD,
+        "lease" => CapSet::LEASE,
+        "audit_write" => CapSet::AUDIT_WRITE,
+        "audit_control" => CapSet::AUDIT_CONTROL,
+        "setfcap" => CapSet::SETFCAP,
+        "mac_override" => CapSet::MAC_OVERRIDE,
+        "mac_admin" => CapSet::MAC_ADMIN,
+        "syslog" => CapSet::SYSLOG,
+        "wake_alarm" => CapSet::WAKE_ALARM,
+        "block_suspend" => CapSet::BLOCK_SUSPEND,
+        "audit_read" => CapSet::AUDIT_READ,
+        "perfmon" => CapSet::PERFMON,
+        "bpf" => CapSet::BPF,
+        "checkpoint_restore" => CapSet::CHECKPOINT_RESTORE,
+        _ => return_errno_with_message!(Errno::EINVAL, "the AppArmor capability is invalid"),
+    };
+
+    Ok(capability)
+}
+
+fn parse_exec_transition(token: &str) -> Result<Option<AppArmorExecTransition>> {
+    match token {
+        "ix" => Ok(Some(AppArmorExecTransition::Inherit)),
+        "ux" => Ok(Some(AppArmorExecTransition::unconfined(
+            AppArmorExecMode::Unsafe,
+        ))),
+        "Ux" => Ok(Some(AppArmorExecTransition::unconfined(
+            AppArmorExecMode::Safe,
+        ))),
+        _ => {
+            let transition = if let Some(profile_name) = token.strip_prefix("px:") {
+                AppArmorExecTransition::profile(
+                    AppArmorProfileName::new(profile_name.to_string())?,
+                    AppArmorExecMode::Unsafe,
+                )
+            } else if let Some(profile_name) = token.strip_prefix("Px:") {
+                AppArmorExecTransition::profile(
+                    AppArmorProfileName::new(profile_name.to_string())?,
+                    AppArmorExecMode::Safe,
+                )
+            } else if let Some(profile_name) = token.strip_prefix("cx:") {
+                AppArmorExecTransition::child(
+                    AppArmorProfileName::new(profile_name.to_string())?,
+                    AppArmorExecMode::Unsafe,
+                )
+            } else if let Some(profile_name) = token.strip_prefix("Cx:") {
+                AppArmorExecTransition::child(
+                    AppArmorProfileName::new(profile_name.to_string())?,
+                    AppArmorExecMode::Safe,
+                )
+            } else {
+                return Ok(None);
+            };
+            Ok(Some(transition))
+        }
+    }
+}
+
+fn parse_permissions(permissions_text: &str) -> Result<AppArmorFilePermission> {
+    let mut permissions = AppArmorFilePermission::empty();
+
+    for permission_text in permissions_text.split(',') {
+        if permission_text.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor permission is empty");
+        }
+        permissions |= parse_permission_token(permission_text)?;
+    }
+
+    if permissions.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor permissions are empty");
+    }
+
+    Ok(permissions)
+}
+
+fn parse_permission_token(permission_text: &str) -> Result<AppArmorFilePermission> {
+    let permissions = match permission_text {
+        "all" => AppArmorFilePermission::all(),
+        "read" => AppArmorFilePermission::READ,
+        "write" => AppArmorFilePermission::WRITE,
+        "execute" | "exec" => AppArmorFilePermission::EXECUTE,
+        "append" => AppArmorFilePermission::APPEND,
+        "mmap" => AppArmorFilePermission::MMAP,
+        "create" => AppArmorFilePermission::CREATE,
+        "delete" => AppArmorFilePermission::DELETE,
+        "link" => AppArmorFilePermission::LINK,
+        "rename" => AppArmorFilePermission::RENAME,
+        "mkdir" => AppArmorFilePermission::MKDIR,
+        "mknod" => AppArmorFilePermission::MKNOD,
+        "symlink" => AppArmorFilePermission::SYMLINK,
+        "setattr" => AppArmorFilePermission::SETATTR,
+        _ => return parse_compact_permissions(permission_text),
+    };
+
+    Ok(permissions)
+}
+
+fn parse_compact_permissions(permission_text: &str) -> Result<AppArmorFilePermission> {
+    let mut permissions = AppArmorFilePermission::empty();
+
+    for permission in permission_text.chars() {
+        permissions |= match permission {
+            'r' => AppArmorFilePermission::READ,
+            'w' => AppArmorFilePermission::WRITE,
+            'x' => AppArmorFilePermission::EXECUTE,
+            'a' => AppArmorFilePermission::APPEND,
+            'm' => AppArmorFilePermission::MMAP,
+            'c' => AppArmorFilePermission::CREATE,
+            'd' => AppArmorFilePermission::DELETE,
+            'l' => AppArmorFilePermission::LINK,
+            'n' => AppArmorFilePermission::RENAME,
+            'k' => AppArmorFilePermission::MKDIR,
+            'b' => AppArmorFilePermission::MKNOD,
+            's' => AppArmorFilePermission::SYMLINK,
+            't' => AppArmorFilePermission::SETATTR,
+            _ => {
+                return_errno_with_message!(Errno::EINVAL, "the AppArmor permission is invalid");
+            }
+        };
+    }
+
+    Ok(permissions)
+}

--- a/kernel/src/security/lsm/modules/apparmor/mod.rs
+++ b/kernel/src/security/lsm/modules/apparmor/mod.rs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! AppArmor-like major LSM.
+
+mod attachment;
+mod binary;
+mod capability;
+mod dfa;
+mod label;
+mod loader;
+mod namespace;
+mod path;
+mod policy;
+mod policy_update;
+mod profile;
+mod state;
+
+pub use self::{
+    binary::AppArmorPolicyOperation,
+    profile::AppArmorProfileName,
+    state::{AppArmorMode, AppArmorTaskState},
+};
+use self::{policy::AppArmorPolicy, policy_update::AppArmorPolicyUpdate};
+use super::super::{
+    BprmCheckContext, BprmCommittedCredsContext, CapableContext, FileCreateContext,
+    FileDeleteContext, FileGetattrContext, FileLinkContext, FileLockContext, FileMmapContext,
+    FileOpenContext, FilePermissionContext, FileReceiveContext, FileRenameContext,
+    FileSetattrContext, LsmFlags, LsmModule,
+    hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook},
+};
+use crate::{prelude::*, process::posix_thread::AsPosixThread, thread::Thread};
+
+pub(super) static APPARMOR_LSM: AppArmorLsm = AppArmorLsm;
+
+static POLICY: AppArmorPolicy = AppArmorPolicy::new();
+
+/// An AppArmor-like major LSM.
+pub(super) struct AppArmorLsm;
+
+impl LsmModule for AppArmorLsm {
+    fn name(&self) -> &'static str {
+        "apparmor"
+    }
+
+    fn flags(&self) -> LsmFlags {
+        LsmFlags::LEGACY_MAJOR | LsmFlags::EXCLUSIVE
+    }
+}
+
+impl LsmAlienAccessHook for AppArmorLsm {}
+
+impl LsmBprmHook for AppArmorLsm {
+    fn on_bprm_check_security(&self, context: &BprmCheckContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_execute(&task_state, context.path_resolver(), context.executable())
+    }
+
+    fn on_bprm_committed_creds(&self, context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+        let task_state = context.credentials().apparmor_task_state();
+        let new_task_state = POLICY.committed_exec_state(
+            &task_state,
+            context.path_resolver(),
+            context.executable(),
+        )?;
+        context
+            .credentials()
+            .set_apparmor_task_state(new_task_state);
+        Ok(())
+    }
+
+    fn on_bprm_secureexec(&self, context: &BprmCheckContext<'_>) -> Result<bool> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(false);
+        };
+
+        POLICY.requires_secure_exec(&task_state, context.path_resolver(), context.executable())
+    }
+}
+
+impl LsmCapabilityHook for AppArmorLsm {
+    fn on_capable(&self, context: &CapableContext<'_>) -> Result<()> {
+        let task_state = context.posix_thread().credentials().apparmor_task_state();
+        POLICY.check_capability(&task_state, context.required_cap())
+    }
+}
+
+impl LsmFileHook for AppArmorLsm {
+    fn on_file_create(&self, context: &FileCreateContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_create(&task_state, context)
+    }
+
+    fn on_file_delete(&self, context: &FileDeleteContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_delete(
+            &task_state,
+            context.path_resolver(),
+            context.parent(),
+            context.name(),
+            context.kind(),
+        )
+    }
+
+    fn on_file_link(&self, context: &FileLinkContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_link(
+            &task_state,
+            context.path_resolver(),
+            context.source(),
+            context.target_parent(),
+            context.target_name(),
+        )
+    }
+
+    fn on_file_open(&self, context: &FileOpenContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_open(
+            &task_state,
+            context.path_resolver(),
+            context.path(),
+            context.access_mode(),
+            context.status_flags(),
+        )
+    }
+
+    fn on_file_rename(&self, context: &FileRenameContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_rename(&task_state, context)
+    }
+
+    fn on_file_setattr(&self, context: &FileSetattrContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_setattr(
+            &task_state,
+            context.path_resolver(),
+            context.path(),
+            context.kind(),
+        )
+    }
+
+    fn on_file_permission(&self, context: &FilePermissionContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_permission(
+            &task_state,
+            context.path_resolver(),
+            context.path(),
+            context.permissions(),
+        )
+    }
+
+    fn on_file_mmap(&self, context: &FileMmapContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_mmap(
+            &task_state,
+            context.path_resolver(),
+            context.path(),
+            context.permissions(),
+        )
+    }
+
+    fn on_file_receive(&self, context: &FileReceiveContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_receive(
+            &task_state,
+            context.path_resolver(),
+            context.path(),
+            context.permissions(),
+        )
+    }
+
+    fn on_file_lock(&self, context: &FileLockContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_lock(
+            &task_state,
+            context.path_resolver(),
+            context.path(),
+            context.permissions(),
+        )
+    }
+
+    fn on_file_getattr(&self, context: &FileGetattrContext<'_>) -> Result<()> {
+        let Some(task_state) = current_task_state() else {
+            return Ok(());
+        };
+
+        POLICY.check_file_getattr(&task_state, context.path_resolver(), context.path())
+    }
+}
+
+/// Loads, replaces, or removes an AppArmor profile from policy text.
+pub fn load_policy(policy_text: &str) -> Result<()> {
+    apply_policy_update(loader::parse_policy_load(policy_text)?)
+}
+
+/// Loads, replaces, or removes an AppArmor profile from binary policy data.
+pub fn load_binary_policy(
+    policy: &[u8],
+    expected_operation: AppArmorPolicyOperation,
+) -> Result<()> {
+    apply_policy_update(binary::unpack_binary_policy(policy, expected_operation)?)
+}
+
+/// Returns whether the data starts with the AppArmor binary policy magic.
+pub fn has_binary_policy_magic(policy: &[u8]) -> bool {
+    binary::has_binary_policy_magic(policy)
+}
+
+fn apply_policy_update(update: AppArmorPolicyUpdate) -> Result<()> {
+    match update {
+        AppArmorPolicyUpdate::Replace(profile) => {
+            POLICY.replace_profile(*profile);
+            Ok(())
+        }
+        AppArmorPolicyUpdate::ReplaceMany(profiles) => {
+            for profile in profiles {
+                POLICY.replace_profile(profile);
+            }
+            Ok(())
+        }
+        AppArmorPolicyUpdate::Remove(profile_name) => {
+            if POLICY.remove_profile(&profile_name).is_none() {
+                return_errno_with_message!(Errno::ENOENT, "the AppArmor profile is not loaded");
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Returns summaries of the implicit and loaded AppArmor profiles.
+pub fn profile_summaries() -> Vec<(AppArmorProfileName, AppArmorMode)> {
+    POLICY.profile_summaries()
+}
+
+/// Returns the root AppArmor policy namespace name.
+pub fn root_namespace_name() -> &'static str {
+    POLICY.root_namespace_name()
+}
+
+/// Creates task state after a mediated immediate profile change.
+pub fn change_profile_state(
+    task_state: &AppArmorTaskState,
+    profile_name: &str,
+) -> Result<AppArmorTaskState> {
+    let profile_name = AppArmorProfileName::new(profile_name.to_string())?;
+    POLICY.change_profile_state(task_state, profile_name)
+}
+
+/// Creates task state after a mediated change-on-exec request.
+pub fn change_onexec_state(
+    task_state: &AppArmorTaskState,
+    profile_name: Option<&str>,
+) -> Result<AppArmorTaskState> {
+    let profile_name = profile_name
+        .map(|profile_name| AppArmorProfileName::new(profile_name.to_string()))
+        .transpose()?;
+    POLICY.change_onexec_state(task_state, profile_name)
+}
+
+/// Removes a loaded AppArmor profile by name.
+pub fn remove_profile_by_name(profile_name: &str) -> Result<()> {
+    let profile_name = AppArmorProfileName::new(profile_name.to_string())?;
+    if profile_name.is_unconfined() {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the implicit unconfined AppArmor profile cannot be removed"
+        );
+    }
+    if POLICY.remove_profile(&profile_name).is_none() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor profile is not loaded");
+    }
+
+    Ok(())
+}
+
+fn current_task_state() -> Option<AppArmorTaskState> {
+    Thread::current()?
+        .as_posix_thread()
+        .map(|thread| thread.credentials().apparmor_task_state())
+}

--- a/kernel/src/security/lsm/modules/apparmor/namespace.rs
+++ b/kernel/src/security/lsm/modules/apparmor/namespace.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{
+    path::AppArmorPathView,
+    profile::{AppArmorProfile, AppArmorProfileName},
+    state::AppArmorMode,
+};
+use crate::prelude::*;
+
+/// An AppArmor policy namespace.
+///
+/// Linux AppArmor supports policy namespaces so containers can carry distinct
+/// policy views. Asterinas currently exposes the root namespace only, but policy
+/// storage is routed through this type so additional namespaces do not require a
+/// second policy-store refactor.
+pub struct AppArmorPolicyNamespace {
+    name: &'static str,
+    profiles: RwLock<BTreeMap<AppArmorProfileName, Arc<AppArmorProfile>>>,
+}
+
+impl AppArmorPolicyNamespace {
+    /// Creates the root AppArmor policy namespace.
+    pub const fn new_root() -> Self {
+        Self {
+            name: "root",
+            profiles: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    /// Returns the namespace name.
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Replaces or inserts a loaded profile.
+    pub fn replace_profile(&self, profile: AppArmorProfile) {
+        let name = profile.name().clone();
+        self.profiles.write().insert(name, Arc::new(profile));
+    }
+
+    /// Removes a loaded profile.
+    pub fn remove_profile(&self, name: &AppArmorProfileName) -> Option<AppArmorProfile> {
+        self.profiles
+            .write()
+            .remove(name)
+            .and_then(|profile| Arc::try_unwrap(profile).ok())
+    }
+
+    /// Looks up a profile by name.
+    pub fn profile(&self, name: &AppArmorProfileName) -> Option<Arc<AppArmorProfile>> {
+        if name.is_unconfined() {
+            return Some(Arc::new(AppArmorProfile::new_unconfined()));
+        }
+
+        self.profiles.read().get(name).cloned()
+    }
+
+    /// Looks up the profile attached to a path.
+    pub fn attached_profile(&self, path_view: &AppArmorPathView) -> Option<Arc<AppArmorProfile>> {
+        self.profiles
+            .read()
+            .values()
+            .find(|profile| profile.matches_attachment(path_view))
+            .cloned()
+    }
+
+    /// Returns summaries of the implicit and loaded profiles.
+    pub fn profile_summaries(&self) -> Vec<(AppArmorProfileName, AppArmorMode)> {
+        let profiles = self.profiles.read();
+        let mut summaries = Vec::with_capacity(profiles.len() + 1);
+
+        summaries.push((AppArmorProfileName::new_unconfined(), AppArmorMode::Enforce));
+        summaries.extend(
+            profiles
+                .values()
+                .map(|profile| (profile.name().clone(), profile.mode())),
+        );
+
+        summaries
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/path.rs
+++ b/kernel/src/security/lsm/modules/apparmor/path.rs
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::profile::AppArmorProfileName;
+use crate::{
+    fs::{
+        file::{AccessMode, StatusFlags},
+        vfs::path::{AbsPathResult, Path, PathResolver},
+    },
+    prelude::*,
+    security::{FileCreateKind, FileDeleteKind, FilePermission, FileSetattrKind},
+};
+
+bitflags! {
+    /// File permissions requested from an AppArmor profile.
+    pub struct AppArmorFilePermission: u32 {
+        /// Reads file contents or directory entries.
+        const READ = 1 << 0;
+        /// Writes file contents.
+        const WRITE = 1 << 1;
+        /// Executes a file.
+        const EXECUTE = 1 << 2;
+        /// Appends file contents.
+        const APPEND = 1 << 3;
+        /// Maps file contents.
+        const MMAP = 1 << 4;
+        /// Creates a filesystem object.
+        const CREATE = 1 << 5;
+        /// Deletes a filesystem object.
+        const DELETE = 1 << 6;
+        /// Creates a hard link.
+        const LINK = 1 << 7;
+        /// Renames a filesystem object.
+        const RENAME = 1 << 8;
+        /// Creates a directory.
+        const MKDIR = 1 << 9;
+        /// Creates a special filesystem node.
+        const MKNOD = 1 << 10;
+        /// Creates a symbolic link.
+        const SYMLINK = 1 << 11;
+        /// Changes file attributes.
+        const SETATTR = 1 << 12;
+    }
+}
+
+impl AppArmorFilePermission {
+    /// Creates file permissions requested by an open operation.
+    pub fn from_open(access_mode: AccessMode, status_flags: StatusFlags) -> Self {
+        let mut permissions = Self::empty();
+
+        if access_mode.is_readable() {
+            permissions |= Self::READ;
+        }
+
+        if access_mode.is_writable() {
+            if status_flags.contains(StatusFlags::O_APPEND) {
+                permissions |= Self::APPEND;
+            } else {
+                permissions |= Self::WRITE;
+            }
+        }
+
+        permissions
+    }
+
+    /// Creates file permissions requested by an execute operation.
+    pub fn for_execute() -> Self {
+        Self::EXECUTE
+    }
+
+    /// Creates file permissions requested by a create operation.
+    pub fn for_create(
+        kind: FileCreateKind,
+        access_mode: Option<AccessMode>,
+        status_flags: StatusFlags,
+    ) -> Self {
+        let mut permissions = Self::CREATE;
+        permissions |= match kind {
+            FileCreateKind::Regular => Self::empty(),
+            FileCreateKind::Directory => Self::MKDIR,
+            FileCreateKind::Device | FileCreateKind::Fifo => Self::MKNOD,
+            FileCreateKind::Symlink => Self::SYMLINK,
+        };
+
+        if let Some(access_mode) = access_mode {
+            permissions |= Self::from_open(access_mode, status_flags);
+        }
+
+        permissions
+    }
+
+    /// Creates file permissions requested by a delete operation.
+    pub fn for_delete(kind: FileDeleteKind) -> Self {
+        let mut permissions = Self::DELETE;
+        if kind == FileDeleteKind::Directory {
+            permissions |= Self::MKDIR;
+        }
+        permissions
+    }
+
+    /// Creates file permissions requested on the source of a link operation.
+    pub fn for_link_source() -> Self {
+        Self::LINK
+    }
+
+    /// Creates file permissions requested on the target of a link operation.
+    pub fn for_link_target() -> Self {
+        Self::CREATE | Self::LINK
+    }
+
+    /// Creates file permissions requested on the source of a rename operation.
+    pub fn for_rename_source() -> Self {
+        Self::DELETE | Self::RENAME
+    }
+
+    /// Creates file permissions requested on the target of a rename operation.
+    pub fn for_rename_target() -> Self {
+        Self::CREATE | Self::RENAME
+    }
+
+    /// Creates file permissions requested by an attribute-change operation.
+    pub fn for_setattr(kind: FileSetattrKind) -> Self {
+        match kind {
+            FileSetattrKind::Mode
+            | FileSetattrKind::Owner
+            | FileSetattrKind::Size
+            | FileSetattrKind::Times => Self::SETATTR,
+        }
+    }
+
+    /// Creates file permissions from generic LSM file permissions.
+    pub fn from_file_permission(permissions: FilePermission) -> Self {
+        let mut apparmor_permissions = Self::empty();
+
+        if permissions.contains(FilePermission::READ) {
+            apparmor_permissions |= Self::READ;
+        }
+        if permissions.contains(FilePermission::WRITE) {
+            apparmor_permissions |= Self::WRITE;
+        }
+        if permissions.contains(FilePermission::EXECUTE) {
+            apparmor_permissions |= Self::EXECUTE;
+        }
+        if permissions.contains(FilePermission::APPEND) {
+            apparmor_permissions |= Self::APPEND;
+        }
+        if permissions.contains(FilePermission::MMAP) {
+            apparmor_permissions |= Self::MMAP;
+        }
+
+        apparmor_permissions
+    }
+
+    /// Converts Linux AppArmor permission bits into local file permissions.
+    pub(super) fn from_linux_bits(bits: u32) -> Self {
+        let mut permissions = Self::empty();
+
+        if bits & linux_file_permission::READ != 0 {
+            permissions |= Self::READ;
+        }
+        if bits & linux_file_permission::WRITE != 0 {
+            permissions |= Self::WRITE;
+        }
+        if bits & linux_file_permission::EXECUTE != 0 {
+            permissions |= Self::EXECUTE;
+        }
+        if bits & linux_file_permission::APPEND != 0 {
+            permissions |= Self::APPEND;
+        }
+        if bits & linux_file_permission::MMAP != 0 {
+            permissions |= Self::MMAP;
+        }
+        if bits & linux_file_permission::CREATE != 0 {
+            permissions |= Self::CREATE;
+        }
+        if bits & linux_file_permission::DELETE != 0 {
+            permissions |= Self::DELETE;
+        }
+        if bits & linux_file_permission::RENAME != 0 {
+            permissions |= Self::RENAME;
+        }
+        if bits & linux_file_permission::SETATTR != 0 {
+            permissions |= Self::SETATTR;
+        }
+        if bits & linux_file_permission::LINK != 0 {
+            permissions |= Self::LINK;
+        }
+
+        permissions
+    }
+
+    /// Converts local file permissions into Linux AppArmor permission bits.
+    pub(super) fn to_linux_bits(self) -> u32 {
+        let mut bits = 0;
+
+        if self.contains(Self::READ) {
+            bits |= linux_file_permission::READ;
+        }
+        if self.contains(Self::WRITE) {
+            bits |= linux_file_permission::WRITE;
+        }
+        if self.contains(Self::EXECUTE) {
+            bits |= linux_file_permission::EXECUTE;
+        }
+        if self.contains(Self::APPEND) {
+            bits |= linux_file_permission::APPEND;
+        }
+        if self.contains(Self::MMAP) {
+            bits |= linux_file_permission::MMAP;
+        }
+        if self.contains(Self::CREATE) {
+            bits |= linux_file_permission::CREATE;
+        }
+        if self.contains(Self::DELETE) {
+            bits |= linux_file_permission::DELETE;
+        }
+        if self.contains(Self::RENAME) {
+            bits |= linux_file_permission::RENAME;
+        }
+        if self.contains(Self::SETATTR) {
+            bits |= linux_file_permission::SETATTR;
+        }
+        if self.contains(Self::LINK) {
+            bits |= linux_file_permission::LINK;
+        }
+
+        bits
+    }
+}
+
+mod linux_file_permission {
+    pub(super) const EXECUTE: u32 = 1 << 0;
+    pub(super) const WRITE: u32 = 1 << 1;
+    pub(super) const READ: u32 = 1 << 2;
+    pub(super) const APPEND: u32 = 1 << 3;
+    pub(super) const CREATE: u32 = 0x0010;
+    pub(super) const DELETE: u32 = 0x0020;
+    pub(super) const RENAME: u32 = 0x0080;
+    pub(super) const SETATTR: u32 = 0x0100;
+    pub(super) const MMAP: u32 = 0x0001_0000;
+    pub(super) const LINK: u32 = 0x0004_0000;
+}
+
+/// A path as seen through a task's current filesystem root.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AppArmorPathView {
+    /// The path can be traced back to the resolver root.
+    Reachable(String),
+    /// The path cannot be traced back to the resolver root.
+    Unreachable(String),
+}
+
+impl AppArmorPathView {
+    /// Builds a path view from a resolved VFS path and resolver.
+    pub fn from_path(path_resolver: &PathResolver, path: &Path) -> Self {
+        match path_resolver.make_abs_path(path) {
+            AbsPathResult::Reachable(path_name) => Self::Reachable(path_name),
+            AbsPathResult::Unreachable(path_name) => Self::Unreachable(path_name),
+        }
+    }
+
+    /// Builds a child path view from a parent path and basename.
+    pub fn from_child_name(path_resolver: &PathResolver, parent: &Path, name: &str) -> Self {
+        match Self::from_path(path_resolver, parent) {
+            Self::Reachable(parent_name) => Self::Reachable(join_child_path(parent_name, name)),
+            Self::Unreachable(parent_name) => Self::Unreachable(join_child_path(parent_name, name)),
+        }
+    }
+
+    /// Returns the visible path text.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Reachable(path_name) | Self::Unreachable(path_name) => path_name.as_str(),
+        }
+    }
+
+    /// Returns whether the path was reachable from the resolver root.
+    pub fn is_reachable(&self) -> bool {
+        matches!(self, Self::Reachable(_))
+    }
+}
+
+fn join_child_path(mut parent_name: String, name: &str) -> String {
+    if parent_name != "/" {
+        parent_name.push('/');
+    }
+    parent_name.push_str(name);
+    parent_name
+}
+
+/// A path pattern in an AppArmor rule.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppArmorPathPattern(String);
+
+impl AppArmorPathPattern {
+    /// Creates a path pattern.
+    pub fn new(pattern: String) -> Self {
+        Self(pattern)
+    }
+
+    /// Returns whether the pattern matches a path.
+    pub fn matches(&self, path_view: &AppArmorPathView) -> bool {
+        glob_matches(self.as_str().as_bytes(), path_view.as_str().as_bytes())
+    }
+
+    /// Returns the pattern text.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+/// The profile transition to apply after a successful executable image load.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AppArmorExecTransition {
+    /// Keeps the current profile.
+    Inherit,
+    /// Switches to the unconfined profile.
+    Unconfined {
+        /// The exec mode requested by the rule qualifier.
+        mode: AppArmorExecMode,
+    },
+    /// Switches to a named profile.
+    Profile {
+        /// The profile selected by the rule qualifier.
+        profile_name: AppArmorProfileName,
+        /// The exec mode requested by the rule qualifier.
+        mode: AppArmorExecMode,
+    },
+    /// Switches to a child profile.
+    Child {
+        /// The child profile selected by the rule qualifier.
+        profile_name: AppArmorProfileName,
+        /// The exec mode requested by the rule qualifier.
+        mode: AppArmorExecMode,
+    },
+}
+
+/// The safety mode requested by an AppArmor exec qualifier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AppArmorExecMode {
+    /// Lowercase qualifiers such as `px`, `cx`, and `ux`.
+    Unsafe,
+    /// Uppercase qualifiers such as `Px`, `Cx`, and `Ux`.
+    Safe,
+}
+
+impl AppArmorExecTransition {
+    /// Creates an unconfined transition.
+    pub fn unconfined(mode: AppArmorExecMode) -> Self {
+        Self::Unconfined { mode }
+    }
+
+    /// Creates a named-profile transition.
+    pub fn profile(profile_name: AppArmorProfileName, mode: AppArmorExecMode) -> Self {
+        Self::Profile { profile_name, mode }
+    }
+
+    /// Creates a child-profile transition.
+    pub fn child(profile_name: AppArmorProfileName, mode: AppArmorExecMode) -> Self {
+        Self::Child { profile_name, mode }
+    }
+
+    /// Returns the target profile name for transitions that change profile.
+    pub fn target_profile(&self) -> Option<AppArmorProfileName> {
+        match self {
+            Self::Inherit => None,
+            Self::Unconfined { .. } => Some(AppArmorProfileName::new_unconfined()),
+            Self::Profile { profile_name, .. } | Self::Child { profile_name, .. } => {
+                Some(profile_name.clone())
+            }
+        }
+    }
+
+    /// Returns whether this transition requested safe exec handling.
+    pub const fn requires_secure_exec(&self) -> bool {
+        matches!(
+            self,
+            Self::Unconfined {
+                mode: AppArmorExecMode::Safe
+            } | Self::Profile {
+                mode: AppArmorExecMode::Safe,
+                ..
+            } | Self::Child {
+                mode: AppArmorExecMode::Safe,
+                ..
+            }
+        )
+    }
+}
+
+/// A file rule keyed by an AppArmor path pattern.
+#[derive(Clone, Debug)]
+pub struct AppArmorPathRule {
+    pattern: AppArmorPathPattern,
+    permissions: AppArmorFilePermission,
+    exec_transition: AppArmorExecTransition,
+    audit: bool,
+    deny: bool,
+}
+
+impl AppArmorPathRule {
+    /// Creates a path rule with an executable transition.
+    pub fn new_with_transition(
+        pattern: AppArmorPathPattern,
+        permissions: AppArmorFilePermission,
+        exec_transition: AppArmorExecTransition,
+        audit: bool,
+        deny: bool,
+    ) -> Self {
+        Self {
+            pattern,
+            permissions,
+            exec_transition,
+            audit,
+            deny,
+        }
+    }
+
+    /// Returns the rule permissions.
+    pub fn permissions(&self) -> AppArmorFilePermission {
+        self.permissions
+    }
+
+    /// Returns the executable transition.
+    pub fn exec_transition(&self) -> &AppArmorExecTransition {
+        &self.exec_transition
+    }
+
+    /// Returns whether this rule matches a path.
+    pub fn matches(&self, path_view: &AppArmorPathView) -> bool {
+        self.pattern.matches(path_view)
+    }
+
+    /// Returns whether accesses matching this rule should be audited.
+    pub fn audit(&self) -> bool {
+        self.audit
+    }
+
+    /// Returns whether this is a deny rule.
+    pub fn deny(&self) -> bool {
+        self.deny
+    }
+}
+
+fn glob_matches(pattern: &[u8], path: &[u8]) -> bool {
+    glob_matches_from(pattern, 0, path, 0)
+}
+
+fn glob_matches_from(pattern: &[u8], pattern_index: usize, path: &[u8], path_index: usize) -> bool {
+    if pattern_index == pattern.len() {
+        return path_index == path.len();
+    }
+
+    match pattern[pattern_index] {
+        b'\\' => match_escaped(pattern, pattern_index, path, path_index),
+        b'?' => {
+            path_index < path.len()
+                && path[path_index] != b'/'
+                && glob_matches_from(pattern, pattern_index + 1, path, path_index + 1)
+        }
+        b'*' => match_star(pattern, pattern_index, path, path_index),
+        byte => {
+            path_index < path.len()
+                && path[path_index] == byte
+                && glob_matches_from(pattern, pattern_index + 1, path, path_index + 1)
+        }
+    }
+}
+
+fn match_escaped(pattern: &[u8], pattern_index: usize, path: &[u8], path_index: usize) -> bool {
+    let literal_index = pattern_index + 1;
+    if literal_index == pattern.len() {
+        return path_index < path.len()
+            && path[path_index] == b'\\'
+            && glob_matches_from(pattern, literal_index, path, path_index + 1);
+    }
+
+    path_index < path.len()
+        && path[path_index] == pattern[literal_index]
+        && glob_matches_from(pattern, literal_index + 1, path, path_index + 1)
+}
+
+fn match_star(pattern: &[u8], pattern_index: usize, path: &[u8], path_index: usize) -> bool {
+    let is_double_star = pattern_index + 1 < pattern.len() && pattern[pattern_index + 1] == b'*';
+    let next_pattern_index = pattern_index + if is_double_star { 2 } else { 1 };
+
+    if glob_matches_from(pattern, next_pattern_index, path, path_index) {
+        return true;
+    }
+
+    let mut next_path_index = path_index;
+    while next_path_index < path.len() {
+        if !is_double_star && path[next_path_index] == b'/' {
+            return false;
+        }
+
+        next_path_index += 1;
+        if glob_matches_from(pattern, next_pattern_index, path, next_path_index) {
+            return true;
+        }
+    }
+
+    false
+}

--- a/kernel/src/security/lsm/modules/apparmor/policy.rs
+++ b/kernel/src/security/lsm/modules/apparmor/policy.rs
@@ -1,0 +1,626 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{
+    namespace::AppArmorPolicyNamespace,
+    path::{AppArmorExecTransition, AppArmorFilePermission, AppArmorPathView},
+    profile::{AppArmorProfile, AppArmorProfileName, AppArmorProfileTransitionKind},
+    state::{AppArmorMode, AppArmorTaskState},
+};
+use crate::{
+    fs::{
+        file::{AccessMode, InodeType, StatusFlags},
+        vfs::{
+            inode::RenameMode,
+            path::{Path, PathResolver},
+        },
+    },
+    prelude::*,
+    process::credentials::capabilities::CapSet,
+    security::{
+        FileDeleteKind, FilePermission, FileSetattrKind,
+        lsm::{FileCreateContext, FileRenameContext},
+    },
+};
+
+/// The in-kernel AppArmor policy store.
+pub struct AppArmorPolicy {
+    root_namespace: AppArmorPolicyNamespace,
+}
+
+impl AppArmorPolicy {
+    /// Creates an empty policy store with the implicit unconfined profile.
+    pub const fn new() -> Self {
+        Self {
+            root_namespace: AppArmorPolicyNamespace::new_root(),
+        }
+    }
+
+    /// Replaces or inserts a loaded profile.
+    pub fn replace_profile(&self, profile: AppArmorProfile) {
+        self.root_namespace.replace_profile(profile);
+    }
+
+    /// Removes a loaded profile.
+    pub fn remove_profile(&self, name: &AppArmorProfileName) -> Option<AppArmorProfile> {
+        self.root_namespace.remove_profile(name)
+    }
+
+    /// Returns summaries of the implicit and loaded profiles.
+    pub fn profile_summaries(&self) -> Vec<(AppArmorProfileName, AppArmorMode)> {
+        self.root_namespace.profile_summaries()
+    }
+
+    /// Returns the root policy namespace name.
+    pub fn root_namespace_name(&self) -> &'static str {
+        self.root_namespace.name()
+    }
+
+    /// Checks whether the task may open a file.
+    pub fn check_file_open(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::from_open(access_mode, status_flags);
+        self.check_path_access(task_state, path_resolver, path, permissions)
+    }
+
+    /// Checks whether the task may create a filesystem object.
+    pub fn check_file_create(
+        &self,
+        task_state: &AppArmorTaskState,
+        context: &FileCreateContext<'_>,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::for_create(
+            context.kind(),
+            context.access_mode(),
+            context.status_flags(),
+        );
+        if let Some(name) = context.name() {
+            return self.check_child_path_access(
+                task_state,
+                context.path_resolver(),
+                context.parent(),
+                name,
+                permissions,
+            );
+        }
+
+        self.check_path_access(
+            task_state,
+            context.path_resolver(),
+            context.parent(),
+            permissions,
+        )
+    }
+
+    /// Checks whether the task may delete a filesystem object.
+    pub fn check_file_delete(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        parent: &Path,
+        name: &str,
+        kind: FileDeleteKind,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::for_delete(kind);
+        self.check_child_path_access(task_state, path_resolver, parent, name, permissions)
+    }
+
+    /// Checks whether the task may create a hard link.
+    pub fn check_file_link(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        source: &Path,
+        target_parent: &Path,
+        target_name: &str,
+    ) -> Result<()> {
+        self.check_path_access(
+            task_state,
+            path_resolver,
+            source,
+            AppArmorFilePermission::for_link_source(),
+        )?;
+
+        self.check_child_path_access(
+            task_state,
+            path_resolver,
+            target_parent,
+            target_name,
+            AppArmorFilePermission::for_link_target(),
+        )
+    }
+
+    /// Checks whether the task may rename a filesystem object.
+    pub fn check_file_rename(
+        &self,
+        task_state: &AppArmorTaskState,
+        context: &FileRenameContext<'_>,
+    ) -> Result<()> {
+        self.check_path_access(
+            task_state,
+            context.path_resolver(),
+            context.source(),
+            AppArmorFilePermission::for_rename_source(),
+        )?;
+
+        self.check_child_path_access(
+            task_state,
+            context.path_resolver(),
+            context.new_parent(),
+            context.new_name(),
+            AppArmorFilePermission::for_rename_target(),
+        )?;
+
+        let Some(target) = context.target() else {
+            return Ok(());
+        };
+        if target == context.source() {
+            return Ok(());
+        }
+        let target_permissions = match context.mode() {
+            RenameMode::Replace => {
+                let kind = if target.type_() == InodeType::Dir {
+                    FileDeleteKind::Directory
+                } else {
+                    FileDeleteKind::NonDirectory
+                };
+                AppArmorFilePermission::for_delete(kind)
+            }
+            RenameMode::NoReplace => AppArmorFilePermission::empty(),
+            RenameMode::Exchange => AppArmorFilePermission::RENAME,
+        };
+        if target_permissions.is_empty() {
+            return Ok(());
+        }
+
+        self.check_path_access(
+            task_state,
+            context.path_resolver(),
+            target,
+            target_permissions,
+        )
+    }
+
+    /// Checks whether the task may change file attributes.
+    pub fn check_file_setattr(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+        kind: FileSetattrKind,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::for_setattr(kind);
+        self.check_path_access(task_state, path_resolver, path, permissions)
+    }
+
+    /// Revalidates access through an existing opened file.
+    pub fn check_file_permission(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+        permissions: FilePermission,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::from_file_permission(permissions);
+        self.check_path_access(task_state, path_resolver, path, permissions)
+    }
+
+    /// Checks whether the task may map a file.
+    pub fn check_file_mmap(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+        permissions: FilePermission,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::from_file_permission(permissions);
+        self.check_path_access(task_state, path_resolver, path, permissions)
+    }
+
+    /// Checks whether the task may receive a file descriptor.
+    pub fn check_file_receive(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+        permissions: FilePermission,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::from_file_permission(permissions);
+        self.check_path_access(task_state, path_resolver, path, permissions)
+    }
+
+    /// Checks whether the task may lock a file.
+    pub fn check_file_lock(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+        permissions: FilePermission,
+    ) -> Result<()> {
+        let permissions = AppArmorFilePermission::from_file_permission(permissions);
+        self.check_path_access(task_state, path_resolver, path, permissions)
+    }
+
+    /// Checks whether the task may query file metadata.
+    pub fn check_file_getattr(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+    ) -> Result<()> {
+        self.check_path_access(
+            task_state,
+            path_resolver,
+            path,
+            AppArmorFilePermission::READ,
+        )
+    }
+
+    /// Checks whether the task may execute a file.
+    pub fn check_execute(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+    ) -> Result<()> {
+        if task_state.is_unconfined() {
+            if let Some(onexec_profile) = task_state.onexec_profile() {
+                self.require_loaded_profile(onexec_profile)?;
+            }
+            return Ok(());
+        }
+
+        let Some(profile) = self.profile(task_state.current_profile()) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor profile is not loaded");
+        };
+
+        let path_view = AppArmorPathView::from_path(path_resolver, path);
+        let outcome = self.check_profile_path_access(
+            &profile,
+            task_state.mode(),
+            &path_view,
+            AppArmorFilePermission::for_execute(),
+        )?;
+
+        if let Some(onexec_profile) = task_state.onexec_profile() {
+            self.require_loaded_profile(onexec_profile)?;
+            return Ok(());
+        }
+
+        self.check_exec_transition_target(&outcome.exec_transition)
+    }
+
+    /// Returns whether executing a file requests secure-execution mode.
+    pub fn requires_secure_exec(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+    ) -> Result<bool> {
+        if task_state.is_unconfined() || task_state.onexec_profile().is_some() {
+            return Ok(false);
+        }
+
+        let Some(profile) = self.profile(task_state.current_profile()) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor profile is not loaded");
+        };
+
+        let path_view = AppArmorPathView::from_path(path_resolver, path);
+        let outcome = self.check_profile_path_access(
+            &profile,
+            task_state.mode(),
+            &path_view,
+            AppArmorFilePermission::for_execute(),
+        )?;
+
+        Ok(outcome.exec_transition.requires_secure_exec())
+    }
+
+    /// Checks whether the task may use a capability.
+    pub fn check_capability(
+        &self,
+        task_state: &AppArmorTaskState,
+        required_cap: CapSet,
+    ) -> Result<()> {
+        if task_state.is_unconfined() {
+            return Ok(());
+        }
+
+        let Some(profile) = self.profile(task_state.current_profile()) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor profile is not loaded");
+        };
+
+        let outcome = profile.evaluate_capability_access(required_cap);
+        let mode = effective_mode(task_state.mode(), profile.mode());
+        if outcome.denied.is_empty() || mode == AppArmorMode::Complain {
+            return Ok(());
+        }
+
+        warn!(
+            "AppArmor denied capability use: profile={} requested={:#x} denied={:#x}",
+            profile.name().as_str(),
+            required_cap.bits(),
+            outcome.denied.bits()
+        );
+        return_errno_with_message!(Errno::EACCES, "AppArmor policy denied capability use");
+    }
+
+    /// Computes task state after a successful `execve`.
+    pub fn committed_exec_state(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+    ) -> Result<AppArmorTaskState> {
+        let path_view = AppArmorPathView::from_path(path_resolver, path);
+
+        if let Some(onexec_profile) = task_state.onexec_profile() {
+            return self.transition_state_to_profile(task_state, onexec_profile.clone());
+        }
+
+        if task_state.is_unconfined() {
+            let Some(attached_profile) = self.root_namespace.attached_profile(&path_view) else {
+                return Ok(task_state.clone());
+            };
+
+            return Ok(
+                task_state.transition_to(attached_profile.name().clone(), attached_profile.mode())
+            );
+        }
+
+        let Some(profile) = self.profile(task_state.current_profile()) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor profile is not loaded");
+        };
+
+        let outcome = self.evaluate_path_access(
+            &profile,
+            task_state.mode(),
+            &path_view,
+            AppArmorFilePermission::for_execute(),
+        )?;
+
+        let Some(target_profile) = outcome.exec_transition.target_profile() else {
+            return Ok(task_state.clone());
+        };
+
+        self.transition_state_to_profile(task_state, target_profile)
+    }
+
+    /// Computes task state after an immediate profile change.
+    pub fn change_profile_state(
+        &self,
+        task_state: &AppArmorTaskState,
+        target_profile: AppArmorProfileName,
+    ) -> Result<AppArmorTaskState> {
+        self.check_profile_transition(
+            task_state,
+            &target_profile,
+            AppArmorProfileTransitionKind::ChangeProfile,
+        )?;
+        let target = self.require_loaded_profile(&target_profile)?;
+
+        Ok(task_state.change_to(target.name().clone(), target.mode()))
+    }
+
+    /// Computes task state after setting a profile for the next `execve`.
+    pub fn change_onexec_state(
+        &self,
+        task_state: &AppArmorTaskState,
+        target_profile: Option<AppArmorProfileName>,
+    ) -> Result<AppArmorTaskState> {
+        let Some(target_profile) = target_profile else {
+            return Ok(task_state.clone().with_onexec_profile(None));
+        };
+
+        self.check_profile_transition(
+            task_state,
+            &target_profile,
+            AppArmorProfileTransitionKind::ChangeOnexec,
+        )?;
+        let target = self.require_loaded_profile(&target_profile)?;
+
+        Ok(task_state
+            .clone()
+            .with_onexec_profile(Some(target.name().clone())))
+    }
+
+    fn check_path_access(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        path: &Path,
+        permissions: AppArmorFilePermission,
+    ) -> Result<()> {
+        if task_state.is_unconfined() {
+            return Ok(());
+        }
+
+        let Some(profile) = self.profile(task_state.current_profile()) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor profile is not loaded");
+        };
+
+        let path_view = AppArmorPathView::from_path(path_resolver, path);
+        self.check_profile_path_access(&profile, task_state.mode(), &path_view, permissions)
+            .map(|_| ())
+    }
+
+    fn check_child_path_access(
+        &self,
+        task_state: &AppArmorTaskState,
+        path_resolver: &PathResolver,
+        parent: &Path,
+        name: &str,
+        permissions: AppArmorFilePermission,
+    ) -> Result<()> {
+        if task_state.is_unconfined() {
+            return Ok(());
+        }
+
+        let Some(profile) = self.profile(task_state.current_profile()) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor profile is not loaded");
+        };
+
+        let path_view = AppArmorPathView::from_child_name(path_resolver, parent, name);
+        self.check_profile_path_access(&profile, task_state.mode(), &path_view, permissions)
+            .map(|_| ())
+    }
+
+    fn profile(&self, name: &AppArmorProfileName) -> Option<Arc<AppArmorProfile>> {
+        self.root_namespace.profile(name)
+    }
+
+    fn transition_state_to_profile(
+        &self,
+        task_state: &AppArmorTaskState,
+        profile_name: AppArmorProfileName,
+    ) -> Result<AppArmorTaskState> {
+        let target = self.require_loaded_profile(&profile_name)?;
+
+        Ok(task_state.transition_to(target.name().clone(), target.mode()))
+    }
+
+    fn check_profile_path_access(
+        &self,
+        profile: &AppArmorProfile,
+        task_mode: AppArmorMode,
+        path_view: &AppArmorPathView,
+        permissions: AppArmorFilePermission,
+    ) -> Result<PathAccessOutcome> {
+        let mode = effective_mode(task_mode, profile.mode());
+        if permissions.is_empty() {
+            return Ok(PathAccessOutcome::allowed(mode));
+        }
+
+        let outcome = self.evaluate_path_access(profile, task_mode, path_view, permissions)?;
+        if outcome.is_allowed() || outcome.mode == AppArmorMode::Complain {
+            return Ok(outcome);
+        }
+
+        warn!(
+            "AppArmor denied file access: profile={} path={} requested={:#x} denied={:#x}",
+            profile.name().as_str(),
+            path_view.as_str(),
+            permissions.bits(),
+            outcome.denied.bits()
+        );
+        return_errno_with_message!(Errno::EACCES, "AppArmor policy denied access");
+    }
+
+    fn check_profile_transition(
+        &self,
+        task_state: &AppArmorTaskState,
+        target_profile: &AppArmorProfileName,
+        kind: AppArmorProfileTransitionKind,
+    ) -> Result<()> {
+        self.require_loaded_profile(target_profile)?;
+        if task_state.is_unconfined() || target_profile == task_state.current_profile() {
+            return Ok(());
+        }
+
+        let Some(profile) = self.profile(task_state.current_profile()) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor profile is not loaded");
+        };
+        let mode = effective_mode(task_state.mode(), profile.mode());
+        if profile.allows_profile_transition(target_profile, kind) || mode == AppArmorMode::Complain
+        {
+            return Ok(());
+        }
+
+        warn!(
+            "AppArmor denied profile transition: profile={} target={} kind={:?}",
+            profile.name().as_str(),
+            target_profile.as_str(),
+            kind
+        );
+        return_errno_with_message!(Errno::EACCES, "AppArmor policy denied profile transition");
+    }
+
+    fn check_exec_transition_target(&self, transition: &AppArmorExecTransition) -> Result<()> {
+        let Some(target_profile) = transition.target_profile() else {
+            return Ok(());
+        };
+
+        self.require_loaded_profile(&target_profile).map(|_| ())
+    }
+
+    fn require_loaded_profile(
+        &self,
+        profile_name: &AppArmorProfileName,
+    ) -> Result<Arc<AppArmorProfile>> {
+        let Some(profile) = self.profile(profile_name) else {
+            return_errno_with_message!(Errno::EACCES, "the AppArmor target profile is not loaded");
+        };
+
+        Ok(profile)
+    }
+
+    fn evaluate_path_access(
+        &self,
+        profile: &AppArmorProfile,
+        task_mode: AppArmorMode,
+        path_view: &AppArmorPathView,
+        permissions: AppArmorFilePermission,
+    ) -> Result<PathAccessOutcome> {
+        let mode = effective_mode(task_mode, profile.mode());
+        if !path_view.is_reachable() {
+            warn!(
+                "AppArmor denied file access to unreachable path: profile={} path={} requested={:#x}",
+                profile.name().as_str(),
+                path_view.as_str(),
+                permissions.bits()
+            );
+
+            if mode == AppArmorMode::Complain {
+                return Ok(PathAccessOutcome {
+                    denied: permissions,
+                    exec_transition: AppArmorExecTransition::Inherit,
+                    mode,
+                });
+            }
+
+            return_errno_with_message!(Errno::EACCES, "AppArmor path is unreachable");
+        }
+
+        let outcome = profile.evaluate_file_access(path_view, permissions)?;
+        let _audit = outcome.audit;
+
+        Ok(PathAccessOutcome {
+            denied: outcome.denied,
+            exec_transition: outcome.exec_transition,
+            mode,
+        })
+    }
+}
+
+fn effective_mode(task_mode: AppArmorMode, profile_mode: AppArmorMode) -> AppArmorMode {
+    if task_mode == AppArmorMode::Complain || profile_mode == AppArmorMode::Complain {
+        AppArmorMode::Complain
+    } else {
+        AppArmorMode::Enforce
+    }
+}
+
+struct PathAccessOutcome {
+    denied: AppArmorFilePermission,
+    exec_transition: AppArmorExecTransition,
+    mode: AppArmorMode,
+}
+
+impl PathAccessOutcome {
+    fn allowed(mode: AppArmorMode) -> Self {
+        Self {
+            denied: AppArmorFilePermission::empty(),
+            exec_transition: AppArmorExecTransition::Inherit,
+            mode,
+        }
+    }
+
+    fn is_allowed(&self) -> bool {
+        self.denied.is_empty()
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/policy.rs
+++ b/kernel/src/security/lsm/modules/apparmor/policy.rs
@@ -337,16 +337,36 @@ impl AppArmorPolicy {
 
         let outcome = profile.evaluate_capability_access(required_cap);
         let mode = effective_mode(task_state.mode(), profile.mode());
-        if outcome.denied.is_empty() || mode == AppArmorMode::Complain {
+        if outcome.denied.is_empty() {
+            if outcome.audit {
+                info!(
+                    "AppArmor audited capability use: profile={} requested={:#x}",
+                    profile.name().as_str(),
+                    required_cap.bits()
+                );
+            }
             return Ok(());
         }
 
-        warn!(
-            "AppArmor denied capability use: profile={} requested={:#x} denied={:#x}",
-            profile.name().as_str(),
-            required_cap.bits(),
-            outcome.denied.bits()
-        );
+        if outcome.audit || !outcome.quiet {
+            let message = if mode == AppArmorMode::Complain {
+                "AppArmor would deny capability use"
+            } else {
+                "AppArmor denied capability use"
+            };
+            warn!(
+                "{}: profile={} requested={:#x} denied={:#x}",
+                message,
+                profile.name().as_str(),
+                required_cap.bits(),
+                outcome.denied.bits()
+            );
+        }
+
+        if mode == AppArmorMode::Complain {
+            return Ok(());
+        }
+
         return_errno_with_message!(Errno::EACCES, "AppArmor policy denied capability use");
     }
 
@@ -497,17 +517,40 @@ impl AppArmorPolicy {
         }
 
         let outcome = self.evaluate_path_access(profile, task_mode, path_view, permissions)?;
-        if outcome.is_allowed() || outcome.mode == AppArmorMode::Complain {
+        if outcome.is_allowed() {
+            if outcome.audit {
+                info!(
+                    "AppArmor audited file access: profile={} path={} requested={:#x}",
+                    profile.name().as_str(),
+                    path_view.as_str(),
+                    permissions.bits()
+                );
+            }
             return Ok(outcome);
         }
 
-        warn!(
-            "AppArmor denied file access: profile={} path={} requested={:#x} denied={:#x}",
-            profile.name().as_str(),
-            path_view.as_str(),
-            permissions.bits(),
-            outcome.denied.bits()
-        );
+        let enforce_denial =
+            outcome.mode != AppArmorMode::Complain || !outcome.explicit_denied.is_empty();
+        if outcome.audit || !outcome.quiet {
+            let message = if enforce_denial {
+                "AppArmor denied file access"
+            } else {
+                "AppArmor would deny file access"
+            };
+            warn!(
+                "{}: profile={} path={} requested={:#x} denied={:#x}",
+                message,
+                profile.name().as_str(),
+                path_view.as_str(),
+                permissions.bits(),
+                outcome.denied.bits()
+            );
+        }
+
+        if !enforce_denial {
+            return Ok(outcome);
+        }
+
         return_errno_with_message!(Errno::EACCES, "AppArmor policy denied access");
     }
 
@@ -578,7 +621,10 @@ impl AppArmorPolicy {
             if mode == AppArmorMode::Complain {
                 return Ok(PathAccessOutcome {
                     denied: permissions,
+                    explicit_denied: AppArmorFilePermission::empty(),
                     exec_transition: AppArmorExecTransition::Inherit,
+                    audit: false,
+                    quiet: false,
                     mode,
                 });
             }
@@ -587,11 +633,13 @@ impl AppArmorPolicy {
         }
 
         let outcome = profile.evaluate_file_access(path_view, permissions)?;
-        let _audit = outcome.audit;
 
         Ok(PathAccessOutcome {
             denied: outcome.denied,
+            explicit_denied: outcome.explicit_denied,
             exec_transition: outcome.exec_transition,
+            audit: outcome.audit,
+            quiet: outcome.quiet,
             mode,
         })
     }
@@ -607,7 +655,10 @@ fn effective_mode(task_mode: AppArmorMode, profile_mode: AppArmorMode) -> AppArm
 
 struct PathAccessOutcome {
     denied: AppArmorFilePermission,
+    explicit_denied: AppArmorFilePermission,
     exec_transition: AppArmorExecTransition,
+    audit: bool,
+    quiet: bool,
     mode: AppArmorMode,
 }
 
@@ -615,7 +666,10 @@ impl PathAccessOutcome {
     fn allowed(mode: AppArmorMode) -> Self {
         Self {
             denied: AppArmorFilePermission::empty(),
+            explicit_denied: AppArmorFilePermission::empty(),
             exec_transition: AppArmorExecTransition::Inherit,
+            audit: false,
+            quiet: false,
             mode,
         }
     }

--- a/kernel/src/security/lsm/modules/apparmor/policy.rs
+++ b/kernel/src/security/lsm/modules/apparmor/policy.rs
@@ -292,7 +292,8 @@ impl AppArmorPolicy {
             return Ok(());
         }
 
-        self.check_exec_transition_target(&outcome.exec_transition)
+        self.exec_transition_target(task_state, &outcome.exec_transition)?;
+        Ok(())
     }
 
     /// Returns whether executing a file requests secure-execution mode.
@@ -318,6 +319,7 @@ impl AppArmorPolicy {
             AppArmorFilePermission::for_execute(),
         )?;
 
+        self.exec_transition_target(task_state, &outcome.exec_transition)?;
         Ok(outcome.exec_transition.requires_secure_exec())
     }
 
@@ -404,11 +406,13 @@ impl AppArmorPolicy {
             AppArmorFilePermission::for_execute(),
         )?;
 
-        let Some(target_profile) = outcome.exec_transition.target_profile() else {
+        let Some(target_profile) =
+            self.exec_transition_target(task_state, &outcome.exec_transition)?
+        else {
             return Ok(task_state.clone());
         };
 
-        self.transition_state_to_profile(task_state, target_profile)
+        Ok(task_state.transition_to(target_profile.name().clone(), target_profile.mode()))
     }
 
     /// Computes task state after an immediate profile change.
@@ -583,12 +587,25 @@ impl AppArmorPolicy {
         return_errno_with_message!(Errno::EACCES, "AppArmor policy denied profile transition");
     }
 
-    fn check_exec_transition_target(&self, transition: &AppArmorExecTransition) -> Result<()> {
+    fn exec_transition_target(
+        &self,
+        task_state: &AppArmorTaskState,
+        transition: &AppArmorExecTransition,
+    ) -> Result<Option<Arc<AppArmorProfile>>> {
+        if let AppArmorExecTransition::Child { profile_name, .. } = transition
+            && !is_child_profile(task_state.current_profile(), profile_name)
+        {
+            return_errno_with_message!(
+                Errno::EACCES,
+                "AppArmor child exec transition target is not a child profile"
+            );
+        }
+
         let Some(target_profile) = transition.target_profile() else {
-            return Ok(());
+            return Ok(None);
         };
 
-        self.require_loaded_profile(&target_profile).map(|_| ())
+        self.require_loaded_profile(&target_profile).map(Some)
     }
 
     fn require_loaded_profile(
@@ -651,6 +668,14 @@ fn effective_mode(task_mode: AppArmorMode, profile_mode: AppArmorMode) -> AppArm
     } else {
         AppArmorMode::Enforce
     }
+}
+
+fn is_child_profile(parent: &AppArmorProfileName, child: &AppArmorProfileName) -> bool {
+    let Some(suffix) = child.as_str().strip_prefix(parent.as_str()) else {
+        return false;
+    };
+
+    suffix.starts_with("//") && suffix.len() > 2
 }
 
 struct PathAccessOutcome {

--- a/kernel/src/security/lsm/modules/apparmor/policy_update.rs
+++ b/kernel/src/security/lsm/modules/apparmor/policy_update.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::profile::{AppArmorProfile, AppArmorProfileName};
+use crate::prelude::*;
+
+/// A policy update decoded from a user-space policy payload.
+pub(super) enum AppArmorPolicyUpdate {
+    /// Inserts or replaces a profile.
+    Replace(Box<AppArmorProfile>),
+    /// Inserts or replaces multiple profiles decoded from one binary payload.
+    ReplaceMany(Vec<AppArmorProfile>),
+    /// Removes a profile.
+    Remove(AppArmorProfileName),
+}

--- a/kernel/src/security/lsm/modules/apparmor/profile.rs
+++ b/kernel/src/security/lsm/modules/apparmor/profile.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{
+    attachment::AppArmorAttachment,
+    capability::AppArmorCapabilityPolicy,
+    dfa::{AppArmorDfaAccessOutcome, AppArmorDfaFilePolicy},
+    path::{AppArmorExecTransition, AppArmorFilePermission, AppArmorPathRule, AppArmorPathView},
+    state::AppArmorMode,
+};
+use crate::{prelude::*, process::credentials::capabilities::CapSet};
+
+/// The name of an AppArmor profile.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AppArmorProfileName(String);
+
+impl AppArmorProfileName {
+    /// The default profile before policy-driven transitions exist.
+    pub const UNCONFINED: &'static str = "unconfined";
+
+    /// Creates a profile name.
+    pub fn new(name: String) -> Result<Self> {
+        if name.is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is empty");
+        }
+
+        Ok(Self(name))
+    }
+
+    /// Creates the default unconfined profile name.
+    pub fn new_unconfined() -> Self {
+        Self(String::from(Self::UNCONFINED))
+    }
+
+    /// Returns whether this is the default unconfined profile.
+    pub fn is_unconfined(&self) -> bool {
+        self.as_str() == Self::UNCONFINED
+    }
+
+    /// Returns the profile name text.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Default for AppArmorProfileName {
+    fn default() -> Self {
+        Self::new_unconfined()
+    }
+}
+
+/// An AppArmor profile.
+#[derive(Clone, Debug)]
+pub struct AppArmorProfile {
+    name: AppArmorProfileName,
+    attachment: AppArmorAttachment,
+    mode: AppArmorMode,
+    file_policy: AppArmorFilePolicy,
+    capability_policy: AppArmorCapabilityPolicy,
+    transition_policy: AppArmorProfileTransitionPolicy,
+}
+
+impl AppArmorProfile {
+    /// Creates a profile.
+    pub fn new(
+        name: AppArmorProfileName,
+        mode: AppArmorMode,
+        file_rules: Vec<AppArmorPathRule>,
+    ) -> Self {
+        Self::new_with_file_policy(name, mode, AppArmorFilePolicy::PathRules(file_rules))
+    }
+
+    /// Creates a profile with an explicit file policy backend.
+    pub(super) fn new_with_file_policy(
+        name: AppArmorProfileName,
+        mode: AppArmorMode,
+        file_policy: AppArmorFilePolicy,
+    ) -> Self {
+        let attachment = AppArmorAttachment::from_profile(&name, None, None);
+        Self::new_with_policies(
+            name,
+            attachment,
+            mode,
+            file_policy,
+            AppArmorCapabilityPolicy::default(),
+        )
+    }
+
+    /// Creates a profile with explicit attachment and file policy backends.
+    pub(super) fn new_with_policies(
+        name: AppArmorProfileName,
+        attachment: AppArmorAttachment,
+        mode: AppArmorMode,
+        file_policy: AppArmorFilePolicy,
+        capability_policy: AppArmorCapabilityPolicy,
+    ) -> Self {
+        Self::new_with_transition_policy(
+            name,
+            attachment,
+            mode,
+            file_policy,
+            capability_policy,
+            AppArmorProfileTransitionPolicy::default(),
+        )
+    }
+
+    /// Creates a profile with explicit policy backends and transition rules.
+    pub(super) fn new_with_transition_policy(
+        name: AppArmorProfileName,
+        attachment: AppArmorAttachment,
+        mode: AppArmorMode,
+        file_policy: AppArmorFilePolicy,
+        capability_policy: AppArmorCapabilityPolicy,
+        transition_policy: AppArmorProfileTransitionPolicy,
+    ) -> Self {
+        Self {
+            name,
+            attachment,
+            mode,
+            file_policy,
+            capability_policy,
+            transition_policy,
+        }
+    }
+
+    /// Creates the default unconfined profile.
+    pub fn new_unconfined() -> Self {
+        Self {
+            name: AppArmorProfileName::new_unconfined(),
+            attachment: AppArmorAttachment::new(None, None),
+            mode: AppArmorMode::Enforce,
+            file_policy: AppArmorFilePolicy::PathRules(Vec::new()),
+            capability_policy: AppArmorCapabilityPolicy::default(),
+            transition_policy: AppArmorProfileTransitionPolicy::default(),
+        }
+    }
+
+    /// Returns the profile name.
+    pub fn name(&self) -> &AppArmorProfileName {
+        &self.name
+    }
+
+    /// Returns the profile mode.
+    pub fn mode(&self) -> AppArmorMode {
+        self.mode
+    }
+
+    /// Returns whether this profile is attached to a path.
+    pub(super) fn matches_attachment(&self, path_view: &AppArmorPathView) -> bool {
+        self.attachment.matches(path_view)
+    }
+
+    /// Evaluates file access for this profile.
+    pub fn evaluate_file_access(
+        &self,
+        path_view: &AppArmorPathView,
+        permissions: AppArmorFilePermission,
+    ) -> Result<AppArmorFileAccessOutcome> {
+        match &self.file_policy {
+            AppArmorFilePolicy::PathRules(rules) => {
+                Ok(evaluate_path_rules(rules, path_view, permissions))
+            }
+            AppArmorFilePolicy::Dfa(policy) => policy
+                .evaluate_path_access(path_view, permissions)
+                .map(AppArmorFileAccessOutcome::from),
+        }
+    }
+
+    /// Evaluates capability access for this profile.
+    pub fn evaluate_capability_access(&self, capabilities: CapSet) -> AppArmorCapabilityOutcome {
+        AppArmorCapabilityOutcome {
+            denied: if self.capability_policy.allows(capabilities) {
+                CapSet::empty()
+            } else {
+                capabilities
+            },
+        }
+    }
+
+    /// Returns whether this profile allows changing to `target`.
+    pub fn allows_profile_transition(
+        &self,
+        target: &AppArmorProfileName,
+        kind: AppArmorProfileTransitionKind,
+    ) -> bool {
+        self.transition_policy.allows(target, kind)
+    }
+}
+
+/// The file-policy backend used by an AppArmor profile.
+#[derive(Clone, Debug)]
+pub(super) enum AppArmorFilePolicy {
+    /// The temporary Asterinas text/debug loader rule list.
+    PathRules(Vec<AppArmorPathRule>),
+    /// Linux AppArmor DFA policy decoded from binary policy.
+    Dfa(Box<AppArmorDfaFilePolicy>),
+}
+
+/// A file-access decision from a profile.
+pub struct AppArmorFileAccessOutcome {
+    /// Permissions denied by the policy.
+    pub denied: AppArmorFilePermission,
+    /// Executable profile transition selected by the matching rule.
+    pub exec_transition: AppArmorExecTransition,
+    /// Whether matching permissions requested auditing.
+    pub audit: bool,
+}
+
+/// A capability-access decision from a profile.
+pub struct AppArmorCapabilityOutcome {
+    /// Capabilities denied by the policy.
+    pub denied: CapSet,
+}
+
+/// A task profile transition requested through procfs attributes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AppArmorProfileTransitionKind {
+    /// Immediately changes the current task profile.
+    ChangeProfile,
+    /// Sets the profile to apply at the next successful `execve`.
+    ChangeOnexec,
+}
+
+/// Profile-to-profile transition rules attached to an AppArmor profile.
+#[derive(Clone, Debug, Default)]
+pub(super) struct AppArmorProfileTransitionPolicy {
+    change_profile: Vec<AppArmorProfileName>,
+    change_onexec: Vec<AppArmorProfileName>,
+}
+
+impl AppArmorProfileTransitionPolicy {
+    /// Creates a profile transition policy.
+    pub(super) fn new(
+        change_profile: Vec<AppArmorProfileName>,
+        change_onexec: Vec<AppArmorProfileName>,
+    ) -> Self {
+        Self {
+            change_profile,
+            change_onexec,
+        }
+    }
+
+    fn allows(&self, target: &AppArmorProfileName, kind: AppArmorProfileTransitionKind) -> bool {
+        let allowed_targets = match kind {
+            AppArmorProfileTransitionKind::ChangeProfile => &self.change_profile,
+            AppArmorProfileTransitionKind::ChangeOnexec => &self.change_onexec,
+        };
+
+        allowed_targets.iter().any(|allowed| allowed == target)
+    }
+}
+
+impl From<AppArmorDfaAccessOutcome> for AppArmorFileAccessOutcome {
+    fn from(outcome: AppArmorDfaAccessOutcome) -> Self {
+        Self {
+            denied: outcome.denied,
+            exec_transition: outcome.exec_transition,
+            audit: outcome.audit,
+        }
+    }
+}
+
+fn evaluate_path_rules(
+    rules: &[AppArmorPathRule],
+    path_view: &AppArmorPathView,
+    permissions: AppArmorFilePermission,
+) -> AppArmorFileAccessOutcome {
+    let mut allowed = AppArmorFilePermission::empty();
+    let mut denied = AppArmorFilePermission::empty();
+    let mut exec_transition = AppArmorExecTransition::Inherit;
+    let mut audit = false;
+
+    for rule in rules {
+        if !rule.matches(path_view) {
+            continue;
+        }
+
+        let matched_permissions = rule.permissions() & permissions;
+        if matched_permissions.is_empty() {
+            continue;
+        }
+
+        audit |= rule.audit();
+        if rule.deny() {
+            denied |= matched_permissions;
+            continue;
+        }
+
+        allowed |= matched_permissions;
+        if matched_permissions.contains(AppArmorFilePermission::EXECUTE) {
+            exec_transition = rule.exec_transition().clone();
+        }
+    }
+
+    let missing = permissions - allowed;
+    AppArmorFileAccessOutcome {
+        denied: denied | missing,
+        exec_transition,
+        audit,
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/profile.rs
+++ b/kernel/src/security/lsm/modules/apparmor/profile.rs
@@ -167,12 +167,15 @@ impl AppArmorProfile {
 
     /// Evaluates capability access for this profile.
     pub fn evaluate_capability_access(&self, capabilities: CapSet) -> AppArmorCapabilityOutcome {
+        let denied = if self.capability_policy.allows(capabilities) {
+            CapSet::empty()
+        } else {
+            capabilities
+        };
         AppArmorCapabilityOutcome {
-            denied: if self.capability_policy.allows(capabilities) {
-                CapSet::empty()
-            } else {
-                capabilities
-            },
+            denied,
+            audit: !(capabilities & self.capability_policy.audit()).is_empty(),
+            quiet: !denied.is_empty() && self.capability_policy.quiet().contains(denied),
         }
     }
 
@@ -199,16 +202,24 @@ pub(super) enum AppArmorFilePolicy {
 pub struct AppArmorFileAccessOutcome {
     /// Permissions denied by the policy.
     pub denied: AppArmorFilePermission,
+    /// Permissions denied by an explicit `deny` rule.
+    pub explicit_denied: AppArmorFilePermission,
     /// Executable profile transition selected by the matching rule.
     pub exec_transition: AppArmorExecTransition,
     /// Whether matching permissions requested auditing.
     pub audit: bool,
+    /// Whether denied permissions should be kept out of routine audit logs.
+    pub quiet: bool,
 }
 
 /// A capability-access decision from a profile.
 pub struct AppArmorCapabilityOutcome {
     /// Capabilities denied by the policy.
     pub denied: CapSet,
+    /// Whether the capability request should be audited.
+    pub audit: bool,
+    /// Whether denied capabilities should be kept out of routine audit logs.
+    pub quiet: bool,
 }
 
 /// A task profile transition requested through procfs attributes.
@@ -253,8 +264,10 @@ impl From<AppArmorDfaAccessOutcome> for AppArmorFileAccessOutcome {
     fn from(outcome: AppArmorDfaAccessOutcome) -> Self {
         Self {
             denied: outcome.denied,
+            explicit_denied: outcome.explicit_denied,
             exec_transition: outcome.exec_transition,
             audit: outcome.audit,
+            quiet: outcome.quiet,
         }
     }
 }
@@ -265,7 +278,7 @@ fn evaluate_path_rules(
     permissions: AppArmorFilePermission,
 ) -> AppArmorFileAccessOutcome {
     let mut allowed = AppArmorFilePermission::empty();
-    let mut denied = AppArmorFilePermission::empty();
+    let mut explicit_denied = AppArmorFilePermission::empty();
     let mut exec_transition = AppArmorExecTransition::Inherit;
     let mut audit = false;
 
@@ -281,7 +294,7 @@ fn evaluate_path_rules(
 
         audit |= rule.audit();
         if rule.deny() {
-            denied |= matched_permissions;
+            explicit_denied |= matched_permissions;
             continue;
         }
 
@@ -293,8 +306,10 @@ fn evaluate_path_rules(
 
     let missing = permissions - allowed;
     AppArmorFileAccessOutcome {
-        denied: denied | missing,
+        denied: explicit_denied | missing,
+        explicit_denied,
         exec_transition,
         audit,
+        quiet: false,
     }
 }

--- a/kernel/src/security/lsm/modules/apparmor/state.rs
+++ b/kernel/src/security/lsm/modules/apparmor/state.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{label::AppArmorLabel, profile::AppArmorProfileName};
+use crate::prelude::*;
+
+/// AppArmor state attached to a task.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppArmorTaskState {
+    label: AppArmorLabel,
+    onexec_profile: Option<AppArmorProfileName>,
+    previous_profile: Option<AppArmorProfileName>,
+    mode: AppArmorMode,
+}
+
+impl AppArmorTaskState {
+    /// Creates the default unconfined AppArmor task state.
+    pub fn new_unconfined() -> Self {
+        Self {
+            label: AppArmorLabel::new_unconfined(),
+            onexec_profile: None,
+            previous_profile: None,
+            mode: AppArmorMode::Enforce,
+        }
+    }
+
+    /// Creates a copy with a profile requested for the next `execve`.
+    pub fn with_onexec_profile(mut self, profile_name: Option<AppArmorProfileName>) -> Self {
+        self.onexec_profile = profile_name;
+        self
+    }
+
+    /// Creates task state after an executable profile transition.
+    pub fn transition_to(&self, profile_name: AppArmorProfileName, mode: AppArmorMode) -> Self {
+        Self {
+            label: AppArmorLabel::new_single(profile_name),
+            onexec_profile: None,
+            previous_profile: Some(self.current_profile().clone()),
+            mode,
+        }
+    }
+
+    /// Creates task state after an immediate profile change.
+    pub fn change_to(&self, profile_name: AppArmorProfileName, mode: AppArmorMode) -> Self {
+        self.transition_to(profile_name, mode)
+    }
+
+    /// Returns the current profile.
+    pub fn current_profile(&self) -> &AppArmorProfileName {
+        self.label.primary_profile()
+    }
+
+    /// Returns whether the current task label is unconfined.
+    pub fn is_unconfined(&self) -> bool {
+        self.label.is_unconfined()
+    }
+
+    /// Returns the profile requested for the next `execve`.
+    pub fn onexec_profile(&self) -> Option<&AppArmorProfileName> {
+        self.onexec_profile.as_ref()
+    }
+
+    /// Returns the previous profile.
+    pub fn previous_profile(&self) -> Option<&AppArmorProfileName> {
+        self.previous_profile.as_ref()
+    }
+
+    /// Returns the current profile mode.
+    pub fn mode(&self) -> AppArmorMode {
+        self.mode
+    }
+}
+
+impl Default for AppArmorTaskState {
+    fn default() -> Self {
+        Self::new_unconfined()
+    }
+}
+
+/// The enforcement mode of an AppArmor profile.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AppArmorMode {
+    /// Denied operations fail.
+    Enforce,
+    /// Denied operations are logged but allowed.
+    Complain,
+}
+
+impl AppArmorMode {
+    /// Parses an AppArmor enforcement mode.
+    pub fn parse(mode: &str) -> Result<Self> {
+        match mode {
+            "enforce" => Ok(Self::Enforce),
+            "complain" => Ok(Self::Complain),
+            _ => return_errno_with_message!(Errno::EINVAL, "the AppArmor mode is invalid"),
+        }
+    }
+
+    /// Returns the mode text.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Enforce => "enforce",
+            Self::Complain => "complain",
+        }
+    }
+}

--- a/kernel/src/security/lsm/modules/capability.rs
+++ b/kernel/src/security/lsm/modules/capability.rs
@@ -2,7 +2,10 @@
 
 use super::super::{
     LsmFlags, LsmModule,
-    hooks::{AlienAccessContext, CapableContext, LsmAlienAccessHook, LsmCapabilityHook},
+    hooks::{
+        AlienAccessContext, CapableContext, LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook,
+        LsmFileHook,
+    },
 };
 use crate::{
     prelude::*,
@@ -46,6 +49,10 @@ impl LsmCapabilityHook for CapabilityLsm {
         );
     }
 }
+
+impl LsmBprmHook for CapabilityLsm {}
+
+impl LsmFileHook for CapabilityLsm {}
 
 impl LsmAlienAccessHook for CapabilityLsm {
     fn on_alien_access(&self, context: &AlienAccessContext) -> Result<()> {

--- a/kernel/src/security/lsm/modules/mod.rs
+++ b/kernel/src/security/lsm/modules/mod.rs
@@ -28,6 +28,7 @@
 //! describes the optional enabled stack. If neither parameter is specified, the
 //! mandatory modules plus the default optional stack are used.
 
+pub(super) mod apparmor;
 mod capability;
 pub mod yama;
 
@@ -46,7 +47,11 @@ aster_cmdline::define_kv_param!("security", LEGACY_SECURITY_PARAM);
 static MANDATORY_MODULES: [&'static dyn LsmModule; 1] = [&capability::CAPABILITY_LSM];
 
 /// All LSM modules compiled into the kernel.
-static ALL_MODULES: [&'static dyn LsmModule; 2] = [&capability::CAPABILITY_LSM, &yama::YAMA_LSM];
+static ALL_MODULES: [&'static dyn LsmModule; 3] = [
+    &capability::CAPABILITY_LSM,
+    &yama::YAMA_LSM,
+    &apparmor::APPARMOR_LSM,
+];
 
 /// The fallback optional LSM stack used when no boot-time selector is specified.
 pub(super) static DEFAULT_OPTIONAL_MODULES: [&'static dyn LsmModule; 1] = [&yama::YAMA_LSM];

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -6,7 +6,7 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use super::super::{
     LsmFlags, LsmModule,
-    hooks::{AlienAccessContext, LsmAlienAccessHook, LsmCapabilityHook},
+    hooks::{AlienAccessContext, LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook},
 };
 use crate::{
     prelude::*,
@@ -71,6 +71,10 @@ impl LsmModule for YamaLsm {
 }
 
 impl LsmCapabilityHook for YamaLsm {}
+
+impl LsmBprmHook for YamaLsm {}
+
+impl LsmFileHook for YamaLsm {}
 
 /// Returns the current Yama scope for alien access.
 pub fn get_scope() -> YamaScope {

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod lsm;
 
+use aster_rights::ReadWriteOp;
 use cfg_if::cfg_if;
 
 cfg_if! {
@@ -11,6 +12,27 @@ cfg_if! {
     }
 }
 
+pub use self::lsm::{
+    AppArmorMode, AppArmorPolicyOperation, AppArmorProfileName, AppArmorTaskState, FileCreateKind,
+    FileDeleteKind, FilePermission, FileSetattrKind, YamaScope,
+};
+use crate::{
+    fs::{
+        file::{AccessMode, StatusFlags},
+        vfs::{
+            inode::RenameMode,
+            path::{Path, PathResolver},
+        },
+    },
+    prelude::*,
+    process::{
+        Credentials, UserNamespace,
+        credentials::capabilities::CapSet,
+        posix_thread::{AsPosixThread, PosixThread},
+    },
+    thread::Thread,
+};
+
 pub(super) fn init() {
     lsm::init();
 
@@ -19,4 +41,328 @@ pub(super) fn init() {
         tsm::init();
         tsm_mr::init();
     });
+}
+
+/// Runs the LSM stack for a capability check.
+pub fn capable(
+    user_namespace: &UserNamespace,
+    capability: CapSet,
+    posix_thread: &PosixThread,
+) -> Result<()> {
+    lsm::capable(lsm::CapableContext::new(
+        user_namespace,
+        posix_thread,
+        capability,
+    ))
+}
+
+/// Returns whether the Yama LSM is enabled.
+pub fn is_yama_enabled() -> bool {
+    lsm::is_yama_enabled()
+}
+
+/// Returns the Yama ptrace scope.
+#[expect(dead_code, reason = "keeps the top-level security facade complete")]
+pub fn get_yama_scope() -> YamaScope {
+    lsm::yama::get_scope()
+}
+
+/// Sets the Yama ptrace scope.
+#[expect(dead_code, reason = "keeps the top-level security facade complete")]
+pub fn set_yama_scope(new_scope: YamaScope) -> Result<()> {
+    lsm::yama::set_scope(new_scope)
+}
+
+/// Returns whether the AppArmor LSM is enabled.
+pub fn is_apparmor_enabled() -> bool {
+    lsm::is_apparmor_enabled()
+}
+
+/// Returns the AppArmor task state for a POSIX thread if the module is active.
+pub fn apparmor_task_state(posix_thread: &PosixThread) -> Option<AppArmorTaskState> {
+    lsm::apparmor_task_state(posix_thread)
+}
+
+/// Loads, replaces, or removes an AppArmor profile from policy text.
+pub fn load_apparmor_policy(policy_text: &str) -> Result<()> {
+    if !is_apparmor_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    }
+
+    lsm::load_apparmor_policy(policy_text)
+}
+
+/// Loads, replaces, or removes an AppArmor profile from binary policy data.
+pub fn load_apparmor_binary_policy(
+    policy: &[u8],
+    expected_operation: AppArmorPolicyOperation,
+) -> Result<()> {
+    if !is_apparmor_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    }
+
+    lsm::load_apparmor_binary_policy(policy, expected_operation)
+}
+
+/// Returns whether the data starts with the AppArmor binary policy magic.
+pub fn has_apparmor_binary_policy_magic(policy: &[u8]) -> bool {
+    lsm::has_apparmor_binary_policy_magic(policy)
+}
+
+/// Removes a loaded AppArmor profile by name.
+pub fn remove_apparmor_profile_by_name(profile_name: &str) -> Result<()> {
+    if !is_apparmor_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    }
+
+    lsm::remove_apparmor_profile_by_name(profile_name)
+}
+
+/// Returns summaries of the implicit and loaded AppArmor profiles.
+pub fn apparmor_profile_summaries() -> Result<Vec<(AppArmorProfileName, AppArmorMode)>> {
+    if !is_apparmor_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    }
+
+    Ok(lsm::apparmor_profile_summaries())
+}
+
+/// Returns the root AppArmor policy namespace name.
+pub fn apparmor_root_namespace_name() -> Result<&'static str> {
+    if !is_apparmor_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    }
+
+    Ok(lsm::apparmor_root_namespace_name())
+}
+
+/// Sets the current POSIX thread to a loaded AppArmor profile.
+pub fn set_current_apparmor_profile(profile_name: &str) -> Result<()> {
+    if !is_apparmor_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    }
+
+    let current_thread = current_thread!();
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+    };
+
+    let task_state = posix_thread.credentials().apparmor_task_state();
+    let target_state = lsm::apparmor_change_profile_state(&task_state, profile_name)?;
+    posix_thread.set_apparmor_task_state(target_state);
+    Ok(())
+}
+
+/// Sets the current POSIX thread's profile requested for the next `execve`.
+pub fn set_current_apparmor_onexec_profile(profile_name: Option<&str>) -> Result<()> {
+    if !is_apparmor_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor LSM is not enabled");
+    }
+
+    let current_thread = current_thread!();
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+    };
+
+    let task_state = posix_thread.credentials().apparmor_task_state();
+    let target_state = lsm::apparmor_change_onexec_state(&task_state, profile_name)?;
+    posix_thread.set_apparmor_task_state(target_state);
+    Ok(())
+}
+
+/// Runs the LSM stack for an executable image check.
+pub fn bprm_check_security(path: &Path, path_resolver: &PathResolver) -> Result<()> {
+    lsm::bprm_check_security(&lsm::BprmCheckContext::new(path, path_resolver))
+}
+
+/// Updates security state after credentials are committed for a new executable.
+pub fn bprm_committed_creds(
+    path: &Path,
+    path_resolver: &PathResolver,
+    credentials: &Credentials<ReadWriteOp>,
+) -> Result<()> {
+    lsm::bprm_committed_creds(&lsm::BprmCommittedCredsContext::new(
+        path,
+        path_resolver,
+        credentials,
+    ))
+}
+
+/// Returns whether the executable should run in secure-execution mode.
+pub fn bprm_secureexec(path: &Path, path_resolver: &PathResolver) -> Result<bool> {
+    lsm::bprm_secureexec(&lsm::BprmCheckContext::new(path, path_resolver))
+}
+
+/// Runs the LSM stack for a file open check.
+pub fn file_open(
+    path: &Path,
+    path_resolver: &PathResolver,
+    access_mode: AccessMode,
+    status_flags: StatusFlags,
+) -> Result<()> {
+    lsm::file_open(&lsm::FileOpenContext::new(
+        path,
+        path_resolver,
+        access_mode,
+        status_flags,
+    ))
+}
+
+/// Runs the LSM stack before creating and opening a file.
+pub fn file_create(
+    parent: &Path,
+    name: Option<&str>,
+    path_resolver: &PathResolver,
+    kind: FileCreateKind,
+    access_mode: Option<AccessMode>,
+    status_flags: StatusFlags,
+) -> Result<()> {
+    lsm::file_create(&lsm::FileCreateContext::new(
+        parent,
+        name,
+        path_resolver,
+        kind,
+        access_mode,
+        status_flags,
+    ))
+}
+
+/// Runs the LSM stack before deleting a filesystem object.
+pub fn file_delete(
+    parent: &Path,
+    name: &str,
+    path_resolver: &PathResolver,
+    kind: FileDeleteKind,
+) -> Result<()> {
+    lsm::file_delete(&lsm::FileDeleteContext::new(
+        parent,
+        name,
+        path_resolver,
+        kind,
+    ))
+}
+
+/// Runs the LSM stack before creating a hard link.
+pub fn file_link(
+    source: &Path,
+    target_parent: &Path,
+    target_name: &str,
+    path_resolver: &PathResolver,
+) -> Result<()> {
+    lsm::file_link(&lsm::FileLinkContext::new(
+        source,
+        target_parent,
+        target_name,
+        path_resolver,
+    ))
+}
+
+/// Runs the LSM stack before renaming a filesystem object.
+pub fn file_rename(
+    source: &Path,
+    new_parent: &Path,
+    new_name: &str,
+    target: Option<&Path>,
+    path_resolver: &PathResolver,
+    mode: RenameMode,
+) -> Result<()> {
+    lsm::file_rename(&lsm::FileRenameContext::new(
+        source,
+        new_parent,
+        new_name,
+        target,
+        path_resolver,
+        mode,
+    ))
+}
+
+/// Runs the LSM stack before changing file attributes.
+pub fn file_setattr(
+    path: &Path,
+    path_resolver: &PathResolver,
+    kind: FileSetattrKind,
+) -> Result<()> {
+    lsm::file_setattr(&lsm::FileSetattrContext::new(path, path_resolver, kind))
+}
+
+/// Runs the LSM stack for access through an existing opened file.
+pub fn file_permission(path: &Path, permissions: FilePermission) -> Result<()> {
+    let Some(path_resolver) = current_path_resolver() else {
+        return Ok(());
+    };
+
+    file_permission_at(path, &path_resolver, permissions)
+}
+
+/// Runs the LSM stack for path access through an existing file-like operation.
+pub fn file_permission_at(
+    path: &Path,
+    path_resolver: &PathResolver,
+    permissions: FilePermission,
+) -> Result<()> {
+    lsm::file_permission(&lsm::FilePermissionContext::new(
+        path,
+        path_resolver,
+        permissions,
+    ))
+}
+
+/// Runs the LSM stack for mapping a file.
+pub fn file_mmap(path: &Path, permissions: FilePermission) -> Result<()> {
+    let Some(path_resolver) = current_path_resolver() else {
+        return Ok(());
+    };
+
+    lsm::file_mmap(&lsm::FileMmapContext::new(
+        path,
+        &path_resolver,
+        permissions,
+    ))
+}
+
+/// Runs the LSM stack for receiving a file descriptor.
+pub fn file_receive(path: &Path, permissions: FilePermission) -> Result<()> {
+    let Some(path_resolver) = current_path_resolver() else {
+        return Ok(());
+    };
+
+    lsm::file_receive(&lsm::FileReceiveContext::new(
+        path,
+        &path_resolver,
+        permissions,
+    ))
+}
+
+/// Runs the LSM stack for locking a file.
+pub fn file_lock(path: &Path, permissions: FilePermission) -> Result<()> {
+    let Some(path_resolver) = current_path_resolver() else {
+        return Ok(());
+    };
+
+    lsm::file_lock(&lsm::FileLockContext::new(
+        path,
+        &path_resolver,
+        permissions,
+    ))
+}
+
+/// Runs the LSM stack before querying file metadata.
+pub fn file_getattr(path: &Path, path_resolver: &PathResolver) -> Result<()> {
+    lsm::file_getattr(&lsm::FileGetattrContext::new(path, path_resolver))
+}
+
+/// Runs the LSM stack before querying metadata through an opened file.
+pub fn file_getattr_current(path: &Path) -> Result<()> {
+    let Some(path_resolver) = current_path_resolver() else {
+        return Ok(());
+    };
+
+    file_getattr(path, &path_resolver)
+}
+
+fn current_path_resolver() -> Option<PathResolver> {
+    let thread = Thread::current()?;
+    let posix_thread = thread.as_posix_thread()?;
+    let fs = posix_thread.read_fs();
+    Some(fs.resolver().read().clone())
 }

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
+    security::{self, FilePermission},
 };
 
 pub fn sys_faccessat(
@@ -81,31 +82,35 @@ fn do_faccessat(
         dirfd, path_name, mode, flags
     );
 
-    let path = {
-        let path_name = path_name.to_string_lossy();
-        let fs_path =
-            FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
+    let path_name = path_name.to_string_lossy();
+    let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
-        let fs_ref = ctx.thread_local.borrow_fs();
-        let path_resolver = fs_ref.resolver().read();
-        if flags.contains(FaccessatFlags::AT_SYMLINK_NOFOLLOW) {
-            path_resolver.lookup_no_follow(&fs_path)?
-        } else {
-            path_resolver.lookup(&fs_path)?
-        }
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    let path = if flags.contains(FaccessatFlags::AT_SYMLINK_NOFOLLOW) {
+        path_resolver.lookup_no_follow(&fs_path)?
+    } else {
+        path_resolver.lookup(&fs_path)?
     };
 
     let inode = path.inode();
+    let mut permissions = FilePermission::empty();
 
     // F_OK is represented by `AccessMode::empty()`, which does not perform permission checks.
     if mode.contains(AccessMode::R_OK) {
         inode.check_permission(Permission::MAY_READ)?;
+        permissions |= FilePermission::READ;
     }
     if mode.contains(AccessMode::W_OK) {
         inode.check_permission(Permission::MAY_WRITE)?;
+        permissions |= FilePermission::WRITE;
     }
     if mode.contains(AccessMode::X_OK) {
         inode.check_permission(Permission::MAY_EXEC)?;
+        permissions |= FilePermission::EXECUTE;
+    }
+    if !permissions.is_empty() {
+        security::file_permission_at(&path, &path_resolver, permissions)?;
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/chmod.rs
+++ b/kernel/src/syscall/chmod.rs
@@ -12,15 +12,22 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
+    security::{self, FileSetattrKind},
 };
 
 pub fn sys_fchmod(raw_fd: RawFileDesc, mode: u16, ctx: &Context) -> Result<SyscallReturn> {
     debug!("raw_fd = {}, mode = 0o{:o}", raw_fd, mode);
 
-    let mut file_table = ctx.thread_local.borrow_file_table_mut();
-    let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
-    file.path().set_mode(InodeMode::from_bits_truncate(mode))?;
-    fs::vfs::notify::on_attr_change(file.path());
+    let path = {
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
+        let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
+        file.path().clone()
+    };
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    security::file_setattr(&path, &path_resolver, FileSetattrKind::Mode)?;
+    path.set_mode(InodeMode::from_bits_truncate(mode))?;
+    fs::vfs::notify::on_attr_change(&path);
     Ok(SyscallReturn::Return(0))
 }
 
@@ -64,20 +71,18 @@ fn do_fchmodat(
         dirfd, path_name, mode, flags,
     );
 
-    let path = {
-        let path_name = path_name.to_string_lossy();
-        let fs_path =
-            FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
+    let path_name = path_name.to_string_lossy();
+    let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
-        let fs_ref = ctx.thread_local.borrow_fs();
-        let path_resolver = fs_ref.resolver().read();
-        if flags.contains(ChmodFlags::AT_SYMLINK_NOFOLLOW) {
-            path_resolver.lookup_no_follow(&fs_path)?
-        } else {
-            path_resolver.lookup(&fs_path)?
-        }
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    let path = if flags.contains(ChmodFlags::AT_SYMLINK_NOFOLLOW) {
+        path_resolver.lookup_no_follow(&fs_path)?
+    } else {
+        path_resolver.lookup(&fs_path)?
     };
 
+    security::file_setattr(&path, &path_resolver, FileSetattrKind::Mode)?;
     path.set_mode(InodeMode::from_bits_truncate(mode))?;
     fs::vfs::notify::on_attr_change(&path);
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    security::{self, FileSetattrKind},
 };
 
 pub fn sys_fchown(raw_fd: RawFileDesc, uid: i32, gid: i32, ctx: &Context) -> Result<SyscallReturn> {
@@ -20,9 +21,14 @@ pub fn sys_fchown(raw_fd: RawFileDesc, uid: i32, gid: i32, ctx: &Context) -> Res
         return Ok(SyscallReturn::Return(0));
     }
 
-    let mut file_table = ctx.thread_local.borrow_file_table_mut();
-    let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
-    let path = file.path();
+    let path = {
+        let mut file_table = ctx.thread_local.borrow_file_table_mut();
+        let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
+        file.path().clone()
+    };
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    security::file_setattr(&path, &path_resolver, FileSetattrKind::Owner)?;
     if let Some(uid) = uid {
         path.set_owner(uid)?;
     }
@@ -73,20 +79,18 @@ pub fn sys_fchownat(
         return Ok(SyscallReturn::Return(0));
     }
 
-    let path = {
-        let path_name = path_name.to_string_lossy();
-        let fs_path =
-            FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
+    let path_name = path_name.to_string_lossy();
+    let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::AllowIfFlag(flags.bits()))?;
 
-        let fs_ref = ctx.thread_local.borrow_fs();
-        let path_resolver = fs_ref.resolver().read();
-        if flags.contains(ChownFlags::AT_SYMLINK_NOFOLLOW) {
-            path_resolver.lookup_no_follow(&fs_path)?
-        } else {
-            path_resolver.lookup(&fs_path)?
-        }
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    let path = if flags.contains(ChownFlags::AT_SYMLINK_NOFOLLOW) {
+        path_resolver.lookup_no_follow(&fs_path)?
+    } else {
+        path_resolver.lookup(&fs_path)?
     };
 
+    security::file_setattr(&path, &path_resolver, FileSetattrKind::Owner)?;
     if let Some(uid) = uid {
         path.set_owner(uid)?;
     }

--- a/kernel/src/syscall/link.rs
+++ b/kernel/src/syscall/link.rs
@@ -29,37 +29,33 @@ pub fn sys_linkat(
         old_dirfd, old_path_name, new_dirfd, new_path_name, flags
     );
 
-    let (old_path, new_path, new_name) = {
-        let old_path_name = old_path_name.to_string_lossy();
-        let new_path_name = new_path_name.to_string_lossy();
+    let old_path_name = old_path_name.to_string_lossy();
+    let new_path_name = new_path_name.to_string_lossy();
 
-        let old_fs_path = FsPath::from_fd_at(
-            old_dirfd,
-            &old_path_name,
-            EmptyPathStr::AllowIfFlag(flags.bits()),
-        )?;
-        let new_fs_path = FsPath::from_fd_at(new_dirfd, &new_path_name, EmptyPathStr::Reject)?;
+    let old_fs_path = FsPath::from_fd_at(
+        old_dirfd,
+        &old_path_name,
+        EmptyPathStr::AllowIfFlag(flags.bits()),
+    )?;
+    let new_fs_path = FsPath::from_fd_at(new_dirfd, &new_path_name, EmptyPathStr::Reject)?;
 
-        let fs_ref = ctx.thread_local.borrow_fs();
-        let path_resolver = fs_ref.resolver().read();
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
 
-        let old_path = if flags.contains(LinkFlags::AT_SYMLINK_FOLLOW) {
-            path_resolver.lookup(&old_fs_path)?
-        } else {
-            path_resolver.lookup_no_follow(&old_fs_path)?
-        };
-        if old_path.type_() == InodeType::Dir {
-            return_errno_with_message!(Errno::EPERM, "the link path is a directory");
-        }
-
-        let (new_path, new_name) = path_resolver
-            .lookup_unresolved_no_follow(&new_fs_path)?
-            .into_parent_and_filename()?;
-
-        (old_path, new_path, new_name)
+    let old_path = if flags.contains(LinkFlags::AT_SYMLINK_FOLLOW) {
+        path_resolver.lookup(&old_fs_path)?
+    } else {
+        path_resolver.lookup_no_follow(&old_fs_path)?
     };
+    if old_path.type_() == InodeType::Dir {
+        return_errno_with_message!(Errno::EPERM, "the link path is a directory");
+    }
 
-    new_path.link(&old_path, &new_name)?;
+    let (new_path, new_name) = path_resolver
+        .lookup_unresolved_no_follow(&new_fs_path)?
+        .into_parent_and_filename()?;
+
+    new_path.link(&old_path, &new_name, &path_resolver)?;
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/src/syscall/mkdir.rs
+++ b/kernel/src/syscall/mkdir.rs
@@ -4,10 +4,11 @@ use super::SyscallReturn;
 use crate::{
     fs,
     fs::{
-        file::{InodeMode, InodeType, file_table::RawFileDesc},
+        file::{InodeMode, InodeType, StatusFlags, file_table::RawFileDesc},
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
+    security::{self, FileCreateKind},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -21,12 +22,11 @@ pub fn sys_mkdirat(
     debug!("dirfd = {}, path = {:?}, mode = {}", dirfd, path, mode);
 
     let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
     let (dir_path, name) = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::from_fd_at(dirfd, &path, EmptyPathStr::Reject)?;
-        fs_ref
-            .resolver()
-            .read()
+        path_resolver
             .lookup_unresolved_no_follow(&fs_path)?
             .into_parent_and_basename()?
     };
@@ -35,6 +35,15 @@ pub fn sys_mkdirat(
         let mask_mode = mode & !fs_ref.umask().get();
         InodeMode::from_bits_truncate(mask_mode)
     };
+    super::check_parent_write_permission(&dir_path)?;
+    security::file_create(
+        &dir_path,
+        Some(&name),
+        &path_resolver,
+        FileCreateKind::Directory,
+        None,
+        StatusFlags::empty(),
+    )?;
     dir_path.new_fs_child(&name, InodeType::Dir, inode_mode)?;
     fs::vfs::notify::on_mkdir(&dir_path, || name);
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/mknod.rs
+++ b/kernel/src/syscall/mknod.rs
@@ -4,13 +4,14 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         self,
-        file::{InodeMode, InodeType, file_table::RawFileDesc},
+        file::{InodeMode, InodeType, StatusFlags, file_table::RawFileDesc},
         vfs::{
             inode::MknodType,
             path::{AT_FDCWD, EmptyPathStr, FsPath},
         },
     },
     prelude::*,
+    security::{self, FileCreateKind},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -33,15 +34,34 @@ pub fn sys_mknodat(
         dirfd, path_name, inode_mode, inode_type, dev
     );
 
+    let path_resolver = fs_ref.resolver().read();
     let (dir_path, name) = {
         let path_name = path_name.to_string_lossy();
         let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::Reject)?;
-        fs_ref
-            .resolver()
-            .read()
+        path_resolver
             .lookup_unresolved_no_follow(&fs_path)?
             .into_parent_and_filename()?
     };
+
+    super::check_parent_write_permission(&dir_path)?;
+
+    let create_kind = match inode_type {
+        InodeType::File => FileCreateKind::Regular,
+        InodeType::CharDevice | InodeType::BlockDevice => FileCreateKind::Device,
+        InodeType::NamedPipe => FileCreateKind::Fifo,
+        InodeType::Socket => {
+            return_errno_with_message!(Errno::EINVAL, "unsupported file types")
+        }
+        _ => return_errno_with_message!(Errno::EPERM, "unimplemented file types"),
+    };
+    security::file_create(
+        &dir_path,
+        Some(&name),
+        &path_resolver,
+        create_kind,
+        None,
+        StatusFlags::empty(),
+    )?;
 
     match inode_type {
         InodeType::File => {
@@ -56,10 +76,8 @@ pub fn sys_mknodat(
         InodeType::NamedPipe => {
             let _ = dir_path.mknod(&name, inode_mode, MknodType::NamedPipe)?;
         }
-        InodeType::Socket => {
-            return_errno_with_message!(Errno::EINVAL, "unsupported file types")
-        }
-        _ => return_errno_with_message!(Errno::EPERM, "unimplemented file types"),
+        InodeType::Socket => unreachable!(),
+        _ => unreachable!(),
     }
     fs::vfs::notify::on_create(&dir_path, || name);
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -11,7 +11,11 @@ pub use clock_gettime::ClockId;
 use ostd::arch::cpu::context::UserContext;
 pub use timer_create::create_timer;
 
-use crate::{cpu::LinuxAbi, prelude::*};
+use crate::{
+    cpu::LinuxAbi,
+    fs::{file::Permission, vfs::path::Path},
+    prelude::*,
+};
 
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv.rs")]
@@ -191,6 +195,18 @@ mod utimens;
 mod wait4;
 mod waitid;
 mod write;
+
+fn check_parent_write_permission(parent_path: &Path) -> Result<()> {
+    if parent_path
+        .inode()
+        .check_permission(Permission::MAY_WRITE)
+        .is_err()
+    {
+        return_errno!(Errno::EACCES);
+    }
+
+    Ok(())
+}
 
 /// This macro is used to define syscall handler.
 /// The first param is the number of parameters,

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -15,6 +15,7 @@ use crate::{
         },
     },
     prelude::*,
+    security::{self, FileCreateKind},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -96,7 +97,7 @@ fn do_open(
     };
 
     let file_handle: Arc<dyn FileLike> = match lookup_res {
-        LookupResult::Resolved(path) => Arc::new(path.open(open_args)?),
+        LookupResult::Resolved(path) => Arc::new(path.open(open_args, path_resolver)?),
         LookupResult::AtParent(result) => {
             if !open_args.creation_flags.contains(CreationFlags::O_CREAT)
                 || open_args.status_flags.contains(StatusFlags::O_PATH)
@@ -111,6 +112,17 @@ fn do_open(
             }
 
             let (parent, tail_name) = result.into_parent_and_basename();
+            super::check_parent_write_permission(&parent)?;
+
+            security::file_create(
+                &parent,
+                Some(&tail_name),
+                path_resolver,
+                FileCreateKind::Regular,
+                Some(open_args.access_mode),
+                open_args.status_flags,
+            )?;
+
             let new_path =
                 parent.new_fs_child(&tail_name, InodeType::File, open_args.inode_mode)?;
             fs::vfs::notify::on_create(&parent, || tail_name.clone());
@@ -146,6 +158,16 @@ fn do_open_tmpfile(
     } else {
         HardLinkability::Linkable
     };
+    super::check_parent_write_permission(&dir_path)?;
+    security::file_create(
+        &dir_path,
+        None,
+        path_resolver,
+        FileCreateKind::Regular,
+        Some(open_args.access_mode),
+        open_args.status_flags,
+    )?;
+
     let tmpfile_path = dir_path.create_tmpfile(open_args.inode_mode, hard_linkability)?;
 
     Ok(Arc::new(InodeHandle::new_unchecked_access(

--- a/kernel/src/syscall/readlink.rs
+++ b/kernel/src/syscall/readlink.rs
@@ -12,6 +12,7 @@ use crate::{
         },
     },
     prelude::*,
+    security::{self, FilePermission},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -40,6 +41,7 @@ pub fn sys_readlinkat(
         let path_name = path_name.to_string_lossy();
         let fs_path = FsPath::from_fd_at(dirfd, &path_name, EmptyPathStr::Allow)?;
         let path = path_resolver.lookup_no_follow(&fs_path)?;
+        security::file_permission_at(&path, &path_resolver, FilePermission::READ)?;
 
         match path.inode().read_link()? {
             SymbolicLink::Plain(s) => s,

--- a/kernel/src/syscall/rename.rs
+++ b/kernel/src/syscall/rename.rs
@@ -10,6 +10,7 @@ use crate::{
         },
     },
     prelude::*,
+    security,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -78,6 +79,22 @@ pub fn sys_renameat2(
             new_name.to_string(),
         )
     };
+
+    super::check_parent_write_permission(&old_parent_path)?;
+    super::check_parent_write_permission(&new_parent_path)?;
+    let target_path = match path_resolver.lookup_at_path(&new_parent_path, &new_name) {
+        Ok(path) => Some(path),
+        Err(error) if error.error() == Errno::ENOENT => None,
+        Err(error) => return Err(error),
+    };
+    security::file_rename(
+        &old_path,
+        &new_parent_path,
+        &new_name,
+        target_path.as_ref(),
+        &path_resolver,
+        mode,
+    )?;
 
     old_parent_path.rename(old_name, &new_parent_path, &new_name, mode)?;
 

--- a/kernel/src/syscall/rmdir.rs
+++ b/kernel/src/syscall/rmdir.rs
@@ -7,6 +7,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, SplitPath, SplitPathError},
     },
     prelude::*,
+    security::{self, FileDeleteKind},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -23,21 +24,18 @@ pub(super) fn sys_rmdirat(
     debug!("dirfd = {}, path_addr = {:?}", dirfd, path_addr);
 
     let path_name = path_name.to_string_lossy();
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
     let (dir_path, name) = {
         let (parent_path_name, target_name) = path_name
             .split_dirname_and_basename()
             .map_err(SplitPathError::reject_root_as_busy)?;
         let fs_path = FsPath::from_fd_at(dirfd, parent_path_name, EmptyPathStr::Reject)?;
-        (
-            ctx.thread_local
-                .borrow_fs()
-                .resolver()
-                .read()
-                .lookup(&fs_path)?,
-            target_name,
-        )
+        (path_resolver.lookup(&fs_path)?, target_name)
     };
 
+    super::check_parent_write_permission(&dir_path)?;
+    security::file_delete(&dir_path, name, &path_resolver, FileDeleteKind::Directory)?;
     dir_path.rmdir(name)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -12,6 +12,7 @@ use crate::{
         },
     },
     prelude::*,
+    security,
     syscall::constants::MAX_FILENAME_LEN,
     time::timespec_t,
 };
@@ -22,6 +23,7 @@ pub fn sys_fstat(raw_fd: RawFileDesc, stat_buf_ptr: Vaddr, ctx: &Context) -> Res
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
 
+    security::file_getattr_current(file.path())?;
     let stat = Stat::from(file.path().metadata());
     ctx.user_space().write_val(stat_buf_ptr, &stat)?;
 
@@ -69,11 +71,13 @@ pub fn sys_fstatat(
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();
-        if flags.contains(StatFlags::AT_SYMLINK_NOFOLLOW) {
+        let path = if flags.contains(StatFlags::AT_SYMLINK_NOFOLLOW) {
             path_resolver.lookup_no_follow(&fs_path)?
         } else {
             path_resolver.lookup(&fs_path)?
-        }
+        };
+        security::file_getattr(&path, &path_resolver)?;
+        path
     };
 
     let stat = Stat::from(path.metadata());

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -11,6 +11,7 @@ use crate::{
         vfs::path::{EmptyPathStr, FsPath, Path},
     },
     prelude::*,
+    security,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -55,11 +56,13 @@ pub fn sys_statx(
 
         let fs_ref = ctx.thread_local.borrow_fs();
         let path_resolver = fs_ref.resolver().read();
-        if flags.contains(StatxFlags::AT_SYMLINK_NOFOLLOW) {
+        let path = if flags.contains(StatxFlags::AT_SYMLINK_NOFOLLOW) {
             path_resolver.lookup_no_follow(&fs_path)?
         } else {
             path_resolver.lookup(&fs_path)?
-        }
+        };
+        security::file_getattr(&path, &path_resolver)?;
+        path
     };
 
     let statx = Statx::new(&path);

--- a/kernel/src/syscall/symlink.rs
+++ b/kernel/src/syscall/symlink.rs
@@ -4,10 +4,11 @@ use super::SyscallReturn;
 use crate::{
     fs,
     fs::{
-        file::{InodeType, file_table::RawFileDesc, mkmod},
+        file::{InodeType, StatusFlags, file_table::RawFileDesc, mkmod},
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
+    security::{self, FileCreateKind},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -30,16 +31,25 @@ pub fn sys_symlinkat(
         return_errno_with_message!(Errno::ENOENT, "the symlink path is empty");
     }
 
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
     let (dir_path, link_name) = {
         let link_path_name = link_path_name.to_string_lossy();
         let fs_path = FsPath::from_fd_at(dirfd, &link_path_name, EmptyPathStr::Reject)?;
-        ctx.thread_local
-            .borrow_fs()
-            .resolver()
-            .read()
+        path_resolver
             .lookup_unresolved_no_follow(&fs_path)?
             .into_parent_and_filename()?
     };
+
+    super::check_parent_write_permission(&dir_path)?;
+    security::file_create(
+        &dir_path,
+        Some(&link_name),
+        &path_resolver,
+        FileCreateKind::Symlink,
+        None,
+        StatusFlags::empty(),
+    )?;
 
     let new_path = dir_path.new_fs_child(&link_name, InodeType::SymLink, mkmod!(a+rwx))?;
     new_path.inode().write_link(&target)?;

--- a/kernel/src/syscall/truncate.rs
+++ b/kernel/src/syscall/truncate.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     prelude::*,
     process::ResourceType,
+    security::{self, FileSetattrKind},
 };
 
 pub fn sys_ftruncate(raw_fd: RawFileDesc, len: isize, ctx: &Context) -> Result<SyscallReturn> {
@@ -19,8 +20,12 @@ pub fn sys_ftruncate(raw_fd: RawFileDesc, len: isize, ctx: &Context) -> Result<S
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
+    let path = file.path().clone();
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    security::file_setattr(&path, &path_resolver, FileSetattrKind::Size)?;
     file.resize(len as usize)?;
-    fs::vfs::notify::on_change(file.path());
+    fs::vfs::notify::on_change(&path);
     Ok(SyscallReturn::Return(0))
 }
 
@@ -30,15 +35,12 @@ pub fn sys_truncate(path_ptr: Vaddr, len: isize, ctx: &Context) -> Result<Syscal
 
     check_length(len, ctx)?;
 
-    let dir_path = {
-        let path_name = path_name.to_string_lossy();
-        let fs_path = FsPath::from_fd_at(AT_FDCWD, &path_name, EmptyPathStr::Reject)?;
-        ctx.thread_local
-            .borrow_fs()
-            .resolver()
-            .read()
-            .lookup(&fs_path)?
-    };
+    let path_name = path_name.to_string_lossy();
+    let fs_path = FsPath::from_fd_at(AT_FDCWD, &path_name, EmptyPathStr::Reject)?;
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
+    let dir_path = path_resolver.lookup(&fs_path)?;
+    security::file_setattr(&dir_path, &path_resolver, FileSetattrKind::Size)?;
     dir_path.resize(len as usize)?;
     fs::vfs::notify::on_change(&dir_path);
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/unlink.rs
+++ b/kernel/src/syscall/unlink.rs
@@ -7,6 +7,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, SplitPath, SplitPathError},
     },
     prelude::*,
+    security::{self, FileDeleteKind},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -26,13 +27,12 @@ pub fn sys_unlinkat(
     debug!("dirfd = {}, path = {:?}", dirfd, path_name);
 
     let path_name = path_name.to_string_lossy();
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
     let (dir_path, name) = {
         let (parent_path_name, target_name) = path_name
             .split_dirname_and_basename()
             .map_err(SplitPathError::reject_root_as_is_dir)?;
-
-        let fs_ref = ctx.thread_local.borrow_fs();
-        let path_resolver = fs_ref.resolver().read();
 
         let parent_fs_path = FsPath::from_fd_at(dirfd, parent_path_name, EmptyPathStr::Reject)?;
         let dir_path = path_resolver.lookup(&parent_fs_path)?;
@@ -54,6 +54,13 @@ pub fn sys_unlinkat(
         (dir_path, target_name)
     };
 
+    super::check_parent_write_permission(&dir_path)?;
+    security::file_delete(
+        &dir_path,
+        name,
+        &path_resolver,
+        FileDeleteKind::NonDirectory,
+    )?;
     dir_path.unlink(name)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/utimens.rs
+++ b/kernel/src/syscall/utimens.rs
@@ -15,6 +15,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
     },
     prelude::*,
+    security::{self, FileSetattrKind},
     time::{clocks::RealTimeCoarseClock, timespec_t, timeval_t},
 };
 
@@ -174,10 +175,10 @@ fn do_utimes(
         Some(pathname.to_string_lossy().into_owned())
     };
 
+    let fs_ref = ctx.thread_local.borrow_fs();
+    let path_resolver = fs_ref.resolver().read();
     let path = if let Some(pathname) = pathname.as_ref() {
         let fs_path = FsPath::from_fd_at(dirfd, pathname, EmptyPathStr::AllowIfFlag(flags.bits()))?;
-        let fs_ref = ctx.thread_local.borrow_fs();
-        let path_resolver = fs_ref.resolver().read();
         if flags.contains(UtimensFlags::AT_SYMLINK_NOFOLLOW) {
             path_resolver.lookup_no_follow(&fs_path)?
         } else {
@@ -200,6 +201,7 @@ fn do_utimes(
         file.path().clone()
     };
 
+    security::file_setattr(&path, &path_resolver, FileSetattrKind::Times)?;
     vfs_utimes(&path, times)
 }
 

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -155,6 +155,11 @@ impl VmMapping {
         self.path.as_ref().map(|path| path.inode())
     }
 
+    /// Returns the file path that backs the mapping.
+    pub(super) fn path(&self) -> Option<&Path> {
+        self.path.as_ref()
+    }
+
     /// Returns a reference to the VMO if this mapping is VMO-backed.
     pub(super) fn vmo(&self) -> Option<&MappedVmo> {
         match &self.mapped_mem {

--- a/kernel/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/src/vm/vmar/vmar_impls/map.rs
@@ -10,6 +10,7 @@ use crate::{
         vfs::path::Path,
     },
     prelude::*,
+    security::{self, FilePermission},
     vm::{page_cache::Vmo, perms::VmPerms},
 };
 
@@ -248,6 +249,10 @@ impl<'a> VmarMapOptions<'a> {
         }
         if self.path.is_some() {
             panic!("Cannot set `mappable` when `path` is already set");
+        }
+
+        if self.perms.contains(VmPerms::EXEC) {
+            security::file_mmap(file.path(), FilePermission::MMAP)?;
         }
 
         let mappable = file.mappable()?;

--- a/kernel/src/vm/vmar/vmar_impls/protect.rs
+++ b/kernel/src/vm/vmar/vmar_impls/protect.rs
@@ -3,7 +3,11 @@
 use core::ops::Range;
 
 use super::{Interval, Vmar, util::get_intersected_range};
-use crate::{prelude::*, vm::perms::VmPerms};
+use crate::{
+    prelude::*,
+    security::{self, FilePermission},
+    vm::perms::VmPerms,
+};
 
 impl Vmar {
     /// Change the permissions of the memory mappings in the specified range.
@@ -24,11 +28,15 @@ impl Vmar {
         let mut protect_mappings = Vec::new();
 
         for vm_mapping in inner.vm_mappings.find(&range) {
-            protect_mappings.push((vm_mapping.range(), vm_mapping.perms()))
+            protect_mappings.push((
+                vm_mapping.range(),
+                vm_mapping.perms(),
+                vm_mapping.path().cloned(),
+            ))
         }
 
         let mut last_mapping_end = range.start;
-        for (vm_mapping_range, vm_mapping_perms) in protect_mappings {
+        for (vm_mapping_range, vm_mapping_perms, path) in protect_mappings {
             if last_mapping_end < vm_mapping_range.start {
                 return_errno_with_message!(
                     Errno::ENOMEM,
@@ -42,6 +50,12 @@ impl Vmar {
             }
             let new_perms = perms | (vm_mapping_perms & VmPerms::ALL_MAY_PERMS);
             new_perms.check()?;
+            if new_perms.contains(VmPerms::EXEC)
+                && !vm_mapping_perms.contains(VmPerms::EXEC)
+                && let Some(path) = path.as_ref()
+            {
+                security::file_mmap(path, FilePermission::MMAP)?;
+            }
 
             let Some(vm_mapping) = inner.remove(&vm_mapping_range.start) else {
                 // This can happen only if the mapping is merged to the previous one (just

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -12,6 +12,8 @@ ENABLE_REGRESSION_TEST ?= false
 # - linux: Define only `__linux__`. Tests may fail in Asterinas.
 REGRESSION_TEST_PLATFORM ?= asterinas
 DNS_SERVER ?= none
+ENABLE_APPARMOR_SMOKE_TEST ?= false
+APPARMOR_SMOKE_POLICY ?=
 # Set Nix's cached tarballs to be live for a longer period of time (30 days) to avoid network traffics.
 # Nix's default value is rather small (1 hour or 3600 seconds).
 NIXPKGS_CACHE_TTL := 2592000 # In seconds
@@ -48,6 +50,14 @@ BUILD_XFSTESTS_IMAGES = true
 endif
 endif
 
+APPARMOR_SMOKE_POLICY_ARG := null
+ifeq ($(ENABLE_APPARMOR_SMOKE_TEST), true)
+ifeq ($(APPARMOR_SMOKE_POLICY),)
+$(error APPARMOR_SMOKE_POLICY must be set when ENABLE_APPARMOR_SMOKE_TEST is true)
+endif
+APPARMOR_SMOKE_POLICY_ARG := $(APPARMOR_SMOKE_POLICY)
+endif
+
 # Decreases the level of verbosity of diagnostic messages from Nix.
 ifeq ($(VERBOSE), 0)
 NIX_QUIET = --quiet -Q
@@ -79,6 +89,7 @@ $(INITRAMFS_IMAGE): $(INITRAMFS)
 		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
 		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
 		--argstr dnsServer ${DNS_SERVER} \
+		--arg apparmorSmokePolicy $(APPARMOR_SMOKE_POLICY_ARG) \
 		--arg initramfsCompressed $(INITRAMFS_COMPRESSED) \
 		--arg smp $(SMP) \
 		--out-link $@ \
@@ -96,6 +107,7 @@ $(INITRAMFS):
 		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
 		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
 		--argstr dnsServer ${DNS_SERVER} \
+		--arg apparmorSmokePolicy $(APPARMOR_SMOKE_POLICY_ARG) \
 		--arg smp $(SMP) \
 		--out-link $@ \
 		nix -A initramfs

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -1,7 +1,8 @@
 { target ? "x86_64", enableBenchmarkTest ? false, enableConformanceTest ? false
 , enableRegressionTest ? false, conformanceTestSuite ? "ltp"
 , conformanceTestWorkDir ? "/tmp", regressionTestPlatform ? "asterinas"
-, dnsServer ? "none", smp ? 1, initramfsCompressed ? true, }:
+, dnsServer ? "none", smp ? 1, initramfsCompressed ? true
+, apparmorSmokePolicy ? null, }:
 let
   crossSystem.config = if target == "x86_64" then
     "x86_64-unknown-linux-gnu"
@@ -39,6 +40,7 @@ in rec {
     conformance = if enableConformanceTest then conformance else null;
     regression = if enableRegressionTest then regression else null;
     dnsServer = dnsServer;
+    inherit apparmorSmokePolicy;
   };
   initramfs-image = pkgs.callPackage ./initramfs-image.nix {
     inherit initramfs;

--- a/test/initramfs/nix/initramfs.nix
+++ b/test/initramfs/nix/initramfs.nix
@@ -1,6 +1,13 @@
 { lib, pkgs, stdenvNoCC, fetchFromGitHub, hostPlatform, writeClosure, busybox
-, benchmark, conformance, regression, dnsServer, }:
+, benchmark, conformance, regression, dnsServer, apparmorSmokePolicy ? null, }:
 let
+  apparmor_smoke =
+    builtins.path { path = ./../../../tools/apparmor/run-smoke-test.sh; };
+  apparmor_smoke_policy = if apparmorSmokePolicy == null then
+    null
+  else
+    builtins.path { path = apparmorSmokePolicy; };
+  apparmor_smoke_busybox = pkgs.pkgsStatic.busybox;
   boot_hello = builtins.path { path = ./../src/boot_hello.sh; };
   init = builtins.path { path = ./../src/init; };
   etc = lib.fileset.toSource {
@@ -17,7 +24,6 @@ let
   resolv_conf = pkgs.callPackage ./resolv_conf.nix { dnsServer = dnsServer; };
   # Whether the initramfs should include evtest, a common tool to debug input devices (`/dev/input/eventX`)
   is_evtest_included = false;
-
   all_pkgs = [ busybox etc resolv_conf ]
     ++ lib.optionals (benchmark != null) [ benchmark.package ]
     ++ lib.optionals (conformance != null) [ conformance.package ]
@@ -40,6 +46,12 @@ in stdenvNoCC.mkDerivation {
 
     cp ${boot_hello} $out/test/boot_hello.sh
     cp ${init} $out/init
+
+    ${lib.optionalString (apparmorSmokePolicy != null) ''
+      cp ${apparmor_smoke} $out/test/apparmor-smoke.sh
+      cp ${apparmor_smoke_policy} $out/test/apparmor-smoke.bin
+      cp ${apparmor_smoke_busybox}/bin/busybox $out/test/apparmor-busybox
+    ''}
 
     cp -r ${etc}/* $out/etc/
 

--- a/test/initramfs/src/regression/security/lsm/apparmor.c
+++ b/test/initramfs/src/regression/security/lsm/apparmor.c
@@ -1,0 +1,870 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <ctype.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef RENAME_EXCHANGE
+#define RENAME_EXCHANGE (1 << 1)
+#endif
+
+#define RAW_O_TMPFILE 020000000
+
+#ifndef __O_TMPFILE
+#define __O_TMPFILE RAW_O_TMPFILE
+#endif
+
+#ifndef O_TMPFILE
+#define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
+#endif
+
+#define CMDLINE_BUFFER_SIZE 4096
+#define FILE_BUFFER_SIZE 4096
+
+static const char *CMDLINE_PATH = "/proc/cmdline";
+static const char *APPARMOR_PROC_DIR_PATH = "/proc/sys/kernel/apparmor";
+static const char *APPARMOR_PROC_PROFILES_PATH =
+	"/proc/sys/kernel/apparmor/profiles";
+static const char *APPARMOR_PROC_CURRENT_PATH =
+	"/proc/sys/kernel/apparmor/current";
+static const char *APPARMOR_PROC_LOAD_PATH = "/proc/sys/kernel/apparmor/load";
+static const char *APPARMOR_ATTR_CURRENT_PATH = "/proc/self/attr/current";
+static const char *APPARMOR_ATTR_EXEC_PATH = "/proc/self/attr/exec";
+static const char *APPARMOR_ATTR_PREV_PATH = "/proc/self/attr/prev";
+static const char *SECURITYFS_MOUNT_DIR = "/tmp/apparmor-securityfs";
+static const char *SECURITYFS_APPARMOR_DIR =
+	"/tmp/apparmor-securityfs/apparmor";
+static const char *SECURITYFS_APPARMOR_PROFILES =
+	"/tmp/apparmor-securityfs/apparmor/profiles";
+static const char *SECURITYFS_APPARMOR_ABI =
+	"/tmp/apparmor-securityfs/apparmor/features/abi";
+
+static bool securityfs_mounted;
+
+static const char *FILE_HOOK_PROFILE_NAME = "asterinas-aa-file-hooks";
+static const char *FILE_HOOK_PREOPENED_PATH = "/tmp/aa-file-preopened";
+static const char *FILE_HOOK_ACCESS_PATH = "/tmp/aa-file-access";
+static const char *FILE_HOOK_MMAP_PATH = "/tmp/aa-file-mmap";
+static const char *FILE_HOOK_GETATTR_PATH = "/tmp/aa-file-getattr";
+static const char *FILE_HOOK_READLINK_PATH = "/tmp/aa-file-readlink";
+static const char *FILE_HOOK_RECEIVE_PATH = "/tmp/aa-file-receive";
+static const char *FILE_HOOK_SYMLINK_TARGET = "/tmp/aa-file-link-target";
+static const char *FILE_HOOK_RENAME_SOURCE_PATH = "/tmp/aa-file-rename-source";
+static const char *FILE_HOOK_RENAME_TARGET_PATH = "/tmp/aa-file-rename-target";
+static const char *FILE_HOOK_EXCHANGE_SOURCE_PATH =
+	"/tmp/aa-file-exchange-source";
+static const char *FILE_HOOK_EXCHANGE_TARGET_PATH =
+	"/tmp/aa-file-exchange-target";
+static const char *EXEC_HELPER_PATH = "/test/security/lsm/apparmor_exec_helper";
+static const char *CHANGE_SOURCE_PROFILE_NAME = "asterinas-aa-change-source";
+static const char *CHANGE_TARGET_PROFILE_NAME = "asterinas-aa-change-target";
+static const char *ONEXEC_TARGET_PROFILE_NAME = "asterinas-aa-onexec-target";
+static const char *EXEC_UNSAFE_SOURCE_PROFILE_NAME =
+	"asterinas-aa-unsafe-source";
+static const char *EXEC_SOURCE_PROFILE_NAME = "asterinas-aa-exec-source";
+static const char *EXEC_UX_SOURCE_PROFILE_NAME = "asterinas-aa-ux-source";
+static const char *EXEC_CHILD_SOURCE_PROFILE_NAME = "asterinas-aa-child-source";
+#define EXEC_CHILD_TARGET_PROFILE_NAME "asterinas-aa-child-target"
+static const char *ONEXEC_OUTPUT_PATH = "/tmp/aa-onexec-current";
+static const char *EXEC_UNSAFE_OUTPUT_PATH = "/tmp/aa-unsafe-current";
+static const char *EXEC_UNSAFE_SECURE_PATH = "/tmp/aa-unsafe-secure";
+static const char *EXEC_TRANSITION_OUTPUT_PATH = "/tmp/aa-exec-current";
+static const char *EXEC_TRANSITION_SECURE_PATH = "/tmp/aa-exec-secure";
+static const char *EXEC_UX_OUTPUT_PATH = "/tmp/aa-ux-current";
+static const char *EXEC_UX_SECURE_PATH = "/tmp/aa-ux-secure";
+static const char *EXEC_CHILD_OUTPUT_PATH = "/tmp/aa-child-current";
+static const char *EXEC_CHILD_SECURE_PATH = "/tmp/aa-child-secure";
+
+static void read_cmdline(char cmdline[CMDLINE_BUFFER_SIZE])
+{
+	int fd = CHECK(open(CMDLINE_PATH, O_RDONLY));
+	ssize_t len = CHECK(read(fd, cmdline, CMDLINE_BUFFER_SIZE - 1));
+
+	cmdline[len] = '\0';
+	CHECK(close(fd));
+}
+
+static char *trim(char *string)
+{
+	char *end;
+
+	while (isspace((unsigned char)*string)) {
+		string++;
+	}
+
+	end = string + strlen(string);
+	while (end > string && isspace((unsigned char)*(end - 1))) {
+		end--;
+	}
+	*end = '\0';
+
+	return string;
+}
+
+static bool find_effective_param(const char *prefix,
+				 char value[CMDLINE_BUFFER_SIZE])
+{
+	char cmdline[CMDLINE_BUFFER_SIZE];
+	char *saveptr = NULL;
+	size_t prefix_len = strlen(prefix);
+	bool found = false;
+
+	read_cmdline(cmdline);
+	for (char *token = strtok_r(cmdline, " \n", &saveptr); token;
+	     token = strtok_r(NULL, " \n", &saveptr)) {
+		if (strncmp(token, prefix, prefix_len) != 0) {
+			continue;
+		}
+
+		CHECK_WITH(snprintf(value, CMDLINE_BUFFER_SIZE, "%s",
+				    token + prefix_len),
+			   _ret >= 0 && _ret < CMDLINE_BUFFER_SIZE);
+		found = true;
+	}
+
+	return found;
+}
+
+static bool module_list_contains(const char *list, const char *module_name)
+{
+	char list_copy[CMDLINE_BUFFER_SIZE];
+	char *saveptr = NULL;
+
+	CHECK_WITH(snprintf(list_copy, sizeof(list_copy), "%s", list),
+		   _ret >= 0 && _ret < (int)sizeof(list_copy));
+	for (char *module = strtok_r(list_copy, ",", &saveptr); module;
+	     module = strtok_r(NULL, ",", &saveptr)) {
+		if (strcmp(trim(module), module_name) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool expect_apparmor_enabled(void)
+{
+	char lsm_param[CMDLINE_BUFFER_SIZE] = "";
+	char security_param[CMDLINE_BUFFER_SIZE] = "";
+
+	if (find_effective_param("lsm=", lsm_param)) {
+		return module_list_contains(lsm_param, "apparmor");
+	}
+
+	if (find_effective_param("security=", security_param)) {
+		return strcmp(trim(security_param), "apparmor") == 0;
+	}
+
+	return false;
+}
+
+static int stat_file_type(const char *path, mode_t file_type)
+{
+	struct stat statbuf;
+
+	if (stat(path, &statbuf) < 0) {
+		return -1;
+	}
+
+	if ((statbuf.st_mode & S_IFMT) != file_type) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int read_text_file(const char *path, char *buffer, size_t buffer_size)
+{
+	int fd;
+	ssize_t len;
+
+	if (buffer_size == 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	len = read(fd, buffer, buffer_size - 1);
+	if (len < 0) {
+		int saved_errno = errno;
+
+		close(fd);
+		errno = saved_errno;
+		return -1;
+	}
+
+	buffer[len] = '\0';
+	if (close(fd) < 0) {
+		return -1;
+	}
+
+	return (int)len;
+}
+
+static int write_text_file(const char *path, const char *text)
+{
+	int fd = open(path, O_WRONLY);
+	size_t len = strlen(text);
+	size_t written = 0;
+
+	if (fd < 0) {
+		return -1;
+	}
+
+	while (written < len) {
+		ssize_t count = write(fd, text + written, len - written);
+
+		if (count < 0) {
+			int saved_errno = errno;
+
+			close(fd);
+			errno = saved_errno;
+			return -1;
+		}
+		written += (size_t)count;
+	}
+
+	if (close(fd) < 0) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int create_text_file(const char *path, const char *text)
+{
+	int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	size_t len = strlen(text);
+	size_t written = 0;
+
+	if (fd < 0) {
+		return -1;
+	}
+
+	while (written < len) {
+		ssize_t count = write(fd, text + written, len - written);
+
+		if (count < 0) {
+			int saved_errno = errno;
+
+			close(fd);
+			errno = saved_errno;
+			return -1;
+		}
+		written += (size_t)count;
+	}
+
+	if (close(fd) < 0) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int read_file_errno(const char *path)
+{
+	char buffer[FILE_BUFFER_SIZE];
+	int fd = open(path, O_RDONLY);
+	int saved_errno = 0;
+
+	if (fd < 0) {
+		saved_errno = errno;
+		errno = 0;
+		return saved_errno;
+	}
+
+	if (read(fd, buffer, sizeof(buffer)) < 0) {
+		saved_errno = errno;
+	}
+
+	if (close(fd) < 0 && saved_errno == 0) {
+		saved_errno = errno;
+	}
+
+	errno = 0;
+	return saved_errno;
+}
+
+static int read_file_contains(const char *path, const char *expected)
+{
+	char buffer[FILE_BUFFER_SIZE];
+
+	if (read_text_file(path, buffer, sizeof(buffer)) < 0) {
+		return -1;
+	}
+
+	if (strstr(buffer, expected) == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int read_file_equals(const char *path, const char *expected)
+{
+	char buffer[FILE_BUFFER_SIZE];
+
+	if (read_text_file(path, buffer, sizeof(buffer)) < 0) {
+		return -1;
+	}
+
+	if (strcmp(buffer, expected) != 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int mount_securityfs(void)
+{
+	if (mkdir(SECURITYFS_MOUNT_DIR, 0755) < 0 && errno != EEXIST) {
+		return -1;
+	}
+
+	if (mount("none", SECURITYFS_MOUNT_DIR, "securityfs", 0, "") < 0) {
+		return -1;
+	}
+
+	securityfs_mounted = true;
+	return 0;
+}
+
+static void cleanup_securityfs_mount(void)
+{
+	if (securityfs_mounted) {
+		umount2(SECURITYFS_MOUNT_DIR, MNT_DETACH);
+		securityfs_mounted = false;
+	}
+	rmdir(SECURITYFS_MOUNT_DIR);
+}
+
+static int send_fd(int socket_fd, int fd)
+{
+	char byte = 'x';
+	struct iovec iov = {
+		.iov_base = &byte,
+		.iov_len = sizeof(byte),
+	};
+	char control[CMSG_SPACE(sizeof(int))];
+	struct msghdr message = {
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+		.msg_control = control,
+		.msg_controllen = sizeof(control),
+	};
+	struct cmsghdr *cmsg;
+
+	memset(control, 0, sizeof(control));
+	cmsg = CMSG_FIRSTHDR(&message);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	memcpy(CMSG_DATA(cmsg), &fd, sizeof(fd));
+	message.msg_controllen = cmsg->cmsg_len;
+
+	return sendmsg(socket_fd, &message, 0);
+}
+
+static int recv_fd(void)
+{
+	char byte;
+	struct iovec iov = {
+		.iov_base = &byte,
+		.iov_len = sizeof(byte),
+	};
+	char control[CMSG_SPACE(sizeof(int))];
+	struct msghdr message = {
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+		.msg_control = control,
+		.msg_controllen = sizeof(control),
+	};
+
+	if (recvmsg(0, &message, 0) < 0) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int expect_eacces(int result)
+{
+	if (result >= 0) {
+		errno = 0;
+		return -1;
+	}
+	if (errno != EACCES) {
+		return -1;
+	}
+	errno = 0;
+	return 0;
+}
+
+static int run_file_hook_child(void)
+{
+	char buffer[16];
+	struct stat statbuf;
+	int preopened_fd = open(FILE_HOOK_PREOPENED_PATH, O_RDONLY);
+	int mmap_fd = open(FILE_HOOK_MMAP_PATH, O_RDONLY);
+	int receive_fd = open(FILE_HOOK_RECEIVE_PATH, O_RDONLY);
+	int sockets[2];
+	void *mapping;
+
+	if (preopened_fd < 0 || mmap_fd < 0 || receive_fd < 0) {
+		return 1;
+	}
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+		return 2;
+	}
+	if (send_fd(sockets[0], receive_fd) < 0) {
+		return 3;
+	}
+	if (dup2(sockets[1], 0) < 0) {
+		return 4;
+	}
+	if (write_text_file(APPARMOR_PROC_CURRENT_PATH,
+			    FILE_HOOK_PROFILE_NAME) < 0) {
+		return 5;
+	}
+
+	if (expect_eacces(read(preopened_fd, buffer, sizeof(buffer))) < 0) {
+		return 10;
+	}
+	if (expect_eacces(access(FILE_HOOK_ACCESS_PATH, R_OK)) < 0) {
+		return 11;
+	}
+	if (expect_eacces(open("/tmp", O_TMPFILE | O_RDWR, 0600)) < 0) {
+		return 12;
+	}
+	if (expect_eacces(stat(FILE_HOOK_GETATTR_PATH, &statbuf)) < 0) {
+		return 13;
+	}
+	if (expect_eacces(readlink(FILE_HOOK_READLINK_PATH, buffer,
+				   sizeof(buffer))) < 0) {
+		return 14;
+	}
+
+	mapping = mmap(NULL, 4096, PROT_READ | PROT_EXEC, MAP_PRIVATE, mmap_fd,
+		       0);
+	if (mapping != MAP_FAILED) {
+		munmap(mapping, 4096);
+		return 15;
+	}
+	if (errno != EACCES) {
+		return 16;
+	}
+	errno = 0;
+
+	mapping = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, mmap_fd, 0);
+	if (mapping == MAP_FAILED) {
+		return 17;
+	}
+	if (expect_eacces(mprotect(mapping, 4096, PROT_READ | PROT_EXEC)) < 0) {
+		munmap(mapping, 4096);
+		return 18;
+	}
+	munmap(mapping, 4096);
+
+	if (expect_eacces(recv_fd()) < 0) {
+		return 19;
+	}
+	if (expect_eacces(rename(FILE_HOOK_RENAME_SOURCE_PATH,
+				 FILE_HOOK_RENAME_TARGET_PATH)) < 0) {
+		return 20;
+	}
+#ifdef SYS_renameat2
+	if (expect_eacces(syscall(SYS_renameat2, AT_FDCWD,
+				  FILE_HOOK_EXCHANGE_SOURCE_PATH, AT_FDCWD,
+				  FILE_HOOK_EXCHANGE_TARGET_PATH,
+				  RENAME_EXCHANGE)) < 0) {
+		return 21;
+	}
+#endif
+
+	return 0;
+}
+
+static int wait_for_child_success(pid_t pid)
+{
+	int status;
+
+	if (waitpid(pid, &status, 0) < 0) {
+		return -1;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		errno = ECHILD;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int run_change_profile_child(void)
+{
+	if (write_text_file(APPARMOR_ATTR_CURRENT_PATH,
+			    CHANGE_SOURCE_PROFILE_NAME) < 0) {
+		return 1;
+	}
+	if (read_file_equals(APPARMOR_ATTR_CURRENT_PATH,
+			     "asterinas-aa-change-source\n") < 0) {
+		return 2;
+	}
+	if (write_text_file(APPARMOR_ATTR_CURRENT_PATH,
+			    CHANGE_TARGET_PROFILE_NAME) < 0) {
+		return 3;
+	}
+	if (read_file_equals(APPARMOR_ATTR_CURRENT_PATH,
+			     "asterinas-aa-change-target\n") < 0) {
+		return 4;
+	}
+	if (read_file_equals(APPARMOR_ATTR_PREV_PATH,
+			     "asterinas-aa-change-source\n") < 0) {
+		return 5;
+	}
+	if (expect_eacces(write_text_file(APPARMOR_ATTR_CURRENT_PATH,
+					  CHANGE_SOURCE_PROFILE_NAME)) < 0) {
+		return 6;
+	}
+
+	return 0;
+}
+
+static int run_onexec_child(void)
+{
+	if (write_text_file(APPARMOR_ATTR_CURRENT_PATH,
+			    CHANGE_SOURCE_PROFILE_NAME) < 0) {
+		return 1;
+	}
+	if (write_text_file(APPARMOR_ATTR_EXEC_PATH,
+			    ONEXEC_TARGET_PROFILE_NAME) < 0) {
+		return 2;
+	}
+	if (read_file_equals(APPARMOR_ATTR_EXEC_PATH,
+			     "asterinas-aa-onexec-target\n") < 0) {
+		return 3;
+	}
+
+	execl(EXEC_HELPER_PATH, EXEC_HELPER_PATH, ONEXEC_OUTPUT_PATH, NULL);
+	return 4;
+}
+
+static int run_exec_transition_child(const char *profile_name,
+				     const char *output_path,
+				     const char *secure_output_path)
+{
+	if (write_text_file(APPARMOR_ATTR_CURRENT_PATH, profile_name) < 0) {
+		return 1;
+	}
+
+	if (secure_output_path != NULL) {
+		execl(EXEC_HELPER_PATH, EXEC_HELPER_PATH, output_path,
+		      secure_output_path, NULL);
+	} else {
+		execl(EXEC_HELPER_PATH, EXEC_HELPER_PATH, output_path, NULL);
+	}
+	return 2;
+}
+
+FN_SETUP(register_securityfs_cleanup)
+{
+	atexit(cleanup_securityfs_mount);
+}
+END_SETUP()
+
+FN_TEST(procfs_visibility_follows_lsm_selection)
+{
+	bool expect_apparmor = expect_apparmor_enabled();
+
+	if (expect_apparmor) {
+		TEST_SUCC(stat_file_type(APPARMOR_PROC_DIR_PATH, S_IFDIR));
+		TEST_SUCC(stat_file_type(APPARMOR_PROC_PROFILES_PATH, S_IFREG));
+		TEST_SUCC(read_file_equals(APPARMOR_PROC_CURRENT_PATH,
+					   "unconfined\n"));
+	} else {
+		TEST_ERRNO(stat_file_type(APPARMOR_PROC_DIR_PATH, S_IFDIR),
+			   ENOENT);
+		TEST_ERRNO(open(APPARMOR_PROC_PROFILES_PATH, O_RDONLY), ENOENT);
+		TEST_ERRNO(open(APPARMOR_PROC_CURRENT_PATH, O_RDONLY), ENOENT);
+	}
+}
+END_TEST()
+
+FN_TEST(task_attr_files_follow_lsm_selection)
+{
+	bool expect_apparmor = expect_apparmor_enabled();
+
+	if (expect_apparmor) {
+		TEST_SUCC(read_file_equals(APPARMOR_ATTR_CURRENT_PATH,
+					   "unconfined\n"));
+		TEST_SUCC(read_file_equals(APPARMOR_ATTR_EXEC_PATH, ""));
+		TEST_SUCC(read_file_equals(APPARMOR_ATTR_PREV_PATH, ""));
+	} else {
+		TEST_RES(read_file_errno(APPARMOR_ATTR_CURRENT_PATH),
+			 _ret == ENOENT);
+		TEST_RES(read_file_errno(APPARMOR_ATTR_EXEC_PATH),
+			 _ret == ENOENT);
+		TEST_RES(read_file_errno(APPARMOR_ATTR_PREV_PATH),
+			 _ret == ENOENT);
+	}
+}
+END_TEST()
+
+FN_TEST(securityfs_visibility_follows_lsm_selection)
+{
+	bool expect_apparmor = expect_apparmor_enabled();
+
+	TEST_SUCC(mount_securityfs());
+
+	if (expect_apparmor) {
+		TEST_SUCC(stat_file_type(SECURITYFS_APPARMOR_DIR, S_IFDIR));
+		TEST_SUCC(
+			stat_file_type(SECURITYFS_APPARMOR_PROFILES, S_IFREG));
+		TEST_SUCC(read_file_contains(
+			SECURITYFS_APPARMOR_ABI,
+			"asterinas-apparmor-linux-filedfa-v1"));
+	} else {
+		TEST_ERRNO(stat_file_type(SECURITYFS_APPARMOR_DIR, S_IFDIR),
+			   ENOENT);
+		TEST_ERRNO(open(SECURITYFS_APPARMOR_PROFILES, O_RDONLY),
+			   ENOENT);
+	}
+
+	cleanup_securityfs_mount();
+}
+END_TEST()
+
+FN_TEST(profile_change_and_exec_transition)
+{
+	static const char change_source_policy[] =
+		"profile asterinas-aa-change-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow change_profile asterinas-aa-change-target\n"
+		"allow change_onexec asterinas-aa-onexec-target\n";
+	static const char change_target_policy[] =
+		"profile asterinas-aa-change-target enforce\n"
+		"allow capability all\n"
+		"allow /** all\n";
+	static const char onexec_target_policy[] =
+		"profile asterinas-aa-onexec-target enforce\n"
+		"allow capability all\n"
+		"allow /** all\n";
+	static const char exec_unsafe_source_policy[] =
+		"profile asterinas-aa-unsafe-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x px:asterinas-aa-exec-target\n";
+	static const char exec_source_policy[] =
+		"profile asterinas-aa-exec-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x Px:asterinas-aa-exec-target\n";
+	static const char exec_target_policy[] =
+		"profile asterinas-aa-exec-target enforce\n"
+		"allow capability all\n"
+		"allow /** all\n";
+	static const char ux_source_policy[] =
+		"profile asterinas-aa-ux-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x Ux\n";
+	static const char child_source_policy[] =
+		"profile asterinas-aa-child-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x Cx:asterinas-aa-child-target\n";
+	static const char child_target_policy[] =
+		"profile asterinas-aa-child-target enforce\n"
+		"allow capability all\n"
+		"allow /** all\n";
+	pid_t child;
+	bool expect_apparmor = expect_apparmor_enabled();
+
+	SKIP_TEST_IF(!expect_apparmor);
+
+	unlink(ONEXEC_OUTPUT_PATH);
+	unlink(EXEC_UNSAFE_OUTPUT_PATH);
+	unlink(EXEC_UNSAFE_SECURE_PATH);
+	unlink(EXEC_TRANSITION_OUTPUT_PATH);
+	unlink(EXEC_TRANSITION_SECURE_PATH);
+	unlink(EXEC_UX_OUTPUT_PATH);
+	unlink(EXEC_UX_SECURE_PATH);
+	unlink(EXEC_CHILD_OUTPUT_PATH);
+	unlink(EXEC_CHILD_SECURE_PATH);
+
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, change_target_policy));
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, onexec_target_policy));
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, change_source_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, exec_target_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH,
+				  exec_unsafe_source_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, exec_source_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, ux_source_policy));
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, child_target_policy));
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, child_source_policy));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_change_profile_child());
+	}
+	TEST_SUCC(wait_for_child_success(child));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_onexec_child());
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(ONEXEC_OUTPUT_PATH,
+				   "asterinas-aa-onexec-target\n"));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_exec_transition_child(EXEC_UNSAFE_SOURCE_PROFILE_NAME,
+						EXEC_UNSAFE_OUTPUT_PATH,
+						EXEC_UNSAFE_SECURE_PATH));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(EXEC_UNSAFE_OUTPUT_PATH,
+				   "asterinas-aa-exec-target\n"));
+	TEST_SUCC(read_file_equals(EXEC_UNSAFE_SECURE_PATH, "0\n"));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_exec_transition_child(EXEC_SOURCE_PROFILE_NAME,
+						EXEC_TRANSITION_OUTPUT_PATH,
+						EXEC_TRANSITION_SECURE_PATH));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(EXEC_TRANSITION_OUTPUT_PATH,
+				   "asterinas-aa-exec-target\n"));
+	TEST_SUCC(read_file_equals(EXEC_TRANSITION_SECURE_PATH, "1\n"));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_exec_transition_child(EXEC_UX_SOURCE_PROFILE_NAME,
+						EXEC_UX_OUTPUT_PATH,
+						EXEC_UX_SECURE_PATH));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(EXEC_UX_OUTPUT_PATH, "unconfined\n"));
+	TEST_SUCC(read_file_equals(EXEC_UX_SECURE_PATH, "1\n"));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_exec_transition_child(EXEC_CHILD_SOURCE_PROFILE_NAME,
+						EXEC_CHILD_OUTPUT_PATH,
+						EXEC_CHILD_SECURE_PATH));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(EXEC_CHILD_OUTPUT_PATH,
+				   EXEC_CHILD_TARGET_PROFILE_NAME "\n"));
+	TEST_SUCC(read_file_equals(EXEC_CHILD_SECURE_PATH, "1\n"));
+
+	unlink(ONEXEC_OUTPUT_PATH);
+	unlink(EXEC_UNSAFE_OUTPUT_PATH);
+	unlink(EXEC_UNSAFE_SECURE_PATH);
+	unlink(EXEC_TRANSITION_OUTPUT_PATH);
+	unlink(EXEC_TRANSITION_SECURE_PATH);
+	unlink(EXEC_UX_OUTPUT_PATH);
+	unlink(EXEC_UX_SECURE_PATH);
+	unlink(EXEC_CHILD_OUTPUT_PATH);
+	unlink(EXEC_CHILD_SECURE_PATH);
+}
+END_TEST()
+
+FN_TEST(file_mediation_revalidates_runtime_operations)
+{
+	static const char policy[] =
+		"profile asterinas-aa-file-hooks enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"deny /tmp/aa-file-preopened r\n"
+		"deny /tmp/aa-file-access r\n"
+		"deny /tmp create\n"
+		"deny /tmp/aa-file-getattr r\n"
+		"deny /tmp/aa-file-readlink r\n"
+		"deny /tmp/aa-file-receive r\n"
+		"deny /tmp/aa-file-mmap mmap\n"
+		"deny /tmp/aa-file-rename-target delete\n"
+		"deny /tmp/aa-file-exchange-target rename\n";
+	pid_t child;
+	bool expect_apparmor = expect_apparmor_enabled();
+
+	SKIP_TEST_IF(!expect_apparmor);
+
+	unlink(FILE_HOOK_PREOPENED_PATH);
+	unlink(FILE_HOOK_ACCESS_PATH);
+	unlink(FILE_HOOK_MMAP_PATH);
+	unlink(FILE_HOOK_GETATTR_PATH);
+	unlink(FILE_HOOK_READLINK_PATH);
+	unlink(FILE_HOOK_RECEIVE_PATH);
+	unlink(FILE_HOOK_SYMLINK_TARGET);
+	unlink(FILE_HOOK_RENAME_SOURCE_PATH);
+	unlink(FILE_HOOK_RENAME_TARGET_PATH);
+	unlink(FILE_HOOK_EXCHANGE_SOURCE_PATH);
+	unlink(FILE_HOOK_EXCHANGE_TARGET_PATH);
+
+	TEST_SUCC(create_text_file(FILE_HOOK_PREOPENED_PATH, "preopened"));
+	TEST_SUCC(create_text_file(FILE_HOOK_ACCESS_PATH, "access"));
+	TEST_SUCC(create_text_file(FILE_HOOK_MMAP_PATH, "mmap"));
+	TEST_SUCC(create_text_file(FILE_HOOK_GETATTR_PATH, "getattr"));
+	TEST_SUCC(create_text_file(FILE_HOOK_RECEIVE_PATH, "receive"));
+	TEST_SUCC(create_text_file(FILE_HOOK_SYMLINK_TARGET, "target"));
+	TEST_SUCC(create_text_file(FILE_HOOK_RENAME_SOURCE_PATH, "source"));
+	TEST_SUCC(create_text_file(FILE_HOOK_RENAME_TARGET_PATH, "target"));
+	TEST_SUCC(create_text_file(FILE_HOOK_EXCHANGE_SOURCE_PATH, "source"));
+	TEST_SUCC(create_text_file(FILE_HOOK_EXCHANGE_TARGET_PATH, "target"));
+	TEST_SUCC(symlink(FILE_HOOK_SYMLINK_TARGET, FILE_HOOK_READLINK_PATH));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, policy));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_file_hook_child());
+	}
+	TEST_SUCC(wait_for_child_success(child));
+
+	unlink(FILE_HOOK_PREOPENED_PATH);
+	unlink(FILE_HOOK_ACCESS_PATH);
+	unlink(FILE_HOOK_MMAP_PATH);
+	unlink(FILE_HOOK_GETATTR_PATH);
+	unlink(FILE_HOOK_READLINK_PATH);
+	unlink(FILE_HOOK_RECEIVE_PATH);
+	unlink(FILE_HOOK_SYMLINK_TARGET);
+	unlink(FILE_HOOK_RENAME_SOURCE_PATH);
+	unlink(FILE_HOOK_RENAME_TARGET_PATH);
+	unlink(FILE_HOOK_EXCHANGE_SOURCE_PATH);
+	unlink(FILE_HOOK_EXCHANGE_TARGET_PATH);
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/lsm/apparmor.c
+++ b/test/initramfs/src/regression/security/lsm/apparmor.c
@@ -51,9 +51,21 @@ static const char *SECURITYFS_APPARMOR_PROFILES =
 	"/tmp/apparmor-securityfs/apparmor/profiles";
 static const char *SECURITYFS_APPARMOR_ABI =
 	"/tmp/apparmor-securityfs/apparmor/features/abi";
+static const char *SECURITYFS_APPARMOR_PERMSTABLE =
+	"/tmp/apparmor-securityfs/apparmor/features/policy/permstable32";
+static const char *SECURITYFS_APPARMOR_FILE_MASK =
+	"/tmp/apparmor-securityfs/apparmor/features/file/mask";
+static const char *SECURITYFS_APPARMOR_DOMAIN_STACK =
+	"/tmp/apparmor-securityfs/apparmor/features/domain/stack";
 
 static bool securityfs_mounted;
 
+static const char *POLICY_MODE_PROFILE_ENFORCE = "asterinas-aa-mode-enforce";
+static const char *POLICY_MODE_PROFILE_COMPLAIN = "asterinas-aa-mode-complain";
+static const char *POLICY_MODE_PROFILE_COMPLAIN_IMPLICIT =
+	"asterinas-aa-mode-complain-implicit";
+static const char *POLICY_REPLACE_PROFILE_NAME = "asterinas-aa-replace-remove";
+static const char *POLICY_MODE_PATH = "/tmp/aa-policy-mode";
 static const char *FILE_HOOK_PROFILE_NAME = "asterinas-aa-file-hooks";
 static const char *FILE_HOOK_PREOPENED_PATH = "/tmp/aa-file-preopened";
 static const char *FILE_HOOK_ACCESS_PATH = "/tmp/aa-file-access";
@@ -335,6 +347,22 @@ static int read_file_equals(const char *path, const char *expected)
 	return 0;
 }
 
+static int read_file_not_contains(const char *path, const char *unexpected)
+{
+	char buffer[FILE_BUFFER_SIZE];
+
+	if (read_text_file(path, buffer, sizeof(buffer)) < 0) {
+		return -1;
+	}
+
+	if (strstr(buffer, unexpected) != NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return 0;
+}
+
 static int mount_securityfs(void)
 {
 	if (mkdir(SECURITYFS_MOUNT_DIR, 0755) < 0 && errno != EEXIST) {
@@ -417,6 +445,38 @@ static int expect_eacces(int result)
 		return -1;
 	}
 	errno = 0;
+	return 0;
+}
+
+static int run_read_policy_mode_child(const char *profile_name,
+				      bool expect_denied)
+{
+	int fd;
+
+	if (write_text_file(APPARMOR_PROC_CURRENT_PATH, profile_name) < 0) {
+		return 1;
+	}
+
+	fd = open(POLICY_MODE_PATH, O_RDONLY);
+	if (expect_denied) {
+		if (fd >= 0) {
+			close(fd);
+			return 2;
+		}
+		if (errno != EACCES) {
+			return 3;
+		}
+		errno = 0;
+		return 0;
+	}
+
+	if (fd < 0) {
+		return 4;
+	}
+	if (close(fd) < 0) {
+		return 5;
+	}
+
 	return 0;
 }
 
@@ -650,6 +710,106 @@ FN_TEST(securityfs_visibility_follows_lsm_selection)
 	}
 
 	cleanup_securityfs_mount();
+}
+END_TEST()
+
+FN_TEST(policy_modes_features_and_lifecycle)
+{
+	static const char enforce_policy[] =
+		"profile asterinas-aa-mode-enforce enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"deny /tmp/aa-policy-mode r audit\n";
+	static const char complain_policy[] =
+		"profile asterinas-aa-mode-complain complain\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"deny /tmp/aa-policy-mode r audit\n";
+	static const char complain_implicit_policy[] =
+		"profile asterinas-aa-mode-complain-implicit complain\n"
+		"allow capability all\n";
+	static const char replace_deny_policy[] =
+		"profile asterinas-aa-replace-remove enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"deny /tmp/aa-policy-mode r\n";
+	static const char replace_allow_policy[] =
+		"profile asterinas-aa-replace-remove enforce\n"
+		"allow capability all\n"
+		"allow /** all\n";
+	static const char remove_policy[] =
+		"remove asterinas-aa-replace-remove\n";
+	pid_t child;
+	bool expect_apparmor = expect_apparmor_enabled();
+
+	SKIP_TEST_IF(!expect_apparmor);
+
+	TEST_SUCC(create_text_file(POLICY_MODE_PATH, "mode"));
+	TEST_SUCC(mount_securityfs());
+	TEST_SUCC(read_file_contains(SECURITYFS_APPARMOR_ABI,
+				     "policy_abi=linux-v5-v9-subset"));
+	TEST_SUCC(read_file_contains(SECURITYFS_APPARMOR_ABI, "complain=yes"));
+	TEST_SUCC(read_file_contains(SECURITYFS_APPARMOR_PERMSTABLE,
+				     "allow deny audit quiet xindex"));
+	TEST_SUCC(read_file_contains(SECURITYFS_APPARMOR_FILE_MASK,
+				     "delete rename setattr"));
+	TEST_ERRNO(stat_file_type(SECURITYFS_APPARMOR_DOMAIN_STACK, S_IFREG),
+		   ENOENT);
+	cleanup_securityfs_mount();
+
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, enforce_policy));
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_read_policy_mode_child(POLICY_MODE_PROFILE_ENFORCE,
+						 true));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, complain_implicit_policy));
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_read_policy_mode_child(
+			POLICY_MODE_PROFILE_COMPLAIN_IMPLICIT, false));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, complain_policy));
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_read_policy_mode_child(POLICY_MODE_PROFILE_COMPLAIN,
+						 true));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, replace_deny_policy));
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_read_policy_mode_child(POLICY_REPLACE_PROFILE_NAME,
+						 true));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+
+	TEST_SUCC(
+		write_text_file(APPARMOR_PROC_LOAD_PATH, replace_allow_policy));
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_read_policy_mode_child(POLICY_REPLACE_PROFILE_NAME,
+						 false));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, remove_policy));
+	TEST_SUCC(read_file_not_contains(APPARMOR_PROC_PROFILES_PATH,
+					 POLICY_REPLACE_PROFILE_NAME));
+
+	unlink(POLICY_MODE_PATH);
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/security/lsm/apparmor.c
+++ b/test/initramfs/src/regression/security/lsm/apparmor.c
@@ -87,18 +87,32 @@ static const char *ONEXEC_TARGET_PROFILE_NAME = "asterinas-aa-onexec-target";
 static const char *EXEC_UNSAFE_SOURCE_PROFILE_NAME =
 	"asterinas-aa-unsafe-source";
 static const char *EXEC_SOURCE_PROFILE_NAME = "asterinas-aa-exec-source";
+static const char *EXEC_IX_SOURCE_PROFILE_NAME = "asterinas-aa-ix-source";
+static const char *EXEC_UX_UNSAFE_SOURCE_PROFILE_NAME =
+	"asterinas-aa-ux-unsafe-source";
 static const char *EXEC_UX_SOURCE_PROFILE_NAME = "asterinas-aa-ux-source";
 static const char *EXEC_CHILD_SOURCE_PROFILE_NAME = "asterinas-aa-child-source";
-#define EXEC_CHILD_TARGET_PROFILE_NAME "asterinas-aa-child-target"
+static const char *EXEC_CX_SOURCE_PROFILE_NAME = "asterinas-aa-cx-source";
+static const char *EXEC_BAD_CHILD_SOURCE_PROFILE_NAME =
+	"asterinas-aa-bad-child-source";
+#define EXEC_CHILD_TARGET_PROFILE_NAME "asterinas-aa-child-source//target"
+#define EXEC_CX_TARGET_PROFILE_NAME "asterinas-aa-cx-source//target"
 static const char *ONEXEC_OUTPUT_PATH = "/tmp/aa-onexec-current";
 static const char *EXEC_UNSAFE_OUTPUT_PATH = "/tmp/aa-unsafe-current";
 static const char *EXEC_UNSAFE_SECURE_PATH = "/tmp/aa-unsafe-secure";
 static const char *EXEC_TRANSITION_OUTPUT_PATH = "/tmp/aa-exec-current";
 static const char *EXEC_TRANSITION_SECURE_PATH = "/tmp/aa-exec-secure";
+static const char *EXEC_IX_OUTPUT_PATH = "/tmp/aa-ix-current";
+static const char *EXEC_IX_SECURE_PATH = "/tmp/aa-ix-secure";
+static const char *EXEC_UX_UNSAFE_OUTPUT_PATH = "/tmp/aa-ux-unsafe-current";
+static const char *EXEC_UX_UNSAFE_SECURE_PATH = "/tmp/aa-ux-unsafe-secure";
 static const char *EXEC_UX_OUTPUT_PATH = "/tmp/aa-ux-current";
 static const char *EXEC_UX_SECURE_PATH = "/tmp/aa-ux-secure";
 static const char *EXEC_CHILD_OUTPUT_PATH = "/tmp/aa-child-current";
 static const char *EXEC_CHILD_SECURE_PATH = "/tmp/aa-child-secure";
+static const char *EXEC_CX_OUTPUT_PATH = "/tmp/aa-cx-current";
+static const char *EXEC_CX_SECURE_PATH = "/tmp/aa-cx-secure";
+static const char *EXEC_DENIED_OUTPUT_PATH = "/tmp/aa-denied-current";
 
 static void read_cmdline(char cmdline[CMDLINE_BUFFER_SIZE])
 {
@@ -601,9 +615,13 @@ static int run_change_profile_child(void)
 			     "asterinas-aa-change-source\n") < 0) {
 		return 5;
 	}
+	if (expect_eacces(write_text_file(APPARMOR_ATTR_EXEC_PATH,
+					  ONEXEC_TARGET_PROFILE_NAME)) < 0) {
+		return 6;
+	}
 	if (expect_eacces(write_text_file(APPARMOR_ATTR_CURRENT_PATH,
 					  CHANGE_SOURCE_PROFILE_NAME)) < 0) {
-		return 6;
+		return 7;
 	}
 
 	return 0;
@@ -643,6 +661,21 @@ static int run_exec_transition_child(const char *profile_name,
 		execl(EXEC_HELPER_PATH, EXEC_HELPER_PATH, output_path, NULL);
 	}
 	return 2;
+}
+
+static int run_denied_exec_transition_child(const char *profile_name)
+{
+	if (write_text_file(APPARMOR_ATTR_CURRENT_PATH, profile_name) < 0) {
+		return 1;
+	}
+
+	execl(EXEC_HELPER_PATH, EXEC_HELPER_PATH, EXEC_DENIED_OUTPUT_PATH,
+	      NULL);
+	if (errno != EACCES) {
+		return 2;
+	}
+
+	return 0;
 }
 
 FN_SETUP(register_securityfs_cleanup)
@@ -766,8 +799,8 @@ FN_TEST(policy_modes_features_and_lifecycle)
 	}
 	TEST_SUCC(wait_for_child_success(child));
 
-	TEST_SUCC(
-		write_text_file(APPARMOR_PROC_LOAD_PATH, complain_implicit_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH,
+				  complain_implicit_policy));
 	child = fork();
 	TEST(child, 0, _ret >= 0);
 	if (child == 0) {
@@ -843,6 +876,16 @@ FN_TEST(profile_change_and_exec_transition)
 		"profile asterinas-aa-exec-target enforce\n"
 		"allow capability all\n"
 		"allow /** all\n";
+	static const char ix_source_policy[] =
+		"profile asterinas-aa-ix-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x ix\n";
+	static const char ux_unsafe_source_policy[] =
+		"profile asterinas-aa-ux-unsafe-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x ux\n";
 	static const char ux_source_policy[] =
 		"profile asterinas-aa-ux-source enforce\n"
 		"allow capability all\n"
@@ -852,11 +895,28 @@ FN_TEST(profile_change_and_exec_transition)
 		"profile asterinas-aa-child-source enforce\n"
 		"allow capability all\n"
 		"allow /** all\n"
-		"allow /test/security/lsm/apparmor_exec_helper x Cx:asterinas-aa-child-target\n";
+		"allow /test/security/lsm/apparmor_exec_helper x Cx:" EXEC_CHILD_TARGET_PROFILE_NAME
+		"\n";
 	static const char child_target_policy[] =
-		"profile asterinas-aa-child-target enforce\n"
+		"profile " EXEC_CHILD_TARGET_PROFILE_NAME " enforce\n"
 		"allow capability all\n"
 		"allow /** all\n";
+	static const char cx_source_policy[] =
+		"profile asterinas-aa-cx-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x cx:" EXEC_CX_TARGET_PROFILE_NAME
+		"\n";
+	static const char cx_target_policy[] =
+		"profile " EXEC_CX_TARGET_PROFILE_NAME " enforce\n"
+		"allow capability all\n"
+		"allow /** all\n";
+	static const char bad_child_source_policy[] =
+		"profile asterinas-aa-bad-child-source enforce\n"
+		"allow capability all\n"
+		"allow /** all\n"
+		"allow /test/security/lsm/apparmor_exec_helper x cx:"
+		"asterinas-aa-exec-target\n";
 	pid_t child;
 	bool expect_apparmor = expect_apparmor_enabled();
 
@@ -867,10 +927,17 @@ FN_TEST(profile_change_and_exec_transition)
 	unlink(EXEC_UNSAFE_SECURE_PATH);
 	unlink(EXEC_TRANSITION_OUTPUT_PATH);
 	unlink(EXEC_TRANSITION_SECURE_PATH);
+	unlink(EXEC_IX_OUTPUT_PATH);
+	unlink(EXEC_IX_SECURE_PATH);
+	unlink(EXEC_UX_UNSAFE_OUTPUT_PATH);
+	unlink(EXEC_UX_UNSAFE_SECURE_PATH);
 	unlink(EXEC_UX_OUTPUT_PATH);
 	unlink(EXEC_UX_SECURE_PATH);
 	unlink(EXEC_CHILD_OUTPUT_PATH);
 	unlink(EXEC_CHILD_SECURE_PATH);
+	unlink(EXEC_CX_OUTPUT_PATH);
+	unlink(EXEC_CX_SECURE_PATH);
+	unlink(EXEC_DENIED_OUTPUT_PATH);
 
 	TEST_SUCC(
 		write_text_file(APPARMOR_PROC_LOAD_PATH, change_target_policy));
@@ -882,11 +949,18 @@ FN_TEST(profile_change_and_exec_transition)
 	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH,
 				  exec_unsafe_source_policy));
 	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, exec_source_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, ix_source_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH,
+				  ux_unsafe_source_policy));
 	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, ux_source_policy));
 	TEST_SUCC(
 		write_text_file(APPARMOR_PROC_LOAD_PATH, child_target_policy));
 	TEST_SUCC(
 		write_text_file(APPARMOR_PROC_LOAD_PATH, child_source_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, cx_target_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH, cx_source_policy));
+	TEST_SUCC(write_text_file(APPARMOR_PROC_LOAD_PATH,
+				  bad_child_source_policy));
 
 	child = fork();
 	TEST(child, 0, _ret >= 0);
@@ -931,6 +1005,30 @@ FN_TEST(profile_change_and_exec_transition)
 	child = fork();
 	TEST(child, 0, _ret >= 0);
 	if (child == 0) {
+		_exit(run_exec_transition_child(EXEC_IX_SOURCE_PROFILE_NAME,
+						EXEC_IX_OUTPUT_PATH,
+						EXEC_IX_SECURE_PATH));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(EXEC_IX_OUTPUT_PATH,
+				   "asterinas-aa-ix-source\n"));
+	TEST_SUCC(read_file_equals(EXEC_IX_SECURE_PATH, "0\n"));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_exec_transition_child(
+			EXEC_UX_UNSAFE_SOURCE_PROFILE_NAME,
+			EXEC_UX_UNSAFE_OUTPUT_PATH,
+			EXEC_UX_UNSAFE_SECURE_PATH));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(EXEC_UX_UNSAFE_OUTPUT_PATH, "unconfined\n"));
+	TEST_SUCC(read_file_equals(EXEC_UX_UNSAFE_SECURE_PATH, "0\n"));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
 		_exit(run_exec_transition_child(EXEC_UX_SOURCE_PROFILE_NAME,
 						EXEC_UX_OUTPUT_PATH,
 						EXEC_UX_SECURE_PATH));
@@ -951,15 +1049,43 @@ FN_TEST(profile_change_and_exec_transition)
 				   EXEC_CHILD_TARGET_PROFILE_NAME "\n"));
 	TEST_SUCC(read_file_equals(EXEC_CHILD_SECURE_PATH, "1\n"));
 
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_exec_transition_child(EXEC_CX_SOURCE_PROFILE_NAME,
+						EXEC_CX_OUTPUT_PATH,
+						EXEC_CX_SECURE_PATH));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_SUCC(read_file_equals(EXEC_CX_OUTPUT_PATH,
+				   EXEC_CX_TARGET_PROFILE_NAME "\n"));
+	TEST_SUCC(read_file_equals(EXEC_CX_SECURE_PATH, "0\n"));
+
+	child = fork();
+	TEST(child, 0, _ret >= 0);
+	if (child == 0) {
+		_exit(run_denied_exec_transition_child(
+			EXEC_BAD_CHILD_SOURCE_PROFILE_NAME));
+	}
+	TEST_SUCC(wait_for_child_success(child));
+	TEST_ERRNO(stat_file_type(EXEC_DENIED_OUTPUT_PATH, S_IFREG), ENOENT);
+
 	unlink(ONEXEC_OUTPUT_PATH);
 	unlink(EXEC_UNSAFE_OUTPUT_PATH);
 	unlink(EXEC_UNSAFE_SECURE_PATH);
 	unlink(EXEC_TRANSITION_OUTPUT_PATH);
 	unlink(EXEC_TRANSITION_SECURE_PATH);
+	unlink(EXEC_IX_OUTPUT_PATH);
+	unlink(EXEC_IX_SECURE_PATH);
+	unlink(EXEC_UX_UNSAFE_OUTPUT_PATH);
+	unlink(EXEC_UX_UNSAFE_SECURE_PATH);
 	unlink(EXEC_UX_OUTPUT_PATH);
 	unlink(EXEC_UX_SECURE_PATH);
 	unlink(EXEC_CHILD_OUTPUT_PATH);
 	unlink(EXEC_CHILD_SECURE_PATH);
+	unlink(EXEC_CX_OUTPUT_PATH);
+	unlink(EXEC_CX_SECURE_PATH);
+	unlink(EXEC_DENIED_OUTPUT_PATH);
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/security/lsm/apparmor_exec_helper.c
+++ b/test/initramfs/src/regression/security/lsm/apparmor_exec_helper.c
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define AT_NULL 0
+#define AT_SECURE 23
+#define BUFFER_SIZE 4096
+
+static int read_text_file(const char *path, char *buffer, size_t buffer_size)
+{
+	int fd;
+	ssize_t len;
+
+	if (buffer_size == 0) {
+		return -1;
+	}
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	len = read(fd, buffer, buffer_size - 1);
+	if (len < 0) {
+		close(fd);
+		return -1;
+	}
+	buffer[len] = '\0';
+
+	return close(fd);
+}
+
+static int write_text_file(const char *path, const char *text)
+{
+	int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	size_t len = strlen(text);
+	size_t written = 0;
+
+	if (fd < 0) {
+		return -1;
+	}
+
+	while (written < len) {
+		ssize_t count = write(fd, text + written, len - written);
+
+		if (count < 0) {
+			close(fd);
+			return -1;
+		}
+		written += (size_t)count;
+	}
+
+	return close(fd);
+}
+
+static int read_at_secure(unsigned long *secure)
+{
+	unsigned long entry[2];
+	int fd = open("/proc/self/auxv", O_RDONLY);
+
+	if (fd < 0) {
+		return -1;
+	}
+
+	while (read(fd, entry, sizeof(entry)) == sizeof(entry)) {
+		if (entry[0] == AT_SECURE) {
+			*secure = entry[1] ? 1 : 0;
+			return close(fd);
+		}
+		if (entry[0] == AT_NULL) {
+			break;
+		}
+	}
+
+	close(fd);
+	return -1;
+}
+
+static int write_at_secure(const char *path)
+{
+	unsigned long secure;
+	char text[4];
+
+	if (read_at_secure(&secure) < 0) {
+		return -1;
+	}
+	snprintf(text, sizeof(text), "%lu\n", secure);
+
+	return write_text_file(path, text);
+}
+
+int main(int argc, char *argv[])
+{
+	char current[BUFFER_SIZE];
+
+	if (argc != 2 && argc != 3) {
+		return 1;
+	}
+	if (read_text_file("/proc/self/attr/current", current,
+			   sizeof(current)) < 0) {
+		return 2;
+	}
+	if (write_text_file(argv[1], current) < 0) {
+		return 3;
+	}
+	if (argc == 3 && write_at_secure(argv[2]) < 0) {
+		return 4;
+	}
+
+	return 0;
+}

--- a/test/initramfs/src/regression/security/lsm/run_apparmor.sh
+++ b/test/initramfs/src/regression/security/lsm/run_apparmor.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+cd /test/security/lsm
+./apparmor
+
+echo "AppArmor regression tests passed."

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -14,6 +14,7 @@ set -e
 ./capability/trusted_xattr
 
 ./lsm/module_selection
+./lsm/apparmor
 ./lsm/yama
 
 ./namespace/cgroup_ns

--- a/tools/apparmor/README.md
+++ b/tools/apparmor/README.md
@@ -1,0 +1,57 @@
+# Asterinas AppArmor Tools
+
+`compile-policy.sh` invokes the Linux `apparmor_parser` userspace compiler and
+emits the binary policy stream accepted by Asterinas AppArmor securityfs policy
+files.
+
+```sh
+tools/apparmor/compile-policy.sh ./profile.apparmor ./profile.bin
+tools/apparmor/inspect-binary-policy.py ./profile.bin
+```
+
+Inside a running Asterinas system with AppArmor selected as the major LSM, load
+the compiled policy through securityfs:
+
+```sh
+mount -t securityfs none /sys/kernel/security
+cat ./profile.bin > /sys/kernel/security/apparmor/.replace
+```
+
+The default feature ABI used by `compile-policy.sh` mirrors the currently
+implemented Asterinas AppArmor kernel surface. Pass `-f FEATURES` or set
+`ASTERINAS_APPARMOR_FEATURES` to compile against a feature file exported from a
+running kernel.
+
+## Runtime Smoke Test
+
+Run the smoke test through the Asterinas initramfs harness:
+
+```sh
+make run_kernel AUTO_TEST=apparmor
+```
+
+This compiles the smoke policy with `apparmor_parser`, packages the policy and
+test script into initramfs, boots with `security=apparmor`, and checks for
+`apparmor smoke: passed` in `qemu.log`.
+
+You can also compile the smoke policy manually on a Linux host with
+`apparmor_parser` installed:
+
+```sh
+tools/apparmor/compile-policy.sh \
+    tools/apparmor/smoke-profile.apparmor \
+    ./smoke-profile.bin
+```
+
+Copy `smoke-profile.bin` and `run-smoke-test.sh` into an Asterinas guest booted
+with AppArmor selected, then run:
+
+```sh
+sh ./run-smoke-test.sh ./smoke-profile.bin
+```
+
+The smoke test mounts `securityfs` if needed, writes the binary policy to
+`/sys/kernel/security/apparmor/.replace`, verifies `/proc/self/attr/exec`
+on-exec transitions and `/proc/self/attr/prev`, switches the test shell through
+the temporary `/proc/sys/kernel/apparmor/current` control file, then verifies
+that a permitted read succeeds and an explicitly denied read fails.

--- a/tools/apparmor/compile-policy.sh
+++ b/tools/apparmor/compile-policy.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# SPDX-License-Identifier: MPL-2.0
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: compile-policy.sh [-f FEATURES] PROFILE OUTPUT
+
+Compiles a Linux AppArmor text profile into the binary policy stream accepted
+by Asterinas securityfs AppArmor policy files.
+
+Environment:
+  APPARMOR_PARSER              apparmor_parser path or command name
+  ASTERINAS_APPARMOR_FEATURES  feature ABI file passed to apparmor_parser -M
+EOF
+}
+
+write_default_features() {
+    cat > "$1" <<'EOF'
+caps {mask {chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_module sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap mac_override mac_admin syslog wake_alarm block_suspend audit_read perfmon bpf checkpoint_restore}}
+file {mask {create read write exec append mmap_exec link}}
+domain {change_profile yes, change_onexec yes, stack yes, version 1.2, fix_binfmt_elf_mmap yes, post_nnp_subset yes, computed_longest_left yes}
+policy {set_load yes, versions {v7 yes, v6 yes, v5 yes}, permstable32 {allow deny subtree cond kill complain prompt audit quiet hide xindex tag label}, permstable32_version {0x000002}}
+EOF
+}
+
+features=${ASTERINAS_APPARMOR_FEATURES:-}
+while getopts "f:h" option; do
+    case "$option" in
+        f)
+            features=$OPTARG
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [ "$#" -ne 2 ]; then
+    usage >&2
+    exit 2
+fi
+
+profile=$1
+output=$2
+parser=${APPARMOR_PARSER:-apparmor_parser}
+
+if ! command -v "$parser" >/dev/null 2>&1; then
+    if [ -x /usr/sbin/apparmor_parser ]; then
+        parser=/usr/sbin/apparmor_parser
+    else
+        echo "compile-policy.sh: apparmor_parser was not found" >&2
+        exit 127
+    fi
+fi
+
+tmp_features=
+tmp_output=$(mktemp "${TMPDIR:-/tmp}/asterinas-apparmor-policy.XXXXXX")
+cleanup() {
+    if [ -n "$tmp_output" ]; then
+        rm -f "$tmp_output"
+    fi
+    if [ -n "$tmp_features" ]; then
+        rm -f "$tmp_features"
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+if [ -z "$features" ]; then
+    tmp_features=$(mktemp "${TMPDIR:-/tmp}/asterinas-apparmor-features.XXXXXX")
+    write_default_features "$tmp_features"
+    features=$tmp_features
+fi
+
+mkdir -p "$(dirname "$output")"
+"$parser" -Q -q -S -M "$features" "$profile" > "$tmp_output"
+mv "$tmp_output" "$output"
+tmp_output=

--- a/tools/apparmor/inspect-binary-policy.py
+++ b/tools/apparmor/inspect-binary-policy.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MPL-2.0
+
+import argparse
+import sys
+
+
+TYPE_U8 = 0
+TYPE_U16 = 1
+TYPE_U32 = 2
+TYPE_U64 = 3
+TYPE_NAME = 4
+TYPE_STRING = 5
+TYPE_BLOB = 6
+TYPE_STRUCT = 7
+TYPE_STRUCT_END = 8
+TYPE_ARRAY = 11
+TYPE_ARRAY_END = 12
+
+TYPE_NAMES = {
+    TYPE_U8: "u8",
+    TYPE_U16: "u16",
+    TYPE_U32: "u32",
+    TYPE_U64: "u64",
+    TYPE_STRING: "string",
+    TYPE_BLOB: "blob",
+    TYPE_STRUCT: "struct",
+    TYPE_ARRAY: "array",
+}
+
+LINUX_KERNEL_ABI_MASK = 0x3FF
+LINUX_FORCE_COMPLAIN_FLAG = 1 << 11
+YYTH_MAGIC = b"\x1b\x5e\x78\x3d"
+
+
+class PolicyError(Exception):
+    pass
+
+
+class Reader:
+    def __init__(self, data):
+        self.data = data
+        self.offset = 0
+
+    def has_remaining(self):
+        return self.offset < len(self.data)
+
+    def peek_u8(self):
+        if not self.has_remaining():
+            return None
+        return self.data[self.offset]
+
+    def read_bytes(self, length):
+        end = self.offset + length
+        if end > len(self.data):
+            raise PolicyError("policy stream is truncated")
+        value = self.data[self.offset:end]
+        self.offset = end
+        return value
+
+    def read_u8_raw(self):
+        return self.read_bytes(1)[0]
+
+    def read_u16_raw(self):
+        return int.from_bytes(self.read_bytes(2), "little")
+
+    def read_u32_raw(self):
+        return int.from_bytes(self.read_bytes(4), "little")
+
+    def read_u64_raw(self):
+        return int.from_bytes(self.read_bytes(8), "little")
+
+    def read_nul_string(self, length):
+        data = self.read_bytes(length)
+        if not data or data[-1] != 0:
+            raise PolicyError("string is not nul-terminated")
+        text = data[:-1].decode("utf-8")
+        if "\0" in text:
+            raise PolicyError("string contains an embedded nul byte")
+        return text
+
+    def read_name(self):
+        length = self.read_u16_raw()
+        return self.read_nul_string(length)
+
+    def read_optional_name(self):
+        if self.peek_u8() != TYPE_NAME:
+            return None
+        self.offset += 1
+        return self.read_name()
+
+    def read_field(self):
+        name = self.read_optional_name()
+        field_type = self.read_u8_raw()
+        if field_type == TYPE_STRUCT_END or field_type == TYPE_ARRAY_END:
+            raise PolicyError("unexpected policy container terminator")
+        value = self.read_value(field_type)
+        return {"name": name, "type": field_type, "value": value}
+
+    def read_value(self, field_type):
+        if field_type == TYPE_U8:
+            return self.read_u8_raw()
+        if field_type == TYPE_U16:
+            return self.read_u16_raw()
+        if field_type == TYPE_U32:
+            return self.read_u32_raw()
+        if field_type == TYPE_U64:
+            return self.read_u64_raw()
+        if field_type == TYPE_STRING:
+            return self.read_nul_string(self.read_u16_raw())
+        if field_type == TYPE_BLOB:
+            return self.read_bytes(self.read_u32_raw())
+        if field_type == TYPE_STRUCT:
+            fields = []
+            while self.peek_u8() != TYPE_STRUCT_END:
+                if self.peek_u8() is None:
+                    raise PolicyError("struct is not terminated")
+                fields.append(self.read_field())
+            self.offset += 1
+            return fields
+        if field_type == TYPE_ARRAY:
+            declared_count = self.read_u16_raw()
+            fields = []
+            while self.peek_u8() != TYPE_ARRAY_END:
+                if self.peek_u8() is None:
+                    raise PolicyError("array is not terminated")
+                fields.append(self.read_field())
+            if self.peek_u8() != TYPE_ARRAY_END:
+                raise PolicyError("array is not terminated")
+            self.offset += 1
+            return {"declared_count": declared_count, "items": fields}
+        raise PolicyError(f"unsupported policy field type {field_type}")
+
+
+def parse_policy(data):
+    reader = Reader(data)
+    fields = []
+    while reader.has_remaining():
+        fields.append(reader.read_field())
+    return fields
+
+
+def walk_fields(fields):
+    for field in fields:
+        yield field
+        value = field["value"]
+        if field["type"] == TYPE_STRUCT:
+            yield from walk_fields(value)
+        elif field["type"] == TYPE_ARRAY:
+            yield from walk_fields(value["items"])
+
+
+def find_named(fields, name):
+    return [field for field in walk_fields(fields) if field["name"] == name]
+
+
+def decode_abi_version(raw_version):
+    if raw_version <= 5:
+        return raw_version
+    return raw_version & LINUX_KERNEL_ABI_MASK
+
+
+def type_name(field):
+    return TYPE_NAMES.get(field["type"], str(field["type"]))
+
+
+def profile_name(profile_field):
+    for child in profile_field["value"]:
+        if child["name"] is None and child["type"] == TYPE_STRING:
+            return child["value"]
+    raise PolicyError("profile struct does not contain a profile name")
+
+
+def profile_mode(profile_field, force_complain):
+    for child in profile_field["value"]:
+        if child["name"] == "flags" and child["type"] == TYPE_STRUCT:
+            raw_values = [
+                item["value"]
+                for item in child["value"]
+                if item["name"] is None and item["type"] == TYPE_U32
+            ]
+            if len(raw_values) < 2:
+                raise PolicyError("profile flags are incomplete")
+            packed_mode = raw_values[1]
+            if force_complain or packed_mode == 1:
+                return "complain"
+            if packed_mode == 0:
+                return "enforce"
+            return f"unsupported({packed_mode})"
+    raise PolicyError("profile flags are missing")
+
+
+def profile_has_file_dfa(profile_field):
+    blobs = [
+        field["value"]
+        for field in walk_fields(profile_field["value"])
+        if field["name"] == "aadfa" and field["type"] == TYPE_BLOB
+    ]
+    for blob in blobs:
+        if blob.find(YYTH_MAGIC) >= 0:
+            return True
+    return False
+
+
+def profile_perm_rows(profile_field):
+    for field in walk_fields(profile_field["value"]):
+        if field["name"] != "perms" or field["type"] != TYPE_STRUCT:
+            continue
+        for child in field["value"]:
+            if child["type"] == TYPE_ARRAY:
+                return child["value"]["declared_count"]
+    return 0
+
+
+def inspect(path):
+    data = path.read_bytes()
+    fields = parse_policy(data)
+    versions = find_named(fields, "version")
+    if not versions or versions[0]["type"] != TYPE_U32:
+        raise PolicyError("policy stream does not contain a Linux AppArmor version")
+
+    raw_version = versions[0]["value"]
+    force_complain = bool(raw_version & LINUX_FORCE_COMPLAIN_FLAG)
+    profiles = [
+        field
+        for field in fields
+        if field["name"] == "profile" and field["type"] == TYPE_STRUCT
+    ]
+    if not profiles:
+        raise PolicyError("policy stream does not contain profiles")
+
+    print(f"format: linux-apparmor-typed-stream")
+    print(f"size: {len(data)} bytes")
+    print(f"abi_version: {decode_abi_version(raw_version)}")
+    print(f"force_complain: {str(force_complain).lower()}")
+    print(f"profiles: {len(profiles)}")
+    for profile in profiles:
+        name = profile_name(profile)
+        mode = profile_mode(profile, force_complain)
+        has_dfa = profile_has_file_dfa(profile)
+        perm_rows = profile_perm_rows(profile)
+        print(
+            f"- name: {name}, mode: {mode}, file_dfa: "
+            f"{str(has_dfa).lower()}, perm_rows: {perm_rows}"
+        )
+
+    unknown_top_level = [
+        field["name"] or type_name(field)
+        for field in fields
+        if field["name"] not in ("version", "namespace", "profile")
+    ]
+    if unknown_top_level:
+        print("unknown_top_level: " + ", ".join(unknown_top_level))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Inspects Linux AppArmor binary policy output for Asterinas."
+    )
+    parser.add_argument("policy", type=argparse.FileType("rb"))
+    args = parser.parse_args()
+
+    class PathAdapter:
+        def __init__(self, file_object):
+            self.file_object = file_object
+
+        def read_bytes(self):
+            return self.file_object.read()
+
+    try:
+        inspect(PathAdapter(args.policy))
+    except PolicyError as error:
+        print(f"inspect-binary-policy.py: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/apparmor/run-smoke-test.sh
+++ b/tools/apparmor/run-smoke-test.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# SPDX-License-Identifier: MPL-2.0
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: run-smoke-test.sh POLICY_BIN [PROFILE_NAME]
+
+Runs an AppArmor policy load and file-read enforcement smoke test inside an
+Asterinas guest booted with security=apparmor or lsm=capability,apparmor,yama.
+
+Compile POLICY_BIN on the host with tools/apparmor/compile-policy.sh before
+copying it into the guest.
+EOF
+}
+
+fail() {
+    echo "apparmor smoke: $*" >&2
+    exit 1
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    usage >&2
+    exit 2
+fi
+
+policy_bin=$1
+profile_name=${2:-asterinas-aa-smoke}
+securityfs_root=${SECURITYFS_ROOT:-/sys/kernel/security}
+apparmor_dir=$securityfs_root/apparmor
+current_file=/proc/sys/kernel/apparmor/current
+allowed_path=/tmp/asterinas-aa-allowed
+denied_path=/tmp/asterinas-aa-denied
+attr_exec=/proc/self/attr/exec
+probe_busybox=/test/apparmor-busybox
+
+[ -r "$policy_bin" ] || fail "policy binary is not readable: $policy_bin"
+[ -x "$probe_busybox" ] || fail "static AppArmor probe busybox is missing: $probe_busybox"
+[ -e /proc/self/attr/current ] || fail "/proc/self/attr/current is missing"
+[ -e /proc/self/attr/exec ] || fail "/proc/self/attr/exec is missing"
+[ -e /proc/self/attr/prev ] || fail "/proc/self/attr/prev is missing"
+[ -e "$current_file" ] || fail "AppArmor current profile control file is missing"
+
+current_profile=$(cat /proc/self/attr/current)
+[ -n "$current_profile" ] || fail "current AppArmor profile is empty"
+
+if [ ! -d "$apparmor_dir" ]; then
+    mkdir -p "$securityfs_root"
+    mount -t securityfs none "$securityfs_root" 2>/dev/null || true
+fi
+
+[ -d "$apparmor_dir" ] || fail "securityfs AppArmor directory is missing"
+[ -w "$apparmor_dir/.replace" ] || fail "securityfs AppArmor .replace is not writable"
+[ -r "$apparmor_dir/profiles" ] || fail "securityfs AppArmor profiles file is missing"
+
+printf 'allowed\n' > "$allowed_path"
+printf 'denied\n' > "$denied_path"
+
+if ! cat "$policy_bin" > "$apparmor_dir/.replace"; then
+    fail "policy load failed"
+fi
+grep -q "^$profile_name " "$apparmor_dir/profiles" \
+    || fail "loaded profile is not listed: $profile_name"
+
+printf '%s' "$profile_name" > "$attr_exec"
+IFS= read -r onexec_profile < "$attr_exec" \
+    || fail "AppArmor on-exec profile is not readable"
+[ "$onexec_profile" = "$profile_name" ] \
+    || fail "expected on-exec profile $profile_name, got $onexec_profile"
+
+set +e
+"$probe_busybox" sh -c '
+profile_name=$1
+allowed_path=$2
+denied_path=$3
+
+IFS= read -r current_profile < /proc/self/attr/current || exit 10
+[ "$current_profile" = "$profile_name" ] || exit 11
+
+IFS= read -r previous_profile < /proc/self/attr/prev || exit 12
+[ "$previous_profile" = unconfined ] || exit 13
+
+: < "$allowed_path" || exit 14
+if ( : < "$denied_path" ) 2>/dev/null; then
+    exit 15
+fi
+' sh "$profile_name" "$allowed_path" "$denied_path"
+child_status=$?
+set -e
+
+[ "$child_status" -eq 0 ] \
+    || fail "on-exec profile transition failed with status $child_status"
+
+printf '\n' > "$attr_exec"
+onexec_profile=$(cat "$attr_exec")
+[ -z "$onexec_profile" ] \
+    || fail "expected cleared on-exec profile, got $onexec_profile"
+
+printf '%s' "$profile_name" > "$current_file"
+IFS= read -r current_profile < /proc/self/attr/current \
+    || fail "current AppArmor profile is not readable after confinement"
+[ "$current_profile" = "$profile_name" ] \
+    || fail "expected current profile $profile_name, got $current_profile"
+
+: < "$allowed_path" || fail "allowed file read was denied"
+
+set +e
+(: < "$denied_path") 2>/dev/null
+denied_status=$?
+set -e
+
+if [ "$denied_status" -eq 0 ]; then
+    fail "denied file read unexpectedly succeeded"
+fi
+
+echo "apparmor smoke: passed"

--- a/tools/apparmor/smoke-profile.apparmor
+++ b/tools/apparmor/smoke-profile.apparmor
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MPL-2.0
+
+profile asterinas-aa-smoke {
+  capability dac_override,
+  capability dac_read_search,
+  capability mac_admin,
+  /** mr,
+  /dev/null rw,
+  deny /tmp/asterinas-aa-denied r,
+}


### PR DESCRIPTION
## Summary

This PR is a follow-up to #3427. It tightens AppArmor policy-observation and policy-transition behavior around audit bits, quiet bits, complain mode, the securityfs feature ABI, and exec-time profile transitions.

The goal is to make the exposed AppArmor behavior closer to the Linux AppArmor model while keeping the advertised ABI honest about the subset Asterinas currently supports. In particular, implicit denials in complain mode are logged and allowed, while explicit `deny` rules remain enforced.

> Depends on #3427. This PR is kept as draft until #3427 lands. After that, the branch should be rebased onto upstream `main` so the diff contains only this follow-up work.

## Changes

- Thread file-policy `audit` and `quiet` bits from parser-backed DFA permstable entries into file mediation outcomes.
- Track explicit file-deny permissions separately from implicit missing-allow denials.
- Align complain-mode file behavior with Linux AppArmor semantics: implicit denials are complain-only, but explicit `deny` rules still block access.
- Thread capability `audit` and `quiet` masks into capability mediation outcomes.
- Emit audit logs for audited allowed accesses and denial logs for enforce/complain decisions.
- Narrow `securityfs` feature reporting to the AppArmor capabilities currently supported by Asterinas: policy ABI v5-v9 subset, file/capability audit, quiet handling, complain mode, and existing profile-transition controls.
- Stop advertising unsupported domain feature nodes, so userspace sees a more accurate feature surface.
- Reuse exec-transition target validation across execute checks, committed exec state, and secure-exec decisions.
- Enforce child-profile transition shape for `cx` / `Cx` style transitions.
- Extend AppArmor regression coverage for enforce deny, complain implicit allow, complain explicit deny, feature ABI visibility, policy replacement/removal, `ix`, `ux` / `Ux`, `cx` / `Cx`, and denied child transitions.

## Validation

- `cargo fmt -p aster-kernel --check`
- `git diff --check`
- `cargo check -p aster-kernel --target x86_64-unknown-none`
- `cargo check -p aster-kernel --target x86_64-unknown-none --no-default-features`
- `cargo clippy -p aster-kernel --target x86_64-unknown-none -- -D warnings`