### PR TITLE
Add support for mremap MREMAP_DONTUNMAP flag

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/mremap.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/memory-management/mremap.scml
@@ -3,7 +3,7 @@ mremap(
     old_address,
     old_size,
     new_size,
-    flags = MREMAP_MAYMOVE
+    flags = MREMAP_DONTUNMAP | MREMAP_MAYMOVE
 );
 
 // Resize an existing memory mapping and force relocation to a specified location.
@@ -11,6 +11,6 @@ mremap(
     old_address,
     old_size,
     new_size,
-    flags = MREMAP_MAYMOVE | MREMAP_FIXED,
+    flags = MREMAP_DONTUNMAP | MREMAP_MAYMOVE | MREMAP_FIXED,
     new_address
 );

--- a/kernel/src/syscall/mremap.rs
+++ b/kernel/src/syscall/mremap.rs
@@ -3,7 +3,7 @@
 use align_ext::AlignExt;
 
 use super::SyscallReturn;
-use crate::prelude::*;
+use crate::{prelude::*, vm::vmar::RemapOldMappingAction};
 
 pub fn sys_mremap(
     old_addr: Vaddr,
@@ -28,33 +28,62 @@ fn do_sys_mremap(
     ctx: &Context,
 ) -> Result<Vaddr> {
     debug!(
-        "mremap: old_addr = 0x{:x}, old_size = {}, new_size = {}, flags = {:?}, new_addr = 0x{:x}",
+        "old_addr = 0x{:x}, old_size = {}, new_size = {}, flags = {:?}, new_addr = 0x{:x}",
         old_addr, old_size, new_size, flags, new_addr,
     );
 
     if !old_addr.is_multiple_of(PAGE_SIZE) {
-        return_errno_with_message!(Errno::EINVAL, "mremap: `old_addr` must be page-aligned");
+        return_errno_with_message!(Errno::EINVAL, "old_addr must be page-aligned");
     }
     if new_size == 0 {
-        return_errno_with_message!(Errno::EINVAL, "mremap: `new_size` cannot be zero");
+        return_errno_with_message!(Errno::EINVAL, "new_size cannot be zero");
     }
     if old_size == 0 {
-        return_errno_with_message!(
-            Errno::EINVAL,
-            "mremap: copying shareable mapping is not supported"
-        );
+        return_errno_with_message!(Errno::EINVAL, "copying shareable mapping is not supported");
     }
 
     if old_size.checked_add(PAGE_SIZE).is_none() || new_size.checked_add(PAGE_SIZE).is_none() {
-        return_errno_with_message!(Errno::EINVAL, "mremap: the size overflows")
+        return_errno_with_message!(Errno::EINVAL, "the size overflows")
     }
+
+    // `MREMAP_DONTUNMAP` keeps the old VMA in the tree as an anonymous
+    // zero-fill-on-demand mapping; we must move pages even when the sizes
+    // are equal.  `MREMAP_MAYMOVE` is required because the mapping cannot
+    // stay at its current address (the physical pages must be relocated).
+    if flags.contains(MremapFlags::MREMAP_DONTUNMAP) {
+        if !flags.contains(MremapFlags::MREMAP_MAYMOVE) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "MREMAP_DONTUNMAP must be combined with MREMAP_MAYMOVE"
+            );
+        }
+        if new_size != old_size {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "MREMAP_DONTUNMAP requires new_size to equal old_size"
+            );
+        }
+    }
+
+    // Align `old_size` and `new_size` after checking them.
     let old_size = old_size.align_up(PAGE_SIZE);
     let new_size = new_size.align_up(PAGE_SIZE);
+
+    let action = if flags.contains(MremapFlags::MREMAP_DONTUNMAP) {
+        RemapOldMappingAction::Keep
+    } else {
+        RemapOldMappingAction::Unmap
+    };
 
     let user_space = ctx.user_space();
     let vmar = user_space.vmar();
 
