### PR TITLE
Add io_uring subsystem

### DIFF
--- a/kernel/src/fs/file/file_handle.rs
+++ b/kernel/src/fs/file/file_handle.rs
@@ -103,6 +103,15 @@ pub trait FileLike: Pollable + Send + Sync + Any {
         return_errno_with_message!(Errno::ENODEV, "the file is not mappable");
     }
 
+    /// Resolves the mappable object and its internal offset for an `mmap` offset.
+    ///
+    /// Most files map one object directly, so the mmap offset is also the VMO
+    /// or device offset. Special files may use Linux-style magic mmap offsets
+    /// to select one of multiple internal objects.
+    fn mappable_at(&self, offset: usize) -> Result<(Mappable, usize)> {
+        Ok((self.mappable()?, offset))
+    }
+
     fn resize(&self, new_size: usize) -> Result<()> {
         return_errno_with_message!(Errno::EINVAL, "resize is not supported");
     }

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -279,6 +279,8 @@ pub enum IoUringOpcode {
     Nop = 0,
     ReadFixed = 4,
     WriteFixed = 5,
+    SendMsg = 9,
+    RecvMsg = 10,
     Read = 22,
     Write = 23,
     Send = 26,

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -269,3 +269,13 @@ pub enum IoUringOpcode {
     Read = 22,
     Write = 23,
 }
+
+/// `enum io_uring_register_op` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L652-L730>.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromInt)]
+pub enum IoUringRegisterOpcode {
+    RegisterBuffers = 0,
+    UnregisterBuffers = 1,
+}

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -281,6 +281,7 @@ pub enum IoUringOpcode {
     WriteFixed = 5,
     SendMsg = 9,
     RecvMsg = 10,
+    Accept = 13,
     Read = 22,
     Write = 23,
     Send = 26,

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -213,7 +213,7 @@ pub struct IoUringSqe {
     pub off: u64,
     pub addr: u64,
     pub len: u32,
-    pub rw_flags: u32,
+    pub op_flags: u32,
     pub user_data: u64,
     pub buf_index: u16,
     pub personality: u16,
@@ -236,6 +236,18 @@ bitflags! {
         const CQE_SKIP_SUCCESS = 1 << 6;
 
         const SUPPORTED = Self::ASYNC.bits;
+    }
+}
+
+impl IoUringSqeFlags {
+    pub fn from_user_bits(bits: u8) -> Result<Self> {
+        let flags = IoUringSqeFlags::from_bits(bits)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown SQE flags"))?;
+        if !flags.difference(IoUringSqeFlags::SUPPORTED).is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "SQE flags are unsupported");
+        }
+
+        Ok(flags)
     }
 }
 

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -281,6 +281,8 @@ pub enum IoUringOpcode {
     WriteFixed = 5,
     Read = 22,
     Write = 23,
+    Send = 26,
+    Recv = 27,
 }
 
 /// `enum io_uring_register_op` in Linux.

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -29,7 +29,9 @@ bitflags! {
         const SQE_MIXED = 1 << 19;
         const SQ_REWIND = 1 << 20;
 
-        const SUPPORTED = Self::CQSIZE.bits
+        const SUPPORTED = Self::SQPOLL.bits
+            | Self::SQ_AFF.bits
+            | Self::CQSIZE.bits
             | Self::CLAMP.bits
             | Self::SUBMIT_ALL.bits;
     }
@@ -60,9 +62,7 @@ bitflags! {
         const EXT_ARG_REG = 1 << 6;
         const NO_IOWAIT = 1 << 7;
 
-        const UNSUPPORTED = Self::SQ_WAKEUP.bits
-            | Self::SQ_WAIT.bits
-            | Self::EXT_ARG.bits
+        const UNSUPPORTED = Self::EXT_ARG.bits
             | Self::REGISTERED_RING.bits
             | Self::ABS_TIMER.bits
             | Self::EXT_ARG_REG.bits
@@ -258,6 +258,17 @@ pub const MAX_CQ_ENTRIES: u32 = 2 * MAX_SQ_ENTRIES;
 pub const IORING_OFF_SQ_RING: usize = 0;
 pub const IORING_OFF_CQ_RING: usize = 0x0800_0000;
 pub const IORING_OFF_SQES: usize = 0x1000_0000;
+
+bitflags! {
+    /// `sq_ring->flags` bits in Linux.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L576-L578>.
+    pub struct SqRingFlags: u32 {
+        const NEED_WAKEUP = 1 << 0;
+        const CQ_OVERFLOW = 1 << 1;
+        const TASKRUN = 1 << 2;
+    }
+}
 
 /// `enum io_uring_op` in Linux.
 ///

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -266,6 +266,8 @@ pub const IORING_OFF_SQES: usize = 0x1000_0000;
 #[derive(Clone, Copy, Debug, PartialEq, TryFromInt)]
 pub enum IoUringOpcode {
     Nop = 0,
+    ReadFixed = 4,
+    WriteFixed = 5,
     Read = 22,
     Write = 23,
 }

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -282,6 +282,7 @@ pub enum IoUringOpcode {
     SendMsg = 9,
     RecvMsg = 10,
     Accept = 13,
+    Connect = 16,
     Read = 22,
     Write = 23,
     Send = 26,

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -266,4 +266,6 @@ pub const IORING_OFF_SQES: usize = 0x1000_0000;
 #[derive(Clone, Copy, Debug, PartialEq, TryFromInt)]
 pub enum IoUringOpcode {
     Nop = 0,
+    Read = 22,
+    Write = 23,
 }

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::*;
+
+bitflags! {
+    /// `IORING_SETUP_*` flags in Linux.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L171-L253>.
+    pub struct IoUringSetupFlags: u32 {
+        const IOPOLL = 1 << 0;
+        const SQPOLL = 1 << 1;
+        const SQ_AFF = 1 << 2;
+        const CQSIZE = 1 << 3;
+        const CLAMP = 1 << 4;
+        const ATTACH_WQ = 1 << 5;
+        const R_DISABLED = 1 << 6;
+        const SUBMIT_ALL = 1 << 7;
+        const COOP_TASKRUN = 1 << 8;
+        const TASKRUN_FLAG = 1 << 9;
+        const SQE128 = 1 << 10;
+        const CQE32 = 1 << 11;
+        const SINGLE_ISSUER = 1 << 12;
+        const DEFER_TASKRUN = 1 << 13;
+        const NO_MMAP = 1 << 14;
+        const REGISTERED_FD_ONLY = 1 << 15;
+        const NO_SQARRAY = 1 << 16;
+        const HYBRID_IOPOLL = 1 << 17;
+        const CQE_MIXED = 1 << 18;
+        const SQE_MIXED = 1 << 19;
+        const SQ_REWIND = 1 << 20;
+
+        const SUPPORTED = Self::CQSIZE.bits
+            | Self::CLAMP.bits
+            | Self::SUBMIT_ALL.bits;
+    }
+}
+
+impl IoUringSetupFlags {
+    pub fn from_user_bits(bits: u32) -> Result<Self> {
+        let flags = IoUringSetupFlags::from_bits(bits)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown io_uring_setup flags"))?;
+        if !flags.difference(IoUringSetupFlags::SUPPORTED).is_empty() {
+            return_errno_with_message!(Errno::EINVAL, "unsupported io_uring_setup flags");
+        }
+        Ok(flags)
+    }
+}
+
+bitflags! {
+    /// `IORING_ENTER_*` flags in Linux.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L599-L609>.
+    pub struct IoUringEnterFlags: u32 {
+        const GETEVENTS = 1 << 0;
+        const SQ_WAKEUP = 1 << 1;
+        const SQ_WAIT = 1 << 2;
+        const EXT_ARG = 1 << 3;
+        const REGISTERED_RING = 1 << 4;
+        const ABS_TIMER = 1 << 5;
+        const EXT_ARG_REG = 1 << 6;
+        const NO_IOWAIT = 1 << 7;
+
+        const UNSUPPORTED = Self::SQ_WAKEUP.bits
+            | Self::SQ_WAIT.bits
+            | Self::EXT_ARG.bits
+            | Self::REGISTERED_RING.bits
+            | Self::ABS_TIMER.bits
+            | Self::EXT_ARG_REG.bits
+            | Self::NO_IOWAIT.bits;
+    }
+}
+
+impl IoUringEnterFlags {
+    pub fn from_user_bits(bits: u32) -> Result<Self> {
+        let flags = Self::from_bits(bits)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown io_uring_enter flags"))?;
+        if flags.intersects(Self::UNSUPPORTED) {
+            return_errno_with_message!(Errno::EINVAL, "unsupported io_uring_enter flags");
+        }
+        Ok(flags)
+    }
+}
+
+bitflags! {
+    /// `io_uring_params->features` bits in Linux.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L630-L647>.
+    pub struct IoUringFeatures: u32 {
+        const SINGLE_MMAP = 1 << 0;
+        const NODROP = 1 << 1;
+        const SUBMIT_STABLE = 1 << 2;
+        const RW_CUR_POS = 1 << 3;
+        const CUR_PERSONALITY = 1 << 4;
+        const FAST_POLL = 1 << 5;
+        const POLL_32BITS = 1 << 6;
+        const SQPOLL_NONFIXED = 1 << 7;
+        const EXT_ARG = 1 << 8;
+        const NATIVE_WORKERS = 1 << 9;
+        const RSRC_TAGS = 1 << 10;
+        const CQE_SKIP = 1 << 11;
+        const LINKED_FILE = 1 << 12;
+        const REG_REG_RING = 1 << 13;
+        const RECVSEND_BUNDLE = 1 << 14;
+        const MIN_TIMEOUT = 1 << 15;
+        const RW_ATTR = 1 << 16;
+        const NO_IOWAIT = 1 << 17;
+    }
+}
+
+/// The fixed header of `struct io_rings` in Linux, before `cqes[]`.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/linux/io_uring_types.h#L156-L224>.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct IoRingMeta {
+    pub sq_head: u32,
+    pub sq_tail: u32,
+    pub cq_head: u32,
+    pub cq_tail: u32,
+    pub sq_ring_mask: u32,
+    pub cq_ring_mask: u32,
+    pub sq_ring_entries: u32,
+    pub cq_ring_entries: u32,
+    pub sq_dropped: u32,
+    pub sq_flags: u32,
+    pub cq_flags: u32,
+    pub cq_overflow: u32,
+    pub padding: [u8; 16],
+}
+
+impl IoRingMeta {
+    pub const fn new(sq_entries: u32, cq_entries: u32) -> Self {
+        Self {
+            sq_head: 0,
+            sq_tail: 0,
+            cq_head: 0,
+            cq_tail: 0,
+            sq_ring_mask: sq_entries - 1,
+            cq_ring_mask: cq_entries - 1,
+            sq_ring_entries: sq_entries,
+            cq_ring_entries: cq_entries,
+            sq_dropped: 0,
+            sq_flags: 0,
+            cq_flags: 0,
+            cq_overflow: 0,
+            padding: [0; 16],
+        }
+    }
+}
+
+/// `struct io_sqring_offsets` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L561-L571>.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct SqRingOffsets {
+    pub head: u32,
+    pub tail: u32,
+    pub ring_mask: u32,
+    pub ring_entries: u32,
+    pub flags: u32,
+    pub dropped: u32,
+    pub array: u32,
+    pub resv1: u32,
+    pub user_addr: u64,
+}
+
+/// `struct io_cqring_offsets` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L580-L590>.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct CqRingOffsets {
+    pub head: u32,
+    pub tail: u32,
+    pub ring_mask: u32,
+    pub ring_entries: u32,
+    pub overflow: u32,
+    pub cqes: u32,
+    pub flags: u32,
+    pub resv1: u32,
+    pub user_addr: u64,
+}
+
+/// `struct io_uring_params` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L614-L625>.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct IoUringParams {
+    pub sq_entries: u32,
+    pub cq_entries: u32,
+    pub flags: u32,
+    pub sq_thread_cpu: u32,
+    pub sq_thread_idle: u32,
+    pub features: u32,
+    pub wq_fd: u32,
+    pub resv: [u32; 3],
+    pub sq_off: SqRingOffsets,
+    pub cq_off: CqRingOffsets,
+}
+
+/// `struct io_uring_sqe` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L32-L120>.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct IoUringSqe {
+    pub opcode: u8,
+    pub flags: u8,
+    pub ioprio: u16,
+    pub fd: i32,
+    pub off: u64,
+    pub addr: u64,
+    pub len: u32,
+    pub rw_flags: u32,
+    pub user_data: u64,
+    pub buf_index: u16,
+    pub personality: u16,
+    pub splice_fd_in: i32,
+    pub addr3: u64,
+    pub pad2: [u64; 1],
+}
+
+bitflags! {
+    /// `sqe->flags` bits in Linux.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L143-L169>.
+    pub struct IoUringSqeFlags: u8 {
+        const FIXED_FILE = 1 << 0;
+        const IO_DRAIN = 1 << 1;
+        const IO_LINK = 1 << 2;
+        const IO_HARDLINK = 1 << 3;
+        const ASYNC = 1 << 4;
+        const BUFFER_SELECT = 1 << 5;
+        const CQE_SKIP_SUCCESS = 1 << 6;
+
+        const SUPPORTED = Self::ASYNC.bits;
+    }
+}
+
+/// `struct io_uring_cqe` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L500-L510>.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct IoUringCqe {
+    pub user_data: u64,
+    pub res: i32,
+    pub flags: u32,
+}
+
+// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/io_uring/io_uring.h#L170-L171>.
+pub const MAX_SQ_ENTRIES: u32 = 32 * 1024;
+pub const MAX_CQ_ENTRIES: u32 = 2 * MAX_SQ_ENTRIES;
+
+// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L548-L553>.
+pub const IORING_OFF_SQ_RING: usize = 0;
+pub const IORING_OFF_CQ_RING: usize = 0x0800_0000;
+pub const IORING_OFF_SQES: usize = 0x1000_0000;
+
+/// `enum io_uring_op` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/include/uapi/linux/io_uring.h#L255-L324>.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromInt)]
+pub enum IoUringOpcode {
+    Nop = 0,
+}

--- a/kernel/src/io_uring/c_types.rs
+++ b/kernel/src/io_uring/c_types.rs
@@ -277,6 +277,8 @@ bitflags! {
 #[derive(Clone, Copy, Debug, PartialEq, TryFromInt)]
 pub enum IoUringOpcode {
     Nop = 0,
+    Readv = 1,
+    Writev = 2,
     ReadFixed = 4,
     WriteFixed = 5,
     SendMsg = 9,

--- a/kernel/src/io_uring/io_context.rs
+++ b/kernel/src/io_uring/io_context.rs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::{cmp::min, fmt::Display};
+
+use super::c_types::{
+    CqRingOffsets, IORING_OFF_CQ_RING, IORING_OFF_SQ_RING, IORING_OFF_SQES, IoRingMeta,
+    IoUringCqe, IoUringFeatures, IoUringParams, IoUringSetupFlags, IoUringSqe, MAX_CQ_ENTRIES,
+    MAX_SQ_ENTRIES, SqRingOffsets,
+};
+use crate::{
+    events::IoEvents,
+    fs::{
+        file::{AccessMode, CreationFlags, FileLike, Mappable, file_table::FdFlags},
+        pseudofs::AnonInodeFs,
+        vfs::path::Path,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+    vm::page_cache::{Vmo, VmoOptions},
+};
+
+/// Owns the file-facing state and shared rings for one `io_uring` instance.
+pub struct IoUringContext {
+    ring_region: RingRegion,
+    sqes_region: SqeRegion,
+    pseudo_path: Path,
+}
+
+/// Backs the shared SQ/CQ ring mapping visible to userspace.
+///
+/// The region contains the fixed `IoRingMeta` header first, followed by the
+/// CQE array (`cqes`) and then the SQ array.
+struct RingRegion {
+    size: usize,
+    sq_array_offset: usize,
+    region: Arc<Vmo>,
+}
+
+struct SqeRegion {
+    size: usize,
+    region: Arc<Vmo>,
+}
+
+impl IoUringContext {
+    pub fn new(config: &IoUringSetupConfig, _ctx: &Context) -> Result<Arc<Self>> {
+        let ring_region = RingRegion::new(config.ring_size, config.sq_array_offset)?;
+        let sqes_region = SqeRegion::new(config.sqes_size)?;
+        let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[io_uring]".to_string());
+        let context = Arc::new(Self {
+            ring_region,
+            sqes_region,
+            pseudo_path,
+        });
+
+        let ring_meta = IoRingMeta::new(config.sq_entries, config.cq_entries);
+        context.ring_region.write_meta(&ring_meta)?;
+
+        Ok(context)
+    }
+
+    fn mmap_region(&self, offset: usize) -> Option<(Arc<Vmo>, usize)> {
+        self.ring_region
+            .mmap_region(offset)
+            .or_else(|| self.sqes_region.mmap_region(offset))
+    }
+}
+
+impl Pollable for IoUringContext {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
+impl FileLike for IoUringContext {
+    fn mappable(&self) -> Result<Mappable> {
+        let (mappable, _) = self.mappable_at(IORING_OFF_SQ_RING)?;
+        Ok(mappable)
+    }
+
+    fn mappable_at(&self, offset: usize) -> Result<(Mappable, usize)> {
+        let Some((region, region_offset)) = self.mmap_region(offset) else {
+            return_errno_with_message!(Errno::EINVAL, "invalid io_uring mmap offset");
+        };
+
+        Ok((Mappable::Vmo(region), region_offset))
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        AccessMode::O_RDWR
+    }
+
+    fn path(&self) -> &Path {
+        &self.pseudo_path
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
+        struct FdInfo {
+            ring: Arc<IoUringContext>,
+            fd_flags: FdFlags,
+        }
+
+        impl Display for FdInfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let mut flags = self.ring.status_flags().bits() | self.ring.access_mode() as u32;
+                if self.fd_flags.contains(FdFlags::CLOEXEC) {
+                    flags |= CreationFlags::O_CLOEXEC.bits();
+                }
+
+                writeln!(f, "pos:\t{}", 0)?;
+                writeln!(f, "flags:\t0{:o}", flags)?;
+                writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
+                writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())?;
+                writeln!(f, "SqThread:\t{}", -1)?;
+                writeln!(f, "SqThreadCpu:\t{}", -1)?;
+                writeln!(f, "UserFiles:\t{}", 0)?;
+                writeln!(f, "UserBufs:\t{}", 0)
+            }
+        }
+
+        Box::new(FdInfo {
+            ring: self,
+            fd_flags,
+        })
+    }
+}
+
+impl RingRegion {
+    fn new(size: usize, sq_array_offset: usize) -> Result<Self> {
+        Ok(Self {
+            size,
+            sq_array_offset,
+            region: VmoOptions::new(size).alloc()?,
+        })
+    }
+
+    fn write_meta(&self, meta: &IoRingMeta) -> Result<()> {
+        self.write_val(0, meta)
+    }
+
+    fn write_val<T: Pod>(&self, offset: usize, value: &T) -> Result<()> {
+        let mut reader = VmReader::from(value.as_bytes()).to_fallible();
+        self.region.write(offset, &mut reader)
+    }
+
+    fn mmap_region(&self, offset: usize) -> Option<(Arc<Vmo>, usize)> {
+        if let Some(region_offset) = offset_in_region(offset, IORING_OFF_SQ_RING, self.size) {
+            return Some((self.region.clone(), region_offset));
+        }
+        if let Some(region_offset) = offset_in_region(offset, IORING_OFF_CQ_RING, self.size) {
+            return Some((self.region.clone(), region_offset));
+        }
+
+        None
+    }
+}
+
+impl SqeRegion {
+    fn new(size: usize) -> Result<Self> {
+        Ok(Self {
+            size,
+            region: VmoOptions::new(size).alloc()?,
+        })
+    }
+
+    fn mmap_region(&self, offset: usize) -> Option<(Arc<Vmo>, usize)> {
+        let region_offset = offset_in_region(offset, IORING_OFF_SQES, self.size)?;
+        Some((self.region.clone(), region_offset))
+    }
+}
+
+fn offset_in_region(offset: usize, base: usize, size: usize) -> Option<usize> {
+    let region_offset = offset.checked_sub(base)?;
+    (region_offset < size).then_some(region_offset)
+}
+
+pub struct IoUringSetupConfig {
+    sq_entries: u32,
+    cq_entries: u32,
+    ring_size: usize,
+    sq_array_offset: usize,
+    sqes_size: usize,
+}
+
+impl IoUringSetupConfig {
+    pub fn new(entries: u32, params: &IoUringParams) -> Result<Self> {
+        if params.resv.iter().any(|reserved| *reserved != 0) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "io_uring_setup reserved fields are not zero"
+            );
+        }
+
+        let flags = IoUringSetupFlags::from_user_bits(params.flags)?;
+        let is_clamp = flags.contains(IoUringSetupFlags::CLAMP);
+        let sq_entries = calculate_entries(entries, MAX_SQ_ENTRIES, is_clamp)?;
+        let cq_entries = if flags.contains(IoUringSetupFlags::CQSIZE) {
+            let cq_entries = calculate_entries(params.cq_entries, MAX_CQ_ENTRIES, is_clamp)?;
+            if cq_entries < sq_entries {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "CQ ring must have at least as many entries as the SQ ring"
+                );
+            }
+            cq_entries
+        } else {
+            sq_entries * 2
+        };
+
+        let sq_array_offset =
+            size_of::<IoRingMeta>() + cq_entries as usize * size_of::<IoUringCqe>();
+        let ring_size = sq_array_offset + sq_entries as usize * size_of::<u32>();
+        let sqes_size = sq_entries as usize * size_of::<IoUringSqe>();
+
+        Ok(Self {
+            sq_entries,
+            cq_entries,
+            ring_size,
+            sq_array_offset,
+            sqes_size,
+        })
+    }
+
+    pub fn write_params(&self, params: &mut IoUringParams) {
+        params.sq_entries = self.sq_entries;
+        params.cq_entries = self.cq_entries;
+        let supported_features = IoUringFeatures::empty();
+        params.features = supported_features.bits();
+        params.wq_fd = 0;
+        params.resv = [0; 3];
+
+        params.sq_off = SqRingOffsets {
+            head: core::mem::offset_of!(IoRingMeta, sq_head) as u32,
+            tail: core::mem::offset_of!(IoRingMeta, sq_tail) as u32,
+            ring_mask: core::mem::offset_of!(IoRingMeta, sq_ring_mask) as u32,
+            ring_entries: core::mem::offset_of!(IoRingMeta, sq_ring_entries) as u32,
+            flags: core::mem::offset_of!(IoRingMeta, sq_flags) as u32,
+            dropped: core::mem::offset_of!(IoRingMeta, sq_dropped) as u32,
+            array: self.sq_array_offset as u32,
+            resv1: 0,
+            user_addr: 0,
+        };
+        params.cq_off = CqRingOffsets {
+            head: core::mem::offset_of!(IoRingMeta, cq_head) as u32,
+            tail: core::mem::offset_of!(IoRingMeta, cq_tail) as u32,
+            ring_mask: core::mem::offset_of!(IoRingMeta, cq_ring_mask) as u32,
+            ring_entries: core::mem::offset_of!(IoRingMeta, cq_ring_entries) as u32,
+            overflow: core::mem::offset_of!(IoRingMeta, cq_overflow) as u32,
+            cqes: size_of::<IoRingMeta>() as u32,
+            flags: core::mem::offset_of!(IoRingMeta, cq_flags) as u32,
+            resv1: 0,
+            user_addr: 0,
+        };
+    }
+}
+
+fn calculate_entries(entries: u32, max_entries: u32, is_clamp: bool) -> Result<u32> {
+    if entries == 0 {
+        return_errno_with_message!(Errno::EINVAL, "the ring entry count is zero");
+    }
+
+    let Some(rounded_entries) = entries.checked_next_power_of_two() else {
+        return_errno_with_message!(Errno::EINVAL, "the ring entry count overflows");
+    };
+    if rounded_entries <= max_entries {
+        return Ok(rounded_entries);
+    }
+    if is_clamp {
+        Ok(max_entries)
+    } else {
+        return_errno_with_message!(Errno::EINVAL, "the ring entry count is too large");
+    }
+}

