### PR TITLE
Simplify some regression tests and remove unnecessary constant definitions

### DIFF
--- a/test/initramfs/src/regression/device/nvme.c
+++ b/test/initramfs/src/regression/device/nvme.c
@@ -19,10 +19,6 @@
 #define BUFFER_SIZE 65536
 #define ALIGNMENT 4096
 
-#ifndef O_DIRECT
-#define O_DIRECT 040000
-#endif
-
 static char *nvme_write_buf;
 static char *nvme_read_buf;
 

--- a/test/initramfs/src/regression/fs/ext2/fallocate.c
+++ b/test/initramfs/src/regression/fs/ext2/fallocate.c
@@ -12,10 +12,6 @@
 
 #define BASE_DIR "/ext2/fallocate"
 
-#ifndef FALLOC_FL_KEEP_SIZE
-#define FALLOC_FL_KEEP_SIZE 0x01
-#endif
-
 FN_SETUP(prepare_base_dir)
 {
 	CHECK_WITH(mkdir(BASE_DIR, 0755), _ret == 0 || errno == EEXIST);

--- a/test/initramfs/src/regression/fs/ext2/xattr.c
+++ b/test/initramfs/src/regression/fs/ext2/xattr.c
@@ -41,9 +41,11 @@ FN_TEST(xattr_set_get_roundtrip)
 }
 END_TEST()
 
-// TODO: xattr_list test is disabled because sys_listxattr only lists one
-// namespace (Trusted when running as root), so user.* xattrs are invisible.
-// This is a VFS-level bug, not ext2-specific.
+// Currently, the `listxattr()` syscall in Asterinas only lists xattrs within
+// one namespace ("Trusted" when running as root), so `user.*` xattrs are
+// invisible. This is a VFS-level bug, not ext2-specific.
+//
+// TODO: Add some tests for xattr listing after this bug has been fixed.
 
 FN_TEST(xattr_remove_enodata)
 {

--- a/test/initramfs/src/regression/fs/statx/btime.c
+++ b/test/initramfs/src/regression/fs/statx/btime.c
@@ -2,12 +2,7 @@
 
 #define _GNU_SOURCE
 
-#include <errno.h>
 #include <fcntl.h>
-#ifndef __asterinas__
-#include <linux/loop.h>
-#include <sys/ioctl.h>
-#endif
 #include <linux/stat.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,68 +17,35 @@
 
 #include "../../common/test.h"
 
-#define RAMFS_MOUNT_POINT "/statx_btime_ramfs"
+#define RAMFS_MOUNT_POINT "/tmp/statx_btime_ramfs"
 #define RAMFS_TEST_FILE RAMFS_MOUNT_POINT "/statx_btime_test_file"
 
-#define EXFAT_MOUNT_POINT "/statx_btime_exfat"
+#define EXFAT_MOUNT_POINT "/tmp/statx_btime_exfat"
 #define EXFAT_TEST_FILE EXFAT_MOUNT_POINT "/statx_btime_test_file"
 #define EXFAT_TEST_FILE_NOT_REQ \
 	EXFAT_MOUNT_POINT "/statx_btime_test_file_not_req"
 
-#ifndef __asterinas__
-#define EXFAT_IMAGE "/tmp/statx_btime_exfat.img"
-#define EXFAT_IMAGE_SIZE (64 * 1024 * 1024)
-#endif
-
 static int fd = -1;
 
-static int created_ramfs_mount_point;
-static int created_exfat_mount_point;
-
 #ifndef __asterinas__
+#include <linux/loop.h>
+#include <sys/ioctl.h>
+
+#define EXFAT_IMAGE "./test/initramfs/build/exfat.img"
+
 static int loop_fd = -1;
 static char loop_path[64];
-#endif
-
-static void make_ramfs_mount_point(void)
-{
-	if (mkdir(RAMFS_MOUNT_POINT, 0755) == 0) {
-		created_ramfs_mount_point = 1;
-		return;
-	}
-}
-
-static void make_exfat_mount_point(void)
-{
-	if (mkdir(EXFAT_MOUNT_POINT, 0755) == 0) {
-		created_exfat_mount_point = 1;
-		return;
-	}
-}
-
-#ifndef __asterinas__
-static void create_exfat_image(void)
-{
-	int image_fd =
-		CHECK(open(EXFAT_IMAGE, O_CREAT | O_TRUNC | O_RDWR, 0600));
-
-	CHECK(ftruncate(image_fd, EXFAT_IMAGE_SIZE));
-	CHECK(close(image_fd));
-	CHECK_WITH(system("mkfs.exfat " EXFAT_IMAGE " >/dev/null"), _ret == 0);
-}
 
 static void attach_loop_device(void)
 {
 	int control_fd = CHECK(open("/dev/loop-control", O_RDWR));
 	int loop_number = CHECK(ioctl(control_fd, LOOP_CTL_GET_FREE));
-
 	CHECK(close(control_fd));
 	CHECK_WITH(snprintf(loop_path, sizeof(loop_path), "/dev/loop%d",
 			    loop_number),
 		   _ret > 0 && (size_t)_ret < sizeof(loop_path));
 
 	int image_fd = CHECK(open(EXFAT_IMAGE, O_RDWR));
-
 	loop_fd = CHECK(open(loop_path, O_RDWR));
 	CHECK(ioctl(loop_fd, LOOP_SET_FD, image_fd));
 	CHECK(close(image_fd));
@@ -92,17 +54,18 @@ static void attach_loop_device(void)
 
 FN_SETUP(prepare)
 {
-	make_ramfs_mount_point();
+	CHECK_WITH(mkdir(RAMFS_MOUNT_POINT, 0755),
+		   _ret == 0 || errno == EEXIST);
 	CHECK(mount("none", RAMFS_MOUNT_POINT, "ramfs", 0, NULL));
 
 	fd = CHECK(open(RAMFS_TEST_FILE, O_CREAT | O_RDWR | O_TRUNC, 0644));
 	CHECK(write(fd, "test", 4));
 
-	make_exfat_mount_point();
+	CHECK_WITH(mkdir(EXFAT_MOUNT_POINT, 0755),
+		   _ret == 0 || errno == EEXIST);
 #ifdef __asterinas__
 	CHECK(mount("/dev/vdb", EXFAT_MOUNT_POINT, "exfat", 0, ""));
 #else
-	create_exfat_image();
 	attach_loop_device();
 	CHECK(mount(loop_path, EXFAT_MOUNT_POINT, "exfat", 0, ""));
 #endif
@@ -114,7 +77,7 @@ FN_TEST(statx_btime_not_requested)
 	struct statx stx;
 	TEST_SUCC(syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_BASIC_STATS,
 			  &stx));
-	TEST_RES(0, (stx.stx_mask & STATX_BTIME) == 0);
+	TEST_RES((stx.stx_mask & STATX_BTIME) == 0, _ret);
 }
 END_TEST()
 
@@ -122,7 +85,7 @@ FN_TEST(statx_btime_ramfs)
 {
 	struct statx stx;
 	TEST_SUCC(syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_BTIME, &stx));
-	TEST_RES(0, stx.stx_btime.tv_sec == 0 && stx.stx_btime.tv_nsec == 0);
+	TEST_RES(stx.stx_btime.tv_sec == 0 && stx.stx_btime.tv_nsec == 0, _ret);
 }
 END_TEST()
 
