### PR TITLE
Fix OSTD publish dry-run for local path dependencies

### DIFF
--- a/.github/workflows/publish_osdk_and_ostd.yml
+++ b/.github/workflows/publish_osdk_and_ostd.yml
@@ -7,6 +7,8 @@ on:
       - VERSION
       - ostd/**
       - osdk/**
+      - .github/workflows/publish_osdk_and_ostd.yml
+      - tools/github_workflows/publish_osdk_and_ostd.sh
   push:
     branches:
       - main

--- a/tools/github_workflows/publish_osdk_and_ostd.sh
+++ b/tools/github_workflows/publish_osdk_and_ostd.sh
@@ -41,24 +41,90 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-# Performs the publish check or publish the crate in directory $1.
-# All the arguments after $1 are passed to `cargo publish`.
-do_publish_for() {
-    pushd $ASTER_SRC_DIR/$1
+# Tracks packages that have already passed `cargo publish --dry-run` in this
+# script. `--dry-run` does not really publish earlier packages to `crates.io`,
+# so later packages patch only these already-checked local `path` dependencies
+# to mirror the dependency state that a real publish would see.
+declare -A DRY_RUN_PUBLISHED_PACKAGES=()
 
-    ADDITIONAL_ARGS="${@:2}"
-    RF="$RUSTFLAGS --check-cfg cfg(ktest)"
+mark_dry_run_published() {
+    DRY_RUN_PUBLISHED_PACKAGES[$1]=true
+}
+
+is_dry_run_published() {
+    [ -n "${DRY_RUN_PUBLISHED_PACKAGES[$1]}" ]
+}
+
+# Performs the publish check or publishes the crate in directory $1.
+# All arguments after $1 are passed to `cargo publish`.
+do_publish_for() {
+    pushd "$ASTER_SRC_DIR/$1"
+    shift
+
+    local ADDITIONAL_ARGS=("$@")
+    local RF="$RUSTFLAGS --check-cfg cfg(ktest)"
 
     if [ -n "$DRY_RUN" ]; then
+        local DEP_NAME DEP_PATH LOCAL_PATH_DEPS MANIFEST_PATH METADATA PACKAGE_METADATA PACKAGE_NAME
+        local PATCH_ARGS=()
+
+        MANIFEST_PATH="$(pwd -P)/Cargo.toml"
+        # `cargo metadata` prints a JSON document for the **whole workspace**,
+        # not only for `MANIFEST_PATH`. Each package entry includes fields such as
+        # `manifest_path`, `name`, and `dependencies`; the `--dry-run` logic below
+        # uses them to find the package being published and its local `path` deps.
+        METADATA=$(cargo metadata --format-version=1 --no-deps --manifest-path "$MANIFEST_PATH")
+
+        # Pick the package entry for the manifest currently being published.
+        PACKAGE_METADATA=$(jq --arg manifest "$MANIFEST_PATH" '
+            .packages[]
+            | select(.manifest_path == $manifest)
+        ' <<< "$METADATA")
+        if [ -z "$PACKAGE_METADATA" ]; then
+            echo "Error: cargo metadata did not contain a package for manifest: $MANIFEST_PATH" >&2
+            exit 1
+        fi
+
+        PACKAGE_NAME=$(jq -r '.name' <<< "$PACKAGE_METADATA")
+        if [ -z "$PACKAGE_NAME" ]; then
+            echo "Error: cargo metadata did not contain a package name for manifest: $MANIFEST_PATH" >&2
+            exit 1
+        fi
+
+        # List local non-dev `path` dependencies as tab-separated
+        # `name<TAB>path` rows.
+        LOCAL_PATH_DEPS=$(jq -r '
+            .dependencies[]
+            | select(.path != null and .source == null and .kind != "dev")
+            | [.name, .path]
+            | @tsv
+        ' <<< "$PACKAGE_METADATA")
+
+        if [ -n "$LOCAL_PATH_DEPS" ]; then
+            while IFS=$'\t' read -r DEP_NAME DEP_PATH; do
+                if is_dry_run_published "$DEP_NAME"; then
+                    PATCH_ARGS+=(--config "patch.crates-io.$DEP_NAME.path=\"$DEP_PATH\"")
+                fi
+            done <<< "$LOCAL_PATH_DEPS"
+        fi
+
         # Perform checks
-        RUSTFLAGS=$RF cargo publish --dry-run --allow-dirty $ADDITIONAL_ARGS
-        RUSTFLAGS=$RF cargo doc $ADDITIONAL_ARGS
+        RUSTFLAGS=$RF cargo publish --dry-run --allow-dirty "${PATCH_ARGS[@]}" "${ADDITIONAL_ARGS[@]}"
+        RUSTFLAGS=$RF cargo doc "${ADDITIONAL_ARGS[@]}"
+
+        mark_dry_run_published "$PACKAGE_NAME"
     else
-        RUSTFLAGS=$RF cargo publish --token $TOKEN $ADDITIONAL_ARGS
+        RUSTFLAGS=$RF cargo publish --token $TOKEN "${ADDITIONAL_ARGS[@]}"
     fi
 
     popd
 }
+
+# The order of `do_publish_for` calls matters:
+# `do_publish_for path/to/crate-a`
+# must appear before
+# `do_publish_for path/to/crate-b`
+# if `crate-a` is a dependency of `crate-b`.
 
 do_publish_for ostd/libs/linux-bzimage/boot-params
 do_publish_for ostd/libs/linux-bzimage/builder


### PR DESCRIPTION
`cargo publish --dry-run` verifies the packaged crate with registry-style dependency resolution. However, earlier dry-run steps do not actually publish packages to `crates.io`, so a later package such as `ostd` may resolve a same-version internal dependency like `ostd-macros` from `crates.io` instead of from the current workspace.

This broke the `ostd` dry-run because the registry version of `ostd-macros` does not include the newly added `early_cmdline_parser` macro. See [this CI failure](https://github.com/asterinas/asterinas/actions/runs/28701482349/job/85120148542), introduced by #3261.

This PR updates `publish_osdk_and_ostd.sh` to track packages that have already passed earlier dry-run publish steps. For later packages, the script reads dependency metadata with `cargo metadata` and automatically adds `patch.crates-io` overrides for eligible local path dependencies, mirroring the dependency state that a real publish would see.

Fixes #3629