--- a/kernel/src/io_uring/io_context.rs
+++ b/kernel/src/io_uring/io_context.rs
@@ -7,6 +7,7 @@ use core::{
     time::Duration,
 };
 
+use align_ext::AlignExt;
 use ostd::{
     cpu::{CpuId, CpuSet},
     sync::WaitQueue,
@@ -74,7 +75,7 @@ struct CqRing {
 /// Backs the shared SQ/CQ ring mapping visible to userspace.
 ///
 /// The region contains the fixed `IoRingMeta` header first, followed by the
-/// CQE array (`cqes`) and then the SQ array.
+/// CQE array (`cqes`) and then the cacheline-aligned SQ array.
 struct RingRegion {
     size: usize,
     sq_array_offset: usize,
@@ -737,8 +738,9 @@ impl IoUringSetupConfig {
             sq_entries * 2
         };
 
+        // TODO: add global "get cache alignment" method instead of using 64
         let sq_array_offset =
-            size_of::<IoRingMeta>() + cq_entries as usize * size_of::<IoUringCqe>();
+            (size_of::<IoRingMeta>() + cq_entries as usize * size_of::<IoUringCqe>()).align_up(64);
         let ring_size = sq_array_offset + sq_entries as usize * size_of::<u32>();
         let sqes_size = sq_entries as usize * size_of::<IoUringSqe>();
 

--- a/kernel/src/io_uring/io_context.rs
+++ b/kernel/src/io_uring/io_context.rs
@@ -14,6 +14,7 @@ use super::{
         IoUringCqe, IoUringFeatures, IoUringParams, IoUringSetupFlags, IoUringSqe,
         MAX_CQ_ENTRIES, MAX_SQ_ENTRIES, SqRingOffsets,
     },
+    ops,
     utils::Completion,
 };
 use crate::{
@@ -156,8 +157,18 @@ impl IoUringContext {
     }
 
     fn submit_sqe(&self, sqe: IoUringSqe) -> Result<()> {
-        let err = Error::with_message(Errno::EINVAL, "unsupported io_uring opcode");
-        self.post_completion(Completion::with_error(sqe.user_data, err))
+        match ops::build_op_request(self, &sqe) {
+            Ok(request) => {
+                if let Some(completion) = request.try_execute_nonblock() {
+                    self.post_completion(completion)?;
+                } else {
+                    self.post_completion(request.execute())?;
+                }
+            }
+            Err(err) => self.post_completion(Completion::with_error(sqe.user_data, err))?,
+        }
+
+        Ok(())
     }
 
     fn mmap_region(&self, offset: usize) -> Option<(Arc<Vmo>, usize)> {

--- a/kernel/src/io_uring/io_context.rs
+++ b/kernel/src/io_uring/io_context.rs
@@ -11,12 +11,13 @@ use ostd::sync::WaitQueue;
 use super::{
     c_types::{
         CqRingOffsets, IORING_OFF_CQ_RING, IORING_OFF_SQ_RING, IORING_OFF_SQES, IoRingMeta,
-        IoUringCqe, IoUringFeatures, IoUringParams, IoUringSetupFlags, IoUringSqe,
+        IoUringCqe, IoUringFeatures, IoUringParams, IoUringRegisterOpcode, IoUringSetupFlags, IoUringSqe,
         MAX_CQ_ENTRIES, MAX_SQ_ENTRIES, SqRingOffsets,
     },
     io_wq::IoWq,
     ops,
-    utils::Completion,
+    register::RegisteredResource,
+    utils::{resolve_registered_buffers, Completion},
 };
 use crate::{
     events::IoEvents,
@@ -27,6 +28,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
+    util::IoVec,
     vm::page_cache::{Vmo, VmoOptions},
 };
 
@@ -38,6 +40,8 @@ pub struct IoUringContext {
     sqes_region: SqeRegion,
 
     io_wq: Arc<IoWq>,
+
+    registered_resource: RegisteredResource,
 
     sq_wait_queue: WaitQueue,
     pollee: Pollee,
@@ -86,6 +90,7 @@ impl IoUringContext {
             cq_ring: Mutex::new(CqRing::new(config)),
             ring_region,
             sqes_region,
+            registered_resource: RegisteredResource::new(),
             io_wq: Arc::new(IoWq::new(context.clone())),
             sq_wait_queue: WaitQueue::new(),
             pollee: Pollee::new(),
@@ -189,6 +194,7 @@ impl IoUringContext {
     }
 
     fn write_fdinfo(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let user_buffers = self.registered_resource.buffer_count();
         let sq_ring = self.sq_ring.lock();
         let cq_ring = self.cq_ring.lock();
         let sq_head = self
@@ -230,9 +236,44 @@ impl IoUringContext {
         writeln!(f, "SqTotalTime:\t{}", 0)?;
         writeln!(f, "SqWorkTime:\t{}", 0)?;
         writeln!(f, "UserFiles:\t{}", 0)?;
-        writeln!(f, "UserBufs:\t{}", 0)?;
+        writeln!(f, "UserBufs:\t{}", user_buffers)?;
         writeln!(f, "PollList:")?;
         writeln!(f, "CqOverflowList:")
+    }
+}
+
+impl IoUringContext {
+    pub fn register(&self, opcode: u32, arg_addr: Vaddr, nr_args: u32) -> Result<()> {
+        match IoUringRegisterOpcode::try_from(opcode)? {
+            IoUringRegisterOpcode::RegisterBuffers => self.register_buffers(arg_addr, nr_args),
+            IoUringRegisterOpcode::UnregisterBuffers => {
+                self.unregister_buffers();
+                Ok(())
+            }
+        }
+    }
+
+    fn register_buffers(&self, arg_addr: Vaddr, nr_args: u32) -> Result<()> {
+        if nr_args == 0 {
+            return_errno_with_message!(Errno::EINVAL, "no io_uring buffers were provided");
+        }
+
+        self.registered_resource.check_buffers_available()?;
+        let buffers = resolve_registered_buffers(arg_addr, nr_args as usize)?;
+        self.registered_resource.register_buffers(buffers)
+    }
+
+    fn unregister_buffers(&self) {
+        self.registered_resource.unregister_buffers();
+    }
+
+    pub(super) fn get_registered_buffer(
+        &self,
+        index: u16,
+        addr: usize,
+        len: usize,
+    ) -> Result<IoVec> {
+        self.registered_resource.get_fixed_buffer(index, addr, len)
     }
 }
 

--- a/kernel/src/io_uring/io_context.rs
+++ b/kernel/src/io_uring/io_context.rs
@@ -4,20 +4,25 @@ use core::{
     cmp::min,
     fmt::Display,
     sync::atomic::{Ordering, fence},
+    time::Duration,
 };
 
-use ostd::sync::WaitQueue;
+use ostd::{
+    cpu::{CpuId, CpuSet},
+    sync::WaitQueue,
+};
 
 use super::{
     c_types::{
         CqRingOffsets, IORING_OFF_CQ_RING, IORING_OFF_SQ_RING, IORING_OFF_SQES, IoRingMeta,
-        IoUringCqe, IoUringFeatures, IoUringParams, IoUringRegisterOpcode, IoUringSetupFlags, IoUringSqe,
-        MAX_CQ_ENTRIES, MAX_SQ_ENTRIES, SqRingOffsets,
+        IoUringCqe, IoUringFeatures, IoUringParams, IoUringRegisterOpcode, IoUringSetupFlags,
+        IoUringSqe, MAX_CQ_ENTRIES, MAX_SQ_ENTRIES, SqRingFlags, SqRingOffsets,
     },
     io_wq::IoWq,
     ops,
     register::RegisteredResource,
-    utils::{resolve_registered_buffers, Completion},
+    sqpoll::SqPoll,
+    utils::{Completion, resolve_registered_buffers},
 };
 use crate::{
     events::IoEvents,
@@ -32,7 +37,7 @@ use crate::{
     vm::page_cache::{Vmo, VmoOptions},
 };
 
-/// Owns the file-facing state, rings, and wait state for one `io_uring` instance.
+/// Owns the file-facing state, rings, and execution state for one `io_uring` instance.
 pub struct IoUringContext {
     sq_ring: Mutex<SqRing>,
     cq_ring: Mutex<CqRing>,
@@ -40,9 +45,10 @@ pub struct IoUringContext {
     sqes_region: SqeRegion,
 
     io_wq: Arc<IoWq>,
-
     registered_resource: RegisteredResource,
+    sqpoll: Option<Arc<SqPoll>>,
 
+    // `IORING_ENTER_SQ_WAIT` waits here until the SQPOLL thread advances SQ head.
     sq_wait_queue: WaitQueue,
     pollee: Pollee,
     pseudo_path: Path,
@@ -81,7 +87,7 @@ struct SqeRegion {
 }
 
 impl IoUringContext {
-    pub fn new(config: &IoUringSetupConfig, _ctx: &Context) -> Result<Arc<Self>> {
+    pub fn new(config: &IoUringSetupConfig, ctx: &Context) -> Result<Arc<Self>> {
         let ring_region = RingRegion::new(config.ring_size, config.sq_array_offset)?;
         let sqes_region = SqeRegion::new(config.sqes_size)?;
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[io_uring]".to_string());
@@ -92,6 +98,9 @@ impl IoUringContext {
             sqes_region,
             registered_resource: RegisteredResource::new(),
             io_wq: Arc::new(IoWq::new(context.clone())),
+            sqpoll: config
+                .is_sqpoll_mode
+                .then(|| Arc::new(SqPoll::new(context.clone()))),
             sq_wait_queue: WaitQueue::new(),
             pollee: Pollee::new(),
             pseudo_path,
@@ -101,6 +110,14 @@ impl IoUringContext {
         context.ring_region.write_meta(&ring_meta)?;
 
         context.io_wq.start_thread(ctx);
+
+        if let Some(sqpoll) = &context.sqpoll {
+            sqpoll.start_thread(
+                ctx,
+                config.sqpoll_cpu_affinity.clone(),
+                config.sqpoll_idle_timeout,
+            );
+        }
 
         Ok(context)
     }
@@ -150,6 +167,18 @@ impl IoUringContext {
                     "not enough io_uring completions",
                 ))
             }
+        })
+    }
+
+    pub fn wait_for_sq_space(&self) -> Result<()> {
+        self.sq_wait_queue.wait_until(|| {
+            self.sq_ring
+                .lock()
+                .has_avaliable_entries(&self.ring_region)
+                .map_or_else(
+                    |err| Some(Err(err)),
+                    |has_avaliable_entries| has_avaliable_entries.then_some(Ok(())),
+                )
         })
     }
 
@@ -277,6 +306,41 @@ impl IoUringContext {
     }
 }
 
+impl IoUringContext {
+    pub fn is_sqpoll_mode(&self) -> bool {
+        self.sqpoll.is_some()
+    }
+
+    pub fn wake_sqpoll_thread(&self) -> Result<()> {
+        let Some(sqpoll) = &self.sqpoll else {
+            return_errno_with_message!(Errno::EOWNERDEAD, "the SQPOLL thread is not available");
+        };
+
+        self.set_sq_need_wakeup(false)?;
+        sqpoll.wake();
+        Ok(())
+    }
+
+    pub(super) fn set_sq_need_wakeup(&self, need_wakeup: bool) -> Result<()> {
+        let flags = self.ring_region.read_sq_flags()?;
+        let new_flags = if need_wakeup {
+            flags | SqRingFlags::NEED_WAKEUP
+        } else {
+            flags & !SqRingFlags::NEED_WAKEUP
+        };
+
+        self.ring_region.write_sq_flags(new_flags)
+    }
+}
+
+impl Drop for IoUringContext {
+    fn drop(&mut self) {
+        if let Some(sqpoll) = &self.sqpoll {
+            sqpoll.stop();
+        }
+    }
+}
+
 impl Pollable for IoUringContext {
     fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
         self.pollee.invalidate();
@@ -367,6 +431,10 @@ impl SqRing {
         ring_region.write_sq_head(self.cached_head)?;
         sq_wait_queue.wake_all();
         Ok(())
+    }
+
+    fn has_avaliable_entries(&self, ring_region: &RingRegion) -> Result<bool> {
+        Ok(self.pending_entry_count(ring_region)? < self.entries)
     }
 }
 
@@ -526,6 +594,16 @@ impl RingRegion {
         self.write_val(core::mem::offset_of!(IoRingMeta, cq_tail), &cq_tail)
     }
 
+    fn read_sq_flags(&self) -> Result<SqRingFlags> {
+        let flags_bits: u32 = self.read_val(core::mem::offset_of!(IoRingMeta, sq_flags))?;
+        Ok(SqRingFlags::from_bits_truncate(flags_bits))
+    }
+
+    fn write_sq_flags(&self, flags: SqRingFlags) -> Result<()> {
+        let flags_bits = flags.bits();
+        self.write_val(core::mem::offset_of!(IoRingMeta, sq_flags), &flags_bits)
+    }
+
     fn increment_sq_dropped(&self) -> Result<()> {
         let dropped: u32 = self.read_val(core::mem::offset_of!(IoRingMeta, sq_dropped))?;
         self.write_val(
@@ -621,6 +699,9 @@ pub struct IoUringSetupConfig {
     ring_size: usize,
     sq_array_offset: usize,
     sqes_size: usize,
+    is_sqpoll_mode: bool,
+    sqpoll_cpu_affinity: CpuSet,
+    sqpoll_idle_timeout: Duration,
 }
 
 impl IoUringSetupConfig {
@@ -633,6 +714,14 @@ impl IoUringSetupConfig {
         }
 
         let flags = IoUringSetupFlags::from_user_bits(params.flags)?;
+
+        if flags.contains(IoUringSetupFlags::SQ_AFF) && !flags.contains(IoUringSetupFlags::SQPOLL) {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "SQPOLL CPU affinity requires the SQPOLL setup flag"
+            );
+        }
+
         let is_clamp = flags.contains(IoUringSetupFlags::CLAMP);
         let sq_entries = calculate_entries(entries, MAX_SQ_ENTRIES, is_clamp)?;
         let cq_entries = if flags.contains(IoUringSetupFlags::CQSIZE) {
@@ -653,12 +742,24 @@ impl IoUringSetupConfig {
         let ring_size = sq_array_offset + sq_entries as usize * size_of::<u32>();
         let sqes_size = sq_entries as usize * size_of::<IoUringSqe>();
 
+        let sqpoll_cpu_affinity = if flags.contains(IoUringSetupFlags::SQ_AFF) {
+            CpuId::try_from(params.sq_thread_cpu as usize)
+                .map_err(|_| Error::with_message(Errno::EINVAL, "SQPOLL CPU is invalid"))?
+                .into()
+        } else {
+            CpuSet::new_full()
+        };
+        let sqpoll_idle_timeout = Duration::from_millis(params.sq_thread_idle as u64);
+
         Ok(Self {
             sq_entries,
             cq_entries,
             ring_size,
             sq_array_offset,
             sqes_size,
+            is_sqpoll_mode: flags.contains(IoUringSetupFlags::SQPOLL),
+            sqpoll_cpu_affinity,
+            sqpoll_idle_timeout,
         })
     }
 

--- a/kernel/src/io_uring/io_context.rs
+++ b/kernel/src/io_uring/io_context.rs
@@ -14,6 +14,7 @@ use super::{
         IoUringCqe, IoUringFeatures, IoUringParams, IoUringSetupFlags, IoUringSqe,
         MAX_CQ_ENTRIES, MAX_SQ_ENTRIES, SqRingOffsets,
     },
+    io_wq::IoWq,
     ops,
     utils::Completion,
 };
@@ -35,6 +36,8 @@ pub struct IoUringContext {
     cq_ring: Mutex<CqRing>,
     ring_region: RingRegion,
     sqes_region: SqeRegion,
+
+    io_wq: Arc<IoWq>,
 
     sq_wait_queue: WaitQueue,
     pollee: Pollee,
@@ -78,11 +81,12 @@ impl IoUringContext {
         let ring_region = RingRegion::new(config.ring_size, config.sq_array_offset)?;
         let sqes_region = SqeRegion::new(config.sqes_size)?;
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[io_uring]".to_string());
-        let context = Arc::new(Self {
+        let context = Arc::new_cyclic(|context| Self {
             sq_ring: Mutex::new(SqRing::new(config)),
             cq_ring: Mutex::new(CqRing::new(config)),
             ring_region,
             sqes_region,
+            io_wq: Arc::new(IoWq::new(context.clone())),
             sq_wait_queue: WaitQueue::new(),
             pollee: Pollee::new(),
             pseudo_path,
@@ -90,6 +94,8 @@ impl IoUringContext {
 
         let ring_meta = IoRingMeta::new(config.sq_entries, config.cq_entries);
         context.ring_region.write_meta(&ring_meta)?;
+
+        context.io_wq.start_thread(ctx);
 
         Ok(context)
     }
@@ -162,7 +168,7 @@ impl IoUringContext {
                 if let Some(completion) = request.try_execute_nonblock() {
                     self.post_completion(completion)?;
                 } else {
-                    self.post_completion(request.execute())?;
+                    self.io_wq.enqueue(request);
                 }
             }
             Err(err) => self.post_completion(Completion::with_error(sqe.user_data, err))?,

--- a/kernel/src/io_uring/io_context.rs
+++ b/kernel/src/io_uring/io_context.rs
@@ -1,11 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{cmp::min, fmt::Display};
+use core::{
+    cmp::min,
+    fmt::Display,
+    sync::atomic::{Ordering, fence},
+};
 
-use super::c_types::{
-    CqRingOffsets, IORING_OFF_CQ_RING, IORING_OFF_SQ_RING, IORING_OFF_SQES, IoRingMeta,
-    IoUringCqe, IoUringFeatures, IoUringParams, IoUringSetupFlags, IoUringSqe, MAX_CQ_ENTRIES,
-    MAX_SQ_ENTRIES, SqRingOffsets,
+use ostd::sync::WaitQueue;
+
+use super::{
+    c_types::{
+        CqRingOffsets, IORING_OFF_CQ_RING, IORING_OFF_SQ_RING, IORING_OFF_SQES, IoRingMeta,
+        IoUringCqe, IoUringFeatures, IoUringParams, IoUringSetupFlags, IoUringSqe,
+        MAX_CQ_ENTRIES, MAX_SQ_ENTRIES, SqRingOffsets,
+    },
+    utils::Completion,
 };
 use crate::{
     events::IoEvents,
@@ -15,15 +24,37 @@ use crate::{
         vfs::path::Path,
     },
     prelude::*,
-    process::signal::{PollHandle, Pollable},
+    process::signal::{PollHandle, Pollable, Pollee},
     vm::page_cache::{Vmo, VmoOptions},
 };
 
-/// Owns the file-facing state and shared rings for one `io_uring` instance.
+/// Owns the file-facing state, rings, and wait state for one `io_uring` instance.
 pub struct IoUringContext {
+    sq_ring: Mutex<SqRing>,
+    cq_ring: Mutex<CqRing>,
     ring_region: RingRegion,
     sqes_region: SqeRegion,
+
+    sq_wait_queue: WaitQueue,
+    pollee: Pollee,
     pseudo_path: Path,
+}
+
+struct SqRing {
+    entries: u32,
+    // Mirrors the kernel-owned SQ head. Userspace observes this value only
+    // after `commit_head` publishes it into shared ring memory.
+    cached_head: u32,
+}
+
+struct CqRing {
+    entries: u32,
+    // Mirrors the kernel-owned CQ tail. Userspace observes this value only
+    // after `commit_tail` publishes it into shared ring memory.
+    cached_tail: u32,
+    // Temporarily holds completions when userspace has not freed CQ slots.
+    // Draining is retried on submit, completion, wait, and poll paths.
+    overflow_completions: VecDeque<Completion>,
 }
 
 /// Backs the shared SQ/CQ ring mapping visible to userspace.
@@ -47,8 +78,12 @@ impl IoUringContext {
         let sqes_region = SqeRegion::new(config.sqes_size)?;
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[io_uring]".to_string());
         let context = Arc::new(Self {
+            sq_ring: Mutex::new(SqRing::new(config)),
+            cq_ring: Mutex::new(CqRing::new(config)),
             ring_region,
             sqes_region,
+            sq_wait_queue: WaitQueue::new(),
+            pollee: Pollee::new(),
             pseudo_path,
         });
 
@@ -58,16 +93,137 @@ impl IoUringContext {
         Ok(context)
     }
 
+    pub fn submit_sqes(&self, to_submit: u32) -> Result<u32> {
+        if to_submit == 0 {
+            return Ok(0);
+        }
+
+        let mut sq_ring = self.sq_ring.lock();
+        let pending = sq_ring.pending_entry_count(&self.ring_region)?;
+        let mut consumed = 0u32;
+        let mut submitted = 0u32;
+
+        // The SQ array contains user-provided indexes into the SQE table. The
+        // kernel consumes them in ring order and advances its cached SQ head.
+        for _ in 0..min(to_submit, pending) {
+            if let Some(sqe) = self.get_sqe(&sq_ring)? {
+                self.submit_sqe(sqe)?;
+                sq_ring.cached_head = sq_ring.cached_head.wrapping_add(1);
+                consumed += 1;
+                submitted += 1;
+            } else {
+                self.ring_region.increment_sq_dropped()?;
+                sq_ring.cached_head = sq_ring.cached_head.wrapping_add(1);
+                consumed += 1;
+                break;
+            };
+        }
+
+        if consumed > 0 {
+            sq_ring.commit_head(&self.ring_region, &self.sq_wait_queue)?;
+        }
+
+        Ok(submitted)
+    }
+
+    pub fn wait_for_completions(&self, min_complete: u32) -> Result<()> {
+        self.wait_events(IoEvents::IN, None, || {
+            let mut cq_ring = self.cq_ring.lock();
+            cq_ring.drain_overflow_completions(&self.ring_region, &self.pollee)?;
+            if cq_ring.pending_entry_count(&self.ring_region)? >= min_complete {
+                Ok(())
+            } else {
+                Err(Error::with_message(
+                    Errno::EAGAIN,
+                    "not enough io_uring completions",
+                ))
+            }
+        })
+    }
+
+    pub(super) fn post_completion(&self, completion: Completion) -> Result<()> {
+        let mut cq_ring = self.cq_ring.lock();
+        cq_ring.post_completion(&self.ring_region, &self.pollee, completion)
+    }
+
+    fn get_sqe(&self, sq_ring: &SqRing) -> Result<Option<IoUringSqe>> {
+        let sq_index = sq_ring.read_array_entry(&self.ring_region)?;
+        if sq_index >= sq_ring.entry_count() {
+            return Ok(None);
+        }
+
+        Ok(Some(self.sqes_region.read_sqe(sq_index)?))
+    }
+
+    fn submit_sqe(&self, sqe: IoUringSqe) -> Result<()> {
+        let err = Error::with_message(Errno::EINVAL, "unsupported io_uring opcode");
+        self.post_completion(Completion::with_error(sqe.user_data, err))
+    }
+
     fn mmap_region(&self, offset: usize) -> Option<(Arc<Vmo>, usize)> {
         self.ring_region
             .mmap_region(offset)
             .or_else(|| self.sqes_region.mmap_region(offset))
     }
+
+    fn check_io_events(&self) -> IoEvents {
+        let mut cq_ring = self.cq_ring.lock();
+        cq_ring.check_io_events(&self.ring_region, &self.pollee)
+    }
+
+    fn write_fdinfo(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let sq_ring = self.sq_ring.lock();
+        let cq_ring = self.cq_ring.lock();
+        let sq_head = self
+            .ring_region
+            .read_sq_head()
+            .unwrap_or(sq_ring.cached_head);
+        let sq_tail = self
+            .ring_region
+            .read_sq_tail()
+            .unwrap_or(sq_ring.cached_head);
+        let cq_head = self.ring_region.read_cq_head().unwrap_or(0);
+        let cq_tail = self
+            .ring_region
+            .read_cq_tail()
+            .unwrap_or(cq_ring.cached_tail);
+        let sqes = sq_tail.wrapping_sub(sq_head).min(sq_ring.entry_count());
+        let cqes = cq_tail.wrapping_sub(cq_head).min(cq_ring.entry_count());
+
+        writeln!(
+            f,
+            "SqMask:\t0x{:x}",
+            sq_ring.entry_count().saturating_sub(1)
+        )?;
+        writeln!(f, "SqHead:\t{}", sq_head)?;
+        writeln!(f, "SqTail:\t{}", sq_tail)?;
+        writeln!(f, "CachedSqHead:\t{}", sq_ring.cached_head)?;
+        writeln!(
+            f,
+            "CqMask:\t0x{:x}",
+            cq_ring.entry_count().saturating_sub(1)
+        )?;
+        writeln!(f, "CqHead:\t{}", cq_head)?;
+        writeln!(f, "CqTail:\t{}", cq_tail)?;
+        writeln!(f, "CachedCqTail:\t{}", cq_ring.cached_tail)?;
+        writeln!(f, "SQEs:\t{}", sqes)?;
+        writeln!(f, "CQEs:\t{}", cqes)?;
+        writeln!(f, "SqThread:\t{}", -1)?;
+        writeln!(f, "SqThreadCpu:\t{}", -1)?;
+        writeln!(f, "SqTotalTime:\t{}", 0)?;
+        writeln!(f, "SqWorkTime:\t{}", 0)?;
+        writeln!(f, "UserFiles:\t{}", 0)?;
+        writeln!(f, "UserBufs:\t{}", 0)?;
+        writeln!(f, "PollList:")?;
+        writeln!(f, "CqOverflowList:")
+    }
 }
 
 impl Pollable for IoUringContext {
-    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
-        IoEvents::empty()
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
+        self.pollee.invalidate();
+        self.pollee
+            .poll_with(mask, poller, || self.check_io_events())
     }
 }
 
@@ -110,10 +266,7 @@ impl FileLike for IoUringContext {
                 writeln!(f, "flags:\t0{:o}", flags)?;
                 writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
                 writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())?;
-                writeln!(f, "SqThread:\t{}", -1)?;
-                writeln!(f, "SqThreadCpu:\t{}", -1)?;
-                writeln!(f, "UserFiles:\t{}", 0)?;
-                writeln!(f, "UserBufs:\t{}", 0)
+                self.ring.write_fdinfo(f)
             }
         }
 
@@ -121,6 +274,160 @@ impl FileLike for IoUringContext {
             ring: self,
             fd_flags,
         })
+    }
+}
+
+impl SqRing {
+    fn new(config: &IoUringSetupConfig) -> Self {
+        Self {
+            entries: config.sq_entries,
+            cached_head: 0,
+        }
+    }
+
+    const fn entry_count(&self) -> u32 {
+        self.entries
+    }
+
+    fn read_array_entry(&self, ring_region: &RingRegion) -> Result<u32> {
+        let array_index = self.cached_head & (self.entries - 1);
+        ring_region.read_sq_array_entry(array_index)
+    }
+
+    fn pending_entry_count(&self, ring_region: &RingRegion) -> Result<u32> {
+        let sq_tail = ring_region.read_sq_tail()?;
+        // Userspace publishes SQ array/SQE contents before updating `sq.tail`;
+        // SQ array and SQE reads must stay after observing this tail value.
+        fence(Ordering::Acquire);
+        Ok(sq_tail.wrapping_sub(self.cached_head).min(self.entries))
+    }
+
+    fn commit_head(&self, ring_region: &RingRegion, sq_wait_queue: &WaitQueue) -> Result<()> {
+        // The kernel must finish consuming SQEs before publishing `sq.head`;
+        // userspace can reuse those SQ slots after observing the new head.
+        fence(Ordering::Release);
+        ring_region.write_sq_head(self.cached_head)?;
+        sq_wait_queue.wake_all();
+        Ok(())
+    }
+}
+
+impl CqRing {
+    fn new(config: &IoUringSetupConfig) -> Self {
+        Self {
+            entries: config.cq_entries,
+            cached_tail: 0,
+            overflow_completions: VecDeque::new(),
+        }
+    }
+
+    const fn entry_count(&self) -> u32 {
+        self.entries
+    }
+
+    fn post_completion(
+        &mut self,
+        ring_region: &RingRegion,
+        pollee: &Pollee,
+        completion: Completion,
+    ) -> Result<()> {
+        if self.try_post_cqe(ring_region, pollee, &completion)? {
+            return Ok(());
+        }
+
+        self.overflow_completions.push_back(completion);
+        self.increment_overflow(ring_region)
+    }
+
+    fn drain_overflow_completions(
+        &mut self,
+        ring_region: &RingRegion,
+        pollee: &Pollee,
+    ) -> Result<()> {
+        while self.has_avaliable_entries(ring_region)? {
+            let Some(completion) = self.overflow_completions.pop_front() else {
+                break;
+            };
+            self.commit_tail(ring_region, pollee, &completion)?;
+        }
+
+        Ok(())
+    }
+
+    fn pending_entry_count(&self, ring_region: &RingRegion) -> Result<u32> {
+        let cq_head = ring_region.read_cq_head()?;
+        // Userspace advances `cq.head` after consuming CQEs; CQ space checks and
+        // later CQE writes must stay after observing reclaimed CQ slots.
+        fence(Ordering::Acquire);
+        Ok(self.cached_tail.wrapping_sub(cq_head).min(self.entries))
+    }
+
+    fn has_pending_entries(&self, ring_region: &RingRegion) -> Result<bool> {
+        Ok(self.pending_entry_count(ring_region)? != 0)
+    }
+
+    fn check_io_events(&mut self, ring_region: &RingRegion, pollee: &Pollee) -> IoEvents {
+        let _ = self.drain_overflow_completions(ring_region, pollee);
+
+        let mut events = IoEvents::empty();
+        if self.has_pending_entries(ring_region).is_ok_and(|has| has) {
+            events |= IoEvents::IN;
+        }
+        if self.has_avaliable_entries(ring_region).is_ok_and(|has| has) {
+            events |= IoEvents::OUT;
+        }
+        events
+    }
+
+    fn try_post_cqe(
+        &mut self,
+        ring_region: &RingRegion,
+        pollee: &Pollee,
+        completion: &Completion,
+    ) -> Result<bool> {
+        self.drain_overflow_completions(ring_region, pollee)?;
+        if !self.has_avaliable_entries(ring_region)? {
+            return Ok(false);
+        }
+
+        self.commit_tail(ring_region, pollee, completion)?;
+        Ok(true)
+    }
+
+    fn commit_tail(
+        &mut self,
+        ring_region: &RingRegion,
+        pollee: &Pollee,
+        completion: &Completion,
+    ) -> Result<()> {
+        let cq_tail = self.cached_tail;
+        let cq_index = cq_tail & (self.entries - 1);
+        let cqe = IoUringCqe {
+            user_data: completion.user_data,
+            res: completion.res,
+            flags: completion.flags,
+        };
+
+        ring_region.write_cqe(cq_index, &cqe)?;
+        let new_cq_tail = cq_tail.wrapping_add(1);
+        // The CQE payload must be visible before publishing `cq.tail`;
+        // userspace treats the tail update as permission to read the CQE.
+        fence(Ordering::Release);
+        ring_region.write_cq_tail(new_cq_tail)?;
+        self.cached_tail = new_cq_tail;
+        // Poll waiters are notified only after the tail is visible.
+        pollee.notify(IoEvents::IN);
+
+        Ok(())
+    }
+
+    fn has_avaliable_entries(&self, ring_region: &RingRegion) -> Result<bool> {
+        Ok(self.pending_entry_count(ring_region)? < self.entries)
+    }
+
+    fn increment_overflow(&self, ring_region: &RingRegion) -> Result<()> {
+        let overflow = ring_region.read_cq_overflow()?;
+        ring_region.write_cq_overflow(overflow.wrapping_add(1))
     }
 }
 
@@ -135,6 +442,73 @@ impl RingRegion {
 
     fn write_meta(&self, meta: &IoRingMeta) -> Result<()> {
         self.write_val(0, meta)
+    }
+
+    fn read_sq_head(&self) -> Result<u32> {
+        self.read_val(core::mem::offset_of!(IoRingMeta, sq_head))
+    }
+
+    fn write_sq_head(&self, sq_head: u32) -> Result<()> {
+        self.write_val(core::mem::offset_of!(IoRingMeta, sq_head), &sq_head)
+    }
+
+    fn read_sq_tail(&self) -> Result<u32> {
+        self.read_val(core::mem::offset_of!(IoRingMeta, sq_tail))
+    }
+
+    fn read_cq_head(&self) -> Result<u32> {
+        self.read_val(core::mem::offset_of!(IoRingMeta, cq_head))
+    }
+
+    fn read_cq_tail(&self) -> Result<u32> {
+        self.read_val(core::mem::offset_of!(IoRingMeta, cq_tail))
+    }
+
+    fn write_cq_tail(&self, cq_tail: u32) -> Result<()> {
+        self.write_val(core::mem::offset_of!(IoRingMeta, cq_tail), &cq_tail)
+    }
+
+    fn increment_sq_dropped(&self) -> Result<()> {
+        let dropped: u32 = self.read_val(core::mem::offset_of!(IoRingMeta, sq_dropped))?;
+        self.write_val(
+            core::mem::offset_of!(IoRingMeta, sq_dropped),
+            &dropped.wrapping_add(1),
+        )
+    }
+
+    fn read_cq_overflow(&self) -> Result<u32> {
+        self.read_val(core::mem::offset_of!(IoRingMeta, cq_overflow))
+    }
+
+    fn write_cq_overflow(&self, cq_overflow: u32) -> Result<()> {
+        self.write_val(core::mem::offset_of!(IoRingMeta, cq_overflow), &cq_overflow)
+    }
+
+    fn read_sq_array_entry(&self, array_index: u32) -> Result<u32> {
+        let array_offset = (array_index as usize)
+            .checked_mul(size_of::<u32>())
+            .and_then(|offset| self.sq_array_offset.checked_add(offset))
+            .ok_or_else(|| {
+                Error::with_message(Errno::EOVERFLOW, "the SQ array offset overflows")
+            })?;
+
+        self.read_val(array_offset)
+    }
+
+    fn write_cqe(&self, cq_index: u32, cqe: &IoUringCqe) -> Result<()> {
+        let cqe_offset = (cq_index as usize)
+            .checked_mul(size_of::<IoUringCqe>())
+            .and_then(|offset| size_of::<IoRingMeta>().checked_add(offset))
+            .ok_or_else(|| Error::with_message(Errno::EOVERFLOW, "the CQE offset overflows"))?;
+
+        self.write_val(cqe_offset, cqe)
+    }
+
+    fn read_val<T: FromZeros + Pod>(&self, offset: usize) -> Result<T> {
+        let mut value = T::new_zeroed();
+        let mut writer = VmWriter::from(value.as_mut_bytes()).to_fallible();
+        self.region.read(offset, &mut writer)?;
+        Ok(value)
     }
 
     fn write_val<T: Pod>(&self, offset: usize, value: &T) -> Result<()> {
@@ -160,6 +534,16 @@ impl SqeRegion {
             size,
             region: VmoOptions::new(size).alloc()?,
         })
+    }
+
+    fn read_sqe(&self, sq_index: u32) -> Result<IoUringSqe> {
+        let offset = (sq_index as usize)
+            .checked_mul(size_of::<IoUringSqe>())
+            .ok_or_else(|| Error::with_message(Errno::EOVERFLOW, "the SQE offset overflows"))?;
+        let mut sqe = IoUringSqe::new_zeroed();
+        let mut writer = VmWriter::from(sqe.as_mut_bytes()).to_fallible();
+        self.region.read(offset, &mut writer)?;
+        Ok(sqe)
     }
 
     fn mmap_region(&self, offset: usize) -> Option<(Arc<Vmo>, usize)> {

--- a/kernel/src/io_uring/io_wq.rs
+++ b/kernel/src/io_uring/io_wq.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::time::Duration;
+
+use ostd::sync::WaitQueue;
+
+use super::{io_context::IoUringContext, ops::IoUringOp, thread::IoUringThreadOptions};
+use crate::prelude::*;
+
+const IO_WORKER_IDLE_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Queues prepared requests for asynchronous execution.
+pub(super) struct IoWq {
+    ring_context: Weak<IoUringContext>,
+    request_queue: Mutex<VecDeque<Arc<dyn IoUringOp>>>,
+    wait_queue: WaitQueue,
+}
+
+enum WorkerWaitResult {
+    Request(Arc<dyn IoUringOp>),
+    IdleTimedOut,
+    Stop,
+}
+
+impl IoWq {
+    pub(super) fn new(ring_context: Weak<IoUringContext>) -> Self {
+        Self {
+            ring_context,
+            request_queue: Mutex::new(VecDeque::new()),
+            wait_queue: WaitQueue::new(),
+        }
+    }
+
+    pub(super) fn start_thread(self: &Arc<Self>, ctx: &Context) {
+        let worker_thread_local =
+            IoUringThreadOptions::clone_thread_local(ctx.thread_local).unwrap();
+        let io_wq = self.clone();
+        IoUringThreadOptions::new(move || io_worker_loop(io_wq), worker_thread_local).spawn();
+    }
+
+    pub(super) fn enqueue(&self, request: Arc<dyn IoUringOp>) {
+        self.request_queue.lock().push_back(request);
+        self.wait_queue.wake_one();
+    }
+
+    fn wait_for_request(&self) -> WorkerWaitResult {
+        let result = self.wait_queue.wait_until_or_timeout(
+            || {
+                if self.ring_context.strong_count() == 0 {
+                    Some(WorkerWaitResult::Stop)
+                } else {
+                    self.request_queue
+                        .lock()
+                        .pop_front()
+                        .map(WorkerWaitResult::Request)
+                }
+            },
+            &IO_WORKER_IDLE_INTERVAL,
+        );
+
+        result.unwrap_or(WorkerWaitResult::IdleTimedOut)
+    }
+}
+
+fn io_worker_loop(io_wq: Arc<IoWq>) {
+    loop {
+        let request = match io_wq.wait_for_request() {
+            WorkerWaitResult::Request(request) => request,
+            WorkerWaitResult::IdleTimedOut => continue,
+            WorkerWaitResult::Stop => break,
+        };
+
+        let completion = request.execute();
+
+        let Some(context) = io_wq.ring_context.upgrade() else {
+            warn!("failed to complete io_uring request: ring context is gone");
+            break;
+        };
+
+        if let Err(err) = context.post_completion(completion) {
+            warn!("failed to complete io_uring request: {:?}", err);
+        }
+    }
+}

--- a/kernel/src/io_uring/mod.rs
+++ b/kernel/src/io_uring/mod.rs
@@ -2,6 +2,7 @@
 
 mod c_types;
 mod io_context;
+mod ops;
 mod utils;
 
 pub(crate) use c_types::{IoUringEnterFlags, IoUringParams};

--- a/kernel/src/io_uring/mod.rs
+++ b/kernel/src/io_uring/mod.rs
@@ -1,3 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod c_types;
+mod io_context;
+
+pub(crate) use c_types::IoUringParams;
+pub(crate) use io_context::{IoUringContext, IoUringSetupConfig};

--- a/kernel/src/io_uring/mod.rs
+++ b/kernel/src/io_uring/mod.rs
@@ -2,7 +2,9 @@
 
 mod c_types;
 mod io_context;
+mod io_wq;
 mod ops;
+mod thread;
 mod utils;
 
 pub(crate) use c_types::{IoUringEnterFlags, IoUringParams};

--- a/kernel/src/io_uring/mod.rs
+++ b/kernel/src/io_uring/mod.rs
@@ -4,6 +4,7 @@ mod c_types;
 mod io_context;
 mod io_wq;
 mod ops;
+mod register;
 mod thread;
 mod utils;
 

--- a/kernel/src/io_uring/mod.rs
+++ b/kernel/src/io_uring/mod.rs
@@ -2,6 +2,7 @@
 
 mod c_types;
 mod io_context;
+mod utils;
 
-pub(crate) use c_types::IoUringParams;
+pub(crate) use c_types::{IoUringEnterFlags, IoUringParams};
 pub(crate) use io_context::{IoUringContext, IoUringSetupConfig};

--- a/kernel/src/io_uring/mod.rs
+++ b/kernel/src/io_uring/mod.rs
@@ -5,6 +5,7 @@ mod io_context;
 mod io_wq;
 mod ops;
 mod register;
+mod sqpoll;
 mod thread;
 mod utils;
 

--- a/kernel/src/io_uring/mod.rs
+++ b/kernel/src/io_uring/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod c_types;

--- a/kernel/src/io_uring/ops/file/mod.rs
+++ b/kernel/src/io_uring/ops/file/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod read;
+mod write;
+
+pub(super) use read::IoUringReadRequest;
+pub(super) use write::IoUringWriteRequest;
+
+// If offs is set to -1, the offset will use (and advance) the file position.
+// Reference: IORING_OP_WRITE in https://man7.org/linux/man-pages/man2/io_uring_enter.2.html
+const CURRENT_FILE_OFFSET: u64 = u64::MAX;

--- a/kernel/src/io_uring/ops/file/mod.rs
+++ b/kernel/src/io_uring/ops/file/mod.rs
@@ -3,8 +3,8 @@
 mod read;
 mod write;
 
-pub(super) use read::IoUringReadRequest;
-pub(super) use write::IoUringWriteRequest;
+pub(super) use read::{IoUringReadRequest, IoUringReadVRequest};
+pub(super) use write::{IoUringWriteRequest, IoUringWriteVRequest};
 
 // If offs is set to -1, the offset will use (and advance) the file position.
 // Reference: IORING_OP_WRITE in https://man7.org/linux/man-pages/man2/io_uring_enter.2.html

--- a/kernel/src/io_uring/ops/file/read.rs
+++ b/kernel/src/io_uring/ops/file/read.rs
@@ -8,7 +8,7 @@ use crate::{
     io_uring::{
         c_types::{IoUringOpcode, IoUringSqe},
         io_context::IoUringContext,
-        ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
+        ops::{IoUringOp, completion_from_result, get_file},
         utils::Completion,
     },
     prelude::*,
@@ -29,8 +29,6 @@ impl IoUringReadRequest {
         sqe: &IoUringSqe,
         force_async: bool,
     ) -> Result<Self> {
-        check_rw_flags(sqe)?;
-
         let buffer = match IoUringOpcode::try_from(sqe.opcode)? {
             IoUringOpcode::Read => IoVec {
                 base: sqe.addr as Vaddr,
@@ -101,8 +99,6 @@ impl IoUringReadVRequest {
         sqe: &IoUringSqe,
         force_async: bool,
     ) -> Result<Self> {
-        check_rw_flags(sqe)?;
-
         Ok(Self {
             user_data: sqe.user_data,
             force_async,

--- a/kernel/src/io_uring/ops/file/read.rs
+++ b/kernel/src/io_uring/ops/file/read.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::task::Task;
+
+use super::CURRENT_FILE_OFFSET;
+use crate::{
+    fs::{self, file::FileLike},
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
+        utils::Completion,
+    },
+    prelude::*,
+    util::IoVec,
+};
+
+pub(in crate::io_uring::ops) struct IoUringReadRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    offset: u64,
+    buffer: IoVec,
+}
+
+impl IoUringReadRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        check_rw_flags(sqe)?;
+
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            offset: sqe.off,
+            buffer: IoVec {
+                base: sqe.addr as Vaddr,
+                len: sqe.len as usize,
+            },
+        })
+    }
+}
+
+impl IoUringOp for IoUringReadRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+            let mut writer = user_space.writer(self.buffer.base, self.buffer.len)?;
+
+            let read_len = if self.offset == CURRENT_FILE_OFFSET {
+                self.file.read(&mut writer)?
+            } else {
+                self.file.read_at(self.offset as usize, &mut writer)?
+            };
+
+            if read_len > 0 {
+                fs::vfs::notify::on_access(&self.file);
+            }
+            Ok(read_len)
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/file/read.rs
+++ b/kernel/src/io_uring/ops/file/read.rs
@@ -6,7 +6,7 @@ use super::CURRENT_FILE_OFFSET;
 use crate::{
     fs::{self, file::FileLike},
     io_uring::{
-        c_types::IoUringSqe,
+        c_types::{IoUringOpcode, IoUringSqe},
         io_context::IoUringContext,
         ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
         utils::Completion,
@@ -25,21 +25,31 @@ pub(in crate::io_uring::ops) struct IoUringReadRequest {
 
 impl IoUringReadRequest {
     pub(in crate::io_uring::ops) fn new(
-        _context: &IoUringContext,
+        context: &IoUringContext,
         sqe: &IoUringSqe,
         force_async: bool,
     ) -> Result<Self> {
         check_rw_flags(sqe)?;
+
+        let buffer = match IoUringOpcode::try_from(sqe.opcode)? {
+            IoUringOpcode::Read => IoVec {
+                base: sqe.addr as Vaddr,
+                len: sqe.len as usize,
+            },
+            IoUringOpcode::ReadFixed => {
+                context.get_registered_buffer(sqe.buf_index, sqe.addr as Vaddr, sqe.len as usize)?
+            }
+            _ => {
+                return_errno_with_message!(Errno::EINVAL, "SQE opcode is not a read operation")
+            }
+        };
 
         Ok(Self {
             user_data: sqe.user_data,
             force_async,
             file: get_file(sqe.fd)?,
             offset: sqe.off,
-            buffer: IoVec {
-                base: sqe.addr as Vaddr,
-                len: sqe.len as usize,
-            },
+            buffer,
         })
     }
 }

--- a/kernel/src/io_uring/ops/file/read.rs
+++ b/kernel/src/io_uring/ops/file/read.rs
@@ -12,7 +12,7 @@ use crate::{
         utils::Completion,
     },
     prelude::*,
-    util::IoVec,
+    util::{IoVec, VmWriterArray},
 };
 
 pub(in crate::io_uring::ops) struct IoUringReadRequest {
@@ -75,6 +75,125 @@ impl IoUringOp for IoUringReadRequest {
             } else {
                 self.file.read_at(self.offset as usize, &mut writer)?
             };
+
+            if read_len > 0 {
+                fs::vfs::notify::on_access(&self.file);
+            }
+            Ok(read_len)
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}
+
+pub(in crate::io_uring::ops) struct IoUringReadVRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    offset: u64,
+    io_vec_ptr: Vaddr,
+    io_vec_count: usize,
+}
+
+impl IoUringReadVRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        check_rw_flags(sqe)?;
+
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            offset: sqe.off,
+            io_vec_ptr: sqe.addr as Vaddr,
+            io_vec_count: sqe.len as usize,
+        })
+    }
+
+    fn read_vectored<'a>(
+        &self,
+        user_space: &'a CurrentUserSpace<'a>,
+        iov_addr: Vaddr,
+        iov_count: usize,
+    ) -> Result<usize> {
+        let mut writer_array = VmWriterArray::from_user_io_vecs(user_space, iov_addr, iov_count)?;
+
+        if self.offset == CURRENT_FILE_OFFSET {
+            self.readv_current_offset(&mut writer_array)
+        } else {
+            if writer_array.writers_mut().is_empty() {
+                let mut empty = [0u8; 0];
+                let mut writer = VmWriter::from(empty.as_mut_slice()).to_fallible();
+                self.file.read_at(self.offset as usize, &mut writer)?;
+                return Ok(0);
+            }
+
+            self.readv_at_offset(&mut writer_array)
+        }
+    }
+
+    fn readv_current_offset(&self, writer_array: &mut VmWriterArray<'_>) -> Result<usize> {
+        let mut total_len = 0;
+
+        for writer in writer_array.writers_mut() {
+            debug_assert!(writer.has_avail());
+
+            match self.file.read(writer) {
+                Ok(read_len) => total_len += read_len,
+                Err(_) if total_len > 0 => break,
+                Err(err) => return Err(err),
+            }
+            if writer.has_avail() {
+                break;
+            }
+        }
+
+        Ok(total_len)
+    }
+
+    fn readv_at_offset(&self, writer_array: &mut VmWriterArray<'_>) -> Result<usize> {
+        let mut total_len = 0;
+        let mut cur_offset = self.offset as usize;
+
+        for writer in writer_array.writers_mut() {
+            debug_assert!(writer.has_avail());
+
+            match self.file.read_at(cur_offset, writer) {
+                Ok(read_len) => {
+                    total_len += read_len;
+                    cur_offset += read_len;
+                }
+                Err(_) if total_len > 0 => break,
+                Err(err) => return Err(err),
+            }
+            if writer.has_avail() {
+                break;
+            }
+        }
+
+        Ok(total_len)
+    }
+}
+
+impl IoUringOp for IoUringReadVRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+
+            let read_len = self.read_vectored(&user_space, self.io_vec_ptr, self.io_vec_count)?;
 
             if read_len > 0 {
                 fs::vfs::notify::on_access(&self.file);

--- a/kernel/src/io_uring/ops/file/write.rs
+++ b/kernel/src/io_uring/ops/file/write.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::task::Task;
+
+use super::CURRENT_FILE_OFFSET;
+use crate::{
+    fs::{self, file::FileLike},
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
+        utils::Completion,
+    },
+    prelude::*,
+    util::IoVec,
+};
+
+pub(in crate::io_uring::ops) struct IoUringWriteRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    offset: u64,
+    buffer: IoVec,
+}
+
+impl IoUringWriteRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        check_rw_flags(sqe)?;
+
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            offset: sqe.off,
+            buffer: IoVec {
+                base: sqe.addr as Vaddr,
+                len: sqe.len as usize,
+            },
+        })
+    }
+}
+
+impl IoUringOp for IoUringWriteRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+            let mut reader = user_space.reader(self.buffer.base, self.buffer.len)?;
+
+            let write_len = if self.offset == CURRENT_FILE_OFFSET {
+                self.file.write(&mut reader)?
+            } else {
+                self.file.write_at(self.offset as usize, &mut reader)?
+            };
+
+            if write_len > 0 {
+                fs::vfs::notify::on_modify(&self.file);
+            }
+            Ok(write_len)
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/file/write.rs
+++ b/kernel/src/io_uring/ops/file/write.rs
@@ -12,7 +12,7 @@ use crate::{
         utils::Completion,
     },
     prelude::*,
-    util::IoVec,
+    util::{IoVec, VmReaderArray},
 };
 
 pub(in crate::io_uring::ops) struct IoUringWriteRequest {
@@ -75,6 +75,125 @@ impl IoUringOp for IoUringWriteRequest {
             } else {
                 self.file.write_at(self.offset as usize, &mut reader)?
             };
+
+            if write_len > 0 {
+                fs::vfs::notify::on_modify(&self.file);
+            }
+            Ok(write_len)
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}
+
+pub(in crate::io_uring::ops) struct IoUringWriteVRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    offset: u64,
+    io_vec_ptr: Vaddr,
+    io_vec_count: usize,
+}
+
+impl IoUringWriteVRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        check_rw_flags(sqe)?;
+
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            offset: sqe.off,
+            io_vec_ptr: sqe.addr as Vaddr,
+            io_vec_count: sqe.len as usize,
+        })
+    }
+
+    fn write_vectored<'a>(
+        &self,
+        user_space: &'a CurrentUserSpace<'a>,
+        iov_addr: Vaddr,
+        iov_count: usize,
+    ) -> Result<usize> {
+        let mut reader_array = VmReaderArray::from_user_io_vecs(user_space, iov_addr, iov_count)?;
+
+        if self.offset == CURRENT_FILE_OFFSET {
+            self.writev_current_offset(&mut reader_array)
+        } else {
+            if reader_array.readers_mut().is_empty() {
+                let empty = [0u8; 0];
+                let mut reader = VmReader::from(empty.as_slice()).to_fallible();
+                self.file.write_at(self.offset as usize, &mut reader)?;
+                return Ok(0);
+            }
+
+            self.writev_at_offset(&mut reader_array)
+        }
+    }
+
+    fn writev_current_offset(&self, reader_array: &mut VmReaderArray<'_>) -> Result<usize> {
+        let mut total_len = 0;
+
+        for reader in reader_array.readers_mut() {
+            debug_assert!(reader.has_remain());
+
+            match self.file.write(reader) {
+                Ok(write_len) => total_len += write_len,
+                Err(_) if total_len > 0 => break,
+                Err(err) => return Err(err),
+            }
+            if reader.has_remain() {
+                break;
+            }
+        }
+
+        Ok(total_len)
+    }
+
+    fn writev_at_offset(&self, reader_array: &mut VmReaderArray<'_>) -> Result<usize> {
+        let mut total_len = 0;
+        let mut cur_offset = self.offset as usize;
+
+        for reader in reader_array.readers_mut() {
+            debug_assert!(reader.has_remain());
+
+            match self.file.write_at(cur_offset, reader) {
+                Ok(write_len) => {
+                    total_len += write_len;
+                    cur_offset += write_len;
+                }
+                Err(_) if total_len > 0 => break,
+                Err(err) => return Err(err),
+            }
+            if reader.has_remain() {
+                break;
+            }
+        }
+
+        Ok(total_len)
+    }
+}
+
+impl IoUringOp for IoUringWriteVRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+
+            let write_len = self.write_vectored(&user_space, self.io_vec_ptr, self.io_vec_count)?;
 
             if write_len > 0 {
                 fs::vfs::notify::on_modify(&self.file);

--- a/kernel/src/io_uring/ops/file/write.rs
+++ b/kernel/src/io_uring/ops/file/write.rs
@@ -6,7 +6,7 @@ use super::CURRENT_FILE_OFFSET;
 use crate::{
     fs::{self, file::FileLike},
     io_uring::{
-        c_types::IoUringSqe,
+        c_types::{IoUringOpcode, IoUringSqe},
         io_context::IoUringContext,
         ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
         utils::Completion,
@@ -25,21 +25,31 @@ pub(in crate::io_uring::ops) struct IoUringWriteRequest {
 
 impl IoUringWriteRequest {
     pub(in crate::io_uring::ops) fn new(
-        _context: &IoUringContext,
+        context: &IoUringContext,
         sqe: &IoUringSqe,
         force_async: bool,
     ) -> Result<Self> {
         check_rw_flags(sqe)?;
+
+        let buffer = match IoUringOpcode::try_from(sqe.opcode)? {
+            IoUringOpcode::Write => IoVec {
+                base: sqe.addr as Vaddr,
+                len: sqe.len as usize,
+            },
+            IoUringOpcode::WriteFixed => {
+                context.get_registered_buffer(sqe.buf_index, sqe.addr as Vaddr, sqe.len as usize)?
+            }
+            _ => {
+                return_errno_with_message!(Errno::EINVAL, "SQE opcode is not a write operation")
+            }
+        };
 
         Ok(Self {
             user_data: sqe.user_data,
             force_async,
             file: get_file(sqe.fd)?,
             offset: sqe.off,
-            buffer: IoVec {
-                base: sqe.addr as Vaddr,
-                len: sqe.len as usize,
-            },
+            buffer,
         })
     }
 }

--- a/kernel/src/io_uring/ops/file/write.rs
+++ b/kernel/src/io_uring/ops/file/write.rs
@@ -8,7 +8,7 @@ use crate::{
     io_uring::{
         c_types::{IoUringOpcode, IoUringSqe},
         io_context::IoUringContext,
-        ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
+        ops::{IoUringOp, completion_from_result, get_file},
         utils::Completion,
     },
     prelude::*,
@@ -29,8 +29,6 @@ impl IoUringWriteRequest {
         sqe: &IoUringSqe,
         force_async: bool,
     ) -> Result<Self> {
-        check_rw_flags(sqe)?;
-
         let buffer = match IoUringOpcode::try_from(sqe.opcode)? {
             IoUringOpcode::Write => IoVec {
                 base: sqe.addr as Vaddr,
@@ -101,8 +99,6 @@ impl IoUringWriteVRequest {
         sqe: &IoUringSqe,
         force_async: bool,
     ) -> Result<Self> {
-        check_rw_flags(sqe)?;
-
         Ok(Self {
             user_data: sqe.user_data,
             force_async,

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 
+mod file;
 mod nop;
+
+use ostd::task::Task;
 
 use super::{
     c_types::{IoUringOpcode, IoUringSqe, IoUringSqeFlags},
     io_context::IoUringContext,
 };
-use crate::{io_uring::utils::Completion, prelude::*};
+use crate::{
+    fs::file::{FileLike, file_table::FileDesc},
+    io_uring::utils::Completion,
+    prelude::*,
+};
 
 pub(super) trait IoUringOp: Send + Sync {
     // Normal operation for io_uring is to try and issue an sqe as
@@ -29,6 +36,16 @@ pub(super) fn build_op_request(
             sqe,
             force_async,
         ))),
+        IoUringOpcode::Read => Ok(Arc::new(file::IoUringReadRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
+        IoUringOpcode::Write => Ok(Arc::new(file::IoUringWriteRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
     }
 }
 
@@ -38,6 +55,21 @@ fn completion_from_result(result: Result<usize>, user_data: u64) -> Completion {
         Err(err) => -(err.error() as i32),
     };
     Completion::new(user_data, result, 0)
+}
+
+fn check_rw_flags(sqe: &IoUringSqe) -> Result<()> {
+    if sqe.rw_flags != 0 {
+        return_errno_with_message!(Errno::EINVAL, "SQE read/write flags are unsupported");
+    }
+    Ok(())
+}
+
+fn get_file(fd: i32) -> Result<Arc<dyn FileLike>> {
+    let file_desc: FileDesc = fd.try_into()?;
+    let task = Task::current().unwrap();
+    let thread_local = task.as_thread_local().unwrap();
+    let file_table = thread_local.borrow_file_table();
+    Ok(file_table.unwrap().read().get_file(file_desc)?.clone())
 }
 
 fn check_sqe_flags(sqe: &IoUringSqe) -> Result<IoUringSqeFlags> {

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -47,6 +47,16 @@ pub(super) fn build_op_request(
             sqe,
             force_async,
         )?)),
+        IoUringOpcode::SendMsg => Ok(Arc::new(net::IoUringSendMsgRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
+        IoUringOpcode::RecvMsg => Ok(Arc::new(net::IoUringRecvMsgRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
         IoUringOpcode::Send => Ok(Arc::new(net::IoUringSendRequest::new(
             context,
             sqe,

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod nop;
+
+use super::{
+    c_types::{IoUringOpcode, IoUringSqe, IoUringSqeFlags},
+    io_context::IoUringContext,
+};
+use crate::{io_uring::utils::Completion, prelude::*};
+
+pub(super) trait IoUringOp: Send + Sync {
+    // Normal operation for io_uring is to try and issue an sqe as
+    // non-blocking first, and if that fails, execute it in async manner.
+    fn try_execute_nonblock(&self) -> Option<Completion>;
+
+    fn execute(&self) -> Completion;
+}
+
+pub(super) fn build_op_request(
+    context: &IoUringContext,
+    sqe: &IoUringSqe,
+) -> Result<Arc<dyn IoUringOp>> {
+    let flags = check_sqe_flags(sqe)?;
+    let force_async = flags.contains(IoUringSqeFlags::ASYNC);
+
+    match IoUringOpcode::try_from(sqe.opcode)? {
+        IoUringOpcode::Nop => Ok(Arc::new(nop::IoUringNopRequest::new(
+            context,
+            sqe,
+            force_async,
+        ))),
+    }
+}
+
+fn completion_from_result(result: Result<usize>, user_data: u64) -> Completion {
+    let result = match result {
+        Ok(value) => i32::try_from(value).unwrap_or(-(Errno::EOVERFLOW as i32)),
+        Err(err) => -(err.error() as i32),
+    };
+    Completion::new(user_data, result, 0)
+}
+
+fn check_sqe_flags(sqe: &IoUringSqe) -> Result<IoUringSqeFlags> {
+    let flags = IoUringSqeFlags::from_bits(sqe.flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown SQE flags"))?;
+    if !flags.difference(IoUringSqeFlags::SUPPORTED).is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "SQE flags are unsupported");
+    }
+
+    Ok(flags)
+}

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -57,6 +57,11 @@ pub(super) fn build_op_request(
             sqe,
             force_async,
         )?)),
+        IoUringOpcode::Accept => Ok(Arc::new(net::IoUringAcceptRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
         IoUringOpcode::Send => Ok(Arc::new(net::IoUringSendRequest::new(
             context,
             sqe,

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -37,16 +37,12 @@ pub(super) fn build_op_request(
             sqe,
             force_async,
         ))),
-        IoUringOpcode::Read | IoUringOpcode::ReadFixed => Ok(Arc::new(file::IoUringReadRequest::new(
-            context,
-            sqe,
-            force_async,
-        )?)),
-        IoUringOpcode::Write | IoUringOpcode::WriteFixed => Ok(Arc::new(file::IoUringWriteRequest::new(
-            context,
-            sqe,
-            force_async,
-        )?)),
+        IoUringOpcode::Read | IoUringOpcode::ReadFixed => Ok(Arc::new(
+            file::IoUringReadRequest::new(context, sqe, force_async)?,
+        )),
+        IoUringOpcode::Write | IoUringOpcode::WriteFixed => Ok(Arc::new(
+            file::IoUringWriteRequest::new(context, sqe, force_async)?,
+        )),
         IoUringOpcode::SendMsg => Ok(Arc::new(net::IoUringSendMsgRequest::new(
             context,
             sqe,

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -40,9 +40,19 @@ pub(super) fn build_op_request(
         IoUringOpcode::Read | IoUringOpcode::ReadFixed => Ok(Arc::new(
             file::IoUringReadRequest::new(context, sqe, force_async)?,
         )),
+        IoUringOpcode::Readv => Ok(Arc::new(file::IoUringReadVRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
         IoUringOpcode::Write | IoUringOpcode::WriteFixed => Ok(Arc::new(
             file::IoUringWriteRequest::new(context, sqe, force_async)?,
         )),
+        IoUringOpcode::Writev => Ok(Arc::new(file::IoUringWriteVRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
         IoUringOpcode::SendMsg => Ok(Arc::new(net::IoUringSendMsgRequest::new(
             context,
             sqe,

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -36,12 +36,12 @@ pub(super) fn build_op_request(
             sqe,
             force_async,
         ))),
-        IoUringOpcode::Read => Ok(Arc::new(file::IoUringReadRequest::new(
+        IoUringOpcode::Read | IoUringOpcode::ReadFixed => Ok(Arc::new(file::IoUringReadRequest::new(
             context,
             sqe,
             force_async,
         )?)),
-        IoUringOpcode::Write => Ok(Arc::new(file::IoUringWriteRequest::new(
+        IoUringOpcode::Write | IoUringOpcode::WriteFixed => Ok(Arc::new(file::IoUringWriteRequest::new(
             context,
             sqe,
             force_async,

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -28,8 +28,12 @@ pub(super) fn build_op_request(
     context: &IoUringContext,
     sqe: &IoUringSqe,
 ) -> Result<Arc<dyn IoUringOp>> {
-    let flags = check_sqe_flags(sqe)?;
-    let force_async = flags.contains(IoUringSqeFlags::ASYNC);
+    let sqe_flags = IoUringSqeFlags::from_user_bits(sqe.flags)?;
+    let force_async = sqe_flags.contains(IoUringSqeFlags::ASYNC);
+
+    if sqe.ioprio != 0 {
+        return_errno_with_message!(Errno::EINVAL, "SQE ioprio is unsupported");
+    }
 
     match IoUringOpcode::try_from(sqe.opcode)? {
         IoUringOpcode::Nop => Ok(Arc::new(nop::IoUringNopRequest::new(
@@ -94,27 +98,10 @@ fn completion_from_result(result: Result<usize>, user_data: u64) -> Completion {
     Completion::new(user_data, result, 0)
 }
 
-fn check_rw_flags(sqe: &IoUringSqe) -> Result<()> {
-    if sqe.rw_flags != 0 {
-        return_errno_with_message!(Errno::EINVAL, "SQE read/write flags are unsupported");
-    }
-    Ok(())
-}
-
 fn get_file(fd: i32) -> Result<Arc<dyn FileLike>> {
     let file_desc: FileDesc = fd.try_into()?;
     let task = Task::current().unwrap();
     let thread_local = task.as_thread_local().unwrap();
     let file_table = thread_local.borrow_file_table();
     Ok(file_table.unwrap().read().get_file(file_desc)?.clone())
-}
-
-fn check_sqe_flags(sqe: &IoUringSqe) -> Result<IoUringSqeFlags> {
-    let flags = IoUringSqeFlags::from_bits(sqe.flags)
-        .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown SQE flags"))?;
-    if !flags.difference(IoUringSqeFlags::SUPPORTED).is_empty() {
-        return_errno_with_message!(Errno::EINVAL, "SQE flags are unsupported");
-    }
-
-    Ok(flags)
 }

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -62,6 +62,11 @@ pub(super) fn build_op_request(
             sqe,
             force_async,
         )?)),
+        IoUringOpcode::Connect => Ok(Arc::new(net::IoUringConnectRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
         IoUringOpcode::Send => Ok(Arc::new(net::IoUringSendRequest::new(
             context,
             sqe,

--- a/kernel/src/io_uring/ops/mod.rs
+++ b/kernel/src/io_uring/ops/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod file;
+mod net;
 mod nop;
 
 use ostd::task::Task;
@@ -42,6 +43,16 @@ pub(super) fn build_op_request(
             force_async,
         )?)),
         IoUringOpcode::Write | IoUringOpcode::WriteFixed => Ok(Arc::new(file::IoUringWriteRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
+        IoUringOpcode::Send => Ok(Arc::new(net::IoUringSendRequest::new(
+            context,
+            sqe,
+            force_async,
+        )?)),
+        IoUringOpcode::Recv => Ok(Arc::new(net::IoUringRecvRequest::new(
             context,
             sqe,
             force_async,

--- a/kernel/src/io_uring/ops/net/accept.rs
+++ b/kernel/src/io_uring/ops/net/accept.rs
@@ -36,7 +36,7 @@ impl IoUringAcceptRequest {
             file: get_file(sqe.fd)?,
             sockaddr_ptr: sqe.addr as Vaddr,
             addrlen_ptr: sqe.off as Vaddr,
-            flags: AcceptFlags::from_bits(sqe.rw_flags)
+            flags: AcceptFlags::from_bits(sqe.op_flags)
                 .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid accept flags"))?,
         })
     }

--- a/kernel/src/io_uring/ops/net/accept.rs
+++ b/kernel/src/io_uring/ops/net/accept.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::task::Task;
+
+use crate::{
+    fs::file::{FileLike, StatusFlags},
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, completion_from_result, get_file},
+        utils::Completion,
+    },
+    net::socket::util::AcceptFlags,
+    prelude::*,
+    util::net as user_net,
+};
+
+pub(in crate::io_uring::ops) struct IoUringAcceptRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    sockaddr_ptr: Vaddr,
+    addrlen_ptr: Vaddr,
+    flags: AcceptFlags,
+}
+
+impl IoUringAcceptRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            sockaddr_ptr: sqe.addr as Vaddr,
+            addrlen_ptr: sqe.off as Vaddr,
+            flags: AcceptFlags::from_bits(sqe.rw_flags)
+                .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid accept flags"))?,
+        })
+    }
+}
+
+impl IoUringOp for IoUringAcceptRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let socket = self.file.as_socket_or_err()?;
+            let (connected_socket, socket_addr) = socket.accept()?;
+
+            if self.flags.is_nonblocking() {
+                connected_socket.set_status_flags(StatusFlags::O_NONBLOCK)?;
+            }
+
+            if self.sockaddr_ptr != 0 {
+                user_net::write_socket_addr_to_user(
+                    &socket_addr,
+                    self.sockaddr_ptr,
+                    self.addrlen_ptr,
+                )?;
+            }
+
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let file_table = thread_local.borrow_file_table();
+            let fd = file_table
+                .unwrap()
+                .write()
+                .insert(connected_socket, self.flags.fd_flags());
+            Ok(fd.into())
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/net/connect.rs
+++ b/kernel/src/io_uring/ops/net/connect.rs
@@ -5,7 +5,7 @@ use crate::{
     io_uring::{
         c_types::IoUringSqe,
         io_context::IoUringContext,
-        ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
+        ops::{IoUringOp, completion_from_result, get_file},
         utils::Completion,
     },
     net::socket::util::SocketAddr,
@@ -26,8 +26,6 @@ impl IoUringConnectRequest {
         sqe: &IoUringSqe,
         force_async: bool,
     ) -> Result<Self> {
-        check_rw_flags(sqe)?;
-
         let addr_len = usize::try_from(sqe.off).map_err(|_| {
             Error::with_message(Errno::EINVAL, "the socket address length is invalid")
         })?;

--- a/kernel/src/io_uring/ops/net/connect.rs
+++ b/kernel/src/io_uring/ops/net/connect.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{
+    fs::file::FileLike,
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, check_rw_flags, completion_from_result, get_file},
+        utils::Completion,
+    },
+    net::socket::util::SocketAddr,
+    prelude::*,
+    util::net as user_net,
+};
+
+pub(in crate::io_uring::ops) struct IoUringConnectRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    socket_addr: SocketAddr,
+}
+
+impl IoUringConnectRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        check_rw_flags(sqe)?;
+
+        let addr_len = usize::try_from(sqe.off).map_err(|_| {
+            Error::with_message(Errno::EINVAL, "the socket address length is invalid")
+        })?;
+        let socket_addr = user_net::read_socket_addr_from_user(sqe.addr as Vaddr, addr_len)?;
+
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            socket_addr,
+        })
+    }
+}
+
+impl IoUringOp for IoUringConnectRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let socket = self.file.as_socket_or_err()?;
+            socket.connect(self.socket_addr.clone())?;
+            Ok(0)
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/net/mod.rs
+++ b/kernel/src/io_uring/ops/net/mod.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod accept;
+mod connect;
 mod recv;
 mod recvmsg;
 mod send;
 mod sendmsg;
 
 pub(super) use accept::IoUringAcceptRequest;
+pub(super) use connect::IoUringConnectRequest;
 pub(super) use recv::IoUringRecvRequest;
 pub(super) use recvmsg::IoUringRecvMsgRequest;
 pub(super) use send::IoUringSendRequest;

--- a/kernel/src/io_uring/ops/net/mod.rs
+++ b/kernel/src/io_uring/ops/net/mod.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
+mod accept;
 mod recv;
 mod recvmsg;
 mod send;
 mod sendmsg;
 
+pub(super) use accept::IoUringAcceptRequest;
 pub(super) use recv::IoUringRecvRequest;
 pub(super) use recvmsg::IoUringRecvMsgRequest;
 pub(super) use send::IoUringSendRequest;

--- a/kernel/src/io_uring/ops/net/mod.rs
+++ b/kernel/src/io_uring/ops/net/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod recv;
+mod send;
+
+pub(super) use recv::IoUringRecvRequest;
+pub(super) use send::IoUringSendRequest;

--- a/kernel/src/io_uring/ops/net/mod.rs
+++ b/kernel/src/io_uring/ops/net/mod.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod recv;
+mod recvmsg;
 mod send;
+mod sendmsg;
 
 pub(super) use recv::IoUringRecvRequest;
+pub(super) use recvmsg::IoUringRecvMsgRequest;
 pub(super) use send::IoUringSendRequest;
+pub(super) use sendmsg::IoUringSendMsgRequest;

--- a/kernel/src/io_uring/ops/net/recv.rs
+++ b/kernel/src/io_uring/ops/net/recv.rs
@@ -37,7 +37,7 @@ impl IoUringRecvRequest {
                 base: sqe.addr as Vaddr,
                 len: sqe.len as usize,
             },
-            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+            flags: SendRecvFlags::from_bits_truncate(sqe.op_flags as i32),
         })
     }
 }

--- a/kernel/src/io_uring/ops/net/recv.rs
+++ b/kernel/src/io_uring/ops/net/recv.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::task::Task;
+
+use crate::{
+    fs::file::FileLike,
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, completion_from_result, get_file},
+        utils::Completion,
+    },
+    net::socket::util::SendRecvFlags,
+    prelude::*,
+    util::IoVec,
+};
+
+pub(in crate::io_uring::ops) struct IoUringRecvRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    buffer: IoVec,
+    flags: SendRecvFlags,
+}
+
+impl IoUringRecvRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            buffer: IoVec {
+                base: sqe.addr as Vaddr,
+                len: sqe.len as usize,
+            },
+            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+        })
+    }
+}
+
+impl IoUringOp for IoUringRecvRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+            let socket = self.file.as_socket_or_err()?;
+            let mut writer = user_space.writer(self.buffer.base, self.buffer.len)?;
+
+            socket.recvmsg(&mut writer, self.flags).map(|(len, _)| len)
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/net/recvmsg.rs
+++ b/kernel/src/io_uring/ops/net/recvmsg.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::{mm::VmIo, task::Task};
+
+use crate::{
+    fs::file::FileLike,
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, completion_from_result, get_file},
+        utils::Completion,
+    },
+    net::socket::util::SendRecvFlags,
+    prelude::*,
+    util::net::CUserMsgHdr,
+};
+
+pub(in crate::io_uring::ops) struct IoUringRecvMsgRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    msghdr_addr: Vaddr,
+    c_user_msghdr: CUserMsgHdr,
+    flags: SendRecvFlags,
+}
+
+impl IoUringRecvMsgRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        let task = Task::current().unwrap();
+        let thread_local = task.as_thread_local().unwrap();
+        let user_space = CurrentUserSpace::new(thread_local);
+        let c_user_msghdr = user_space.read_val::<CUserMsgHdr>(sqe.addr as Vaddr)?;
+        if c_user_msghdr.msg_control != 0 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "io_uring recvmsg control messages are unsupported"
+            );
+        }
+
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            msghdr_addr: sqe.addr as Vaddr,
+            c_user_msghdr,
+            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+        })
+    }
+}
+
+impl IoUringOp for IoUringRecvMsgRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let socket = self.file.as_socket_or_err()?;
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+            let mut writer = self
+                .c_user_msghdr
+                .copy_writer_array_from_user(&user_space)?;
+            let (len, message_header) = socket.recvmsg(&mut writer, self.flags)?;
+
+            let mut c_user_msghdr = self.c_user_msghdr;
+            c_user_msghdr.msg_namelen =
+                c_user_msghdr.write_socket_addr_to_user(message_header.addr())?;
+            c_user_msghdr.msg_controllen = 0;
+            user_space.write_val(self.msghdr_addr, &c_user_msghdr)?;
+
+            Ok(len)
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/net/recvmsg.rs
+++ b/kernel/src/io_uring/ops/net/recvmsg.rs
@@ -47,7 +47,7 @@ impl IoUringRecvMsgRequest {
             file: get_file(sqe.fd)?,
             msghdr_addr: sqe.addr as Vaddr,
             c_user_msghdr,
-            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+            flags: SendRecvFlags::from_bits_truncate(sqe.op_flags as i32),
         })
     }
 }

--- a/kernel/src/io_uring/ops/net/send.rs
+++ b/kernel/src/io_uring/ops/net/send.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::task::Task;
+
+use crate::{
+    fs::file::FileLike,
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, completion_from_result, get_file},
+        utils::Completion,
+    },
+    net::socket::util::{MessageHeader, SendRecvFlags},
+    prelude::*,
+    util::IoVec,
+};
+
+pub(in crate::io_uring::ops) struct IoUringSendRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    buffer: IoVec,
+    flags: SendRecvFlags,
+}
+
+impl IoUringSendRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            buffer: IoVec {
+                base: sqe.addr as Vaddr,
+                len: sqe.len as usize,
+            },
+            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+        })
+    }
+}
+
+impl IoUringOp for IoUringSendRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+            let socket = self.file.as_socket_or_err()?;
+            let mut reader = user_space.reader(self.buffer.base, self.buffer.len)?;
+
+            socket.sendmsg(
+                &mut reader,
+                MessageHeader::new(None, Vec::new()),
+                self.flags,
+            )
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/net/send.rs
+++ b/kernel/src/io_uring/ops/net/send.rs
@@ -37,7 +37,7 @@ impl IoUringSendRequest {
                 base: sqe.addr as Vaddr,
                 len: sqe.len as usize,
             },
-            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+            flags: SendRecvFlags::from_bits_truncate(sqe.op_flags as i32),
         })
     }
 }

