### PR TITLE
Implement memory locking syscalls

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -169,10 +169,10 @@ which are summarized in the table below.
 | 146     | sched_get_priority_max | ✅             | 💯 |
 | 147     | sched_get_priority_min | ✅             | 💯 |
 | 148     | sched_rr_get_interval  | ❌             | N/A |
-| 149     | mlock                  | ❌             | N/A |
-| 150     | munlock                | ❌             | N/A |
-| 151     | mlockall               | ❌             | N/A |
-| 152     | munlockall             | ❌             | N/A |
+| 149     | mlock                  | ✅             | 💯 |
+| 150     | munlock                | ✅             | 💯 |
+| 151     | mlockall               | ✅             | 🚧 |
+| 152     | munlockall             | ✅             | 💯 |
 | 153     | vhangup                | ❌             | N/A |
 | 154     | modify_ldt             | ❌             | N/A |
 | 155     | pivot_root             | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/README.md
@@ -79,6 +79,20 @@ Silently-ignored protection flags:
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/mprotect.2.html).
 
+### `mlock`, `munlock`, `mlockall`, and `munlockall`
+
+Supported functionality in SCML:
+
+```c
+{{#include mlock.scml}}
+```
+
+Unsupported flags:
+* `MCL_ONFAULT`
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/mlock.2.html).
+
 ### `madvise`
 
 Supported functionality in SCML:

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/mlock.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/mlock.scml
@@ -1,0 +1,14 @@
+// Lock pages in the process address space.
+mlock(addr, len);
+
+// Unlock pages in the process address space.
+munlock(addr, len);
+
+mlockall_flags = MCL_CURRENT |
+    MCL_FUTURE;
+
+// Lock all current and/or future mappings in the process address space.
+mlockall(flags = <mlockall_flags>);
+
+// Unlock all locked mappings in the process address space.
+munlockall();

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -38,7 +38,7 @@ pub use process::{
     Session, Sid, Terminal, broadcast_signal_async, enqueue_signal_async, spawn_init_process,
 };
 pub use process_filter::ProcessFilter;
-pub use process_vm::{INIT_STACK_SIZE, LockedHeap, ProcessVm, VmarSnapshot};
+pub use process_vm::{FutureMemoryLock, INIT_STACK_SIZE, LockedHeap, ProcessVm, VmarSnapshot};
 pub use rlimit::ResourceType;
 pub use stats::collect_process_creation_count;
 pub use term_status::TermStatus;

