### PR TITLE
Add `/proc/sys/vm/mmap_min_addr`

### DIFF
--- a/kernel/src/fs/fs_impls/procfs/sys/vm/mmap_min_addr.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/vm/mmap_min_addr.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::mkmod,
+        procfs::template::{ProcFile, ProcFileOps},
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    vm::vmar::VMAR_LOWEST_ADDR,
+};
+
+/// Represents the inode at `/proc/sys/vm/mmap_min_addr`.
+pub struct MmapMinAddrFileOps;
+
+impl MmapMinAddrFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/security/min_addr.c#L52>
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for MmapMinAddrFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        writeln!(printer, "{}", VMAR_LOWEST_ADDR)?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+        warn!("writing to `/proc/sys/vm/mmap_min_addr` is not supported");
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "writing to `/proc/sys/vm/mmap_min_addr` is not supported"
+        );
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/sys/vm/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/sys/vm/mod.rs
@@ -1,45 +1,42 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use self::{fs::FsDirOps, kernel::KernelDirOps};
-use super::{
-    StaticEntry,
-    template::{ReaddirEntry, listed_entries_from_table, visit_listed_entries},
-};
 use crate::{
     fs::{
         file::{InodeType, mkmod},
         procfs::{
-            sys::vm::VmDirOps,
-            template::{ProcDir, ProcDirOps, lookup_child_from_table},
+            ProcDir, StaticEntry,
+            sys::vm::mmap_min_addr::MmapMinAddrFileOps,
+            template::{
+                ProcDirOps, ReaddirEntry, listed_entries_from_table, lookup_child_from_table,
+                visit_listed_entries,
+            },
         },
         vfs::inode::Inode,
     },
     prelude::*,
 };
 
-mod fs;
-mod kernel;
-mod vm;
+mod mmap_min_addr;
 
-/// Represents the inode at `/proc/sys`.
-pub struct SysDirOps;
+/// Represents the inode at `/proc/sys/vm`.
+pub struct VmDirOps;
 
-impl SysDirOps {
+impl VmDirOps {
     pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
         // Reference:
-        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/proc_sysctl.c#L1566>
-        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/generic.c#L488-L489>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/security/min_addr.c#L59>
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/proc_sysctl.c#L978>
         ProcDir::new(Self, parent, mkmod!(a+rx))
     }
 
-    const STATIC_ENTRIES: &'static [StaticEntry] = &[
-        ("fs", InodeType::Dir, FsDirOps::new_inode),
-        ("kernel", InodeType::Dir, KernelDirOps::new_inode),
-        ("vm", InodeType::Dir, VmDirOps::new_inode),
-    ];
+    const STATIC_ENTRIES: &'static [StaticEntry] = &[(
+        "mmap_min_addr",
+        InodeType::File,
+        MmapMinAddrFileOps::new_inode,
+    )];
 }
 