--- a/kernel/src/io_uring/ops/net/sendmsg.rs
+++ b/kernel/src/io_uring/ops/net/sendmsg.rs
@@ -48,7 +48,7 @@ impl IoUringSendMsgRequest {
             file: get_file(sqe.fd)?,
             c_user_msghdr,
             addr,
-            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+            flags: SendRecvFlags::from_bits_truncate(sqe.op_flags as i32),
         })
     }
 }

--- a/kernel/src/io_uring/ops/net/sendmsg.rs
+++ b/kernel/src/io_uring/ops/net/sendmsg.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::{mm::VmIo, task::Task};
+
+use crate::{
+    fs::file::FileLike,
+    io_uring::{
+        c_types::IoUringSqe,
+        io_context::IoUringContext,
+        ops::{IoUringOp, completion_from_result, get_file},
+        utils::Completion,
+    },
+    net::socket::util::{MessageHeader, SendRecvFlags, SocketAddr},
+    prelude::*,
+    util::net::CUserMsgHdr,
+};
+
+pub(in crate::io_uring::ops) struct IoUringSendMsgRequest {
+    user_data: u64,
+    force_async: bool,
+    file: Arc<dyn FileLike>,
+    c_user_msghdr: CUserMsgHdr,
+    addr: Option<SocketAddr>,
+    flags: SendRecvFlags,
+}
+
+impl IoUringSendMsgRequest {
+    pub(in crate::io_uring::ops) fn new(
+        _context: &IoUringContext,
+        sqe: &IoUringSqe,
+        force_async: bool,
+    ) -> Result<Self> {
+        let task = Task::current().unwrap();
+        let thread_local = task.as_thread_local().unwrap();
+        let user_space = CurrentUserSpace::new(thread_local);
+        let c_user_msghdr = user_space.read_val::<CUserMsgHdr>(sqe.addr as Vaddr)?;
+        if c_user_msghdr.msg_control != 0 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "io_uring sendmsg control messages are unsupported"
+            );
+        }
+        let addr = c_user_msghdr.read_socket_addr_from_user()?;
+
+        Ok(Self {
+            user_data: sqe.user_data,
+            force_async,
+            file: get_file(sqe.fd)?,
+            c_user_msghdr,
+            addr,
+            flags: SendRecvFlags::from_bits_truncate(sqe.rw_flags as i32),
+        })
+    }
+}
+
+impl IoUringOp for IoUringSendMsgRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        None
+    }
+
+    fn execute(&self) -> Completion {
+        let result = (|| {
+            let socket = self.file.as_socket_or_err()?;
+            let task = Task::current().unwrap();
+            let thread_local = task.as_thread_local().unwrap();
+            let user_space = CurrentUserSpace::new(thread_local);
+            let mut reader = self
+                .c_user_msghdr
+                .copy_reader_array_from_user(&user_space)?;
+
+            socket.sendmsg(
+                &mut reader,
+                MessageHeader::new(self.addr.clone(), Vec::new()),
+                self.flags,
+            )
+        })();
+
+        completion_from_result(result, self.user_data)
+    }
+}

