### PR TITLE
Remove redundant fences in RISC-V DMA sync

### DIFF
--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -145,10 +145,6 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(range: Range<Vaddr>) {
             }
         }
     }
-
-    // Ensure that all cache operations have completed before proceeding.
-    // SAFETY: Performing a memory fence is always safe.
-    unsafe { core::arch::asm!("fence rw, rw", options(nostack)) };
 }
 
 /// Activates the given root-level page table.

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -121,12 +121,12 @@ pub(crate) fn can_sync_dma() -> bool {
 ///  - the virtual address range and DMA direction correspond correctly to a
 ///    DMA region;
 ///  - `can_sync_dma()` is `true`.
-pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(range: Range<Vaddr>) {
+pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(mut range: Range<Vaddr>) {
     debug_assert!(can_sync_dma());
 
     static CMO_MANAGEMENT_BLOCK_SIZE: Once<usize> = Once::new();
     let cmo_management_block_size = *CMO_MANAGEMENT_BLOCK_SIZE.call_once(|| {
-        DEVICE_TREE
+        let block_size = DEVICE_TREE
             .get()
             .unwrap()
             .cpus()
@@ -135,8 +135,14 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(range: Range<Vaddr>) {
             .property("riscv,cbom-block-size")
             .expect("Failed to find `riscv,cbom-block-size` property of the CPU node")
             .as_usize()
-            .expect("Failed to parse `riscv,cbom-block-size` property of the CPU node")
+            .expect("Failed to parse `riscv,cbom-block-size` property of the CPU node");
+        assert!(block_size.is_power_of_two());
+        assert!(block_size <= PAGE_SIZE);
+        block_size
     });
+
+    // Start at an aligned address, so the following loop can cover every byte in the range.
+    range.start &= !(cmo_management_block_size - 1);
 
     for addr in range.step_by(cmo_management_block_size) {
         // Performing cache maintenance operations is required for correctness

--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -153,10 +153,6 @@ pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(range: Range<Vaddr>) {
             }
         }
     }
-
-    // Ensure that all cache operations have completed before proceeding.
-    // SAFETY: Performing a memory fence is always safe.
-    unsafe { core::arch::asm!("fence rw, rw", options(nostack)) };
 }
 
 /// Activates the given root-level page table.


### PR DESCRIPTION
The fence is added in https://github.com/asterinas/asterinas/pull/2299, but I can't find any related discussions there. (cc @junyang-zh and @jellllly420 )

According to the RISC-V docs, https://docs.riscv.org/reference/isa/v20260120/unpriv/cmo.html#20-1-4-1-1-preserved-program-order says:
> For cache-block management instructions, the resulting invalidate, clean, and flush operations behave as stores in the PPO rules subject to one additional overlapping address rule. Specifically, if a precedes b in program order, then a will precede b in the global memory order if:
> a is an invalidate, clean, or flush, b is a load, and a and b access overlapping memory addresses

There are two cases:
 1.
```
sync_from_device(); // cbo.inv
read_dma_region(); // memory loads
```

The matches the additional rule as quoted above:
> a is an invalidate, clean, or flush, b is a load, and a and b access overlapping memory addresses

So the program order is preserved.

 2.
```
write_dma_region(); // memory stores
sync_to_device(); // cbo.clean
```

In this case, the rule is (https://docs.riscv.org/reference/isa/v20260120/unpriv/rvwmo.html#18-1-1-3-preserved-program-order):
> memory operation a precedes memory operation b in preserved program order (and hence also in the global memory order) if a precedes b in program order, a and b both access regular main memory (rather than I/O regions), and any of the following hold:
> Overlapping-Address Orderings:
> b is a store, and a and b access overlapping memory addresses

where `cbo.clean` is a "store" operation, as quoted at the beginning:
> the resulting invalidate, clean, and flush operations **behave as stores in the PPO rules** subject to one additional overlapping address rule

So the program order is also preserved.

---

The Linux implementation does not have any `fence`s. See:
 1. https://elixir.bootlin.com/linux/v7.1.2/source/arch/riscv/mm/dma-noncoherent.c#L18-L115
 2. https://elixir.bootlin.com/linux/v7.1.2/source/arch/riscv/include/asm/errata_list.h#L101-L115