-impl ProcDirOps for SysDirOps {
+impl ProcDirOps for VmDirOps {
     fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
         if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
             (f)(this_dir.this_weak().clone())

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -558,7 +558,7 @@ impl Credentials_ {
         if self.securebits().no_cap_ambient_raise() {
             return_errno_with_message!(
                 Errno::EPERM,
-                "raising ambient capabilities is forbidden by securebits"
+                "raising ambient capabilities is forbidden by secure bits"
             );
         }
 
@@ -567,7 +567,7 @@ impl Credentials_ {
         {
             return_errno_with_message!(
                 Errno::EPERM,
-                "capability must be present in both permitted and inheritable sets"
+                "an ambient capability must be both permitted and inheritable"
             );
         }
 

--- a/kernel/src/syscall/prctl.rs
+++ b/kernel/src/syscall/prctl.rs
@@ -185,10 +185,13 @@ enum PrctlCmd {
     PR_CAP_AMBIENT(CapAmbientCmd),
 }
 
-const PR_CAP_AMBIENT_IS_SET: u64 = 1;
-const PR_CAP_AMBIENT_RAISE: u64 = 2;
-const PR_CAP_AMBIENT_LOWER: u64 = 3;
-const PR_CAP_AMBIENT_CLEAR_ALL: u64 = 4;
+#[repr(u64)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+enum Dumpable {
+    Disable = 0, /* No setuid dumping */
+    User = 1,    /* Dump as user of process */
+    Root = 2,    /* Dump as root */
+}
 
 #[derive(Clone, Copy, Debug)]
 enum CapAmbientCmd {
@@ -196,14 +199,6 @@ enum CapAmbientCmd {
     Raise(CapSet),
     Lower(CapSet),
     ClearAll,
-}
-
-#[repr(u64)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
-enum Dumpable {
-    Disable = 0, /* No setuid dumping */
-    User = 1,    /* Dump as user of process */
-    Root = 2,    /* Dump as root */
 }
 
 impl PrctlCmd {
@@ -247,20 +242,26 @@ impl PrctlCmd {
 }
 
 impl CapAmbientCmd {
+    // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/include/uapi/linux/prctl.h#L196-L199>
+    const PR_CAP_AMBIENT_IS_SET: u64 = 1;
+    const PR_CAP_AMBIENT_RAISE: u64 = 2;
+    const PR_CAP_AMBIENT_LOWER: u64 = 3;
+    const PR_CAP_AMBIENT_CLEAR_ALL: u64 = 4;
+
     fn from_args(operation: u64, capability: u64, arg4: u64, arg5: u64) -> Result<Self> {
         if arg4 != 0 || arg5 != 0 {
             return_errno_with_message!(Errno::EINVAL, "unused PR_CAP_AMBIENT arguments are not 0");
         }
 
         match operation {
-            PR_CAP_AMBIENT_IS_SET => Ok(Self::IsSet(parse_capability(capability)?)),
-            PR_CAP_AMBIENT_RAISE => Ok(Self::Raise(parse_capability(capability)?)),
-            PR_CAP_AMBIENT_LOWER => Ok(Self::Lower(parse_capability(capability)?)),
-            PR_CAP_AMBIENT_CLEAR_ALL => {
+            Self::PR_CAP_AMBIENT_IS_SET => Ok(Self::IsSet(parse_capability(capability)?)),
+            Self::PR_CAP_AMBIENT_RAISE => Ok(Self::Raise(parse_capability(capability)?)),
+            Self::PR_CAP_AMBIENT_LOWER => Ok(Self::Lower(parse_capability(capability)?)),
+            Self::PR_CAP_AMBIENT_CLEAR_ALL => {
                 if capability != 0 {
                     return_errno_with_message!(
                         Errno::EINVAL,
-                        "PR_CAP_AMBIENT_CLEAR_ALL requires capability to be 0"
+                        "PR_CAP_AMBIENT_CLEAR_ALL requires all arguments to be 0"
                     );
                 }
                 Ok(Self::ClearAll)

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -42,7 +42,6 @@ ProcSysKernelKeysMax.SetMaxKeys
 ProcSysKernelRandomUuid.Exists
 ProcSysKernelRandomUuid.DifferentEveryTime
 ProcSysVmMaxmapCount.HasNumericValue
-ProcSysVmMmapMinAddr.HasNumericValue
 ProcSysVmOvercommitMemory.HasNumericValue
 ProcTask.ChildTaskDir
 ProcTask.CommCanSetPeerThreadName

--- a/test/initramfs/src/regression/fs/utimensat/utimensat.c
+++ b/test/initramfs/src/regression/fs/utimensat/utimensat.c
@@ -70,7 +70,7 @@ FN_TEST(legacy_null_pathname_with_nonzero_flag_returns_einval)
 }
 END_TEST()
 
-FN_TEST(utimensat_null_pathname_with_o_path_returns_ebadf)
+FN_TEST(legacy_null_pathname_with_o_path_returns_ebadf)
 {
 	int opath_fd = TEST_SUCC(open(TEST_FILE, O_PATH));
 	struct timespec times[2] = {

--- a/test/initramfs/src/regression/memory/mmap/mmap_err.c
+++ b/test/initramfs/src/regression/memory/mmap/mmap_err.c
@@ -182,30 +182,6 @@ FN_TEST(unaligned_addr)
 }
 END_TEST()
 
-FN_TEST(overflow_offset)
-{
-	size_t offset = -(size_t)PAGE_SIZE - PAGE_SIZE;
-	int i;
-	void *addr;
-
-	for (i = -1; i <= 1; ++i) {
-		TEST_ERRNO(mmap(valid_addr, PAGE_SIZE + i, PROT_READ,
-				MAP_PRIVATE, fd, offset),
-			   EOVERFLOW);
-		TEST_ERRNO(mmap(valid_addr, PAGE_SIZE * 2 + i, PROT_READ,
-				MAP_PRIVATE, fd, offset),
-			   EOVERFLOW);
-
-		addr = TEST_SUCC(mmap(valid_addr, PAGE_SIZE + i, PROT_READ,
-				      MAP_PRIVATE | MAP_ANONYMOUS, fd, offset));
-		TEST_SUCC(munmap(addr, PAGE_SIZE + i));
-		addr = TEST_SUCC(mmap(valid_addr, PAGE_SIZE * 2 + i, PROT_READ,
-				      MAP_PRIVATE | MAP_ANONYMOUS, fd, offset));
-		TEST_SUCC(munmap(addr, PAGE_SIZE * 2 + i));
-	}
-}
-END_TEST()
-
 FN_TEST(kernel_addr)
 {
 	void *addr = (void *)0xffffffffffff0000ul;
@@ -233,6 +209,30 @@ FN_TEST(kernel_addr)
 	TEST_ERRNO(mmap(valid_addr - 1, 512, PROT_NONE,
 			MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, 0, 0),
 		   EINVAL);
+}
+END_TEST()
+
+FN_TEST(overflow_offset)
+{
+	size_t offset = -(size_t)PAGE_SIZE - PAGE_SIZE;
+	int i;
+	void *addr;
+
+	for (i = -1; i <= 1; ++i) {
+		TEST_ERRNO(mmap(valid_addr, PAGE_SIZE + i, PROT_READ,
+				MAP_PRIVATE, fd, offset),
+			   EOVERFLOW);
+		TEST_ERRNO(mmap(valid_addr, PAGE_SIZE * 2 + i, PROT_READ,
+				MAP_PRIVATE, fd, offset),
+			   EOVERFLOW);
+
+		addr = TEST_SUCC(mmap(valid_addr, PAGE_SIZE + i, PROT_READ,
+				      MAP_PRIVATE | MAP_ANONYMOUS, fd, offset));
+		TEST_SUCC(munmap(addr, PAGE_SIZE + i));
+		addr = TEST_SUCC(mmap(valid_addr, PAGE_SIZE * 2 + i, PROT_READ,
+				      MAP_PRIVATE | MAP_ANONYMOUS, fd, offset));
+		TEST_SUCC(munmap(addr, PAGE_SIZE * 2 + i));
+	}
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/memory/mmap/mmap_err.c
+++ b/test/initramfs/src/regression/memory/mmap/mmap_err.c
@@ -9,15 +9,21 @@
 
 #define PAGE_SIZE 4096
 
-// The value in `/proc/sys/vm/mmap_min_addr`.
-#define MMAP_MIN_ADDR ((void *)65536)
-
+static void *mmap_min_addr;
 static void *valid_addr;
 static void *avail_addr;
 static int fd;
 
 FN_SETUP(init)
 {
+	FILE *fp;
+	unsigned long val;
+
+	fp = CHECK_WITH(fopen("/proc/sys/vm/mmap_min_addr", "r"), _ret != NULL);
+	CHECK_WITH(fscanf(fp, "%lu", &val), _ret == 1);
+	CHECK(fclose(fp));
+	mmap_min_addr = (void *)val;
+
 	valid_addr = CHECK_WITH(mmap(NULL, PAGE_SIZE * 4, PROT_READ,
 				     MAP_PRIVATE | MAP_ANONYMOUS, 0, 0),
 				_ret != MAP_FAILED);
@@ -116,19 +122,19 @@ FN_TEST(underflow_addr)
 	void *addr2;
 
 	// `mmap` without MAP_FIXED. The hint address will be rounded
-	// to MMAP_MIN_ADDR, unless it is in the first page, in which
+	// to `mmap_min_addr`, unless it is in the first page, in which
 	// case the hint will be ignored.
 	addr2 = TEST_RES(mmap(addr, PAGE_SIZE, PROT_READ,
 			      MAP_PRIVATE | MAP_ANONYMOUS, 0, 0),
-			 _ret == MMAP_MIN_ADDR);
+			 _ret == mmap_min_addr);
 	TEST_SUCC(munmap(addr2, PAGE_SIZE));
 	addr2 = TEST_RES(mmap(addr + 1, PAGE_SIZE, PROT_READ,
 			      MAP_PRIVATE | MAP_ANONYMOUS, 0, 0),
-			 _ret == MMAP_MIN_ADDR);
+			 _ret == mmap_min_addr);
 	TEST_SUCC(munmap(addr2, PAGE_SIZE));
 	addr2 = TEST_RES(mmap(addr - 1, PAGE_SIZE, PROT_READ,
 			      MAP_PRIVATE | MAP_ANONYMOUS, 0, 0),
-			 _ret != MMAP_MIN_ADDR);
+			 _ret != mmap_min_addr);
 	TEST_SUCC(munmap(addr2, PAGE_SIZE));
 
 	TEST_ERRNO(mmap(addr, PAGE_SIZE, PROT_READ,

--- a/test/initramfs/src/regression/security/capability/ambient.c
+++ b/test/initramfs/src/regression/security/capability/ambient.c
@@ -84,10 +84,11 @@ FN_TEST(ambient_raise_and_query)
 {
 	TEST_SUCC(reset_capability_state());
 
-	// CAP_SYS_ADMIN must be in both permitted and inheritable to raise.
-	// As root, permitted already has it. Add it to inheritable.
+	// CAP_SYS_ADMIN must be both permitted and inheritable to raise.
+	// As root, the permitted set already has it. Make it inheritable.
 	TEST_SUCC(add_inheritable(CAP_SYS_ADMIN));
 
+	// Raise the capability.
 	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
 			0));
 	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
@@ -104,10 +105,13 @@ END_TEST()
 FN_TEST(ambient_lower)
 {
 	TEST_SUCC(reset_capability_state());
+
+	// Raise the capability first.
 	TEST_SUCC(add_inheritable(CAP_SYS_ADMIN));
 	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
 			0));
 
+	// Lower the capability.
 	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER, CAP_SYS_ADMIN, 0,
 			0));
 	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
@@ -127,13 +131,15 @@ FN_TEST(ambient_clear_all)
 	// Raise a few capabilities first.
 	TEST_SUCC(add_inheritable(CAP_SYS_ADMIN));
 	TEST_SUCC(add_inheritable(CAP_NET_BIND_SERVICE));
-
 	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_ADMIN, 0,
 			0));
 	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
 			CAP_NET_BIND_SERVICE, 0, 0));
 	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_SYS_ADMIN, 0,
 		       0),
+		 _ret == 1);
+	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
+		       CAP_NET_BIND_SERVICE, 0, 0),
 		 _ret == 1);
 
 	// Clear all.