@@ -134,7 +97,7 @@ FN_TEST(exfat_statx_btime_not_requested)
 	TEST_SUCC(syscall(SYS_statx, test_fd, "", AT_EMPTY_PATH,
 			  STATX_BASIC_STATS, &stx));
 	// exfat supports birth time, so `STATX_BTIME` should be set even if not requested
-	TEST_RES(0, (stx.stx_mask & STATX_BTIME) != 0);
+	TEST_RES((stx.stx_mask & STATX_BTIME) != 0, _ret);
 	TEST_SUCC(close(test_fd));
 }
 END_TEST()
@@ -154,11 +117,12 @@ FN_TEST(exfat_statx_reports_birth_time)
 	TEST_RES(write(test_fd, "test", 4), _ret == 4);
 	TEST_SUCC(syscall(SYS_statx, test_fd, "", AT_EMPTY_PATH, STATX_BTIME,
 			  &stx));
-	TEST_RES(0, (stx.stx_mask & STATX_BTIME) != 0);
-	TEST_RES(0, stx.stx_btime.tv_sec != 0 || stx.stx_btime.tv_nsec != 0);
+	TEST_RES((stx.stx_mask & STATX_BTIME) != 0, _ret);
+	TEST_RES(stx.stx_btime.tv_sec != 0 || stx.stx_btime.tv_nsec != 0, _ret);
 	// Verify that the birth time is within the time window around file creation
-	TEST_RES(0, stx.stx_btime.tv_sec >= before_create.tv_sec - 1);
-	TEST_RES(0, stx.stx_btime.tv_sec <= after_create.tv_sec + 1);
+	TEST_RES(stx.stx_btime.tv_sec >= before_create.tv_sec - 1, _ret);
+	TEST_RES(stx.stx_btime.tv_sec <= after_create.tv_sec + 1, _ret);
+
 	TEST_SUCC(close(test_fd));
 }
 END_TEST()
@@ -175,14 +139,9 @@ FN_SETUP(cleanup)
 #ifndef __asterinas__
 	CHECK(ioctl(loop_fd, LOOP_CLR_FD));
 	CHECK(close(loop_fd));
-	CHECK(unlink(EXFAT_IMAGE));
 #endif
 