--- a/kernel/src/process/process_vm/heap.rs
+++ b/kernel/src/process/process_vm/heap.rs
@@ -104,7 +104,12 @@ impl Heap {
     /// This behavior is consistent with the Linux `brk` syscall.
     //
     // Reference: <https://elixir.bootlin.com/linux/v6.16.9/source/mm/mmap.c#L115>
-    pub fn modify_heap_end(&self, new_heap_end: Vaddr, ctx: &Context) -> Result<Vaddr, Vaddr> {
+    pub fn modify_heap_end(
+        &self,
+        new_heap_end: Vaddr,
+        ctx: &Context,
+        memlock_limit: Option<usize>,
+    ) -> Result<Vaddr, Vaddr> {
         let user_space = ctx.user_space();
         let vmar = user_space.vmar();
 
@@ -140,7 +145,7 @@ impl Heap {
         // the heap mapping.
         // For simplicity, we set `check_single_mapping` to `true` to ensure that the
         // heap region contains only a single mapping.
-        vmar.resize_mapping(heap_start, old_size, new_size, true)
+        vmar.resize_mapping(heap_start, old_size, new_size, true, memlock_limit)
             .map_err(|_| current_heap_end)?;
 
         inner.heap_range = new_heap_range;

--- a/kernel/src/process/process_vm/mod.rs
+++ b/kernel/src/process/process_vm/mod.rs
@@ -31,6 +31,22 @@ use crate::{
     vm::vmar::{Vmar, VmarHandle},
 };
 
+/// The memory lock policy for future mappings.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FutureMemoryLock {
+    /// Future mappings should not be locked.
+    Disabled,
+    /// Future mappings should be locked.
+    Enabled,
+}
+
+impl FutureMemoryLock {
+    /// Returns whether future mappings should be locked.
+    pub fn is_enabled(self) -> bool {
+        self == Self::Enabled
+    }
+}
+
 /*
  * The user's virtual memory space layout looks like below.
  *

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -72,6 +72,7 @@ macro_rules! import_generic_syscall_entries {
             memfd_create::sys_memfd_create,
             mkdir::sys_mkdirat,
             mknod::sys_mknodat,
+            mlock::{sys_mlock, sys_mlockall, sys_munlock, sys_munlockall},
             mmap::sys_mmap,
             mount::sys_mount,
             mprotect::sys_mprotect,
@@ -382,6 +383,10 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_FADVISE64 = 223              => sys_fadvise64(args[..4]);
             SYS_MPROTECT = 226               => sys_mprotect(args[..3]);
             SYS_MSYNC = 227                  => sys_msync(args[..3]);
+            SYS_MLOCK = 228                  => sys_mlock(args[..2]);
+            SYS_MUNLOCK = 229                => sys_munlock(args[..2]);
+            SYS_MLOCKALL = 230               => sys_mlockall(args[..1]);
+            SYS_MUNLOCKALL = 231             => sys_munlockall(args[..0]);
             SYS_MADVISE = 233                => sys_madvise(args[..3]);
             SYS_ACCEPT4 = 242                => sys_accept4(args[..4]);
             SYS_WAIT4 = 260                  => sys_wait4(args[..4]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -72,6 +72,7 @@ use super::{
     memfd_create::sys_memfd_create,
     mkdir::{sys_mkdir, sys_mkdirat},
     mknod::{sys_mknod, sys_mknodat},
+    mlock::{sys_mlock, sys_mlockall, sys_munlock, sys_munlockall},
     mmap::sys_mmap,
     mount::sys_mount,
     mprotect::sys_mprotect,
@@ -209,6 +210,10 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_MSYNC = 26             => sys_msync(args[..3]);
     SYS_SCHED_YIELD = 24       => sys_sched_yield(args[..0]);
     SYS_MADVISE = 28           => sys_madvise(args[..3]);
+    SYS_MLOCK = 149            => sys_mlock(args[..2]);
+    SYS_MUNLOCK = 150          => sys_munlock(args[..2]);
+    SYS_MLOCKALL = 151         => sys_mlockall(args[..1]);
+    SYS_MUNLOCKALL = 152       => sys_munlockall(args[..0]);
     SYS_DUP = 32               => sys_dup(args[..1]);
     SYS_DUP2 = 33              => sys_dup2(args[..2]);
     SYS_PAUSE = 34             => sys_pause(args[..0]);

--- a/kernel/src/syscall/brk.rs
+++ b/kernel/src/syscall/brk.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{prelude::*, syscall::SyscallReturn};
+use super::{SyscallReturn, mlock};
+use crate::prelude::*;
 
 /// expand the user heap to new heap end, returns the new heap end if expansion succeeds.
 pub fn sys_brk(heap_end: u64, ctx: &Context) -> Result<SyscallReturn> {
@@ -13,10 +14,11 @@ pub fn sys_brk(heap_end: u64, ctx: &Context) -> Result<SyscallReturn> {
 
     let user_space = ctx.user_space();
     let user_heap = user_space.vmar().process_vm().heap();
+    let memlock_limit = mlock::memlock_limit(ctx);
 
     let current_heap_end = match new_heap_end {
         Some(addr) => user_heap
-            .modify_heap_end(addr, ctx)
+            .modify_heap_end(addr, ctx, memlock_limit)
             .unwrap_or_else(|cur_heap_end| cur_heap_end),
         None => user_heap.lock().heap_range().end,
     };

--- a/kernel/src/syscall/mlock.rs
+++ b/kernel/src/syscall/mlock.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::ops::Range;
+
+use align_ext::AlignExt;
+use bitflags::bitflags;
+
+use super::SyscallReturn;
+use crate::{
+    prelude::*,
+    process::{FutureMemoryLock, ResourceType, credentials::capabilities::CapSet},
+    security::lsm::hooks as lsm_hooks,
+    vm::vmar::VMAR_CAP_ADDR,
+};
+
+bitflags! {
+    struct MLockAllFlags: u32 {
+        const MCL_CURRENT = 1;
+        const MCL_FUTURE = 2;
+        const MCL_ONFAULT = 4;
+    }
+}
+
+pub fn sys_mlock(addr: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn> {
+    let range = check_range(addr, len)?;
+    if range.is_empty() {
+        return Ok(SyscallReturn::Return(0));
+    }
+
+    let limit = memlock_limit(ctx);
+    ctx.user_space().vmar().lock_range(range, limit)?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_munlock(addr: Vaddr, len: usize, ctx: &Context) -> Result<SyscallReturn> {
+    let range = check_range(addr, len)?;
+    if range.is_empty() {
+        return Ok(SyscallReturn::Return(0));
+    }
+
+    ctx.user_space().vmar().unlock_range(range)?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_mlockall(flags: u32, ctx: &Context) -> Result<SyscallReturn> {
+    let flags = MLockAllFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown mlockall flags"))?;
+
+    if flags.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "invalid mlockall flags");
+    }
+
+    if flags.contains(MLockAllFlags::MCL_ONFAULT) {
+        return_errno_with_message!(Errno::EINVAL, "MCL_ONFAULT is not supported");
+    }
+
+    let limit = memlock_limit(ctx);
+    let future_memory_lock = if flags.contains(MLockAllFlags::MCL_FUTURE) {
+        FutureMemoryLock::Enabled
+    } else {
+        FutureMemoryLock::Disabled
+    };
+    ctx.user_space().vmar().lock_all(
+        flags.contains(MLockAllFlags::MCL_CURRENT),
+        future_memory_lock,
+        limit,
+    )?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_munlockall(ctx: &Context) -> Result<SyscallReturn> {
+    let user_space = ctx.user_space();
+    let vmar = user_space.vmar();
+    vmar.unlock_all();
+
+    Ok(SyscallReturn::Return(0))
+}
+
+fn check_range(addr: Vaddr, len: usize) -> Result<Range<Vaddr>> {
+    if len == 0 {
+        return Ok(addr..addr);
+    }
+
+    let start = addr.align_down(PAGE_SIZE);
+    let end = addr
+        .checked_add(len)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "the memory range overflows"))?;
+    let end = if end.is_multiple_of(PAGE_SIZE) {
+        end
+    } else {
+        end.checked_add(PAGE_SIZE - 1)
+            .ok_or_else(|| Error::with_message(Errno::ENOMEM, "the memory range overflows"))?
+            .align_down(PAGE_SIZE)
+    };
+
+    if end > VMAR_CAP_ADDR {
+        return_errno_with_message!(Errno::ENOMEM, "the memory range is not in userspace");
+    }
+
+    Ok(start..end)
+}
+
+pub(super) fn memlock_limit(ctx: &Context) -> Option<usize> {
+    if lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+        ctx.thread_local.borrow_user_ns().as_ref(),
+        ctx.posix_thread,
+        CapSet::IPC_LOCK,
+    ))
+    .is_ok()
+    {
+        return None;
+    }
+
+    let limit = ctx
+        .posix_thread
+        .process()
+        .resource_limits()
+        .get_rlimit(ResourceType::RLIMIT_MEMLOCK)
+        .get_cur();
+
+    usize::try_from(limit).ok()
+}

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -2,7 +2,7 @@
 
 use align_ext::AlignExt;
 
-use super::SyscallReturn;
+use super::{SyscallReturn, mlock};
 use crate::{
     fs::file::file_table::{RawFileDesc, get_file_fast},
     prelude::*,
@@ -77,6 +77,7 @@ fn do_sys_mmap(
     let vmar = user_space.vmar();
     let vm_map_options = {
         let mut options = vmar.new_map(len, vm_perms)?;
+        options = options.memlock_limit(mlock::memlock_limit(ctx));
 
         if option.flags().is_fixed() {
             if option.flags().contains(MMapFlags::MAP_FIXED_NOREPLACE) {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -85,6 +85,7 @@ mod madvise;
 mod memfd_create;
 mod mkdir;
 mod mknod;
+mod mlock;
 mod mmap;
 mod mount;
 mod mprotect;

--- a/kernel/src/syscall/mremap.rs
+++ b/kernel/src/syscall/mremap.rs
@@ -2,7 +2,7 @@
 
 use align_ext::AlignExt;
 
-use super::SyscallReturn;
+use super::{SyscallReturn, mlock};
 use crate::prelude::*;
 
 pub fn sys_mremap(
@@ -53,19 +53,20 @@ fn do_sys_mremap(
 
     let user_space = ctx.user_space();
     let vmar = user_space.vmar();
+    let memlock_limit = mlock::memlock_limit(ctx);
 
     if !flags.contains(MremapFlags::MREMAP_FIXED) && new_size <= old_size {
         // We can shrink a old range which spans multiple mappings. See
         // <https://github.com/google/gvisor/blob/95d875276806484f974ce9e95556a561331f8e22/test/syscalls/linux/mremap.cc#L100-L117>.
-        vmar.resize_mapping(old_addr, old_size, new_size, false)?;
+        vmar.resize_mapping(old_addr, old_size, new_size, false, memlock_limit)?;
         return Ok(old_addr);
     }
 
     if flags.contains(MremapFlags::MREMAP_MAYMOVE) {
         if flags.contains(MremapFlags::MREMAP_FIXED) {
-            vmar.remap(old_addr, old_size, Some(new_addr), new_size)
+            vmar.remap(old_addr, old_size, Some(new_addr), new_size, memlock_limit)
         } else {
-            vmar.remap(old_addr, old_size, None, new_size)
+            vmar.remap(old_addr, old_size, None, new_size, memlock_limit)
         }
     } else {
         if flags.contains(MremapFlags::MREMAP_FIXED) {
@@ -82,7 +83,7 @@ fn do_sys_mremap(
         // if the `MREMAP_MAYMOVE` flag is not set, and the mapping cannot
         // be expanded at the current `Vaddr`, we should return an `ENOMEM`.
         // However, `resize_mapping` returns a `EACCES` in this case.
-        vmar.resize_mapping(old_addr, old_size, new_size, true)?;
+        vmar.resize_mapping(old_addr, old_size, new_size, true, memlock_limit)?;
         Ok(old_addr)
     }
 }

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -81,6 +81,8 @@ pub struct VmMapping {
     /// Whether the mapping needs to handle surrounding pages when handling
     /// page fault.
     handle_page_faults_around: bool,
+    /// Whether this mapping is locked in memory by `mlock` or `mlockall`.
+    is_locked: bool,
     /// The permissions of pages in the mapping.
     ///
     /// All pages within the same `VmMapping` have the same permissions.
@@ -112,11 +114,22 @@ impl VmMapping {
             path,
             is_shared,
             handle_page_faults_around,
+            is_locked: false,
             perms,
         }
     }
 
     pub(super) fn new_fork(&self) -> VmMapping {
+        VmMapping {
+            mapped_mem: self.mapped_mem.dup(),
+            path: self.path.clone(),
+            is_locked: false,
+            ..*self
+        }
+    }
+
+    /// Duplicates the mapping metadata while preserving its lock state.
+    pub(super) fn dup(&self) -> VmMapping {
         VmMapping {
             mapped_mem: self.mapped_mem.dup(),
             path: self.path.clone(),
@@ -127,6 +140,7 @@ impl VmMapping {
     pub(super) fn clone_for_remap_at(&self, va: Vaddr) -> VmMapping {
         let mut vm_mapping = self.new_fork();
         vm_mapping.map_to_addr = va;
+        vm_mapping.is_locked = self.is_locked;
         vm_mapping
     }
 
@@ -148,6 +162,11 @@ impl VmMapping {
     /// Returns the permissions of pages in the mapping.
     pub fn perms(&self) -> VmPerms {
         self.perms
+    }
+
+    /// Returns whether this mapping is locked in memory.
+    pub fn is_locked(&self) -> bool {
+        self.is_locked
     }
 
     /// Returns the inode of the file that backs the mapping.
@@ -335,6 +354,36 @@ impl VmMapping {
 /****************************** Page faults **********************************/
 
 impl VmMapping {
+    /// Populates pages in the specified range of this mapping.
+    ///
+    /// The range must be page-aligned and contained in this mapping.
+    pub(super) fn populate_range(
+        &self,
+        vm_space: &VmSpace,
+        range: &Range<Vaddr>,
+        rss_delta: &mut RssDelta,
+    ) -> Result<()> {
+        debug_assert!(range.start.is_multiple_of(PAGE_SIZE));
+        debug_assert!(range.end.is_multiple_of(PAGE_SIZE));
+        debug_assert!(self.range().start <= range.start && range.end <= self.range().end);
+
+        for addr in range.clone().step_by(PAGE_SIZE) {
+            let preempt_guard = disable_preempt();
+            let mut cursor = vm_space.cursor(&preempt_guard, &(addr..addr + PAGE_SIZE))?;
+            let (_, item) = cursor.query().unwrap();
+            if item.is_some() {
+                continue;
+            }
+            drop(cursor);
+            drop(preempt_guard);
+
+            let page_fault_info = PageFaultInfo::new(addr, VmPerms::READ).force();
+            self.handle_page_fault(vm_space, &page_fault_info, rss_delta)?;
+        }
+
+        Ok(())
+    }
+
     /// Handles a page fault.
     pub(super) fn handle_page_fault(
         &self,
@@ -759,6 +808,11 @@ impl VmMapping {
             (self, None)
         }
     }
+
+    /// Changes whether the mapping is locked in memory.
+    pub(super) fn set_locked(self, is_locked: bool) -> Self {
+        Self { is_locked, ..self }
+    }
 }
 
 /************************** VM Space operations ******************************/
@@ -962,6 +1016,7 @@ fn try_merge(left: &VmMapping, right: &VmMapping) -> Option<VmMapping> {
     let is_adjacent = left.map_end() == right.map_to_addr();
     let is_type_equal = left.is_shared == right.is_shared
         && left.handle_page_faults_around == right.handle_page_faults_around
+        && left.is_locked == right.is_locked
         && left.perms == right.perms;
 
     if !is_adjacent || !is_type_equal {

--- a/kernel/src/vm/vmar/vmar_impls/lock.rs
+++ b/kernel/src/vm/vmar/vmar_impls/lock.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::ops::Range;
+
+use super::{Interval, RssDelta, VMAR_CAP_ADDR, Vmar, util::get_intersected_range};
+use crate::{prelude::*, process::FutureMemoryLock};
+
+impl Vmar {
+    /// Locks the memory mappings in the specified range.
+    ///
+    /// The range's start and end addresses must be page-aligned.
+    ///
+    /// If the range contains unmapped pages, an [`ENOMEM`] error will be returned.
+    ///
+    /// [`ENOMEM`]: Errno::ENOMEM
+    pub fn lock_range(&self, range: Range<Vaddr>, limit: Option<usize>) -> Result<()> {
+        debug_assert!(range.start.is_multiple_of(PAGE_SIZE));
+        debug_assert!(range.end.is_multiple_of(PAGE_SIZE));
+
+        let mut inner = self.inner.write();
+        let new_locked_size = inner.new_locked_size(&range)?;
+
+        if let Some(limit) = limit
+            && inner.locked_vm.saturating_add(new_locked_size) > limit
+        {
+            return_errno_with_message!(Errno::ENOMEM, "the memory lock limit is reached");
+        }
+
+        let mut rss_delta = RssDelta::new(self);
+        inner.populate_range(&self.vm_space, &range, &mut rss_delta)?;
+        inner.set_mapping_locks(range, true);
+        inner.locked_vm += new_locked_size;
+
+        Ok(())
+    }
+
+    /// Applies `mlockall` to current and/or future memory mappings.
+    pub fn lock_all(
+        &self,
+        lock_current: bool,
+        future_memory_lock: FutureMemoryLock,
+        limit: Option<usize>,
+    ) -> Result<()> {
+        let mut inner = self.inner.write();
+
+        if lock_current {
+            let new_locked_size = inner.all_new_locked_size();
+
+            if let Some(limit) = limit
+                && inner.locked_vm.saturating_add(new_locked_size) > limit
+            {
+                return_errno_with_message!(Errno::ENOMEM, "the memory lock limit is reached");
+            }
+
+            let mut rss_delta = RssDelta::new(self);
+            inner.populate_range(&self.vm_space, &(0..VMAR_CAP_ADDR), &mut rss_delta)?;
+            inner.set_mapping_locks(0..VMAR_CAP_ADDR, true);
+            inner.locked_vm += new_locked_size;
+        }
+
+        inner.future_memory_lock = future_memory_lock;
+
+        Ok(())
+    }
+
+    /// Unlocks the memory mappings in the specified range.
+    ///
+    /// The range's start and end addresses must be page-aligned.
+    pub fn unlock_range(&self, range: Range<Vaddr>) -> Result<()> {
+        debug_assert!(range.start.is_multiple_of(PAGE_SIZE));
+        debug_assert!(range.end.is_multiple_of(PAGE_SIZE));
+
+        let mut inner = self.inner.write();
+        inner.check_range_mapped(&range)?;
+        let locked_size = inner.locked_size(&range);
+        inner.set_mapping_locks(range, false);
+        inner.locked_vm = inner.locked_vm.saturating_sub(locked_size);
+
+        Ok(())
+    }
+
+    /// Unlocks all memory mappings.
+    pub fn unlock_all(&self) {
+        let mut inner = self.inner.write();
+        let full_range = 0..VMAR_CAP_ADDR;
+        inner.set_mapping_locks(full_range, false);
+        inner.locked_vm = 0;
+        inner.future_memory_lock = FutureMemoryLock::Disabled;
+    }
+}
+
+impl super::VmarInner {
+    fn new_locked_size(&self, range: &Range<Vaddr>) -> Result<usize> {
+        let mut new_locked_size = 0;
+        let mut last_mapping_end = range.start;
+
+        for vm_mapping in self.vm_mappings.find(range) {
+            if last_mapping_end < vm_mapping.map_to_addr() {
+                return_errno_with_message!(
+                    Errno::ENOMEM,
+                    "the range contains pages that are not mapped"
+                );
+            }
+            last_mapping_end = vm_mapping.map_end();
+
+            if vm_mapping.is_locked() {
+                continue;
+            }
+
+            let intersected_range = get_intersected_range(range, &vm_mapping.range());
+            new_locked_size += intersected_range.len();
+        }
+
+        if last_mapping_end < range.end {
+            return_errno_with_message!(
+                Errno::ENOMEM,
+                "the range contains pages that are not mapped"
+            );
+        }
+
+        Ok(new_locked_size)
+    }
+
+    fn check_range_mapped(&self, range: &Range<Vaddr>) -> Result<()> {
+        let mut last_mapping_end = range.start;
+
+        for vm_mapping in self.vm_mappings.find(range) {
+            if last_mapping_end < vm_mapping.map_to_addr() {
+                return_errno_with_message!(
+                    Errno::ENOMEM,
+                    "the range contains pages that are not mapped"
+                );
+            }
+            last_mapping_end = vm_mapping.map_end();
+        }
+
+        if last_mapping_end < range.end {
+            return_errno_with_message!(
+                Errno::ENOMEM,
+                "the range contains pages that are not mapped"
+            );
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn check_extra_lock_size_fits_limit(
+        &self,
+        extra_lock_size: usize,
+        limit: Option<usize>,
+    ) -> Result<()> {
+        if let Some(limit) = limit
+            && self.locked_vm.saturating_add(extra_lock_size) > limit
+        {
+            return_errno_with_message!(Errno::ENOMEM, "the memory lock limit is reached");
+        }
+
+        Ok(())
+    }
+
+    fn all_new_locked_size(&self) -> usize {
+        let mut new_locked_size = 0;
+
+        for vm_mapping in self.vm_mappings.iter() {
+            if !vm_mapping.is_locked() {
+                new_locked_size += vm_mapping.map_size();
+            }
+        }
+
+        new_locked_size
+    }
+
+    fn populate_range(
+        &self,
+        vm_space: &ostd::mm::VmSpace,
+        range: &Range<Vaddr>,
+        rss_delta: &mut RssDelta,
+    ) -> Result<()> {
+        for vm_mapping in self.vm_mappings.find(range) {
+            let intersected_range = get_intersected_range(range, &vm_mapping.range());
+            vm_mapping.populate_range(vm_space, &intersected_range, rss_delta)?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn locked_size(&self, range: &Range<Vaddr>) -> usize {
+        let mut locked_size = 0;
+
+        for vm_mapping in self.vm_mappings.find(range) {
+            if !vm_mapping.is_locked() {
+                continue;
+            }
+
+            let intersected_range = get_intersected_range(range, &vm_mapping.range());
+            locked_size += intersected_range.len();
+        }
+
+        locked_size
+    }
+
+    fn set_mapping_locks(&mut self, range: Range<Vaddr>, is_locked: bool) {
+        let mut mappings_to_update = Vec::new();
+
+        for vm_mapping in self.vm_mappings.find(&range) {
+            mappings_to_update.push(vm_mapping.range());
+        }
+
+        for vm_mapping_range in mappings_to_update {
+            let Some(vm_mapping) = self.remove(&vm_mapping_range.start) else {
+                continue;
+            };
+
+            let vm_mapping_range = vm_mapping.range();
+            let intersected_range = get_intersected_range(&range, &vm_mapping_range);
+            let (left, taken, right) = vm_mapping.split_range(&intersected_range);
+
+            if let Some(left) = left {
+                self.insert_without_try_merge(left);
+            }
+            if let Some(right) = right {
+                self.insert_without_try_merge(right);
+            }
+
+            self.insert_try_merge(taken.set_locked(is_locked));
+        }
+    }
+}

--- a/kernel/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/src/vm/vmar/vmar_impls/map.rs
@@ -65,6 +65,7 @@ pub struct VmarMapOptions<'a> {
     size: usize,
     offset: VmarMapOffset,
     align: usize,
+    memlock_limit: Option<usize>,
     // Whether the mapping is mapped with `MAP_SHARED`.
     is_shared: bool,
     // Whether the mapping needs to handle surrounding pages when handling
@@ -109,6 +110,7 @@ impl<'a> VmarMapOptions<'a> {
             size,
             offset: VmarMapOffset::Any,
             align: PAGE_SIZE,
+            memlock_limit: None,
             is_shared: false,
             handle_page_faults_around: false,
         }
@@ -197,6 +199,12 @@ impl<'a> VmarMapOptions<'a> {
         self
     }
 
+    /// Sets the `RLIMIT_MEMLOCK` limit for locking this new mapping.
+    pub fn memlock_limit(mut self, memlock_limit: Option<usize>) -> Self {
+        self.memlock_limit = memlock_limit;
+        self
+    }
+
     /// Sets the mapping's offset inside the VMAR.
     ///
     /// The offset must satisfy the alignment requirement.
@@ -274,11 +282,13 @@ impl<'a> VmarMapOptions<'a> {
             size: map_size,
             offset,
             align,
+            memlock_limit,
             is_shared,
             handle_page_faults_around,
         } = self;
 
         let mut inner = parent.inner.write();
+        let lock_new_mapping = inner.future_memory_lock.is_enabled();
 
         inner
             .check_extra_size_fits_rlimit(map_size)
@@ -292,6 +302,25 @@ impl<'a> VmarMapOptions<'a> {
                     Err(err)
                 }
             })?;
+        if lock_new_mapping {
+            let replaced_locked_size = match offset {
+                VmarMapOffset::FixedReplace(map_to_addr) => map_to_addr
+                    .checked_add(map_size)
+                    .map_or(0, |map_end| inner.locked_size(&(map_to_addr..map_end))),
+                _ => 0,
+            };
+            inner
+                .check_extra_lock_size_fits_limit(map_size - replaced_locked_size, memlock_limit)?;
+            if let VmarMapOffset::FixedReplace(map_to_addr) = offset
+                && let Some(map_end) = map_to_addr.checked_add(map_size)
+                && inner.count_overlap_size(map_to_addr..map_end) > 0
+            {
+                return_errno_with_message!(
+                    Errno::ENOMEM,
+                    "map: replacing mappings with a locked fixed mapping is not supported"
+                );
+            }
+        }
 
         // Allocates a free region.
         debug!(
@@ -353,7 +382,7 @@ impl<'a> VmarMapOptions<'a> {
         };
 
         // Build the mapping.
-        let vm_mapping = VmMapping::new(
+        let mut vm_mapping = VmMapping::new(
             NonZeroUsize::new(map_size).unwrap(),
             map_to_addr,
             mapped_mem,
@@ -362,6 +391,9 @@ impl<'a> VmarMapOptions<'a> {
             handle_page_faults_around,
             perms | may_perms,
         );
+        if lock_new_mapping {
+            vm_mapping = vm_mapping.set_locked(true);
+        }
 
         // Populate device memory if needed before adding to VMAR.
         //
@@ -375,6 +407,17 @@ impl<'a> VmarMapOptions<'a> {
 
         // Add the mapping to the VMAR.
         inner.insert_try_merge(vm_mapping);
+        if lock_new_mapping {
+            inner.locked_vm += map_size;
+            let mut rss_delta = RssDelta::new(parent);
+            let map_range = map_to_addr..map_to_addr + map_size;
+            inner.populate_range_or_rollback(
+                parent.vm_space(),
+                map_range.clone(),
+                map_range,
+                &mut rss_delta,
+            )?;
+        }
 
         Ok(map_to_addr)
     }

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -2,6 +2,7 @@
 
 mod access_alien;
 mod fork;
+mod lock;
 pub(super) mod map;
 pub(super) mod page_fault;
 mod protect;
@@ -28,7 +29,7 @@ use super::{
 };
 use crate::{
     prelude::*,
-    process::{INIT_STACK_SIZE, Process, ProcessVm, ResourceType},
+    process::{FutureMemoryLock, INIT_STACK_SIZE, Process, ProcessVm, ResourceType},
     vm::vmar::is_userspace_vaddr_range,
 };
 
@@ -172,6 +173,10 @@ struct VmarInner {
     vm_mappings: IntervalSet<Vaddr, VmMapping>,
     /// The total mapped memory in bytes.
     total_vm: usize,
+    /// The total locked memory in bytes.
+    locked_vm: usize,
+    /// Whether future mappings should be locked in memory.
+    future_memory_lock: FutureMemoryLock,
 }
 
 impl VmarInner {
@@ -179,6 +184,8 @@ impl VmarInner {
         Self {
             vm_mappings: IntervalSet::new(),
             total_vm: 0,
+            locked_vm: 0,
+            future_memory_lock: FutureMemoryLock::Disabled,
         }
     }
 
@@ -266,6 +273,58 @@ impl VmarInner {
         Some(vm_mapping)
     }
 
+    fn populate_range_or_rollback(
+        &mut self,
+        vm_space: &VmSpace,
+        populate_range: Range<Vaddr>,
+        rollback_range: Range<Vaddr>,
+        rss_delta: &mut RssDelta,
+    ) -> Result<()> {
+        let populate_result = {
+            let vm_mapping = self.vm_mappings.find_one(&populate_range.start).unwrap();
+            debug_assert!(vm_mapping.range().start <= populate_range.start);
+            debug_assert!(populate_range.end <= vm_mapping.range().end);
+
+            vm_mapping.populate_range(vm_space, &populate_range, rss_delta)
+        };
+
+        if let Err(error) = populate_result {
+            let _ = self.alloc_free_region_exact_truncate(
+                vm_space,
+                rollback_range.start,
+                rollback_range.len(),
+                rss_delta,
+            );
+            return Err(error);
+        }
+
+        Ok(())
+    }
+
+    fn expand_mapping_with_lock_policy(
+        &mut self,
+        mapping_addr: Vaddr,
+        split_addr: Vaddr,
+        expand_size: usize,
+        lock_expanded_range: bool,
+    ) -> Range<Vaddr> {
+        let vm_mapping = self.remove(&mapping_addr).unwrap();
+        if vm_mapping.is_locked() == lock_expanded_range {
+            self.insert_try_merge(vm_mapping.enlarge(expand_size));
+        } else {
+            let expanded_mapping = vm_mapping.enlarge(expand_size);
+            let (old_mapping, expanded_mapping) = expanded_mapping.split(split_addr);
+            self.insert_try_merge(old_mapping);
+            self.insert_try_merge(expanded_mapping.set_locked(lock_expanded_range));
+        }
+
+        if lock_expanded_range {
+            self.locked_vm += expand_size;
+        }
+
+        split_addr..split_addr + expand_size
+    }
+
     /// Finds a set of [`VmMapping`]s that intersect with the provided range.
     fn query(&self, range: &Range<Vaddr>) -> impl Iterator<Item = &VmMapping> {
         self.vm_mappings.find(range)
@@ -332,6 +391,9 @@ impl VmarInner {
                 self.insert_without_try_merge(right);
             }
 
+            if taken.is_locked() {
+                self.locked_vm = self.locked_vm.saturating_sub(taken.map_size());
+            }
             rss_delta.add(taken.rss_type(), -(taken.unmap(vm_space) as isize));
         }
 
@@ -402,6 +464,7 @@ impl VmarInner {
         old_size: usize,
         new_size: usize,
         rss_delta: &mut RssDelta,
+        memlock_limit: Option<usize>,
     ) -> Result<()> {
         debug_assert_eq!(map_addr % PAGE_SIZE, 0);
         debug_assert_eq!(old_size % PAGE_SIZE, 0);
@@ -451,10 +514,27 @@ impl VmarInner {
             return_errno_with_message!(Errno::EFAULT, "device mappings cannot be expanded");
         }
 
-        self.check_extra_size_fits_rlimit(new_size - old_size)?;
-        let last_mapping = self.remove(&last_mapping_addr).unwrap();
-        let last_mapping = last_mapping.enlarge(new_size - old_size);
-        self.insert_try_merge(last_mapping);
+        let expand_size = new_size - old_size;
+        self.check_extra_size_fits_rlimit(expand_size)?;
+        let lock_expanded_range = last_mapping.is_locked() || self.future_memory_lock.is_enabled();
+        if lock_expanded_range {
+            self.check_extra_lock_size_fits_limit(expand_size, memlock_limit)?;
+        }
+
+        let expanded_range = self.expand_mapping_with_lock_policy(
+            last_mapping_addr,
+            old_map_end,
+            expand_size,
+            lock_expanded_range,
+        );
+        if lock_expanded_range {
+            self.populate_range_or_rollback(
+                vm_space,
+                expanded_range.clone(),
+                expanded_range,
+                rss_delta,
+            )?;
+        }
         Ok(())
     }
 }

--- a/kernel/src/vm/vmar/vmar_impls/page_fault.rs
+++ b/kernel/src/vm/vmar/vmar_impls/page_fault.rs
@@ -59,7 +59,7 @@ impl PageFaultInfo {
     }
 
     /// Marks this page fault as forced.
-    pub(super) fn force(mut self) -> Self {
+    pub(in crate::vm::vmar) fn force(mut self) -> Self {
         self.is_forced = true;
         self
     }

--- a/kernel/src/vm/vmar/vmar_impls/remap.rs
+++ b/kernel/src/vm/vmar/vmar_impls/remap.rs
@@ -31,6 +31,7 @@ impl Vmar {
         old_size: usize,
         new_size: usize,
         check_single_mapping: bool,
+        memlock_limit: Option<usize>,
     ) -> Result<()> {
         let mut inner = self.inner.write();
         let mut rss_delta = RssDelta::new(self);
@@ -44,7 +45,14 @@ impl Vmar {
         // `map_addr..map_addr + old_size` have a mapping. If not,
         // we should return an `Err`.
 
-        inner.resize_mapping(&self.vm_space, map_addr, old_size, new_size, &mut rss_delta)
+        inner.resize_mapping(
+            &self.vm_space,
+            map_addr,
+            old_size,
+            new_size,
+            &mut rss_delta,
+            memlock_limit,
+        )
     }
 
     /// Remaps the original mapping to a new address and/or size.
@@ -69,6 +77,7 @@ impl Vmar {
         old_size: usize,
         new_addr: Option<Vaddr>,
         new_size: usize,
+        memlock_limit: Option<usize>,
     ) -> Result<Vaddr> {
         debug_assert_eq!(old_addr % PAGE_SIZE, 0);
         debug_assert_eq!(old_size % PAGE_SIZE, 0);
@@ -76,7 +85,6 @@ impl Vmar {
 
         let mut inner = self.inner.write();
         let mut rss_delta = RssDelta::new(self);
-
         let Some(old_mapping) = inner.vm_mappings.find_one(&old_addr) else {
             return_errno_with_message!(
                 Errno::EFAULT,
@@ -90,7 +98,26 @@ impl Vmar {
                     "remap: device mappings cannot be expanded"
                 );
             }
-            inner.check_extra_size_fits_rlimit(new_size - old_size)?;
+            let expand_size = new_size - old_size;
+            inner.check_extra_size_fits_rlimit(expand_size)?;
+            let lock_expanded_range =
+                old_mapping.is_locked() || inner.future_memory_lock.is_enabled();
+            if lock_expanded_range {
+                inner.check_extra_lock_size_fits_limit(expand_size, memlock_limit)?;
+            }
+            if let Some(new_addr) = new_addr
+                && lock_expanded_range
+                && is_userspace_vaddr_range(new_addr, new_size)
+                && let Some(new_end) = new_addr.checked_add(new_size)
+                && let Some(old_end) = old_addr.checked_add(old_size)
+                && !is_intersected(&(old_addr..old_end), &(new_addr..new_end))
+                && inner.count_overlap_size(new_addr..new_end) > 0
+            {
+                return_errno_with_message!(
+                    Errno::ENOMEM,
+                    "remap: replacing mappings with a locked fixed expansion is not supported"
+                );
+            }
         }
 
         // Shrink the old mapping first.
@@ -140,31 +167,93 @@ impl Vmar {
                     .is_ok()
             {
                 let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
-                let old_mapping = inner.remove(&old_mapping_addr).unwrap();
-                let new_mapping = old_mapping.enlarge(new_size - old_size);
-                inner.insert_try_merge(new_mapping);
+                let expand_size = new_size - old_size;
+                let lock_expanded_range = {
+                    let old_mapping = inner.vm_mappings.find_one(&old_mapping_addr).unwrap();
+                    old_mapping.is_locked() || inner.future_memory_lock.is_enabled()
+                };
+                let expanded_range = inner.expand_mapping_with_lock_policy(
+                    old_mapping_addr,
+                    old_range.end,
+                    expand_size,
+                    lock_expanded_range,
+                );
+                if lock_expanded_range {
+                    inner.populate_range_or_rollback(
+                        &self.vm_space,
+                        expanded_range.clone(),
+                        expanded_range,
+                        &mut rss_delta,
+                    )?;
+                }
                 return Ok(old_range.start);
             }
 
             inner.alloc_free_region(new_size, PAGE_SIZE)?
         };
 
-        // Create a new `VmMapping`.
+        let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
         let old_mapping = {
-            let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
-            let vm_mapping = inner.remove(&old_mapping_addr).unwrap();
-            let (left, old_mapping, right) = vm_mapping.split_range(&old_range);
-            if let Some(left) = left {
-                inner.insert_without_try_merge(left);
-            }
-            if let Some(right) = right {
-                inner.insert_without_try_merge(right);
-            }
+            let vm_mapping = inner.vm_mappings.find_one(&old_mapping_addr).unwrap();
+            let (_, old_mapping, _) = vm_mapping.dup().split_range(&old_range);
             old_mapping
         };
+
         // Note that we have ensured that `new_size >= old_size` at the beginning.
+        let expand_size = new_size - old_size;
         let new_mapping = old_mapping.clone_for_remap_at(new_range.start);
-        inner.insert_try_merge(new_mapping.enlarge(new_size - old_size));
+        let split_addr = new_range.start + old_size;
+        let (new_mapping, expanded_mapping, lock_expanded_range) = if expand_size == 0 {
+            (new_mapping, None, false)
+        } else {
+            let lock_expanded_range =
+                old_mapping.is_locked() || inner.future_memory_lock.is_enabled();
+            let (new_mapping, expanded_mapping) = if new_mapping.is_locked() == lock_expanded_range
+            {
+                (new_mapping.enlarge(expand_size), None)
+            } else {
+                let expanded_mapping = new_mapping.enlarge(expand_size);
+                let split_addr = new_range.start + old_size;
+                let (old_mapping, expanded_mapping) = expanded_mapping.split(split_addr);
+                (
+                    old_mapping,
+                    Some(expanded_mapping.set_locked(lock_expanded_range)),
+                )
+            };
+            if lock_expanded_range {
+                inner.locked_vm += expand_size;
+            }
+            (new_mapping, expanded_mapping, lock_expanded_range)
+        };
+
+        if lock_expanded_range {
+            let (_, temporary_expanded_mapping) = old_mapping
+                .clone_for_remap_at(new_range.start)
+                .enlarge(expand_size)
+                .split(split_addr);
+            inner.insert_without_try_merge(temporary_expanded_mapping.set_locked(true));
+            let expanded_range = split_addr..split_addr + expand_size;
+            inner.populate_range_or_rollback(
+                &self.vm_space,
+                expanded_range,
+                split_addr..split_addr + expand_size,
+                &mut rss_delta,
+            )?;
+            let _ = inner.remove(&split_addr);
+        }
+
+        let vm_mapping = inner.remove(&old_mapping_addr).unwrap();
+        let (left, _, right) = vm_mapping.split_range(&old_range);
+        if let Some(left) = left {
+            inner.insert_without_try_merge(left);
+        }
+        if let Some(right) = right {
+            inner.insert_without_try_merge(right);
+        }
+        inner.insert_try_merge(new_mapping);
+        if let Some(expanded_mapping) = expanded_mapping {
+            inner.insert_try_merge(expanded_mapping);
+        }
 
         let preempt_guard = disable_preempt();
         let total_range = old_range.start.min(new_range.start)..old_range.end.max(new_range.end);

--- a/kernel/src/vm/vmar/vmar_impls/unmap.rs
+++ b/kernel/src/vm/vmar/vmar_impls/unmap.rs
@@ -17,6 +17,7 @@ impl Vmar {
     pub(super) fn clear(&self) {
         let mut inner = self.inner.write();
         inner.vm_mappings.clear();
+        inner.locked_vm = 0;
 
         // Keep `inner` locked to avoid race conditions.
         let preempt_guard = disable_preempt();

--- a/test/initramfs/src/regression/memory/mlock.c
+++ b/test/initramfs/src/regression/memory/mlock.c
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../common/capability.h"
+#include "../common/test.h"
+
+#define PAGE_SIZE 4096
+
+static void *map_pages(size_t nr_pages)
+{
+	void *addr = mmap(NULL, nr_pages * PAGE_SIZE, PROT_READ | PROT_WRITE,
+			  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+	if (addr == MAP_FAILED) {
+		return NULL;
+	}
+
+	return addr;
+}
+
+static int set_memlock_limit(rlim_t limit)
+{
+	struct rlimit rlim = {
+		.rlim_cur = limit,
+		.rlim_max = limit,
+	};
+
+	return setrlimit(RLIMIT_MEMLOCK, &rlim);
+}
+
+static int run_quota_test(void (*test_func)(void))
+{
+	pid_t pid = CHECK(fork());
+	int status;
+
+	if (pid == 0) {
+		drop_capability(CAP_IPC_LOCK);
+		test_func();
+		_exit(0);
+	}
+
+	CHECK(waitpid(pid, &status, 0));
+	if (!WIFEXITED(status)) {
+		return -1;
+	}
+
+	return WEXITSTATUS(status);
+}
+
+static void exit_if_failed(int condition)
+{
+	if (!condition) {
+		_exit(1);
+	}
+}
+
+FN_TEST(mlock_and_munlock)
+{
+	void *addr = map_pages(1);
+
+	TEST_RES((long)addr, _ret != 0);
+	TEST_SUCC(mlock(addr, PAGE_SIZE));
+	TEST_SUCC(munlock(addr, PAGE_SIZE));
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
+}
+END_TEST()
+
+FN_TEST(mlock_error_cases)
+{
+	void *addr = map_pages(2);
+
+	TEST_RES((long)addr, _ret != 0);
+	TEST_SUCC(munmap(addr + PAGE_SIZE, PAGE_SIZE));
+	TEST_SUCC(mlock(addr + 1, PAGE_SIZE - 1));
+	TEST_SUCC(munlock(addr + 1, PAGE_SIZE - 1));
+	TEST_ERRNO(mlock(addr + 1, PAGE_SIZE), ENOMEM);
+	TEST_ERRNO(mlock(addr, PAGE_SIZE * 2), ENOMEM);
+	TEST_ERRNO(munlock(addr, PAGE_SIZE * 2), ENOMEM);
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
+}
+END_TEST()
+
+static void quota_mlock_does_not_charge_twice(void)
+{
+	void *addr = map_pages(1);
+
+	exit_if_failed(addr != NULL);
+	exit_if_failed(set_memlock_limit(PAGE_SIZE) == 0);
+	exit_if_failed(mlock(addr, PAGE_SIZE) == 0);
+	exit_if_failed(mlock(addr, PAGE_SIZE) == 0);
+	errno = 0;
+	exit_if_failed(mlock(addr, PAGE_SIZE * 2) == -1 && errno == ENOMEM);
+	exit_if_failed(munlock(addr, PAGE_SIZE) == 0);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+}
+
+FN_TEST(mlock_does_not_charge_twice)
+{
+	TEST_RES(run_quota_test(quota_mlock_does_not_charge_twice), _ret == 0);
+}
+END_TEST()
+
+static void quota_mlockall_current(void)
+{
+	void *addr = map_pages(1);
+
+	exit_if_failed(addr != NULL);
+	exit_if_failed(set_memlock_limit(RLIM_INFINITY) == 0);
+	exit_if_failed(mlockall(MCL_CURRENT) == 0);
+	exit_if_failed(munlockall() == 0);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+}
+
+FN_TEST(mlockall_current)
+{
+	TEST_RES(run_quota_test(quota_mlockall_current), _ret == 0);
+}
+END_TEST()
+
+static void quota_mlockall_future(void)
+{
+	void *addr;
+
+	exit_if_failed(set_memlock_limit(PAGE_SIZE) == 0);
+	exit_if_failed(mlockall(MCL_FUTURE) == 0);
+	addr = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	exit_if_failed(addr != MAP_FAILED);
+	errno = 0;
+	exit_if_failed(mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+			    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) == MAP_FAILED &&
+		       errno == ENOMEM);
+	exit_if_failed(munlockall() == 0);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+
+	addr = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	exit_if_failed(addr != MAP_FAILED);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+}
+
+FN_TEST(mlockall_future)
+{
+	TEST_RES(run_quota_test(quota_mlockall_future), _ret == 0);
+}
+END_TEST()
+
+static void quota_mmap_fixed_future_preserves_target(void)
+{
+	char *new_addr = map_pages(1);
+	void *mapped;
+
+	exit_if_failed(new_addr != NULL);
+	new_addr[0] = 0x5a;
+	exit_if_failed(mlockall(MCL_FUTURE) == 0);
+	errno = 0;
+	mapped = mmap(new_addr, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		      MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+	exit_if_failed(mapped == MAP_FAILED);
+	exit_if_failed(errno == ENOMEM);
+	exit_if_failed(new_addr[0] == 0x5a);
+	exit_if_failed(munmap(new_addr, PAGE_SIZE) == 0);
+	exit_if_failed(munlockall() == 0);
+}
+
+FN_TEST(mmap_fixed_future_preserves_target)
+{
+	TEST_RES(run_quota_test(quota_mmap_fixed_future_preserves_target),
+		 _ret == 0);
+}
+END_TEST()
+
+static void quota_mremap_locked_resize(void)
+{
+	void *addr = map_pages(2);
+	void *blocker;
+	void *remapped;
+
+	exit_if_failed(addr != NULL);
+	blocker = (char *)addr + PAGE_SIZE;
+	exit_if_failed(munmap(blocker, PAGE_SIZE) == 0);
+	exit_if_failed(set_memlock_limit(PAGE_SIZE) == 0);
+	exit_if_failed(mlock(addr, PAGE_SIZE) == 0);
+	errno = 0;
+	remapped = mremap(addr, PAGE_SIZE, PAGE_SIZE * 2, 0);
+	exit_if_failed(remapped == MAP_FAILED);
+	exit_if_failed(errno == ENOMEM);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+}
+
+FN_TEST(mremap_locked_resize_checks_quota)
+{
+	TEST_RES(run_quota_test(quota_mremap_locked_resize), _ret == 0);
+}
+END_TEST()
+
+static void quota_mremap_locked_move_preserves_lock(void)
+{
+	void *addr = map_pages(1);
+	void *new_addr = map_pages(1);
+
+	exit_if_failed(addr != NULL);
+	exit_if_failed(new_addr != NULL);
+	exit_if_failed(set_memlock_limit(PAGE_SIZE) == 0);
+	exit_if_failed(mlock(addr, PAGE_SIZE) == 0);
+	new_addr = mremap(addr, PAGE_SIZE, PAGE_SIZE,
+			  MREMAP_MAYMOVE | MREMAP_FIXED, new_addr);
+	exit_if_failed(new_addr != MAP_FAILED);
+	exit_if_failed(mlock(new_addr, PAGE_SIZE) == 0);
+	exit_if_failed(munmap(new_addr, PAGE_SIZE) == 0);
+}
+
+FN_TEST(mremap_locked_move_preserves_lock)
+{
+	TEST_RES(run_quota_test(quota_mremap_locked_move_preserves_lock),
+		 _ret == 0);
+}
+END_TEST()
+
+static void quota_mremap_locked_maymove_checks_quota(void)
+{
+	void *addr = map_pages(2);
+	void *blocker;
+	void *remapped;
+
+	exit_if_failed(addr != NULL);
+	blocker = (char *)addr + PAGE_SIZE;
+	exit_if_failed(set_memlock_limit(PAGE_SIZE) == 0);
+	exit_if_failed(mlock(addr, PAGE_SIZE) == 0);
+	errno = 0;
+	remapped = mremap(addr, PAGE_SIZE, PAGE_SIZE * 2, MREMAP_MAYMOVE);
+	exit_if_failed(remapped == MAP_FAILED);
+	exit_if_failed(errno == ENOMEM);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+	exit_if_failed(munmap(blocker, PAGE_SIZE) == 0);
+}
+
+FN_TEST(mremap_locked_maymove_checks_quota)
+{
+	TEST_RES(run_quota_test(quota_mremap_locked_maymove_checks_quota),
+		 _ret == 0);
+}
+END_TEST()
+
+static void quota_mremap_future_preserves_target(void)
+{
+	char *addr = map_pages(1);
+	char *new_addr = map_pages(2);
+
+	exit_if_failed(addr != NULL);
+	exit_if_failed(new_addr != NULL);
+	new_addr[0] = 0x5a;
+	exit_if_failed(mlockall(MCL_FUTURE) == 0);
+	errno = 0;
+	exit_if_failed(mremap(addr, PAGE_SIZE, PAGE_SIZE * 2,
+			      MREMAP_MAYMOVE | MREMAP_FIXED,
+			      new_addr) == MAP_FAILED);
+	exit_if_failed(errno == ENOMEM);
+	exit_if_failed(new_addr[0] == 0x5a);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+	exit_if_failed(munmap(new_addr, PAGE_SIZE * 2) == 0);
+	exit_if_failed(munlockall() == 0);
+}
+
+FN_TEST(mremap_fixed_future_expansion_preserves_target)
+{
+	TEST_RES(run_quota_test(quota_mremap_future_preserves_target),
+		 _ret == 0);
+}
+END_TEST()
+
+static void quota_mmap_fixed_future_empty_target_succeeds(void)
+{
+	char *addr = map_pages(1);
+	void *mapped;
+
+	exit_if_failed(addr != NULL);
+	exit_if_failed(munmap(addr, PAGE_SIZE) == 0);
+	exit_if_failed(mlockall(MCL_FUTURE) == 0);
+	mapped = mmap(addr, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		      MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+	exit_if_failed(mapped == addr);
+	exit_if_failed(munmap(mapped, PAGE_SIZE) == 0);
+	exit_if_failed(munlockall() == 0);
+}
+
+FN_TEST(mmap_fixed_future_empty_target_succeeds)
+{
+	TEST_RES(run_quota_test(quota_mmap_fixed_future_empty_target_succeeds),
+		 _ret == 0);
+}
+END_TEST()
+
+static void quota_mremap_future_empty_target_succeeds(void)
+{
+	char *addr = map_pages(1);
+	char *new_addr = map_pages(2);
+	void *remapped;
+
+	exit_if_failed(addr != NULL);
+	exit_if_failed(new_addr != NULL);
+	exit_if_failed(munmap(new_addr, PAGE_SIZE * 2) == 0);
+	exit_if_failed(mlockall(MCL_FUTURE) == 0);
+	remapped = mremap(addr, PAGE_SIZE, PAGE_SIZE * 2,
+			  MREMAP_MAYMOVE | MREMAP_FIXED, new_addr);
+	exit_if_failed(remapped == new_addr);
+	exit_if_failed(munmap(remapped, PAGE_SIZE * 2) == 0);
+	exit_if_failed(munlockall() == 0);
+}
+
+FN_TEST(mremap_fixed_future_empty_target_succeeds)
+{
+	TEST_RES(run_quota_test(quota_mremap_future_empty_target_succeeds),
+		 _ret == 0);
+}
+END_TEST()
+
+static void quota_brk_locked_growth_checks_quota(void)
+{
+	uintptr_t current_break = (uintptr_t)sbrk(0);
+	void *heap_page = (void *)((current_break - 1) & ~(PAGE_SIZE - 1));
+	uintptr_t new_break = current_break + PAGE_SIZE;
+	long actual_break;
+
+	exit_if_failed(current_break != (uintptr_t)-1);
+	exit_if_failed(set_memlock_limit(PAGE_SIZE) == 0);
+	exit_if_failed(mlock(heap_page, PAGE_SIZE) == 0);
+	actual_break = syscall(SYS_brk, new_break);
+	exit_if_failed(actual_break == (long)current_break);
+	exit_if_failed(munlock(heap_page, PAGE_SIZE) == 0);
+}
+
+FN_TEST(brk_locked_growth_checks_quota)
+{
+	TEST_RES(run_quota_test(quota_brk_locked_growth_checks_quota),
+		 _ret == 0);
+}
+END_TEST()
+
+FN_TEST(mlockall_invalid_flags)
+{
+	TEST_ERRNO(mlockall(0), EINVAL);
+	TEST_ERRNO(mlockall(MCL_ONFAULT), EINVAL);
+	TEST_ERRNO(mlockall(MCL_CURRENT | MCL_ONFAULT), EINVAL);
+}
+END_TEST()

--- a/test/initramfs/src/regression/memory/run_test.sh
+++ b/test/initramfs/src/regression/memory/run_test.sh
@@ -4,6 +4,7 @@
 
 set -e
 
+./mlock
 ./mmap/mmap_and_fork
 ./mmap/mmap_and_mprotect
 ./mmap/mmap_and_mremap


### PR DESCRIPTION
## Summary

Implement memory-locking syscall support at the VMAR metadata and accounting level.

This PR adds support for:

- `mlock`
- `munlock`
- `mlockall`
- `munlockall`

The implementation tracks locked VM ranges in `VmMapping` metadata and maintains per-VMAR locked-byte accounting through `locked_vm`. It enforces `RLIMIT_MEMLOCK` for non-privileged processes and allows `CAP_IPC_LOCK` callers to bypass the limit.

## Details

This change includes:

- syscall registration for `mlock`, `munlock`, `mlockall`, and `munlockall`
- range validation for overflow, userspace bounds, unmapped holes, and Linux-style page rounding
- `MCL_CURRENT` support for currently mapped VM ranges
- `MCL_FUTURE` support for future `mmap` mappings
- `munlockall` cleanup of current lock state and future-lock policy
- lock accounting across `mmap`, `munmap`, `MAP_FIXED`, `mremap`, and `brk` growth
- fork behavior that does not inherit memory-lock state
- documentation and SCML updates for memory-locking syscall coverage
- regression tests for lock/unlock behavior, quota checks, invalid flags, unaligned ranges, `mremap`, and `brk`

`MCL_ONFAULT` is explicitly unsupported and returns `EINVAL`.

## Scope

This PR implements memory-locking syscall semantics at the VMAR metadata/accounting level. It does not yet physically pin resident pages or integrate with page reclaim/swap behavior.

## Local Review

Local review was performed with the Asterinas code-review workflow before PR preparation. The final review pass found no remaining blocking findings.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `make run_kernel AUTO_TEST=regression`
- GitHub Actions CI for PR #3537

All GitHub Actions checks are passing on the current PR head.