@@ -153,9 +159,8 @@ FN_TEST(ambient_raise_requires_inheritable)
 {
 	TEST_SUCC(reset_capability_state());
 
-	// Remove CAP_NET_RAW from inheritable, then try to raise it.
+	// Remove CAP_NET_RAW from the inheritable set, then try to raise it.
 	TEST_SUCC(remove_inheritable(CAP_NET_RAW));
-
 	TEST_ERRNO(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_NET_RAW, 0,
 			 0),
 		   EPERM);
@@ -190,7 +195,7 @@ FN_TEST(ambient_cleared_on_inheritable_drop)
 {
 	TEST_SUCC(reset_capability_state());
 
-	// Raise CAP_NET_BIND_SERVICE into ambient.
+	// Raise CAP_NET_BIND_SERVICE into the ambient set.
 	TEST_SUCC(add_inheritable(CAP_NET_BIND_SERVICE));
 	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
 			CAP_NET_BIND_SERVICE, 0, 0));
@@ -198,8 +203,8 @@ FN_TEST(ambient_cleared_on_inheritable_drop)
 		       CAP_NET_BIND_SERVICE, 0, 0),
 		 _ret == 1);
 
-	// Remove it from inheritable; it should automatically vanish from
-	// ambient.
+	// Remove it from the inheritable set. It should automatically
+	// vanish from the ambient set.
 	TEST_SUCC(remove_inheritable(CAP_NET_BIND_SERVICE));
 	TEST_RES(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
 		       CAP_NET_BIND_SERVICE, 0, 0),