-	if (created_exfat_mount_point) {
-		CHECK(rmdir(EXFAT_MOUNT_POINT));
-	}
-	if (created_ramfs_mount_point) {
-		CHECK(rmdir(RAMFS_MOUNT_POINT));
-	}
+	CHECK(rmdir(EXFAT_MOUNT_POINT));
+	CHECK(rmdir(RAMFS_MOUNT_POINT));
 }
 END_SETUP()

--- a/test/initramfs/src/regression/fs/tmpfile/tmpfile.c
+++ b/test/initramfs/src/regression/fs/tmpfile/tmpfile.c
@@ -4,7 +4,6 @@
 
 #include <dirent.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -22,20 +21,7 @@
 #define DATA "hello from tmpfile"
 #define DATA_LEN (sizeof(DATA) - 1)
 
-#define RAW_O_TMPFILE 020000000
-
-/* O_TMPFILE may not be defined on older glibc. */
-#ifndef __O_TMPFILE
-#define __O_TMPFILE RAW_O_TMPFILE
-#endif
-
-#ifndef O_TMPFILE
-#define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
-#endif
-
-#ifndef AT_EMPTY_PATH
-#define AT_EMPTY_PATH 0x1000
-#endif
+#define RAW_O_TMPFILE (O_TMPFILE & ~O_DIRECTORY)
 
 static void cleanup_test_files(void)
 {
@@ -116,7 +102,6 @@ FN_TEST(tmpfile_open_with_o_path_yields_path_fd)
 
 	fd = TEST_SUCC(open(TEST_DIR, O_TMPFILE | O_PATH | O_RDWR, 0666));
 	TEST_ERRNO(read(fd, buf, sizeof(buf)), EBADF);
-
 	TEST_SUCC(close(fd));
 }
 END_TEST()

--- a/test/initramfs/src/regression/process/clone3/clone_process.c
+++ b/test/initramfs/src/regression/process/clone3/clone_process.c
@@ -19,10 +19,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#ifndef CLONE_PIDFD
-#define CLONE_PIDFD 0x00001000
-#endif
-
 static pid_t sys_clone3(struct clone_args *args)
 {
 	return syscall(SYS_clone3, args, sizeof(struct clone_args));

--- a/test/initramfs/src/regression/process/execve/execve_memfd.c
+++ b/test/initramfs/src/regression/process/execve/execve_memfd.c
@@ -3,7 +3,6 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
@@ -15,14 +14,6 @@
 
 #define EXECUTABLE_PATH "/test/process/execve/hello"
 #define MFD_NAME "test_memfd_execve"
-
-#ifndef MFD_NOEXEC_SEAL
-#define MFD_NOEXEC_SEAL 0x0008U
-#endif
-
-#ifndef F_SEAL_EXEC
-#define F_SEAL_EXEC 0x0020U
-#endif
 
 FN_TEST(memfd_noexec_seal)
 {

--- a/test/initramfs/src/regression/process/pthread/pthread_test.c
+++ b/test/initramfs/src/regression/process/pthread/pthread_test.c
@@ -7,11 +7,12 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <sys/syscall.h>
+
+// SYS_gettid only exists in certain architectures.
 #ifndef SYS_gettid
-#error "SYS_gettid unavailable on this system"
+#error "SYS_gettid is unavailable for this architecture"
 #endif
 
 #define gettid() ((pid_t)syscall(SYS_gettid))

--- a/test/initramfs/src/regression/process/signal/sigaltstack.c
+++ b/test/initramfs/src/regression/process/signal/sigaltstack.c
@@ -13,6 +13,9 @@
 
 #define ALT_STACK_SIZE (SIGSTKSZ + 40960)
 
+// SS_AUTODISARM is defined in <linux/signal.h>, but we cannot include it
+// because doing so would cause conflicts between structure definitions in libc
+// and those in <linux/signal.h>.
 #ifndef SS_AUTODISARM
 #define SS_AUTODISARM (1 << 31)
 #endif


### PR DESCRIPTION
I think there is no need to define constants like.
```c
#ifndef CLONE_PIDFD
#define CLONE_PIDFD 0x00001000
#endif
```
We should just ensure the correct header is included. Unless we cannot, for example:
```c
// SS_AUTODISARM is defined in <linux/signal.h>, but we cannot include it
// because doing so would cause conflicts between structure definitions in libc
// and those in <linux/signal.h>.
#ifndef SS_AUTODISARM
#define SS_AUTODISARM (1 << 31)
#endif
```

In addition, the `btime.c` test introduced (from @cchanging's comment https://github.com/asterinas/asterinas/pull/3394#discussion_r3456734067) is a bit too complex. Can we just:
 - use `#define EXFAT_IMAGE "./test/initramfs/build/exfat.img"`;
 - remove unnecessary `created_ramfs_mount_point`;
 - re-locate test directories to `/tmp/xxx` to avoid polluting the root directory;
 - group `/dev/loop`-related methods, constants, and variables together to improve readability.