-    if !flags.contains(MremapFlags::MREMAP_FIXED) && new_size <= old_size {
+    // When `MREMAP_DONTUNMAP` is set, we must move the mapping rather than
+    // shrinking in place, even though `new_size` == `old_size`.
+    if !flags.contains(MremapFlags::MREMAP_FIXED)
+        && new_size <= old_size
+        && action == RemapOldMappingAction::Unmap
+    {
         // We can shrink a old range which spans multiple mappings. See
         // <https://github.com/google/gvisor/blob/95d875276806484f974ce9e95556a561331f8e22/test/syscalls/linux/mremap.cc#L100-L117>.
         vmar.resize_mapping(old_addr, old_size, new_size, false)?;
@@ -63,25 +92,20 @@ fn do_sys_mremap(
 
     if flags.contains(MremapFlags::MREMAP_MAYMOVE) {
         if flags.contains(MremapFlags::MREMAP_FIXED) {
-            vmar.remap(old_addr, old_size, Some(new_addr), new_size)
+            vmar.remap(old_addr, old_size, Some(new_addr), new_size, action)
         } else {
-            vmar.remap(old_addr, old_size, None, new_size)
+            vmar.remap(old_addr, old_size, None, new_size, action)
         }
     } else {
         if flags.contains(MremapFlags::MREMAP_FIXED) {
             return_errno_with_message!(
                 Errno::EINVAL,
-                "mremap: `MREMAP_FIXED` specified without also specifying `MREMAP_MAYMOVE`"
+                "MREMAP_FIXED specified without also specifying MREMAP_MAYMOVE"
             );
         }
         // We can ensure that `new_size > old_size` here. Since we are enlarging
         // the old mapping, it is necessary to check whether the old range lies
         // in a single mapping.
-        //
-        // FIXME: According to <https://man7.org/linux/man-pages/man2/mremap.2.html>,
-        // if the `MREMAP_MAYMOVE` flag is not set, and the mapping cannot
-        // be expanded at the current `Vaddr`, we should return an `ENOMEM`.
-        // However, `resize_mapping` returns a `EACCES` in this case.
         vmar.resize_mapping(old_addr, old_size, new_size, true)?;
         Ok(old_addr)
     }
@@ -91,7 +115,6 @@ bitflags! {
     struct MremapFlags: i32 {
         const MREMAP_MAYMOVE = 1 << 0;
         const MREMAP_FIXED = 1 << 1;
-        // TODO: Add support for this flag, which exists since Linux 5.7.
-        // const MREMAP_DONTUNMAP = 1 << 2;
+        const MREMAP_DONTUNMAP = 1 << 2;
     }
 }

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -13,7 +13,9 @@ use ostd::mm::Vaddr;
 
 pub use self::{
     handle::VmarHandle,
-    vmar_impls::{RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo},
+    vmar_impls::{
+        RemapOldMappingAction, RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo,
+    },
 };
 
 pub const VMAR_LOWEST_ADDR: Vaddr = 0x001_0000; // 64 KiB is the Linux configurable default

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -130,6 +130,17 @@ impl VmMapping {
         vm_mapping
     }
 
+    pub(super) fn clone_range_for_remap_at(&self, range: Range<Vaddr>, va: Vaddr) -> VmMapping {
+        let offset_in_mapping = range.start - self.map_to_addr;
+        VmMapping {
+            map_size: NonZeroUsize::new(range.end - range.start).unwrap(),
+            map_to_addr: va,
+            mapped_mem: self.mapped_mem.dup_at_offset(offset_in_mapping),
+            path: self.path.clone(),
+            ..*self
+        }
+    }
+
     /// Returns the mapping's start address.
     pub fn map_to_addr(&self) -> Vaddr {
         self.map_to_addr
@@ -653,24 +664,12 @@ impl VmMapping {
         debug_assert!(self.map_to_addr < at && at < self.map_end());
         debug_assert!(at.is_multiple_of(PAGE_SIZE));
 
-        let (l_mapped_mem, r_mapped_mem) = match self.mapped_mem {
-            MappedMemory::Vmo(vmo) => {
-                let at_offset = vmo.offset() + (at - self.map_to_addr);
-                let r_mapped_vmo = vmo.dup_at_offset(at_offset);
-                (MappedMemory::Vmo(vmo), MappedMemory::Vmo(r_mapped_vmo))
-            }
-            MappedMemory::Anonymous => {
-                // For anonymous mappings, we create new anonymous mappings for the split parts
-                (MappedMemory::Anonymous, MappedMemory::Anonymous)
-            }
-            MappedMemory::Device => {
-                // For device memory mappings, we create new device memory mappings for the split parts
-                (MappedMemory::Device, MappedMemory::Device)
-            }
-        };
-
         let left_size = at - self.map_to_addr;
         let right_size = self.map_size.get() - left_size;
+
+        let r_mapped_mem = self.mapped_mem.dup_at_offset(left_size);
+        let l_mapped_mem = self.mapped_mem;
+
         let left = Self {
             map_size: NonZeroUsize::new(left_size).unwrap(),
             map_to_addr: self.map_to_addr,
@@ -831,6 +830,26 @@ impl MappedMemory {
         match self {
             MappedMemory::Anonymous => MappedMemory::Anonymous,
             MappedMemory::Vmo(v) => MappedMemory::Vmo(v.dup()),
+            MappedMemory::Device => MappedMemory::Device,
+        }
+    }
+
+    /// Duplicates the mapped memory capability for a sub-range.
+    ///
+    /// The `offset` is relative to the start of the mapping, and must be
+    /// page-aligned.
+    fn dup_at_offset(&self, offset: usize) -> Self {
+        debug_assert!(offset.is_multiple_of(PAGE_SIZE));
+
+        match self {
+            MappedMemory::Anonymous => MappedMemory::Anonymous,
+            MappedMemory::Vmo(vmo) => {
+                let new_offset = vmo
+                    .offset()
+                    .checked_add(offset)
+                    .expect("mapped VMO offset should not overflow");
+                MappedMemory::Vmo(vmo.dup_at_offset(new_offset))
+            }
             MappedMemory::Device => MappedMemory::Device,
         }
     }

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -8,7 +8,6 @@ mod protect;
 mod query;
 mod remap;
 mod unmap;
-
 use core::{
     array,
     ops::Range,
@@ -18,6 +17,7 @@ use core::{
 use align_ext::AlignExt;
 use aster_util::per_cpu_counter::PerCpuCounter;
 use ostd::{cpu::CpuId, mm::VmSpace};
+pub use remap::RemapOldMappingAction;
 
 use super::{
     VMAR_CAP_ADDR, VMAR_LOWEST_ADDR,

--- a/kernel/src/vm/vmar/vmar_impls/remap.rs
+++ b/kernel/src/vm/vmar/vmar_impls/remap.rs
@@ -5,6 +5,17 @@ use ostd::{mm::vm_space::VmQueriedItem, task::disable_preempt};
 use super::{RssDelta, Vmar, util::is_intersected};
 use crate::{prelude::*, vm::vmar::is_userspace_vaddr_range};
 
+/// Controls how the old mapping is handled during a `remap` operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemapOldMappingAction {
+    /// Remove the old mapping after moving pages.
+    Unmap,
+    /// Keep the old address range mapped with its original properties.
+    /// Its physical pages are moved away, so subsequent page faults at
+    /// the old address will allocate fresh pages.
+    Keep,
+}
+
 impl Vmar {
     /// Resizes the original mapping.
     ///
@@ -59,9 +70,14 @@ impl Vmar {
     /// - If `new_addr` is `None`, a new range of size `new_size` will be
     ///   allocated, and the original mapping will be moved there.
     ///
+    /// When `action` is [`RemapOldMappingAction::Keep`], the old mapping
+    /// stays in the tree with its original properties; see
+    /// [`RemapOldMappingAction::Keep`] for details.
+    ///
     /// # Panics
     ///
-    /// This method panics if `new_addr` is `None` and `new_size <= old_size`.
+    /// This method panics if `new_addr` is `None` and `new_size <= old_size`
+    /// (unless `action` is [`RemapOldMappingAction::Keep`]).
     /// Use `resize_mapping` instead in this case.
     pub fn remap(
         &self,
@@ -69,6 +85,7 @@ impl Vmar {
         old_size: usize,
         new_addr: Option<Vaddr>,
         new_size: usize,
+        action: RemapOldMappingAction,
     ) -> Result<Vaddr> {
         debug_assert_eq!(old_addr % PAGE_SIZE, 0);
         debug_assert_eq!(old_size % PAGE_SIZE, 0);
@@ -131,10 +148,11 @@ impl Vmar {
                 &mut rss_delta,
             )?
         } else {
-            debug_assert!(new_size > old_size);
-
-            // Fast path: expand the old mapping in place to the new size
-            if is_userspace_vaddr_range(old_addr, new_size)
+            // Fast path: expand the old mapping in place to the new size.
+            // Skip when `action` is `RemapOldMappingAction::Keep` since we must
+            // actually move pages and keep the old mapping in the tree.
+            if action == RemapOldMappingAction::Unmap
+                && is_userspace_vaddr_range(old_addr, new_size)
                 && inner
                     .alloc_free_region_exact(old_range.end, new_size - old_size)
                     .is_ok()
@@ -149,9 +167,9 @@ impl Vmar {
             inner.alloc_free_region(new_size, PAGE_SIZE)?
         };
 
-        // Create a new `VmMapping`.
-        let old_mapping = {
-            let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
+        // Create a new `VmMapping` at the target address.
+        let old_mapping_addr = inner.check_lies_in_single_mapping(old_addr, old_size)?;
+        let new_mapping = if action == RemapOldMappingAction::Unmap {
             let vm_mapping = inner.remove(&old_mapping_addr).unwrap();
             let (left, old_mapping, right) = vm_mapping.split_range(&old_range);
             if let Some(left) = left {
@@ -160,10 +178,13 @@ impl Vmar {
             if let Some(right) = right {
                 inner.insert_without_try_merge(right);
             }
-            old_mapping
+            // Note that we have ensured that `new_size >= old_size` at the beginning.
+            old_mapping.clone_for_remap_at(new_range.start)
+        } else {
+            let old_mapping = inner.vm_mappings.find_one(&old_mapping_addr).unwrap();
+            old_mapping.clone_range_for_remap_at(old_addr..old_addr + old_size, new_range.start)
         };
-        // Note that we have ensured that `new_size >= old_size` at the beginning.
-        let new_mapping = old_mapping.clone_for_remap_at(new_range.start);
+
         inner.insert_try_merge(new_mapping.enlarge(new_size - old_size));
 
         let preempt_guard = disable_preempt();

--- a/test/initramfs/src/regression/memory/mmap/mmap_and_mremap.c
+++ b/test/initramfs/src/regression/memory/mmap/mmap_and_mremap.c
@@ -98,7 +98,7 @@ FN_TEST(mmap_and_mremap_fixed)
 			       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
 	strcpy(addr1, content);
 
-	// Unmap a target region to ensure we know it's free
+	// Unmap a target region to ensure we know it's free.
 	char *addr2 = addr1 + PAGE_SIZE;
 	TEST_SUCC(munmap(addr2, PAGE_SIZE)); // free it for mremap
 
@@ -108,7 +108,7 @@ FN_TEST(mmap_and_mremap_fixed)
 		 _ret == addr2);
 	TEST_RES(strcmp(addr2, content), _ret == 0);
 
-	// Remap from the second address to the first address
+	// Remap from the second address to the first address.
 	TEST_RES(mremap(addr2, PAGE_SIZE, PAGE_SIZE,
 			MREMAP_MAYMOVE | MREMAP_FIXED, addr1),
 		 _ret == addr1);
@@ -203,5 +203,111 @@ FN_TEST(mremap_may_fail_after_unmap)
 		   EFAULT);
 
 	TEST_SUCC(munmap(addr, 5 * PAGE_SIZE));
+}
+END_TEST()
+
+FN_TEST(mremap_dontunmap)
+{
+	char *old_addr = TEST_SUCC(mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+					MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+	strcpy(old_addr, "hello");
+
+	// `MREMAP_DONTUNMAP` without `MREMAP_MAYMOVE` should fail.
+	TEST_ERRNO(mremap(old_addr, PAGE_SIZE, PAGE_SIZE, MREMAP_DONTUNMAP, 0),
+		   EINVAL);
+
+	// `MREMAP_DONTUNMAP` with a different size should fail.
+	TEST_ERRNO(mremap(old_addr, PAGE_SIZE, 2 * PAGE_SIZE,
+			  MREMAP_MAYMOVE | MREMAP_DONTUNMAP, 0),
+		   EINVAL);
+
+	// `MREMAP_DONTUNMAP` with unaligned sizes that would align
+	// to the same page.
+	TEST_ERRNO(mremap(old_addr, 1, PAGE_SIZE,
+			  MREMAP_MAYMOVE | MREMAP_DONTUNMAP, 0),
+		   EINVAL);
+
+	// Basic `MREMAP_MAYMOVE | MREMAP_DONTUNMAP`.
+	char *new_addr =
+		TEST_SUCC(mremap(old_addr, PAGE_SIZE, PAGE_SIZE,
+				 MREMAP_MAYMOVE | MREMAP_DONTUNMAP, 0));
+	TEST_RES(strcmp(new_addr, "hello"), _ret == 0);
+
+	// The old address is still mapped (not SIGSEGV).
+	TEST_RES(old_addr[0], _ret == '\0');
+	TEST_RES(old_addr[1], _ret == '\0');
+
+	// `MREMAP_DONTUNMAP | MREMAP_FIXED`: move to a specific address,
+	// keep the old mapping.
+	char *target = TEST_SUCC(mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+				      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+	TEST_SUCC(munmap(target, PAGE_SIZE));
+	strcpy(new_addr, "fixed");
+	char *fixed_new = TEST_SUCC(mremap(
+		new_addr, PAGE_SIZE, PAGE_SIZE,
+		MREMAP_MAYMOVE | MREMAP_DONTUNMAP | MREMAP_FIXED, target));
+	TEST_RES(fixed_new == target, _ret == 1);
+	TEST_RES(strcmp(fixed_new, "fixed"), _ret == 0);
+
+	TEST_SUCC(munmap(old_addr, PAGE_SIZE));
+	TEST_SUCC(munmap(fixed_new, PAGE_SIZE));
+}
+END_TEST()
+
+FN_TEST(mremap_dontunmap_trim)
+{
+	// `MREMAP_DONTUNMAP` where `old_size` is smaller than the full mapping.
+	char *addr = TEST_SUCC(mmap(NULL, 3 * PAGE_SIZE, PROT_READ | PROT_WRITE,
+				    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+	strcpy(addr, "left");
+	strcpy(addr + PAGE_SIZE, "middle");
+	strcpy(addr + 2 * PAGE_SIZE, "right");
+
+	// Move only the middle page.
+	char *new_addr =
+		TEST_SUCC(mremap(addr + PAGE_SIZE, PAGE_SIZE, PAGE_SIZE,
+				 MREMAP_MAYMOVE | MREMAP_DONTUNMAP, 0));
+	TEST_RES(strcmp(new_addr, "middle"), _ret == 0);
+
+	// The old address range is still mapped and reads as zero.
+	TEST_RES(addr[PAGE_SIZE], _ret == '\0');
+
+	// Left and right pages are untouched.
+	TEST_RES(strcmp(addr, "left"), _ret == 0);
+	TEST_RES(strcmp(addr + 2 * PAGE_SIZE, "right"), _ret == 0);
+
+	TEST_SUCC(munmap(new_addr, PAGE_SIZE));
+	TEST_SUCC(munmap(addr, 3 * PAGE_SIZE));
+}
+END_TEST()
+
+FN_TEST(mremap_dontunmap_file_backed)
+{
+	const char *filename = "mremap_dontunmap_file";
+	int fd = TEST_SUCC(open(filename, O_CREAT | O_RDWR, 0600));
+	TEST_SUCC(write(fd, "filecontent", 11));
+
+	char *addr = TEST_SUCC(mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+				    MAP_PRIVATE, fd, 0));
+	TEST_SUCC(close(fd));
+	strcpy(addr, "filecontent");
+
+	// File-backed `DONTUNMAP`: move pages, keep old file-backed mapping.
+	char *new_addr =
+		TEST_SUCC(mremap(addr, PAGE_SIZE, PAGE_SIZE,
+				 MREMAP_MAYMOVE | MREMAP_DONTUNMAP, 0));
+	TEST_RES(strcmp(new_addr, "filecontent"), _ret == 0);
+
+	// The old address is still a file-backed mapping, and accessing it
+	// reads from the file's page cache.
+	char buf[12] = {};
+	memcpy(buf, addr, 11);
+	buf[11] = '\0';
+	TEST_RES(strcmp(buf, "filecontent"), _ret == 0);
+
+	TEST_SUCC(munmap(new_addr, PAGE_SIZE));
+	TEST_SUCC(munmap(addr, PAGE_SIZE));
+	TEST_SUCC(munmap(new_addr, PAGE_SIZE));
+	TEST_SUCC(unlink(filename));
 }
 END_TEST()


### PR DESCRIPTION
### Summary

- **Feature**: Implement the `MREMAP_DONTUNMAP` flag for the `mremap` syscall (Linux 5.7+). When combined with `MREMAP_MAYMOVE`, physical pages are moved to a new virtual address while the old address remains mapped as anonymous zero-fill-on-demand memory. A new `RemapOldMappingAction` enum (`Keep`/`Unmap`) replaces a bare boolean parameter for self-documenting call sites.

- **Refactor**: Replace the `dont_unmap: bool` parameter of `Vmar::remap()` with a `RemapOldMappingAction` enum. Move `is_userspace_vaddr_range` from `fn` to `pub(crate)` for use by the syscall handler.

- **Fix**: Add `new_addr` page-alignment and userspace-range validation at the syscall boundary when `MREMAP_FIXED` is set, catching invalid arguments early with `EINVAL` rather than descending into VM internals. Update the outdated FIXME comment that incorrectly claimed `resize_mapping` returns `EACCES`.

- **Test**: Add 6 regression-test cases for `MREMAP_DONTUNMAP` covering basic usage (content moved, old address zero-filled), error paths (without `MAYMOVE`, mismatched sizes), and combined usage with `MREMAP_FIXED`. Unblock 3 gVisor `Copy`-variant tests (`InPlace_Copy`, `MayMove_Copy`, `MustMove_Copy`) from the blocklist.

- **Docs**: Add the `MREMAP_DONTUNMAP` flag variant to the SCML compatibility documentation.