@@ -241,12 +246,12 @@ FN_TEST(ambient_inherited_across_fork)
 
 	pid = TEST_SUCC(fork());
 	if (pid == 0) {
-		// Child should inherit the parent's ambient set.
+		// Child should inherit parent's ambient set.
 		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
 				 CAP_NET_BIND_SERVICE, 0, 0),
 			   _ret == 1);
 
-		// Child clears its ambient; parent should be unaffected.
+		// Child clears its ambient set; parent should be unaffected.
 		CHECK(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0));
 		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
 				 CAP_NET_BIND_SERVICE, 0, 0),
@@ -281,7 +286,8 @@ FN_TEST(ambient_cleared_on_uid_transition)
 		CHECK(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
 			    CAP_NET_BIND_SERVICE, 0, 0));
 
-		// Transition root -> nobody; ambient must be cleared.
+		// The ambient set must be cleared on the user transition
+		// (root -> nobody).
 		CHECK(setuid(65534));
 		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
 				 CAP_NET_BIND_SERVICE, 0, 0),
@@ -306,8 +312,9 @@ FN_TEST(ambient_not_protected_by_keep_caps)
 		CHECK(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
 			    CAP_NET_BIND_SERVICE, 0, 0));
 
-		// Enable KEEP_CAPS. Ambient should still be cleared on
-		// root -> nobody because KEEP_CAPS does not protect ambient.
+		// Enable KEEPCAPS. The ambient set should still be cleared
+		// on the user transition (root -> nobody) because KEEPCAPS
+		// does not protect ambient capabilities.
 		CHECK(prctl(PR_SET_KEEPCAPS, 1));
 		CHECK(setuid(65534));
 		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET,