--- a/kernel/src/io_uring/ops/nop.rs
+++ b/kernel/src/io_uring/ops/nop.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::{IoUringOp, completion_from_result};
+use crate::io_uring::{IoUringContext, c_types::IoUringSqe, utils::Completion};
+
+pub(super) struct IoUringNopRequest {
+    user_data: u64,
+    force_async: bool,
+}
+
+impl IoUringNopRequest {
+    pub(super) fn new(_context: &IoUringContext, sqe: &IoUringSqe, force_async: bool) -> Self {
+        Self {
+            user_data: sqe.user_data,
+            force_async,
+        }
+    }
+}
+
+impl IoUringOp for IoUringNopRequest {
+    fn try_execute_nonblock(&self) -> Option<Completion> {
+        if self.force_async {
+            return None;
+        }
+
+        Some(completion_from_result(Ok(0), self.user_data))
+    }
+
+    fn execute(&self) -> Completion {
+        completion_from_result(Ok(0), self.user_data)
+    }
+}

--- a/kernel/src/io_uring/register.rs
+++ b/kernel/src/io_uring/register.rs
@@ -47,12 +47,7 @@ impl RegisteredResource {
         *self.buffers.lock() = None;
     }
 
-    pub(super) fn get_fixed_buffer(
-        &self,
-        index: u16,
-        addr: Vaddr,
-        len: usize,
-    ) -> Result<IoVec> {
+    pub(super) fn get_fixed_buffer(&self, index: u16, addr: Vaddr, len: usize) -> Result<IoVec> {
         let registered_buffers = self.buffers.lock();
         let Some(buffer) = registered_buffers
             .as_ref()

--- a/kernel/src/io_uring/register.rs
+++ b/kernel/src/io_uring/register.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::{prelude::*, util::IoVec};
+
+// Matches Linux `IORING_MAX_REG_BUFFERS`.
+//
+// Reference: <https://elixir.bootlin.com/linux/v7.1.2/source/io_uring/rsrc.c#L34-L35>.
+pub(super) const MAX_REGISTERED_BUFFERS: usize = 1 << 14;
+
+pub(super) struct RegisteredResource {
+    buffers: Mutex<Option<Box<[IoVec]>>>,
+}
+
+impl RegisteredResource {
+    pub(super) fn new() -> Self {
+        Self {
+            buffers: Mutex::new(None),
+        }
+    }
+
+    pub(super) fn check_buffers_available(&self) -> Result<()> {
+        if self.buffers.lock().is_some() {
+            return_errno_with_message!(Errno::EBUSY, "io_uring buffers are already registered");
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn buffer_count(&self) -> usize {
+        self.buffers
+            .lock()
+            .as_ref()
+            .map_or(0, |buffers| buffers.len())
+    }
+
+    pub(super) fn register_buffers(&self, buffers: Box<[IoVec]>) -> Result<()> {
+        let mut registered_buffers = self.buffers.lock();
+        if registered_buffers.is_some() {
+            return_errno_with_message!(Errno::EBUSY, "io_uring buffers are already registered");
+        }
+
+        *registered_buffers = Some(buffers);
+        Ok(())
+    }
+
+    pub(super) fn unregister_buffers(&self) {
+        *self.buffers.lock() = None;
+    }
+
+    pub(super) fn get_fixed_buffer(
+        &self,
+        index: u16,
+        addr: Vaddr,
+        len: usize,
+    ) -> Result<IoVec> {
+        let registered_buffers = self.buffers.lock();
+        let Some(buffer) = registered_buffers
+            .as_ref()
+            .and_then(|buffers| buffers.get(index as usize))
+        else {
+            return_errno_with_message!(Errno::EFAULT, "the fixed buffer is not registered");
+        };
+
+        let end = addr
+            .checked_add(len)
+            .ok_or_else(|| Error::with_message(Errno::EOVERFLOW, "the fixed buffer overflows"))?;
+        let buffer_end = buffer.base.checked_add(buffer.len).ok_or_else(|| {
+            Error::with_message(Errno::EOVERFLOW, "the registered buffer overflows")
+        })?;
+
+        if addr < buffer.base || end > buffer_end {
+            return_errno_with_message!(Errno::EFAULT, "the fixed buffer range is not registered");
+        }
+
+        Ok(IoVec { base: addr, len })
+    }
+}

--- a/kernel/src/io_uring/sqpoll.rs
+++ b/kernel/src/io_uring/sqpoll.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::time::Duration;
+
+use ostd::{cpu::CpuSet, sync::WaitQueue};
+
+use super::{io_context::IoUringContext, thread::IoUringThreadOptions};
+use crate::{prelude::*, thread::Thread};
+
+const SQPOLL_IDLE_INTERVAL: Duration = Duration::from_millis(1);
+
+pub(super) struct SqPoll {
+    ring_context: Weak<IoUringContext>,
+    state: Mutex<SqPollState>,
+    wait_queue: WaitQueue,
+}
+
+struct SqPollState {
+    is_sleeping: bool,
+    should_stop: bool,
+}
+
+impl SqPoll {
+    pub(super) fn new(ring_context: Weak<IoUringContext>) -> Self {
+        Self {
+            ring_context,
+            state: Mutex::new(SqPollState {
+                is_sleeping: false,
+                should_stop: false,
+            }),
+            wait_queue: WaitQueue::new(),
+        }
+    }
+
+    pub(super) fn start_thread(
+        self: &Arc<Self>,
+        ctx: &Context,
+        cpu_affinity: CpuSet,
+        idle_timeout: Duration,
+    ) {
+        let sqpoll_thread_local =
+            IoUringThreadOptions::clone_thread_local(ctx.thread_local).unwrap();
+
+        let sqpoll = self.clone();
+        IoUringThreadOptions::new(
+            move || sqpoll_loop(sqpoll, idle_timeout),
+            sqpoll_thread_local,
+        )
+        .cpu_affinity(cpu_affinity)
+        .spawn();
+    }
+
+    pub(super) fn wake(&self) -> bool {
+        let should_wake = {
+            let mut state = self.state.lock();
+            if !state.is_sleeping {
+                false
+            } else {
+                state.is_sleeping = false;
+                true
+            }
+        };
+
+        if should_wake {
+            self.wait_queue.wake_one();
+        }
+        should_wake
+    }
+
+    pub(super) fn stop(&self) {
+        {
+            let mut state = self.state.lock();
+            state.should_stop = true;
+            state.is_sleeping = false;
+        }
+        self.wait_queue.wake_all();
+    }
+
+    fn prepare_sleep(&self, context: &IoUringContext) -> Result<bool> {
+        let mut state = self.state.lock();
+        if state.should_stop {
+            return Ok(false);
+        }
+
+        state.is_sleeping = true;
+
+        if let Err(err) = context.set_sq_need_wakeup(true) {
+            self.wake();
+            return Err(err);
+        }
+
+        Ok(true)
+    }
+
+    fn wait_for_wakeup(&self) {
+        self.wait_queue.wait_until(|| {
+            let state = self.state.lock();
+            (!state.is_sleeping || state.should_stop).then_some(())
+        });
+    }
+}
+
+fn sqpoll_loop(sqpoll: Arc<SqPoll>, idle_timeout: Duration) {
+    let wait_queue = WaitQueue::new();
+    let mut idle_elapsed = Duration::ZERO;
+
+    loop {
+        let Some(context) = sqpoll.ring_context.upgrade() else {
+            break;
+        };
+
+        let submitted = match context.submit_sqes(u32::MAX) {
+            Ok(submitted) => submitted,
+            Err(err) => {
+                warn!("failed to submit SQPOLL io_uring requests: {:?}", err);
+                0
+            }
+        };
+
+        if submitted == 0 {
+            if idle_elapsed >= idle_timeout {
+                let should_sleep = match sqpoll.prepare_sleep(&context) {
+                    Ok(should_sleep) => should_sleep,
+                    Err(err) => {
+                        warn!("failed to put SQPOLL io_uring thread to sleep: {:?}", err);
+                        false
+                    }
+                };
+                drop(context);
+
+                if should_sleep {
+                    sqpoll.wait_for_wakeup();
+                }
+                idle_elapsed = Duration::ZERO;
+                continue;
+            }
+
+            drop(context);
+            let wait_interval = SQPOLL_IDLE_INTERVAL.min(idle_timeout - idle_elapsed);
+            let _ = wait_queue.wait_until_or_timeout(|| -> Option<()> { None }, &wait_interval);
+            idle_elapsed = idle_elapsed.saturating_add(wait_interval);
+        } else {
+            drop(context);
+            idle_elapsed = Duration::ZERO;
+            Thread::yield_now();
+        }
+    }
+}

--- a/kernel/src/io_uring/thread.rs
+++ b/kernel/src/io_uring/thread.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::{
+    cpu::CpuSet,
+    task::{Task, TaskOptions},
+};
+
+use crate::{
+    prelude::*,
+    process::posix_thread::{SuppUserContext, ThreadLocal},
+    sched::{Nice, SchedPolicy},
+    thread::{AsThread, Thread, oops},
+};
+
+struct IoUringThread;
+
+pub(super) struct IoUringThreadOptions {
+    func: Option<Box<dyn FnOnce() + Send>>,
+    thread_local: ThreadLocal,
+    cpu_affinity: CpuSet,
+    sched_policy: SchedPolicy,
+}
+
+impl IoUringThreadOptions {
+    pub(super) fn clone_thread_local(thread_local: &ThreadLocal) -> Result<ThreadLocal> {
+        let vmar = {
+            let vmar_ref = thread_local.vmar().borrow();
+            let Some(vmar) = vmar_ref.as_ref() else {
+                return_errno_with_message!(Errno::EFAULT, "the current thread has no user VMAR");
+            };
+            vmar.clone_handle()
+        };
+        let file_table = thread_local.borrow_file_table().unwrap().clone();
+        let fs = thread_local.borrow_fs().clone();
+        let user_ns = thread_local.borrow_user_ns().clone();
+        let ns_proxy = thread_local.borrow_ns_proxy().unwrap().clone();
+
+        Ok(ThreadLocal::new(
+            0,
+            0,
+            vmar,
+            file_table,
+            fs,
+            SuppUserContext::new(),
+            user_ns,
+            ns_proxy,
+        ))
+    }
+
+    pub(super) fn new<F>(func: F, thread_local: ThreadLocal) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        Self {
+            func: Some(Box::new(func)),
+            thread_local,
+            cpu_affinity: CpuSet::new_full(),
+            sched_policy: SchedPolicy::Fair(Nice::default()),
+        }
+    }
+
+    pub(super) fn cpu_affinity(mut self, cpu_affinity: CpuSet) -> Self {
+        self.cpu_affinity = cpu_affinity;
+        self
+    }
+
+    #[track_caller]
+    pub(super) fn spawn(self) -> Arc<Thread> {
+        let task = self.build();
+        let thread = task.as_thread().unwrap().clone();
+        thread.run();
+        thread
+    }
+
+    fn build(mut self) -> Arc<Task> {
+        let task_fn = self.func.take().unwrap();
+        let thread_fn = move || {
+            let _ = oops::catch_panics_as_oops(task_fn);
+            current_thread!().exit();
+        };
+
+        Arc::new_cyclic(|weak_task| {
+            let thread = {
+                let cpu_affinity = self.cpu_affinity;
+                let sched_policy = self.sched_policy;
+                Arc::new(Thread::new(
+                    weak_task.clone(),
+                    IoUringThread,
+                    cpu_affinity,
+                    sched_policy,
+                ))
+            };
+
+            TaskOptions::new(thread_fn)
+                .data(thread)
+                .local_data(self.thread_local)
+                .build()
+                .unwrap()
+        })
+    }
+}

--- a/kernel/src/io_uring/utils.rs
+++ b/kernel/src/io_uring/utils.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::*;
+
+/// Stores a completion queue entry payload before it is published.
+#[derive(Clone, Copy)]
+pub(super) struct Completion {
+    pub(super) user_data: u64,
+    pub(super) res: i32,
+    pub(super) flags: u32,
+}
+
+impl Completion {
+    pub(super) fn new(user_data: u64, res: i32, flags: u32) -> Self {
+        Self {
+            user_data,
+            res,
+            flags,
+        }
+    }
+
+    pub(super) fn with_error(user_data: u64, err: Error) -> Self {
+        Self::new(user_data, -(err.error() as i32), 0)
+    }
+}

--- a/kernel/src/io_uring/utils.rs
+++ b/kernel/src/io_uring/utils.rs
@@ -1,6 +1,29 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::prelude::*;
+use ostd::task::Task;
+
+use crate::{
+    io_uring::register::MAX_REGISTERED_BUFFERS,
+    prelude::*,
+    util::{IoVec, copy_iovs_and_convert},
+};
+
+pub(super) fn resolve_registered_buffers(
+    iov_addr: Vaddr,
+    iov_count: usize,
+) -> Result<Box<[IoVec]>> {
+    let task = Task::current().unwrap();
+    let thread_local = task.as_thread_local().unwrap();
+    let user_space = CurrentUserSpace::new(thread_local);
+
+    let buffers = copy_iovs_and_convert(&user_space, iov_addr, iov_count, |iov, _| Ok(*iov))?;
+
+    if buffers.len() > MAX_REGISTERED_BUFFERS {
+        return_errno_with_message!(Errno::EINVAL, "too many io_uring buffers to register");
+    }
+
+    Ok(buffers)
+}
 
 /// Stores a completion queue entry payload before it is published.
 #[derive(Clone, Copy)]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -50,6 +50,7 @@ mod error;
 mod events;
 mod fs;
 mod init;
+mod io_uring;
 mod ipc;
 mod net;
 mod prelude;

--- a/kernel/src/net/socket/util/mod.rs
+++ b/kernel/src/net/socket/util/mod.rs
@@ -13,6 +13,6 @@ pub use linger_option::LingerOption;
 pub(super) use message_header::CControlHeader;
 pub use message_header::{ControlMessage, MessageHeader};
 pub(super) use port_privilege::check_port_privilege;
-pub use send_recv_flags::SendRecvFlags;
+pub use send_recv_flags::{AcceptFlags, SendRecvFlags};
 pub use shutdown_cmd::SockShutdownCmd;
 pub use socket_addr::SocketAddr;

--- a/kernel/src/net/socket/util/send_recv_flags.rs
+++ b/kernel/src/net/socket/util/send_recv_flags.rs
@@ -2,7 +2,10 @@
 
 use aster_bigtcp::socket::ReceiveBehavior;
 
-use crate::prelude::*;
+use crate::{
+    fs::file::{CreationFlags, StatusFlags, file_table::FdFlags},
+    prelude::*,
+};
 
 bitflags! {
     /// Flags used for send/recv.
@@ -53,6 +56,30 @@ impl SendRecvFlags {
             ReceiveBehavior::Peek
         } else {
             ReceiveBehavior::Recv
+        }
+    }
+}
+
+const NONBLOCK: u32 = StatusFlags::O_NONBLOCK.bits();
+const CLOEXEC: u32 = CreationFlags::O_CLOEXEC.bits();
+
+bitflags! {
+    pub struct AcceptFlags: u32 {
+        const SOCK_NONBLOCK = NONBLOCK;
+        const SOCK_CLOEXEC = CLOEXEC;
+    }
+}
+
+impl AcceptFlags {
+    pub fn is_nonblocking(&self) -> bool {
+        self.contains(Self::SOCK_NONBLOCK)
+    }
+
+    pub fn fd_flags(&self) -> FdFlags {
+        if self.contains(Self::SOCK_CLOEXEC) {
+            FdFlags::CLOEXEC
+        } else {
+            FdFlags::empty()
         }
     }
 }

--- a/kernel/src/net/socket/util/socket_addr.rs
+++ b/kernel/src/net/socket/util/socket_addr.rs
@@ -7,7 +7,7 @@ use crate::{
     prelude::*,
 };
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SocketAddr {
     Unix(UnixSocketAddr),
     IPv4(Ipv4Address, PortNum),

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -46,7 +46,7 @@ pub use name::{MAX_THREAD_NAME_LEN, ThreadName};
 pub use personality::Personality;
 pub use posix_thread_ext::AsPosixThread;
 pub use robust_list::RobustListHead;
-pub use thread_local::{AsThreadLocal, FileTableRefMut, ThreadLocal};
+pub use thread_local::{AsThreadLocal, FileTableRefMut, SuppUserContext, ThreadLocal};
 
 pub struct PosixThread {
     // Immutable part

--- a/kernel/src/process/posix_thread/thread_local.rs
+++ b/kernel/src/process/posix_thread/thread_local.rs
@@ -60,7 +60,7 @@ pub struct ThreadLocal {
 
 impl ThreadLocal {
     #[expect(clippy::too_many_arguments)]
-    pub(super) fn new(
+    pub(crate) fn new(
         set_child_tid: Vaddr,
         clear_child_tid: Vaddr,
         vmar: VmarHandle,

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -3,9 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs::file::{
-        CreationFlags, StatusFlags,
-        file_table::{FdFlags, RawFileDesc, get_file_fast},
+        StatusFlags,
+        file_table::{RawFileDesc, get_file_fast},
     },
+    net::socket::util::AcceptFlags,
     prelude::*,
     util::net::write_socket_addr_to_user,
 };
@@ -18,7 +19,7 @@ pub fn sys_accept(
 ) -> Result<SyscallReturn> {
     debug!("sockfd = {sockfd}, sockaddr_ptr = 0x{sockaddr_ptr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
-    do_accept(sockfd, sockaddr_ptr, addrlen_ptr, Flags::empty(), ctx)
+    do_accept(sockfd, sockaddr_ptr, addrlen_ptr, AcceptFlags::empty(), ctx)
 }
 
 pub fn sys_accept4(
@@ -29,7 +30,7 @@ pub fn sys_accept4(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     debug!("raw flags = 0x{:x}", flags);
-    let flags = Flags::from_bits(flags)
+    let flags = AcceptFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid accept4 flags"))?;
     debug!(
         "sockfd = {}, sockaddr_ptr = 0x{:x}, addrlen_ptr = 0x{:x}, flags = {:?}",
@@ -43,7 +44,7 @@ fn do_accept(
     sockfd: RawFileDesc,
     sockaddr_ptr: Vaddr,
     addrlen_ptr: Vaddr,
-    flags: Flags,
+    flags: AcceptFlags,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
@@ -58,15 +59,9 @@ fn do_accept(
         })?
     };
 
-    if flags.contains(Flags::SOCK_NONBLOCK) {
+    if flags.is_nonblocking() {
         connected_socket.set_status_flags(StatusFlags::O_NONBLOCK)?;
     }
-
-    let fd_flags = if flags.contains(Flags::SOCK_CLOEXEC) {
-        FdFlags::CLOEXEC
-    } else {
-        FdFlags::empty()
-    };
 
     if sockaddr_ptr != 0 {
         write_socket_addr_to_user(&socket_addr, sockaddr_ptr, addrlen_ptr)?;
@@ -74,18 +69,8 @@ fn do_accept(
 
     let fd = {
         let mut file_table_locked = file_table.unwrap().write();
-        file_table_locked.insert(connected_socket, fd_flags)
+        file_table_locked.insert(connected_socket, flags.fd_flags())
     };
 
     Ok(SyscallReturn::Return(fd.into()))
 }
-
-bitflags! {
-    struct Flags: u32 {
-        const SOCK_NONBLOCK = NONBLOCK;
-        const SOCK_CLOEXEC = CLOEXEC;
-    }
-}
-
-const NONBLOCK: u32 = StatusFlags::O_NONBLOCK.bits();
-const CLOEXEC: u32 = CreationFlags::O_CLOEXEC.bits();

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -62,7 +62,7 @@ macro_rules! import_generic_syscall_entries {
             getuid::sys_getuid,
             getxattr::{sys_fgetxattr, sys_getxattr, sys_lgetxattr},
             inotify::{sys_inotify_add_watch, sys_inotify_init1, sys_inotify_rm_watch},
-            io_uring::{sys_io_uring_enter, sys_io_uring_setup},
+            io_uring::{sys_io_uring_enter, sys_io_uring_register, sys_io_uring_setup},
             ioctl::sys_ioctl,
             kill::sys_kill,
             link::sys_linkat,
@@ -402,6 +402,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
             SYS_IO_URING_SETUP = 425         => sys_io_uring_setup(args[..2]);
             SYS_IO_URING_ENTER = 426         => sys_io_uring_enter(args[..6]);
+            SYS_IO_URING_REGISTER = 427      => sys_io_uring_register(args[..4]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
             SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -62,7 +62,7 @@ macro_rules! import_generic_syscall_entries {
             getuid::sys_getuid,
             getxattr::{sys_fgetxattr, sys_getxattr, sys_lgetxattr},
             inotify::{sys_inotify_add_watch, sys_inotify_init1, sys_inotify_rm_watch},
-            io_uring::sys_io_uring_setup,
+            io_uring::{sys_io_uring_enter, sys_io_uring_setup},
             ioctl::sys_ioctl,
             kill::sys_kill,
             link::sys_linkat,
@@ -401,6 +401,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_STATX = 291                  => sys_statx(args[..5]);
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
             SYS_IO_URING_SETUP = 425         => sys_io_uring_setup(args[..2]);
+            SYS_IO_URING_ENTER = 426         => sys_io_uring_enter(args[..6]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
             SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -62,6 +62,7 @@ macro_rules! import_generic_syscall_entries {
             getuid::sys_getuid,
             getxattr::{sys_fgetxattr, sys_getxattr, sys_lgetxattr},
             inotify::{sys_inotify_add_watch, sys_inotify_init1, sys_inotify_rm_watch},
+            io_uring::sys_io_uring_setup,
             ioctl::sys_ioctl,
             kill::sys_kill,
             link::sys_linkat,
@@ -399,6 +400,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_PWRITEV2 = 287               => sys_pwritev2(args[..6]);
             SYS_STATX = 291                  => sys_statx(args[..5]);
             SYS_PIDFD_SEND_SIGNAL = 424      => sys_pidfd_send_signal(args[..4]);
+            SYS_IO_URING_SETUP = 425         => sys_io_uring_setup(args[..2]);
             SYS_PIDFD_OPEN = 434             => sys_pidfd_open(args[..2]);
             SYS_CLONE3 = 435                 => sys_clone3(args[..2], &user_ctx);
             SYS_CLOSE_RANGE = 436            => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -62,7 +62,7 @@ use super::{
     getxattr::{sys_fgetxattr, sys_getxattr, sys_lgetxattr},
     impl_syscall_nums_and_dispatch_fn,
     inotify::{sys_inotify_add_watch, sys_inotify_init, sys_inotify_init1, sys_inotify_rm_watch},
-    io_uring::sys_io_uring_setup,
+    io_uring::{sys_io_uring_enter, sys_io_uring_setup},
     ioctl::sys_ioctl,
     kill::sys_kill,
     link::{sys_link, sys_linkat},
@@ -416,6 +416,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
     SYS_IO_URING_SETUP = 425   => sys_io_uring_setup(args[..2]);
+    SYS_IO_URING_ENTER = 426   => sys_io_uring_enter(args[..6]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -62,6 +62,7 @@ use super::{
     getxattr::{sys_fgetxattr, sys_getxattr, sys_lgetxattr},
     impl_syscall_nums_and_dispatch_fn,
     inotify::{sys_inotify_add_watch, sys_inotify_init, sys_inotify_init1, sys_inotify_rm_watch},
+    io_uring::sys_io_uring_setup,
     ioctl::sys_ioctl,
     kill::sys_kill,
     link::{sys_link, sys_linkat},
@@ -414,6 +415,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PWRITEV2 = 328         => sys_pwritev2(args[..6]);
     SYS_STATX = 332            => sys_statx(args[..5]);
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
+    SYS_IO_URING_SETUP = 425   => sys_io_uring_setup(args[..2]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -62,7 +62,7 @@ use super::{
     getxattr::{sys_fgetxattr, sys_getxattr, sys_lgetxattr},
     impl_syscall_nums_and_dispatch_fn,
     inotify::{sys_inotify_add_watch, sys_inotify_init, sys_inotify_init1, sys_inotify_rm_watch},
-    io_uring::{sys_io_uring_enter, sys_io_uring_setup},
+    io_uring::{sys_io_uring_enter, sys_io_uring_register, sys_io_uring_setup},
     ioctl::sys_ioctl,
     kill::sys_kill,
     link::{sys_link, sys_linkat},
@@ -417,6 +417,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_PIDFD_SEND_SIGNAL = 424 => sys_pidfd_send_signal(args[..4]);
     SYS_IO_URING_SETUP = 425   => sys_io_uring_setup(args[..2]);
     SYS_IO_URING_ENTER = 426   => sys_io_uring_enter(args[..6]);
+    SYS_IO_URING_REGISTER = 427 => sys_io_uring_register(args[..4]);
     SYS_PIDFD_OPEN = 434       => sys_pidfd_open(args[..2]);
     SYS_CLONE3 = 435           => sys_clone3(args[..2], &user_ctx);
     SYS_CLOSE_RANGE = 436      => sys_close_range(args[..3]);

--- a/kernel/src/syscall/io_uring.rs
+++ b/kernel/src/syscall/io_uring.rs
@@ -6,9 +6,13 @@ use ostd::mm::VmIo;
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::FdFlags,
-    io_uring::{IoUringContext, IoUringParams, IoUringSetupConfig},
+    fs::file::{
+        FileLike,
+        file_table::{FdFlags, RawFileDesc, get_file_fast},
+    },
+    io_uring::{IoUringContext, IoUringEnterFlags, IoUringParams, IoUringSetupConfig},
     prelude::*,
+    process::{posix_thread::ContextPthreadAdminApi, signal::sig_mask::SigMask},
 };
 
 pub fn sys_io_uring_setup(
@@ -30,4 +34,54 @@ pub fn sys_io_uring_setup(
     let fd = file_table_locked.insert(ring, FdFlags::CLOEXEC);
 
     Ok(SyscallReturn::Return(fd.into()))
+}
+
+pub fn sys_io_uring_enter(
+    raw_fd: RawFileDesc,
+    to_submit: u32,
+    min_complete: u32,
+    flags: u32,
+    sig_addr: Vaddr,
+    sigsz: usize,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let enter_flags = IoUringEnterFlags::from_user_bits(flags)?;
+    debug!(
+        "raw_fd = {}, to_submit = {}, min_complete = {}, flags = {:?}, sig_addr = 0x{:x}, sigsz = {}",
+        raw_fd, to_submit, min_complete, enter_flags, sig_addr, sigsz
+    );
+
+    let ring_file = get_ring_file(raw_fd, ctx)?;
+    let ring = ring_context(&ring_file)?;
+    let submitted = ring.submit_sqes(to_submit)?;
+
+    if enter_flags.contains(IoUringEnterFlags::GETEVENTS) && min_complete > 0 {
+        if sig_addr != 0 {
+            // `IORING_ENTER_EXT_ARG` and `IORING_ENTER_EXT_ARG_REG` are rejected by
+            // `IoUringEnterFlags::from_user_bits`, so `sig_addr` only interpreted as
+            // the legacy `sigset_t *` argument here.
+            let sigmask = ctx.user_space().read_val::<SigMask>(sig_addr)?;
+            ctx.save_and_set_sig_mask(sigmask);
+        }
+        ring.wait_for_completions(min_complete)?;
+    }
+
+    Ok(SyscallReturn::Return(submitted as _))
+}
+
+fn get_ring_file(raw_fd: RawFileDesc, ctx: &Context) -> Result<Arc<dyn FileLike>> {
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, raw_fd.try_into()?).into_owned();
+
+    if file.as_ref().downcast_ref::<IoUringContext>().is_none() {
+        return_errno_with_message!(Errno::EINVAL, "the FD is not an io_uring file");
+    }
+
+    Ok(file)
+}
+
+fn ring_context(file: &Arc<dyn FileLike>) -> Result<&IoUringContext> {
+    file.as_ref()
+        .downcast_ref::<IoUringContext>()
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "the FD is not an io_uring file"))
 }

--- a/kernel/src/syscall/io_uring.rs
+++ b/kernel/src/syscall/io_uring.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! System call handlers for `io_uring`.
+
+use ostd::mm::VmIo;
+
+use super::SyscallReturn;
+use crate::{
+    fs::file::file_table::FdFlags,
+    io_uring::{IoUringContext, IoUringParams, IoUringSetupConfig},
+    prelude::*,
+};
+
+pub fn sys_io_uring_setup(
+    entries: u32,
+    params_addr: Vaddr,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let mut params = ctx.user_space().read_val::<IoUringParams>(params_addr)?;
+    debug!("entries = {}, params = {:?}", entries, params);
+
+    let setup_config = IoUringSetupConfig::new(entries, &params)?;
+    let ring = IoUringContext::new(&setup_config, ctx)?;
+
+    setup_config.write_params(&mut params);
+    ctx.user_space().write_val(params_addr, &params)?;
+
+    let file_table = ctx.thread_local.borrow_file_table();
+    let mut file_table_locked = file_table.unwrap().write();
+    let fd = file_table_locked.insert(ring, FdFlags::CLOEXEC);
+
+    Ok(SyscallReturn::Return(fd.into()))
+}

--- a/kernel/src/syscall/io_uring.rs
+++ b/kernel/src/syscall/io_uring.rs
@@ -69,6 +69,25 @@ pub fn sys_io_uring_enter(
     Ok(SyscallReturn::Return(submitted as _))
 }
 
+pub fn sys_io_uring_register(
+    raw_fd: RawFileDesc,
+    opcode: u32,
+    arg_addr: Vaddr,
+    nr_args: u32,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    let ring_file = get_ring_file(raw_fd, ctx)?;
+    let ring = ring_context(&ring_file)?;
+    debug!(
+        "raw_fd = {}, opcode = {}, nr_args = {}",
+        raw_fd, opcode, nr_args
+    );
+
+    ring.register(opcode, arg_addr, nr_args)?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
 fn get_ring_file(raw_fd: RawFileDesc, ctx: &Context) -> Result<Arc<dyn FileLike>> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?).into_owned();

--- a/kernel/src/syscall/io_uring.rs
+++ b/kernel/src/syscall/io_uring.rs
@@ -53,7 +53,18 @@ pub fn sys_io_uring_enter(
 
     let ring_file = get_ring_file(raw_fd, ctx)?;
     let ring = ring_context(&ring_file)?;
-    let submitted = ring.submit_sqes(to_submit)?;
+    let submitted = if ring.is_sqpoll_mode() {
+        if enter_flags.contains(IoUringEnterFlags::SQ_WAKEUP) {
+            ring.wake_sqpoll_thread()?;
+        }
+        if enter_flags.contains(IoUringEnterFlags::SQ_WAIT) {
+            ring.wait_for_sq_space()?;
+        }
+
+        to_submit
+    } else {
+        ring.submit_sqes(to_submit)?
+    };
 
     if enter_flags.contains(IoUringEnterFlags::GETEVENTS) && min_complete > 0 {
         if sig_addr != 0 {

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -131,8 +131,8 @@ fn do_sys_mmap(
 
             options = options
                 .may_perms(vm_may_perms)
-                .mappable(file.as_ref().as_ref())?
                 .vmo_offset(offset)
+                .mappable(file.as_ref().as_ref())?
                 .handle_page_faults_around();
         }
 

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -75,6 +75,7 @@ mod gettimeofday;
 mod getuid;
 mod getxattr;
 mod inotify;
+mod io_uring;
 mod ioctl;
 mod kill;
 mod link;

--- a/kernel/src/util/iovec.rs
+++ b/kernel/src/util/iovec.rs
@@ -76,7 +76,7 @@ pub(super) const MAX_IO_VECTOR_LENGTH: usize = 1024;
 const MAX_TOTAL_IOV_BYTES: usize = isize::MAX as usize;
 
 /// The util function for create [`VmReader`]/[`VmWriter`]s.
-fn copy_iovs_and_convert<'a, T: 'a>(
+pub fn copy_iovs_and_convert<'a, T: 'a>(
     user_space: &'a CurrentUserSpace<'a>,
     start_addr: Vaddr,
     count: usize,

--- a/kernel/src/util/iovec.rs
+++ b/kernel/src/util/iovec.rs
@@ -9,9 +9,9 @@ use crate::prelude::*;
 
 /// A kernel space I/O vector.
 #[derive(Clone, Copy, Debug)]
-struct IoVec {
-    base: Vaddr,
-    len: usize,
+pub struct IoVec {
+    pub base: Vaddr,
+    pub len: usize,
 }
 
 /// A user space I/O vector.

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -10,6 +10,6 @@ mod read_cstring;
 pub mod ring_buffer;
 
 pub use copy_compact::CopyCompat;
-pub use iovec::{MultiRead, MultiWrite, VmReaderArray, VmWriterArray};
+pub use iovec::{IoVec, MultiRead, MultiWrite, VmReaderArray, VmWriterArray};
 pub use padded::padded;
 pub use read_cstring::ReadCString;

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -10,6 +10,8 @@ mod read_cstring;
 pub mod ring_buffer;
 
 pub use copy_compact::CopyCompat;
-pub use iovec::{IoVec, MultiRead, MultiWrite, VmReaderArray, VmWriterArray};
+pub use iovec::{
+    IoVec, MultiRead, MultiWrite, VmReaderArray, VmWriterArray, copy_iovs_and_convert,
+};
 pub use padded::padded;
 pub use read_cstring::ReadCString;

--- a/kernel/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/src/vm/vmar/vmar_impls/map.rs
@@ -250,7 +250,8 @@ impl<'a> VmarMapOptions<'a> {
             panic!("Cannot set `mappable` when `path` is already set");
         }
 
-        let mappable = file.mappable()?;
+        let (mappable, vmo_offset) = file.mappable_at(self.vmo_offset)?;
+        self.vmo_offset = vmo_offset;
         self.mappable = Some(mappable);
         self.path = Some(file.path().clone());
 
@@ -326,11 +327,10 @@ impl<'a> VmarMapOptions<'a> {
         // Parse the `Mappable` and prepare the `MappedMemory`.
         let (mapped_mem, io_mem) = match mappable {
             Some(Mappable::Vmo(vmo)) => {
-                if let Some(ref path) = path {
-                    debug_assert!(Arc::ptr_eq(
-                        &vmo,
-                        &path.inode().page_cache().unwrap().as_vmo().clone()
-                    ));
+                if let Some(ref path) = path
+                    && let Some(page_cache) = path.inode().page_cache()
+                {
+                    debug_assert!(Arc::ptr_eq(&vmo, &page_cache.as_vmo().clone()));
                 }
 
                 let is_writable_tracked = if let Some(ref path) = path

--- a/test/initramfs/nix/regression/default.nix
+++ b/test/initramfs/nix/regression/default.nix
@@ -24,6 +24,10 @@ let
   tdxAttest = callPackage ./tdx-attest.nix { };
 
   allPkgs = lib.genAttrs subDirs commonBuild // {
+    io = callPackage ./common.nix (commonArgs // {
+      dir = "io";
+      extraBuildInputs = [ pkgs.liburing ];
+    });
     network = callPackage ./common.nix (commonArgs // {
       dir = "network";
       extraAttrs = { C_FLAGS = "-I${pkgs.libnl.dev}/include/libnl3"; };

--- a/test/initramfs/src/conformance/gvisor/Makefile
+++ b/test/initramfs/src/conformance/gvisor/Makefile
@@ -23,6 +23,7 @@ TESTS ?= \
 	getdents_test \
 	inotify_test \
 	ioctl_test \
+	iouring_test \
 	link_test \
 	lseek_test \
 	memfd_test \

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1883,8 +1883,8 @@ statx03
 
 # membarrier01
 
-# io_uring01
-# io_uring02
+io_uring01
+io_uring02
 
 # Tests below may cause kernel memory leak
 # perf_event_open03

--- a/test/initramfs/src/regression/io/Makefile
+++ b/test/initramfs/src/regression/io/Makefile
@@ -4,5 +4,6 @@ SUBDIRS := \
 	epoll \
 	eventfd2 \
 	file_io \
+	liburing \
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/io/liburing/Makefile
+++ b/test/initramfs/src/regression/io/liburing/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+EXTRA_C_FLAGS := -luring
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/io/liburing/file.c
+++ b/test/initramfs/src/regression/io/liburing/file.c
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <liburing.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_io_uring_setup
+#define SYS_io_uring_setup __NR_io_uring_setup
+#endif
+
+#ifndef SYS_io_uring_enter
+#define SYS_io_uring_enter __NR_io_uring_enter
+#endif
+
+#define QUEUE_DEPTH 8
+#define TEST_FILE "/tmp/io_uring_file_test"
+
+static const char POSITIONAL_MESSAGE[] =
+	"Asterinas io_uring positional file I/O";
+static const char CURRENT_OFFSET_MESSAGE[] =
+	"Asterinas io_uring current-offset file I/O";
+
+enum {
+	FILE_POSITIONAL_WRITE_USER_DATA = 0x102,
+	FILE_POSITIONAL_READ_USER_DATA = 0x103,
+	FILE_CURRENT_WRITE_USER_DATA = 0x104,
+	FILE_CURRENT_READ_USER_DATA = 0x105,
+	FILE_AFTER_DROP_USER_DATA = 0x106,
+};
+
+static void fail_errno(const char *message)
+{
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void fail_uring(const char *message, int ret)
+{
+	errno = -ret;
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void fail_message(const char *message)
+{
+	fprintf(stderr, "%s\n", message);
+	exit(EXIT_FAILURE);
+}
+
+static void init_ring(struct io_uring *ring)
+{
+	int ret = io_uring_queue_init(QUEUE_DEPTH, ring, 0);
+	if (ret < 0) {
+		fail_uring("io_uring_queue_init", ret);
+	}
+}
+
+static struct io_uring_sqe *get_sqe(struct io_uring *ring,
+				    const char *operation)
+{
+	struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+	if (sqe == NULL) {
+		fprintf(stderr, "%s: failed to get an SQE\n", operation);
+		exit(EXIT_FAILURE);
+	}
+
+	return sqe;
+}
+
+static void submit_one(struct io_uring *ring, const char *operation)
+{
+	int ret = io_uring_submit(ring);
+	if (ret < 0) {
+		fail_uring(operation, ret);
+	}
+	if (ret != 1) {
+		fprintf(stderr, "%s: submitted %d SQEs, expected 1\n",
+			operation, ret);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static int wait_cqe_res_user_data(struct io_uring *ring, const char *operation,
+				  unsigned long long expected_user_data)
+{
+	struct io_uring_cqe *cqe;
+	int ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret < 0) {
+		fail_uring(operation, ret);
+	}
+
+	if ((unsigned long long)cqe->user_data != expected_user_data) {
+		fprintf(stderr, "%s: got user_data %llu, expected %llu\n",
+			operation, (unsigned long long)cqe->user_data,
+			expected_user_data);
+		exit(EXIT_FAILURE);
+	}
+
+	int res = cqe->res;
+	io_uring_cqe_seen(ring, cqe);
+	if (res < 0) {
+		fail_uring(operation, res);
+	}
+
+	return res;
+}
+
+static void expect_cqe_res_user_data(struct io_uring *ring,
+				     const char *operation,
+				     unsigned long long expected_user_data,
+				     int expected_res)
+{
+	int res = wait_cqe_res_user_data(ring, operation, expected_user_data);
+	if (res != expected_res) {
+		fprintf(stderr, "%s: got CQE result %d, expected %d\n",
+			operation, res, expected_res);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void test_invalid_sq_array_dropped(struct io_uring *ring)
+{
+	unsigned dropped_before = *ring->sq.kdropped;
+	struct io_uring_sqe *sqe = get_sqe(ring, "io_uring invalid SQ array");
+	io_uring_prep_nop(sqe);
+
+	unsigned slot = (ring->sq.sqe_tail - 1) & *ring->sq.kring_mask;
+	ring->sq.array[slot] = *ring->sq.kring_entries;
+
+	int ret = io_uring_submit(ring);
+	ring->sq.array[slot] = slot;
+	if (ret < 0) {
+		fail_uring("io_uring invalid SQ array submit", ret);
+	}
+	if (ret != 0) {
+		fprintf(stderr,
+			"io_uring invalid SQ array: submitted %d SQEs, expected 0\n",
+			ret);
+		exit(EXIT_FAILURE);
+	}
+	if (*ring->sq.kdropped != dropped_before + 1) {
+		fprintf(stderr,
+			"io_uring invalid SQ array: dropped %u, expected %u\n",
+			*ring->sq.kdropped, dropped_before + 1);
+		exit(EXIT_FAILURE);
+	}
+	if (*ring->cq.ktail - *ring->cq.khead != 0) {
+		fail_message(
+			"io_uring invalid SQ array unexpectedly posted a CQE");
+	}
+
+	sqe = get_sqe(ring, "io_uring NOP after invalid SQ array");
+	io_uring_prep_nop(sqe);
+	sqe->user_data = FILE_AFTER_DROP_USER_DATA;
+	submit_one(ring, "io_uring NOP after invalid SQ array submit");
+	expect_cqe_res_user_data(ring, "io_uring NOP after invalid SQ array",
+				 FILE_AFTER_DROP_USER_DATA, 0);
+	printf("[io_uring:file] invalid SQ array dropped\n");
+}
+
+static void test_positional_read_write(struct io_uring *ring)
+{
+	int fd = open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, 0600);
+	if (fd < 0) {
+		fail_errno("open");
+	}
+
+	struct io_uring_sqe *sqe = get_sqe(ring, "io_uring file write");
+	io_uring_prep_write(sqe, fd, POSITIONAL_MESSAGE,
+			    sizeof(POSITIONAL_MESSAGE), 0);
+	sqe->user_data = FILE_POSITIONAL_WRITE_USER_DATA;
+	submit_one(ring, "io_uring file write submit");
+	expect_cqe_res_user_data(ring, "io_uring file write",
+				 FILE_POSITIONAL_WRITE_USER_DATA,
+				 sizeof(POSITIONAL_MESSAGE));
+	printf("[io_uring:file] write completed\n");
+
+	char read_buffer[sizeof(POSITIONAL_MESSAGE)] = {};
+	sqe = get_sqe(ring, "io_uring file read");
+	io_uring_prep_read(sqe, fd, read_buffer, sizeof(read_buffer), 0);
+	sqe->user_data = FILE_POSITIONAL_READ_USER_DATA;
+	submit_one(ring, "io_uring file read submit");
+	expect_cqe_res_user_data(ring, "io_uring file read",
+				 FILE_POSITIONAL_READ_USER_DATA,
+				 sizeof(read_buffer));
+
+	if (memcmp(read_buffer, POSITIONAL_MESSAGE,
+		   sizeof(POSITIONAL_MESSAGE)) != 0) {
+		fail_message("io_uring file read returned unexpected data");
+	}
+	printf("[io_uring:file] positional read data verified\n");
+
+	if (close(fd) < 0) {
+		fail_errno("close");
+	}
+	if (unlink(TEST_FILE) < 0) {
+		fail_errno("unlink");
+	}
+}
+
+static void test_current_offset_read_write(struct io_uring *ring)
+{
+	int fd = open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, 0600);
+	if (fd < 0) {
+		fail_errno("open");
+	}
+
+	struct io_uring_sqe *sqe =
+		get_sqe(ring, "io_uring current-offset write");
+	io_uring_prep_write(sqe, fd, CURRENT_OFFSET_MESSAGE,
+			    sizeof(CURRENT_OFFSET_MESSAGE), -1);
+	sqe->user_data = FILE_CURRENT_WRITE_USER_DATA;
+	submit_one(ring, "io_uring current-offset write submit");
+	expect_cqe_res_user_data(ring, "io_uring current-offset write",
+				 FILE_CURRENT_WRITE_USER_DATA,
+				 sizeof(CURRENT_OFFSET_MESSAGE));
+
+	if (lseek(fd, 0, SEEK_SET) < 0) {
+		fail_errno("lseek");
+	}
+
+	char read_buffer[sizeof(CURRENT_OFFSET_MESSAGE)] = {};
+	sqe = get_sqe(ring, "io_uring current-offset read");
+	io_uring_prep_read(sqe, fd, read_buffer, sizeof(read_buffer), -1);
+	sqe->user_data = FILE_CURRENT_READ_USER_DATA;
+	submit_one(ring, "io_uring current-offset read submit");
+	expect_cqe_res_user_data(ring, "io_uring current-offset read",
+				 FILE_CURRENT_READ_USER_DATA,
+				 sizeof(read_buffer));
+
+	if (memcmp(read_buffer, CURRENT_OFFSET_MESSAGE,
+		   sizeof(CURRENT_OFFSET_MESSAGE)) != 0) {
+		fail_message(
+			"io_uring current-offset read returned unexpected data");
+	}
+	printf("[io_uring:file] current-offset read data verified\n");
+
+	if (close(fd) < 0) {
+		fail_errno("close");
+	}
+	if (unlink(TEST_FILE) < 0) {
+		fail_errno("unlink");
+	}
+}
+
+int main(void)
+{
+	setbuf(stdout, NULL);
+	alarm(30);
+	printf("[io_uring:file] starting\n");
+
+	struct io_uring ring;
+	init_ring(&ring);
+	test_invalid_sq_array_dropped(&ring);
+	test_positional_read_write(&ring);
+	test_current_offset_read_write(&ring);
+	io_uring_queue_exit(&ring);
+
+	printf("[io_uring:file] PASS\n");
+	return EXIT_SUCCESS;
+}

--- a/test/initramfs/src/regression/io/liburing/net.c
+++ b/test/initramfs/src/regression/io/liburing/net.c
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <liburing.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define QUEUE_DEPTH 8
+static const char CLIENT_MESSAGE[] = "Asterinas io_uring client message";
+static const char SERVER_MESSAGE[] = "Asterinas io_uring server response";
+
+#define CLIENT_PORT_START 40000
+#define CLIENT_PORT_END 40100
+
+enum {
+	CLIENT_CONNECT_USER_DATA = 0x201,
+	CLIENT_SENDMSG_USER_DATA = 0x202,
+	CLIENT_RECVMSG_USER_DATA = 0x203,
+	SERVER_ACCEPT_USER_DATA = 0x204,
+	SERVER_RECVMSG_USER_DATA = 0x205,
+	SERVER_SENDMSG_USER_DATA = 0x206,
+};
+
+static void fail_errno(const char *message)
+{
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void fail_uring(const char *message, int ret)
+{
+	errno = -ret;
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void fail_message(const char *message)
+{
+	fprintf(stderr, "%s\n", message);
+	exit(EXIT_FAILURE);
+}
+
+static void init_ring(struct io_uring *ring)
+{
+	int ret = io_uring_queue_init(QUEUE_DEPTH, ring, 0);
+	if (ret < 0) {
+		fail_uring("io_uring_queue_init", ret);
+	}
+}
+
+static struct io_uring_sqe *get_sqe(struct io_uring *ring,
+				    const char *operation)
+{
+	struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+	if (sqe == NULL) {
+		fprintf(stderr, "%s: failed to get an SQE\n", operation);
+		exit(EXIT_FAILURE);
+	}
+
+	return sqe;
+}
+
+static void submit_one(struct io_uring *ring, const char *operation)
+{
+	int ret = io_uring_submit(ring);
+	if (ret < 0) {
+		fail_uring(operation, ret);
+	}
+	if (ret != 1) {
+		fprintf(stderr, "%s: submitted %d SQEs, expected 1\n",
+			operation, ret);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static int wait_cqe_res_user_data(struct io_uring *ring, const char *operation,
+				  unsigned long long expected_user_data)
+{
+	struct io_uring_cqe *cqe;
+	int ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret < 0) {
+		fail_uring(operation, ret);
+	}
+
+	if ((unsigned long long)cqe->user_data != expected_user_data) {
+		fprintf(stderr, "%s: got user_data %llu, expected %llu\n",
+			operation, (unsigned long long)cqe->user_data,
+			expected_user_data);
+		exit(EXIT_FAILURE);
+	}
+
+	int res = cqe->res;
+	io_uring_cqe_seen(ring, cqe);
+	if (res < 0) {
+		fail_uring(operation, res);
+	}
+
+	return res;
+}
+
+static void expect_cqe_res_user_data(struct io_uring *ring,
+				     const char *operation,
+				     unsigned long long expected_user_data,
+				     int expected_res)
+{
+	int res = wait_cqe_res_user_data(ring, operation, expected_user_data);
+	if (res != expected_res) {
+		fprintf(stderr, "%s: got CQE result %d, expected %d\n",
+			operation, res, expected_res);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void sendmsg_all(struct io_uring *ring, int fd, const char *buffer,
+			size_t len, const char *operation,
+			unsigned long long user_data)
+{
+	size_t total_len = 0;
+	while (total_len < len) {
+		struct iovec iov = {
+			.iov_base = (void *)(buffer + total_len),
+			.iov_len = len - total_len,
+		};
+		struct msghdr msg = {
+			.msg_iov = &iov,
+			.msg_iovlen = 1,
+		};
+
+		struct io_uring_sqe *sqe = get_sqe(ring, operation);
+		io_uring_prep_sendmsg(sqe, fd, &msg, 0);
+		sqe->user_data = user_data;
+		submit_one(ring, operation);
+
+		int sent_len =
+			wait_cqe_res_user_data(ring, operation, user_data);
+		if (sent_len <= 0) {
+			fail_message("io_uring sendmsg returned zero");
+		}
+		total_len += sent_len;
+	}
+}
+
+static void recvmsg_exact(struct io_uring *ring, int fd, char *buffer,
+			  size_t len, const char *operation,
+			  unsigned long long user_data)
+{
+	size_t total_len = 0;
+	while (total_len < len) {
+		struct iovec iov = {
+			.iov_base = buffer + total_len,
+			.iov_len = len - total_len,
+		};
+		struct msghdr msg = {
+			.msg_iov = &iov,
+			.msg_iovlen = 1,
+		};
+
+		struct io_uring_sqe *sqe = get_sqe(ring, operation);
+		io_uring_prep_recvmsg(sqe, fd, &msg, 0);
+		sqe->user_data = user_data;
+		submit_one(ring, operation);
+
+		int recv_len =
+			wait_cqe_res_user_data(ring, operation, user_data);
+		if (recv_len <= 0) {
+			fail_message("io_uring recvmsg reached EOF");
+		}
+		total_len += recv_len;
+	}
+}
+
+static int create_listener(struct sockaddr_in *server_addr)
+{
+	int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (listen_fd < 0) {
+		fail_errno("socket");
+	}
+
+	int enable = 1;
+	if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &enable,
+		       sizeof(enable)) < 0) {
+		fail_errno("setsockopt");
+	}
+
+	memset(server_addr, 0, sizeof(*server_addr));
+	server_addr->sin_family = AF_INET;
+	server_addr->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	server_addr->sin_port = 0;
+
+	if (bind(listen_fd, (struct sockaddr *)server_addr,
+		 sizeof(*server_addr)) < 0) {
+		fail_errno("bind");
+	}
+	if (listen(listen_fd, 8) < 0) {
+		fail_errno("listen");
+	}
+
+	socklen_t addr_len = sizeof(*server_addr);
+	if (getsockname(listen_fd, (struct sockaddr *)server_addr, &addr_len) <
+	    0) {
+		fail_errno("getsockname");
+	}
+
+	printf("[io_uring:net] listening on 127.0.0.1:%u\n",
+	       ntohs(server_addr->sin_port));
+	return listen_fd;
+}
+
+static void bind_client_socket(int sock)
+{
+	struct sockaddr_in client_addr;
+	memset(&client_addr, 0, sizeof(client_addr));
+	client_addr.sin_family = AF_INET;
+	client_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	for (int port = CLIENT_PORT_START; port < CLIENT_PORT_END; port++) {
+		client_addr.sin_port = htons(port);
+		if (bind(sock, (struct sockaddr *)&client_addr,
+			 sizeof(client_addr)) == 0) {
+			printf("[io_uring:net] client bound to 127.0.0.1:%d\n",
+			       port);
+			return;
+		}
+		if (errno != EADDRINUSE) {
+			fail_errno("client bind");
+		}
+	}
+
+	fail_message("no client port is available");
+}
+
+static void run_network_client(struct sockaddr_in server_addr)
+{
+	alarm(30);
+
+	struct io_uring ring;
+	init_ring(&ring);
+
+	int sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) {
+		fail_errno("client socket");
+	}
+	bind_client_socket(sock);
+
+	struct io_uring_sqe *sqe = get_sqe(&ring, "io_uring connect");
+	io_uring_prep_connect(sqe, sock, (struct sockaddr *)&server_addr,
+			      sizeof(server_addr));
+	sqe->user_data = CLIENT_CONNECT_USER_DATA;
+	submit_one(&ring, "io_uring connect submit");
+	expect_cqe_res_user_data(&ring, "io_uring connect",
+				 CLIENT_CONNECT_USER_DATA, 0);
+	printf("[io_uring:net] client connected\n");
+
+	sendmsg_all(&ring, sock, CLIENT_MESSAGE, sizeof(CLIENT_MESSAGE),
+		    "io_uring client sendmsg", CLIENT_SENDMSG_USER_DATA);
+
+	char response[sizeof(SERVER_MESSAGE)] = {};
+	recvmsg_exact(&ring, sock, response, sizeof(response),
+		      "io_uring client recvmsg", CLIENT_RECVMSG_USER_DATA);
+
+	if (memcmp(response, SERVER_MESSAGE, sizeof(SERVER_MESSAGE)) != 0) {
+		fail_message("io_uring client received unexpected data");
+	}
+	printf("[io_uring:net] client exchange verified\n");
+
+	if (close(sock) < 0) {
+		fail_errno("client close");
+	}
+	io_uring_queue_exit(&ring);
+	exit(EXIT_SUCCESS);
+}
+
+static void test_network_io(void)
+{
+	struct sockaddr_in server_addr;
+	int listen_fd = create_listener(&server_addr);
+
+	pid_t child = fork();
+	if (child < 0) {
+		fail_errno("fork");
+	}
+	if (child == 0) {
+		if (close(listen_fd) < 0) {
+			fail_errno("child close listen socket");
+		}
+		run_network_client(server_addr);
+	}
+
+	struct io_uring ring;
+	init_ring(&ring);
+
+	struct sockaddr_in peer_addr;
+	socklen_t peer_addr_len = sizeof(peer_addr);
+	struct io_uring_sqe *sqe = get_sqe(&ring, "io_uring accept");
+	io_uring_prep_accept(sqe, listen_fd, (struct sockaddr *)&peer_addr,
+			     &peer_addr_len, 0);
+	sqe->user_data = SERVER_ACCEPT_USER_DATA;
+	submit_one(&ring, "io_uring accept submit");
+	int accepted_fd = wait_cqe_res_user_data(&ring, "io_uring accept",
+						 SERVER_ACCEPT_USER_DATA);
+	printf("[io_uring:net] server accepted connection\n");
+
+	char request[sizeof(CLIENT_MESSAGE)] = {};
+	recvmsg_exact(&ring, accepted_fd, request, sizeof(request),
+		      "io_uring server recvmsg", SERVER_RECVMSG_USER_DATA);
+
+	if (memcmp(request, CLIENT_MESSAGE, sizeof(CLIENT_MESSAGE)) != 0) {
+		fail_message("io_uring server received unexpected data");
+	}
+
+	sendmsg_all(&ring, accepted_fd, SERVER_MESSAGE, sizeof(SERVER_MESSAGE),
+		    "io_uring server sendmsg", SERVER_SENDMSG_USER_DATA);
+	printf("[io_uring:net] server exchange verified\n");
+
+	int status;
+	if (waitpid(child, &status, 0) != child) {
+		fail_errno("waitpid");
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS) {
+		fail_message("io_uring client exited with failure");
+	}
+
+	if (close(accepted_fd) < 0) {
+		fail_errno("close accepted socket");
+	}
+	if (close(listen_fd) < 0) {
+		fail_errno("close listen socket");
+	}
+
+	io_uring_queue_exit(&ring);
+}
+
+int main(void)
+{
+	setbuf(stdout, NULL);
+	alarm(30);
+	printf("[io_uring:net] starting\n");
+
+	test_network_io();
+
+	printf("[io_uring:net] PASS\n");
+	return EXIT_SUCCESS;
+}

--- a/test/initramfs/src/regression/io/liburing/sqpoll.c
+++ b/test/initramfs/src/regression/io/liburing/sqpoll.c
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <liburing.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define QUEUE_DEPTH 8
+#define TEST_FILE "/tmp/io_uring_sqpoll_test"
+#define SQPOLL_IDLE_TIMEOUT_MS 1
+#define SQPOLL_SLEEP_RETRY_COUNT 1000
+
+static const char SQPOLL_MESSAGE[] = "Asterinas io_uring SQPOLL file I/O";
+static const char SQPOLL_WAKE_MESSAGE[] =
+	"Asterinas io_uring SQPOLL wakeup file I/O";
+
+enum {
+	SQPOLL_WRITE_USER_DATA = 0x301,
+	SQPOLL_READ_USER_DATA = 0x302,
+	SQPOLL_WAKE_WRITE_USER_DATA = 0x303,
+	SQPOLL_WAKE_READ_USER_DATA = 0x304,
+};
+
+static void fail_errno(const char *message)
+{
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void fail_uring(const char *message, int ret)
+{
+	errno = -ret;
+	perror(message);
+	exit(EXIT_FAILURE);
+}
+
+static void fail_message(const char *message)
+{
+	fprintf(stderr, "%s\n", message);
+	exit(EXIT_FAILURE);
+}
+
+static struct io_uring_sqe *get_sqe(struct io_uring *ring,
+				    const char *operation)
+{
+	struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+	if (sqe == NULL) {
+		fprintf(stderr, "%s: failed to get an SQE\n", operation);
+		exit(EXIT_FAILURE);
+	}
+
+	return sqe;
+}
+
+static void submit_one(struct io_uring *ring, const char *operation)
+{
+	int ret = io_uring_submit(ring);
+	if (ret < 0) {
+		fail_uring(operation, ret);
+	}
+	if (ret != 1) {
+		fprintf(stderr, "%s: submitted %d SQEs, expected 1\n",
+			operation, ret);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static int wait_cqe_res_user_data(struct io_uring *ring, const char *operation,
+				  unsigned long long expected_user_data)
+{
+	struct io_uring_cqe *cqe;
+	int ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret < 0) {
+		fail_uring(operation, ret);
+	}
+
+	if ((unsigned long long)cqe->user_data != expected_user_data) {
+		fprintf(stderr, "%s: got user_data %llu, expected %llu\n",
+			operation, (unsigned long long)cqe->user_data,
+			expected_user_data);
+		exit(EXIT_FAILURE);
+	}
+
+	int res = cqe->res;
+	io_uring_cqe_seen(ring, cqe);
+	if (res < 0) {
+		fail_uring(operation, res);
+	}
+
+	return res;
+}
+
+static void expect_cqe_res_user_data(struct io_uring *ring,
+				     const char *operation,
+				     unsigned long long expected_user_data,
+				     int expected_res)
+{
+	int res = wait_cqe_res_user_data(ring, operation, expected_user_data);
+	if (res != expected_res) {
+		fprintf(stderr, "%s: got CQE result %d, expected %d\n",
+			operation, res, expected_res);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void init_sqpoll_ring(struct io_uring *ring)
+{
+	struct io_uring_params params = {
+		.flags = IORING_SETUP_SQPOLL,
+		.sq_thread_idle = SQPOLL_IDLE_TIMEOUT_MS,
+	};
+
+	int ret = io_uring_queue_init_params(QUEUE_DEPTH, ring, &params);
+	if (ret < 0) {
+		fail_uring("io_uring_queue_init_params SQPOLL", ret);
+	}
+}
+
+static void wait_for_sqpoll_sleep(struct io_uring *ring)
+{
+	for (int i = 0; i < SQPOLL_SLEEP_RETRY_COUNT; i++) {
+		if (*ring->sq.kflags & IORING_SQ_NEED_WAKEUP) {
+			printf("[io_uring:sqpoll] SQPOLL thread slept\n");
+			return;
+		}
+
+		usleep(1000);
+	}
+
+	fail_message("io_uring SQPOLL thread did not enter NEED_WAKEUP");
+}
+
+static void test_sqpoll_read_write(struct io_uring *ring, int fd,
+				   const char *message, size_t message_len,
+				   unsigned long long write_user_data,
+				   unsigned long long read_user_data)
+{
+	if (ftruncate(fd, 0) < 0) {
+		fail_errno("ftruncate");
+	}
+
+	struct io_uring_sqe *sqe = get_sqe(ring, "io_uring SQPOLL write");
+	io_uring_prep_write(sqe, fd, message, message_len, 0);
+	sqe->user_data = write_user_data;
+	submit_one(ring, "io_uring SQPOLL write submit");
+	expect_cqe_res_user_data(ring, "io_uring SQPOLL write", write_user_data,
+				 message_len);
+
+	char read_buffer[128] = {};
+	if (message_len > sizeof(read_buffer)) {
+		fail_message("io_uring SQPOLL read buffer is too small");
+	}
+
+	sqe = get_sqe(ring, "io_uring SQPOLL read");
+	io_uring_prep_read(sqe, fd, read_buffer, message_len, 0);
+	sqe->user_data = read_user_data;
+	submit_one(ring, "io_uring SQPOLL read submit");
+	expect_cqe_res_user_data(ring, "io_uring SQPOLL read", read_user_data,
+				 message_len);
+
+	if (memcmp(read_buffer, message, message_len) != 0) {
+		fail_message("io_uring SQPOLL read returned unexpected data");
+	}
+}
+
+int main(void)
+{
+	setbuf(stdout, NULL);
+	alarm(30);
+	printf("[io_uring:sqpoll] starting\n");
+
+	struct io_uring ring;
+	init_sqpoll_ring(&ring);
+
+	int fd = open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, 0600);
+	if (fd < 0) {
+		fail_errno("open");
+	}
+
+	test_sqpoll_read_write(&ring, fd, SQPOLL_MESSAGE,
+			       sizeof(SQPOLL_MESSAGE), SQPOLL_WRITE_USER_DATA,
+			       SQPOLL_READ_USER_DATA);
+	printf("[io_uring:sqpoll] file read/write verified\n");
+
+	wait_for_sqpoll_sleep(&ring);
+	test_sqpoll_read_write(&ring, fd, SQPOLL_WAKE_MESSAGE,
+			       sizeof(SQPOLL_WAKE_MESSAGE),
+			       SQPOLL_WAKE_WRITE_USER_DATA,
+			       SQPOLL_WAKE_READ_USER_DATA);
+	printf("[io_uring:sqpoll] wakeup read/write verified\n");
+
+	if (close(fd) < 0) {
+		fail_errno("close");
+	}
+	if (unlink(TEST_FILE) < 0) {
+		fail_errno("unlink");
+	}
+	io_uring_queue_exit(&ring);
+
+	printf("[io_uring:sqpoll] PASS\n");
+	return EXIT_SUCCESS;
+}

--- a/test/initramfs/src/regression/io/run_test.sh
+++ b/test/initramfs/src/regression/io/run_test.sh
@@ -16,3 +16,7 @@ set -e
 ./file_io/fcntl_lock
 ./file_io/file_err
 ./file_io/iovec_err
+
+./liburing/file
+./liburing/net
+./liburing/sqpoll


### PR DESCRIPTION
## Motivation

`io_uring` has become a common Linux asynchronous I/O interface. Modern runtimes, network services, databases, and test suites may use it directly. Asterinas needs a native implementation to provide the Linux-compatible `io_uring_setup`, `io_uring_enter`, and `io_uring_register` interfaces.

## Design

### Design Overview

The `io_uring` design separates the userspace ABI from the kernel state that implements it. Userspace publishes submission queue entries (SQEs) into shared memory. The kernel consumes those entries, turns each valid SQE into an operation object, executes the operation either immediately or on an io_uring worker, and finally publishes a completion queue entry (CQE) back into shared memory.

The end-to-end path follows this sequence.

```text
io_uring_setup
    -> create IoUringContext
    -> map SQ/CQ/SQE regions to userspace

userspace
    -> write SQE table and SQ array
    -> advance sq.tail

io_uring_enter
    -> consume SQ array entries
    -> read SQEs
    -> build IoUringOp requests
    -> execute inline or enqueue to IoWq
    -> post CQEs

userspace
    -> observe cq.tail
    -> consume CQEs
    -> advance cq.head
```

This structure separates the ABI-facing ring mechanics from operation-specific logic. The ring code only knows how to consume SQEs and post CQEs. The operation modules know how to validate and execute individual opcodes. The registration code owns resources that can be referenced by later SQEs.

### System Call Surface

The subsystem implements these Linux-facing entry points.

* `io_uring_setup` creates a ring and installs it as an anonymous inode file.
* `io_uring_enter` drives submission: it consumes SQEs directly in normal mode, or wakes and waits for SQPOLL in SQPOLL mode, and optionally waits for completions.
* `io_uring_register` attaches ring-local resources, currently fixed user buffers.

The returned file descriptor is the handle for every later operation on the ring. The file object is an `IoUringContext`. It implements `FileLike` so that `mmap` can expose the shared ring regions, and it implements `Pollable` so userspace can wait for completions with normal polling interfaces.

### Ring Object Model

The state owned by `IoUringContext` includes the following components.

* `RingRegion`, the shared SQ/CQ metadata, CQE array, and SQ array mapping.
* `SqeRegion`, the shared SQE table mapping.
* `SqRing`, the kernel-owned submission-side cursor.
* `CqRing`, the kernel-owned completion-side cursor and overflow list.
* `RegisteredResource`, resources installed by `io_uring_register`.
* `IoWq`, the asynchronous execution queue.
* Optional `SqPoll`, enabled by `IORING_SETUP_SQPOLL`.
* Wait queues and poll state for `io_uring_enter`, `poll`, and SQPOLL wakeups.

The ring memory layout follows the Linux ABI.

```text
RingRegion
+-------------------+
| IoRingMeta        |
+-------------------+
| CQE array         |
+-------------------+
| SQ array          |
+-------------------+

SqeRegion
+-------------------+
| SQE array         |
+-------------------+
```

`IORING_OFF_SQ_RING` and `IORING_OFF_CQ_RING` map into `RingRegion`. `IORING_OFF_SQES` maps into `SqeRegion`. The setup path writes Linux-compatible offsets into `io_uring_params`, so liburing and Linux tests can find the same fields they expect on Linux. See [ltp io_uring01](<https://github.com/linux-test-project/ltp/blob/20250930/testcases/kernel/syscalls/io_uring/io_uring01.c#L70-L125>) for a representative userspace mapping sequence.

### Submission Path

Userspace submits work in two steps. First it writes SQEs into the SQE table and writes SQE indexes into the SQ array. Then it advances `sq.tail`. The kernel treats the tail update as the publication point.

`IoUringContext::submit_sqes` is the single entry point for consuming SQEs. It is called by `io_uring_enter` in the normal mode, or by the SQPOLL thread in SQPOLL mode. The submission path is as follows.

1. Locks `SqRing`.
2. Reads `sq.tail` from shared memory.
3. Calculates how many SQ array entries are pending.
4. Reads each SQ array entry in ring order.
5. Uses the SQ array value as an index into the SQE table.
6. Converts each SQE into an operation request.
7. Advances the cached SQ head.
8. Publishes the new `sq.head` after consumed entries are complete.

An SQ array entry that names an out-of-range SQE index is dropped before the SQE table is read. The kernel advances `sq.head`, increments `sq.dropped`, and does not post a CQE because there is no valid SQE from which to obtain `user_data`. If an SQE is well-formed enough to identify `user_data` but fails validation, the error completion uses that `user_data`.

### Operation Model

Each supported opcode has a request type implementing `IoUringOp`.

```rust
trait IoUringOp: Send + Sync {
    fn try_execute_nonblock(&self) -> Option<Completion>;
    fn execute(&self) -> Completion;
}
```

`build_op_request` is the common decoder. It validates shared SQE flags, checks the opcode, and dispatches to the operation-specific constructor. The constructor captures submission-time state: for example the target file, socket address, user buffer range, fixed buffer range, message header, or accept flags.

`try_execute_nonblock` is the inline fast path. Blocking operations currently return `None`, which causes the request to be queued on `IoWq`. Future operations can use this hook for true nonblocking fast paths, such as file read operations that are already in page cache.

Successful operations produce nonnegative byte counts or file descriptors. Errors become negative errno values in `cqe.res`. The completion conversion is centralized so individual operations return ordinary `Result<usize>` where possible.

### Execution Contexts

`io_uring` uses kernel-managed execution contexts for two separate purposes.

* `IoWq` executes prepared requests asynchronously.
* `SqPoll` consumes SQEs without requiring userspace to enter the kernel for every submission.

Both are created with `IoUringThreadOptions`. This helper is local to `kernel/src/io_uring/`. It clones the submitter's execution context that io_uring operations need.

* VMAR handle for user-memory access.
* File table reference for file descriptor lookups and accepted sockets.
* File-system context.
* User namespace and namespace proxy references.
* Optional CPU affinity for SQPOLL.

The resulting thread data is `IoUringThread`, not `PosixThread`. These threads are kernel implementation details and are not visible as user-created POSIX threads. They still carry `ThreadLocal`, because file and memory operations depend on that context.

`IoWq` owns a queue of prepared `Arc<dyn IoUringOp>` requests. The worker waits for requests, calls `execute`, and posts the returned completion if the ring still exists. `IoWq` is intentionally separate from the generic kernel workqueue. The generic workqueue is designed for ordinary deferred kernel closures, while io_uring work must run in a task that carries the submitter-derived `ThreadLocal`. Read and write operations, for example, obtain the current task's `ThreadLocal` before copying user buffers. Running those operations on a kernel workqueue worker would lose the VMAR, file table, file-system, and namespace context cloned by `IoUringThreadOptions`.

`SqPoll` owns its state and thread handle. It repeatedly calls `IoUringContext::submit_sqes`. After its idle timeout, it sets `IORING_SQ_NEED_WAKEUP`, marks itself sleeping, and waits until `io_uring_enter` wakes it with `IORING_ENTER_SQ_WAKEUP`. Dropping the ring stops the SQPOLL thread.

### Completion Path

All completions go through `IoUringContext::post_completion`. `CqRing` writes the CQE payload first, then publishes the new `cq.tail`. Only after `cq.tail` is visible does the ring notify poll waiters.

If the CQ has no free slots, the completion is pushed into `CqRing::overflow_completions` and `cq_overflow` is incremented. Overflow draining is retried in these cases.

* A new completion is posted.
* `io_uring_enter` waits for completions.
* The ring is polled.

### Registered Resources

`io_uring_register` installs resources that belong to one ring and can be referenced by later SQEs. The current implementation supports these operations.

* `IORING_REGISTER_BUFFERS`
* `IORING_UNREGISTER_BUFFERS`

`RegisteredResource` is the kernel-side registry. It currently stores only registered user buffers, but it is intentionally separate from file read/write operations. That gives the design three clear phases.

* Registration installs or removes resource tables.
* SQE constructors resolve resource references at submission time.
* Request execution uses already-resolved handles or ranges.

### Synchronization and Memory Ordering

The SQ and CQ rings are ordinary memory in VMO mappings shared with userspace. Correctness depends on explicit ordering at publication points.

For the SQ, ordering works as follows.

* Userspace writes SQEs and SQ array entries, then publishes them by advancing `sq.tail`.
* The kernel reads `sq.tail`, then performs an **acquire fence** before reading SQ array entries and SQEs.
* After consuming SQ entries, the kernel performs a **release fence** before writing `sq.head`.
* Userspace may reuse SQ slots only after observing the advanced `sq.head`.

For the CQ, ordering works as follows.

* The kernel writes the CQE payload first.
* The kernel performs a **release fence** before publishing the new `cq.tail`.
* Userspace reads `cq.tail` with acquire semantics before consuming CQEs.
* Userspace advances `cq.head` after consuming CQEs.
* The kernel reads `cq.head`, then performs an **acquire fence** before treating CQ slots as available.

`IoUringContext` also uses separate locks for SQ and CQ kernel state. The SQ lock ensures that `io_uring_enter` and SQPOLL cannot consume the same SQ entry twice. The CQ lock ensures that synchronous submission, worker completion, and SQPOLL-driven submission cannot publish conflicting CQ tail values.

## Current Results

The current implementation can pass the LTP `io_uring01` and `io_uring02` and gvisor iouring_test(Skipped 4 tests beacuase of `!IsRunningOnGvisor()`).

The regression suite also contains simple liburing-based programs under `test/initramfs/src/regression/io/io_uring/`. These programs exercise NOP, ring setup validation, SQ array error handling, positional and current-offset file read/write, and basic TCP socket operations through liburing.

## Drawbacks, Alternatives, and Unknowns

### Drawbacks

* The design intentionally implements a subset of Linux `io_uring`. Some applications may probe successfully but still need unsupported features such as request links, drains, cancellation, timeouts, fixed files, personalities, or advanced polling. 
* The implementation cannot currently reuse the existing generic workqueue. That workqueue schedules plain deferred closures on generic worker tasks, while io_uring workers need submitter-derived `ThreadLocal` state for user-memory access, file table access, file-system context, and namespace context. Reusing the generic workqueue directly would either lose this execution context or require new workqueue APIs for context-bound workers and ring-owned completion handling.
* Most real I/O operations currently default to asynchronous worker execution. Although `IoUringOp::try_execute_nonblock` exists as the inline nonblocking hook, file operations do not yet have a convenient `FileLike`-level way to express "try this operation without blocking." For example, a read operation could in principle reach into the VMO and use `Vmo::try_operate_on_range`, but doing so from the io_uring layer would step outside file semantics such as current-offset handling, access notification, and file-type-specific read behavior. A future design should expose nonblocking reads and writes through `FileLike` directly.

## Prior Art and References

* Linux `io_uring` core implementation: <https://elixir.bootlin.com/linux/v7.1.2/source/io_uring/io_uring.c>
* `io_uring_setup(2)`: <https://man7.org/linux/man-pages/man2/io_uring_setup.2.html>
* `io_uring_enter(2)`: <https://man7.org/linux/man-pages/man2/io_uring_enter.2.html>
* `io_uring_register(2)`: <https://man7.org/linux/man-pages/man2/io_uring_register.2.html>
