### PR TITLE
Remove duplicate titles in `kernel-parameters.md`

### DIFF
--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -57,7 +57,6 @@ virtio_mmio.device=0x200@0x5950f000:10
 virtio_mmio.device=1K@0x1001e000:74
 ```
 
-## Asterinas-specific
 ### `earlycon`
 
 Enable the early console to output logs during the early stages of system boot.


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/3a34935ba3ebdfbc96472e992acda5a74d3b9352/book/src/kernel/linux-compatibility/kernel-parameters.md?plain=1#L112-L114

https://github.com/asterinas/asterinas/blob/3a34935ba3ebdfbc96472e992acda5a74d3b9352/book/src/kernel/linux-compatibility/kernel-parameters.md?plain=1#L60-L61

The titles are duplicate in https://github.com/asterinas/asterinas/pull/3261. Remove the duplicate title.