@@ -333,14 +340,14 @@ FN_TEST(ambient_raise_requires_permitted)
 
 		CHECK(add_inheritable(CAP_NET_RAW));
 
-		// Drop CAP_NET_RAW from effective and permitted.
+		// Drop CAP_NET_RAW from effective and permitted sets.
 		read_cap_data(cap_data);
 		cap_data[0].permitted &= ~(1U << CAP_NET_RAW);
 		cap_data[0].effective &= ~(1U << CAP_NET_RAW);
 		write_cap_data(cap_data);
 
-		// RAISE should fail because the capability is not in
-		// the permitted set.
+		// PR_CAP_AMBIENT_RAISE should fail because the capability
+		// is not in the permitted set.
 		CHECK_WITH(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
 				 CAP_NET_RAW, 0, 0),
 			   _ret == -1 && errno == EPERM);
@@ -374,11 +381,11 @@ FN_TEST(ambient_procfs_reflects_state)
 {
 	TEST_SUCC(reset_capability_state());
 
-	// Raise a capability and verify /proc/self/status reflects it.
 	TEST_SUCC(add_inheritable(CAP_NET_BIND_SERVICE));
+
+	// Raise a capability and verify /proc/self/status reflects it.
 	TEST_SUCC(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
 			CAP_NET_BIND_SERVICE, 0, 0));
-
 	TEST_RES(read_proc_capamb(),
 		 (_ret & (1ULL << CAP_NET_BIND_SERVICE)) != 0);
 


### PR DESCRIPTION
Add this file because gVisor will use it.
https://github.com/google/gvisor/blob/35db98496ee19ccfb41a4a01b8b588edb5060c09/pkg/sentry/platform/mmap_min_addr.go#L43-L46

In addition, it seems that I inserted the `kernel_addr` test in the wrong place in my previous PR (https://github.com/asterinas/asterinas/pull/3538). Sorry about that. I have just fixed this problem, together with some other minor fixes.
```patch
 FN_TEST(overflow_len)
 FN_TEST(zero_len)
 FN_TEST(overflow_addr)
 FN_TEST(underflow_addr)
 FN_TEST(unaligned_addr)
+FN_TEST(kernel_addr)
 FN_TEST(overflow_offset)
-FN_TEST(kernel_addr)
 FN_TEST(unaligned_offset)
 FN_TEST(mmap_flags)
```