### PR TITLE
Support SEM_UNDO for System V semaphores

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/inter-process-communication/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/inter-process-communication/README.md
@@ -46,9 +46,6 @@ Supported functionality in SCML:
 {{#include semop_and_semtimedop.scml}}
 ```
 
-Unsupported semaphore flags:
-* `SEM_UNDO`
-
 Supported and unsupported functionality of `semtimedop` are the same as `semop`.
 The SCML rules are omitted for brevity.
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/inter-process-communication/semop_and_semtimedop.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/inter-process-communication/semop_and_semtimedop.scml
@@ -1,5 +1,5 @@
 struct sembuf = {
-    sem_flg = IPC_NOWAIT,
+    sem_flg = IPC_NOWAIT | SEM_UNDO,
     ..
 };
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/README.md
@@ -80,9 +80,6 @@ Unsupported flags:
 * `CLONE_NEWTIME`
 * `CLONE_NEWUSER`
 
-Silently-ignored flags:
-* `CLONE_SYSVSEM`
-
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/unshare.2.html).
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/unshare.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/namespaces-cgroups-and-security/unshare.scml
@@ -1,2 +1,2 @@
 // Disassociate parts of the process execution context
-unshare(flags = CLONE_FILES | CLONE_FS | CLONE_NEWNS | CLONE_NEWUTS | CLONE_THREAD | CLONE_SIGHAND | CLONE_VM);
+unshare(flags = CLONE_FILES | CLONE_FS | CLONE_NEWNS | CLONE_NEWUTS | CLONE_THREAD | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_VM);

--- a/kernel/src/ipc/ipc_ids.rs
+++ b/kernel/src/ipc/ipc_ids.rs
@@ -45,9 +45,9 @@ impl<T> IpcIds<T> {
     }
 
     /// Removes the object identified by `id`.
-    pub(super) fn remove<F>(&self, id: IpcId, may_remove: F) -> Result<()>
+    pub(super) fn remove<R, F>(&self, id: IpcId, may_remove: F) -> Result<R>
     where
-        F: FnOnce(&T) -> Result<()>,
+        F: FnOnce(&T) -> Result<R>,
     {
         use alloc::collections::btree_map::Entry;
 
@@ -57,12 +57,12 @@ impl<T> IpcIds<T> {
             return_errno_with_message!(Errno::EINVAL, "the ID does not exist");
         };
 
-        may_remove(entry.get())?;
+        let result = may_remove(entry.get())?;
         entry.remove();
 
         self.id_allocator.lock().free(id.get() as usize);
 
-        Ok(())
+        Ok(result)
     }
 
     /// Inserts a new object with an automatically allocated ID.

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -164,12 +164,6 @@ impl IpcNamespace {
         });
     }
 
-    pub fn sem_undo_token_matches(&self, semid: IpcId, token: SemUndoToken) -> bool {
-        self.sem_ids
-            .with(semid, |sem_set| sem_set.sem_undo_token() == token)
-            .unwrap_or(false)
-    }
-
     fn clear_sem_undo_set(&self, semid: IpcId, token: SemUndoToken) {
         self.visit_sem_undo_lists(|list| list.clear_set(self, semid, token));
     }

--- a/kernel/src/ipc/ipc_ns.rs
+++ b/kernel/src/ipc/ipc_ns.rs
@@ -18,13 +18,15 @@ use super::{
     semaphore::system_v::{
         PermissionMode,
         sem_set::{SEMMNI, SemaphoreSet},
+        sem_undo::{SemUndoList, SemUndoToken},
     },
 };
 use crate::{
     fs::pseudofs::{NsCommonOps, NsType, StashedDentry},
     prelude::*,
     process::{
-        Credentials, UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread,
+        Credentials, Pid, UserNamespace, credentials::capabilities::CapSet,
+        posix_thread::PosixThread,
     },
     security::lsm::hooks as lsm_hooks,
 };
@@ -41,6 +43,8 @@ use crate::{
 pub struct IpcNamespace {
     /// Semaphore sets within this namespace.
     sem_ids: IpcIds<SemaphoreSet>,
+    /// Semaphore undo lists that have entries for this namespace.
+    sem_undo_lists: Mutex<Vec<Weak<SemUndoList>>>,
     /// Owner user namespace.
     owner: Arc<UserNamespace>,
     /// Stashed dentry for nsfs.
@@ -69,6 +73,7 @@ impl IpcNamespace {
 
         Arc::new(Self {
             sem_ids,
+            sem_undo_lists: Mutex::new(Vec::new()),
             owner,
             stashed_dentry,
         })
@@ -111,7 +116,73 @@ impl IpcNamespace {
     where
         F: FnOnce(&SemaphoreSet) -> Result<()>,
     {
-        self.sem_ids.remove(semid, may_remove)
+        let token = self.sem_ids.remove(semid, |sem_set| {
+            may_remove(sem_set)?;
+            Ok(sem_set.sem_undo_token())
+        })?;
+        self.clear_sem_undo_set(semid, token);
+        Ok(())
+    }
+
+    /// Registers a semaphore undo list for later `SEM_SETVAL` and `IPC_RMID` cleanup.
+    pub fn register_sem_undo_list(&self, sem_undo_list: &Arc<SemUndoList>) {
+        let mut sem_undo_lists = self.sem_undo_lists.lock();
+        let mut exists = false;
+
+        sem_undo_lists.retain(|weak_list| {
+            let Some(list) = weak_list.upgrade() else {
+                return false;
+            };
+
+            if Arc::ptr_eq(&list, sem_undo_list) {
+                exists = true;
+            }
+            true
+        });
+
+        if !exists {
+            sem_undo_lists.push(Arc::downgrade(sem_undo_list));
+        }
+    }
+
+    /// Clears all undo entries for one semaphore.
+    pub fn clear_sem_undo_entries(&self, semid: IpcId, token: SemUndoToken, sem_num: usize) {
+        self.visit_sem_undo_lists(|list| list.clear_sem(self, semid, token, sem_num));
+    }
+
+    /// Applies one semaphore undo adjustment.
+    pub fn apply_sem_undo(
+        &self,
+        semid: IpcId,
+        token: SemUndoToken,
+        sem_num: usize,
+        adjustment: i32,
+        pid: Pid,
+    ) {
+        let _ = self.sem_ids.with(semid, |sem_set| {
+            sem_set.apply_undo(token, sem_num, adjustment, pid);
+        });
+    }
+
+    pub fn sem_undo_token_matches(&self, semid: IpcId, token: SemUndoToken) -> bool {
+        self.sem_ids
+            .with(semid, |sem_set| sem_set.sem_undo_token() == token)
+            .unwrap_or(false)
+    }
+
+    fn clear_sem_undo_set(&self, semid: IpcId, token: SemUndoToken) {
+        self.visit_sem_undo_lists(|list| list.clear_set(self, semid, token));
+    }
+
+    fn visit_sem_undo_lists(&self, mut visit: impl FnMut(&SemUndoList)) {
+        self.sem_undo_lists.lock().retain(|weak_list| {
+            let Some(list) = weak_list.upgrade() else {
+                return false;
+            };
+
+            visit(&list);
+            true
+        });
     }
 
     /// Returns the existing semaphore set or creates a new one.

--- a/kernel/src/ipc/semaphore/system_v/mod.rs
+++ b/kernel/src/ipc/semaphore/system_v/mod.rs
@@ -6,6 +6,7 @@ use bitflags::bitflags;
 
 pub mod sem;
 pub mod sem_set;
+pub mod sem_undo;
 
 bitflags! {
     pub struct PermissionMode: u16{

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -12,6 +12,7 @@ use ostd::sync::{Waiter, Waker};
 use super::{
     PermissionMode,
     sem_set::{SEMVMX, SemSetInner},
+    sem_undo::{SemUndoList, SemUndoOp, SemUndoToken},
 };
 use crate::{
     ipc::{IpcFlags, IpcId, IpcNamespace},
@@ -54,6 +55,7 @@ pub(super) struct PendingOp {
     sops: Vec<SemBuf>,
     status: Arc<AtomicStatus>,
     waker: Option<Arc<Waker>>,
+    sem_undo_token: Arc<Mutex<Option<SemUndoToken>>>,
     pid: Pid,
 }
 
@@ -65,14 +67,15 @@ pub(super) enum PendingBlocker {
 }
 
 impl PendingOp {
-    fn new(sops: Vec<SemBuf>, pid: Pid, num_sems: usize) -> Result<Self> {
+    fn new(
+        sops: Vec<SemBuf>,
+        pid: Pid,
+        num_sems: usize,
+        sem_undo_token: Arc<Mutex<Option<SemUndoToken>>>,
+    ) -> Result<Self> {
         for op in sops.iter() {
             if op.sem_num as usize >= num_sems {
                 return_errno_with_message!(Errno::EFBIG, "the semaphore number is out of bounds");
-            }
-            if IpcFlags::from_bits_truncate(op.sem_flags as u32).contains(IpcFlags::SEM_UNDO) {
-                // TODO: Add support for the `SEM_UNDO` flag
-                return_errno_with_message!(Errno::EINVAL, "SEM_UNDO is not supported yet");
             }
         }
 
@@ -80,6 +83,7 @@ impl PendingOp {
             sops,
             status: Arc::new(AtomicStatus::new(Status::Pending)),
             waker: None,
+            sem_undo_token,
             pid,
         })
     }
@@ -90,6 +94,10 @@ impl PendingOp {
 
     pub(super) fn set_status(&self, status: Status) {
         self.status.store(status, Ordering::Relaxed);
+    }
+
+    fn set_sem_undo_token(&self, token: SemUndoToken) {
+        *self.sem_undo_token.lock() = Some(token);
     }
 
     pub(super) fn waker(&self) -> Option<&Arc<Waker>> {
@@ -195,6 +203,8 @@ pub fn sem_op(
     }
 
     let is_alter = check_alter_sop(&sops);
+    let undo_ops = collect_undo_ops(&sops);
+    let sem_undo_list = (!undo_ops.is_empty()).then(|| ctx.process.sem_undo_list());
 
     // TODO: Support permission check
     warn!("Semaphore operation doesn't support permission check now");
@@ -202,26 +212,40 @@ pub fn sem_op(
     enum SemOpResult {
         Completed {
             status: Status,
+            token: Option<SemUndoToken>,
         },
         Pending {
             status: Arc<AtomicStatus>,
             waiter: Waiter,
+            token: Arc<Mutex<Option<SemUndoToken>>>,
         },
     }
 
     let sem_op_result = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
-        let mut pending_op = PendingOp::new(sops, ctx.process.pid(), sem_set.num_sems())?;
+        let sem_undo_token = Arc::new(Mutex::new(None));
+        let mut pending_op = PendingOp::new(
+            sops,
+            ctx.process.pid(),
+            sem_set.num_sems(),
+            sem_undo_token.clone(),
+        )?;
 
         let mut inner = sem_set.inner();
 
         // Try to perform the operation without blocking
         if let Some(status) = perform_atomic_semop(&mut inner.sems, &mut pending_op) {
             if status != Status::Normal {
-                return Ok(SemOpResult::Completed { status });
+                return Ok(SemOpResult::Completed {
+                    status,
+                    token: None,
+                });
             }
 
+            let token = sem_set.sem_undo_token();
+            pending_op.set_sem_undo_token(token);
+
             if is_alter {
-                let wake_queue = do_smart_update(&mut inner, &pending_op);
+                let wake_queue = do_smart_update(&mut inner, &pending_op, token);
                 for wake_op in wake_queue {
                     if let Some(waker) = wake_op.waker {
                         waker.wake_up();
@@ -231,7 +255,10 @@ pub fn sem_op(
 
             sem_set.update_otime();
 
-            return Ok(SemOpResult::Completed { status });
+            return Ok(SemOpResult::Completed {
+                status,
+                token: Some(token),
+            });
         }
 
         // Prepare to wait
@@ -246,12 +273,29 @@ pub fn sem_op(
             inner.pending_const.push_back(pending_op);
         }
 
-        Ok(SemOpResult::Pending { status, waiter })
+        Ok(SemOpResult::Pending {
+            status,
+            waiter,
+            token: sem_undo_token,
+        })
     })?;
 
-    fn map_status_to_result(status: Status, waiter_error: Option<Error>) -> Result<()> {
+    fn finish_sem_op(
+        status: Status,
+        waiter_error: Option<Error>,
+        sem_undo_list: Option<&Arc<SemUndoList>>,
+        ipc_ns: &Arc<IpcNamespace>,
+        sem_id: IpcId,
+        token: Option<SemUndoToken>,
+        undo_ops: &[SemUndoOp],
+    ) -> Result<()> {
         match status {
-            Status::Normal => Ok(()),
+            Status::Normal => {
+                if let (Some(sem_undo_list), Some(token)) = (sem_undo_list, token) {
+                    sem_undo_list.record(ipc_ns.clone(), sem_id, token, undo_ops);
+                }
+                Ok(())
+            }
             Status::Removed => {
                 return_errno_with_message!(Errno::EIDRM, "the semaphore set is removed");
             }
@@ -276,11 +320,25 @@ pub fn sem_op(
         }
     }
 
-    let (waiter_result, status) = match sem_op_result {
-        SemOpResult::Completed { status } => return map_status_to_result(status, None),
-        SemOpResult::Pending { status, waiter } => {
+    let (waiter_result, status, token) = match sem_op_result {
+        SemOpResult::Completed { status, token } => {
+            return finish_sem_op(
+                status,
+                None,
+                sem_undo_list.as_ref(),
+                ipc_ns,
+                sem_id,
+                token,
+                &undo_ops,
+            );
+        }
+        SemOpResult::Pending {
+            status,
+            waiter,
+            token,
+        } => {
             let result = waiter.pause_timeout(&timeout.as_ref().into());
-            (result, status)
+            (result, status, token)
         }
     };
 
@@ -300,7 +358,28 @@ pub fn sem_op(
         });
     }
 
-    map_status_to_result(status.load(Ordering::Relaxed), waiter_result.err())
+    finish_sem_op(
+        status.load(Ordering::Relaxed),
+        waiter_result.err(),
+        sem_undo_list.as_ref(),
+        ipc_ns,
+        sem_id,
+        *token.lock(),
+        &undo_ops,
+    )
+}
+
+fn collect_undo_ops(sops: &[SemBuf]) -> Vec<SemUndoOp> {
+    sops.iter()
+        .filter_map(|op| {
+            let flags = IpcFlags::from_bits_truncate(op.sem_flags as u32);
+            if !flags.contains(IpcFlags::SEM_UNDO) || op.sem_op == 0 {
+                return None;
+            }
+
+            Some(SemUndoOp::new(op.sem_num as usize, -i32::from(op.sem_op)))
+        })
+        .collect()
 }
 
 /// Checks whether there are two operations that will operate on the same semaphore and the first
@@ -342,16 +421,20 @@ fn check_alter_sop(sops: &[SemBuf]) -> bool {
 /// them.
 ///
 /// Reference: <https://elixir.bootlin.com/linux/v6.0.9/source/ipc/sem.c#L1029>
-fn do_smart_update(inner: &mut SemSetInner, pending_op: &PendingOp) -> LinkedList<PendingOp> {
+fn do_smart_update(
+    inner: &mut SemSetInner,
+    pending_op: &PendingOp,
+    token: SemUndoToken,
+) -> LinkedList<PendingOp> {
     let mut wake_queue = LinkedList::new();
 
     let (sems, pending_alter, pending_const) = inner.field_mut();
 
     if !pending_const.is_empty() {
-        do_smart_wakeup_zero(sems, pending_const, pending_op, &mut wake_queue);
+        do_smart_wakeup_zero(sems, pending_const, pending_op, token, &mut wake_queue);
     }
     if !pending_alter.is_empty() {
-        let _ = update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
+        let _ = update_pending_alter(sems, pending_alter, pending_const, token, &mut wake_queue);
     }
 
     wake_queue
@@ -368,6 +451,7 @@ pub(super) fn update_pending_alter(
     sems: &mut [Semaphore],
     pending_alter: &mut LinkedList<PendingOp>,
     pending_const: &mut LinkedList<PendingOp>,
+    token: SemUndoToken,
     wake_queue: &mut LinkedList<PendingOp>,
 ) -> bool {
     let mut has_completed = false;
@@ -379,6 +463,9 @@ pub(super) fn update_pending_alter(
             continue;
         };
         alter_op.set_status(status);
+        if status == Status::Normal {
+            alter_op.set_sem_undo_token(token);
+        }
 
         let mut alter_op = cursor.remove_current_as_list().unwrap();
         if status != Status::Normal {
@@ -387,7 +474,13 @@ pub(super) fn update_pending_alter(
         }
         has_completed = true;
 
-        do_smart_wakeup_zero(sems, pending_const, alter_op.front().unwrap(), wake_queue);
+        do_smart_wakeup_zero(
+            sems,
+            pending_const,
+            alter_op.front().unwrap(),
+            token,
+            wake_queue,
+        );
         wake_queue.append(&mut alter_op);
 
         // Retry from the beginning since we've performed some alteration.
@@ -405,11 +498,12 @@ fn do_smart_wakeup_zero(
     sems: &mut [Semaphore],
     pending_const: &mut LinkedList<PendingOp>,
     pending_op: &PendingOp,
+    token: SemUndoToken,
     wake_queue: &mut LinkedList<PendingOp>,
 ) {
     for sop in pending_op.sops_iter() {
         if sems.get(sop.sem_num as usize).unwrap().val == 0 {
-            let _ = wake_const_ops(sems, pending_const, wake_queue);
+            let _ = wake_const_ops(sems, pending_const, token, wake_queue);
             return;
         }
     }
@@ -425,6 +519,7 @@ fn do_smart_wakeup_zero(
 pub(super) fn wake_const_ops(
     sems: &mut [Semaphore],
     pending_const: &mut LinkedList<PendingOp>,
+    token: SemUndoToken,
     wake_queue: &mut LinkedList<PendingOp>,
 ) -> bool {
     let mut has_completed = false;
@@ -434,6 +529,9 @@ pub(super) fn wake_const_ops(
         if let Some(status) = perform_atomic_semop(sems, const_op) {
             has_completed |= status == Status::Normal;
             const_op.set_status(status);
+            if status == Status::Normal {
+                const_op.set_sem_undo_token(token);
+            }
             wake_queue.append(&mut cursor.remove_current_as_list().unwrap());
         } else {
             cursor.move_next();

--- a/kernel/src/ipc/semaphore/system_v/sem.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem.rs
@@ -55,8 +55,15 @@ pub(super) struct PendingOp {
     sops: Vec<SemBuf>,
     status: Arc<AtomicStatus>,
     waker: Option<Arc<Waker>>,
-    sem_undo_token: Arc<Mutex<Option<SemUndoToken>>>,
+    sem_undo_record: Option<SemUndoRecord>,
     pid: Pid,
+}
+
+struct SemUndoRecord {
+    list: Arc<SemUndoList>,
+    ipc_ns: Arc<IpcNamespace>,
+    sem_id: IpcId,
+    ops: Vec<SemUndoOp>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -71,7 +78,7 @@ impl PendingOp {
         sops: Vec<SemBuf>,
         pid: Pid,
         num_sems: usize,
-        sem_undo_token: Arc<Mutex<Option<SemUndoToken>>>,
+        sem_undo_record: Option<SemUndoRecord>,
     ) -> Result<Self> {
         for op in sops.iter() {
             if op.sem_num as usize >= num_sems {
@@ -83,7 +90,7 @@ impl PendingOp {
             sops,
             status: Arc::new(AtomicStatus::new(Status::Pending)),
             waker: None,
-            sem_undo_token,
+            sem_undo_record,
             pid,
         })
     }
@@ -96,8 +103,12 @@ impl PendingOp {
         self.status.store(status, Ordering::Relaxed);
     }
 
-    fn set_sem_undo_token(&self, token: SemUndoToken) {
-        *self.sem_undo_token.lock() = Some(token);
+    fn record_sem_undo(&self, token: SemUndoToken) {
+        if let Some(record) = &self.sem_undo_record {
+            record
+                .list
+                .record(record.ipc_ns.clone(), record.sem_id, token, &record.ops);
+        }
     }
 
     pub(super) fn waker(&self) -> Option<&Arc<Waker>> {
@@ -204,7 +215,12 @@ pub fn sem_op(
 
     let is_alter = check_alter_sop(&sops);
     let undo_ops = collect_undo_ops(&sops);
-    let sem_undo_list = (!undo_ops.is_empty()).then(|| ctx.process.sem_undo_list());
+    let sem_undo_record = (!undo_ops.is_empty()).then(|| SemUndoRecord {
+        list: ctx.process.sem_undo_list(),
+        ipc_ns: ipc_ns.clone(),
+        sem_id,
+        ops: undo_ops,
+    });
 
     // TODO: Support permission check
     warn!("Semaphore operation doesn't support permission check now");
@@ -212,37 +228,27 @@ pub fn sem_op(
     enum SemOpResult {
         Completed {
             status: Status,
-            token: Option<SemUndoToken>,
         },
         Pending {
             status: Arc<AtomicStatus>,
             waiter: Waiter,
-            token: Arc<Mutex<Option<SemUndoToken>>>,
         },
     }
 
     let sem_op_result = ipc_ns.with_sem_set(sem_id, PermissionMode::empty(), |sem_set| {
-        let sem_undo_token = Arc::new(Mutex::new(None));
-        let mut pending_op = PendingOp::new(
-            sops,
-            ctx.process.pid(),
-            sem_set.num_sems(),
-            sem_undo_token.clone(),
-        )?;
+        let mut pending_op =
+            PendingOp::new(sops, ctx.process.pid(), sem_set.num_sems(), sem_undo_record)?;
 
         let mut inner = sem_set.inner();
 
         // Try to perform the operation without blocking
         if let Some(status) = perform_atomic_semop(&mut inner.sems, &mut pending_op) {
             if status != Status::Normal {
-                return Ok(SemOpResult::Completed {
-                    status,
-                    token: None,
-                });
+                return Ok(SemOpResult::Completed { status });
             }
 
             let token = sem_set.sem_undo_token();
-            pending_op.set_sem_undo_token(token);
+            pending_op.record_sem_undo(token);
 
             if is_alter {
                 let wake_queue = do_smart_update(&mut inner, &pending_op, token);
@@ -255,10 +261,7 @@ pub fn sem_op(
 
             sem_set.update_otime();
 
-            return Ok(SemOpResult::Completed {
-                status,
-                token: Some(token),
-            });
+            return Ok(SemOpResult::Completed { status });
         }
 
         // Prepare to wait
@@ -273,29 +276,12 @@ pub fn sem_op(
             inner.pending_const.push_back(pending_op);
         }
 
-        Ok(SemOpResult::Pending {
-            status,
-            waiter,
-            token: sem_undo_token,
-        })
+        Ok(SemOpResult::Pending { status, waiter })
     })?;
 
-    fn finish_sem_op(
-        status: Status,
-        waiter_error: Option<Error>,
-        sem_undo_list: Option<&Arc<SemUndoList>>,
-        ipc_ns: &Arc<IpcNamespace>,
-        sem_id: IpcId,
-        token: Option<SemUndoToken>,
-        undo_ops: &[SemUndoOp],
-    ) -> Result<()> {
+    fn finish_sem_op(status: Status, waiter_error: Option<Error>) -> Result<()> {
         match status {
-            Status::Normal => {
-                if let (Some(sem_undo_list), Some(token)) = (sem_undo_list, token) {
-                    sem_undo_list.record(ipc_ns.clone(), sem_id, token, undo_ops);
-                }
-                Ok(())
-            }
+            Status::Normal => Ok(()),
             Status::Removed => {
                 return_errno_with_message!(Errno::EIDRM, "the semaphore set is removed");
             }
@@ -320,25 +306,13 @@ pub fn sem_op(
         }
     }
 
-    let (waiter_result, status, token) = match sem_op_result {
-        SemOpResult::Completed { status, token } => {
-            return finish_sem_op(
-                status,
-                None,
-                sem_undo_list.as_ref(),
-                ipc_ns,
-                sem_id,
-                token,
-                &undo_ops,
-            );
+    let (waiter_result, status) = match sem_op_result {
+        SemOpResult::Completed { status } => {
+            return finish_sem_op(status, None);
         }
-        SemOpResult::Pending {
-            status,
-            waiter,
-            token,
-        } => {
+        SemOpResult::Pending { status, waiter } => {
             let result = waiter.pause_timeout(&timeout.as_ref().into());
-            (result, status, token)
+            (result, status)
         }
     };
 
@@ -358,15 +332,7 @@ pub fn sem_op(
         });
     }
 
-    finish_sem_op(
-        status.load(Ordering::Relaxed),
-        waiter_result.err(),
-        sem_undo_list.as_ref(),
-        ipc_ns,
-        sem_id,
-        *token.lock(),
-        &undo_ops,
-    )
+    finish_sem_op(status.load(Ordering::Relaxed), waiter_result.err())
 }
 
 fn collect_undo_ops(sops: &[SemBuf]) -> Vec<SemUndoOp> {
@@ -464,7 +430,7 @@ pub(super) fn update_pending_alter(
         };
         alter_op.set_status(status);
         if status == Status::Normal {
-            alter_op.set_sem_undo_token(token);
+            alter_op.record_sem_undo(token);
         }
 
         let mut alter_op = cursor.remove_current_as_list().unwrap();
@@ -530,7 +496,7 @@ pub(super) fn wake_const_ops(
             has_completed |= status == Status::Normal;
             const_op.set_status(status);
             if status == Status::Normal {
-                const_op.set_sem_undo_token(token);
+                const_op.record_sem_undo(token);
             }
             wake_queue.append(&mut cursor.remove_current_as_list().unwrap());
         } else {

--- a/kernel/src/ipc/semaphore/system_v/sem_set.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_set.rs
@@ -4,8 +4,9 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use aster_rights::ReadOp;
 
-use super::sem::{
-    PendingBlocker, PendingOp, Semaphore, Status, update_pending_alter, wake_const_ops,
+use super::{
+    sem::{PendingBlocker, PendingOp, Semaphore, Status, update_pending_alter, wake_const_ops},
+    sem_undo::SemUndoToken,
 };
 use crate::{
     ipc::{IpcKey, IpcPermission},
@@ -31,6 +32,8 @@ pub const SEMVMX: i32 = 32767;
 #[expect(dead_code)]
 pub const SEMAEM: i32 = SEMVMX;
 
+static NEXT_SEM_UNDO_KEY: AtomicU64 = AtomicU64::new(1);
+
 #[derive(Debug)]
 pub struct SemaphoreSet {
     /// Number of semaphores in the set
@@ -43,6 +46,10 @@ pub struct SemaphoreSet {
     sem_ctime: AtomicU64,
     /// Last `semop` time
     sem_otime: AtomicU64,
+    /// Unique key used to distinguish reused semaphore IDs in `SEM_UNDO` entries.
+    sem_undo_key: u64,
+    /// Epoch bumped whenever older `SEM_UNDO` entries must be invalidated.
+    sem_undo_epoch: AtomicU64,
 }
 
 // Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/asm-generic/ipcbuf.h#L22>.
@@ -162,7 +169,7 @@ impl SemaphoreSet {
         self.num_sems
     }
 
-    pub fn setval(&self, sem_num: usize, val: i32, pid: Pid) -> Result<()> {
+    pub fn setval(&self, sem_num: usize, val: i32, pid: Pid) -> Result<SemUndoToken> {
         if !(0..=SEMVMX).contains(&val) {
             return_errno_with_message!(Errno::ERANGE, "the semaphore value exceeds SEMVMX");
         }
@@ -173,16 +180,23 @@ impl SemaphoreSet {
             return_errno_with_message!(Errno::EINVAL, "the semaphore number is out of bounds");
         };
 
+        let cleared_token = self.advance_sem_undo_epoch();
         sem.set_val(val);
         sem.set_latest_modified_pid(pid);
 
         let mut wake_queue = LinkedList::new();
         let mut has_completed_op = false;
         if val == 0 {
-            has_completed_op |= wake_const_ops(sems, pending_const, &mut wake_queue);
+            has_completed_op |=
+                wake_const_ops(sems, pending_const, self.sem_undo_token(), &mut wake_queue);
         }
-        has_completed_op |=
-            update_pending_alter(sems, pending_alter, pending_const, &mut wake_queue);
+        has_completed_op |= update_pending_alter(
+            sems,
+            pending_alter,
+            pending_const,
+            self.sem_undo_token(),
+            &mut wake_queue,
+        );
 
         for wake_op in wake_queue {
             if let Some(waker) = wake_op.waker() {
@@ -195,7 +209,45 @@ impl SemaphoreSet {
             self.update_otime();
         }
 
-        Ok(())
+        Ok(cleared_token)
+    }
+
+    pub fn apply_undo(&self, token: SemUndoToken, sem_num: usize, adjustment: i32, pid: Pid) {
+        if self.sem_undo_token() != token {
+            return;
+        }
+
+        let mut inner = self.inner();
+        if self.sem_undo_token() != token {
+            return;
+        }
+
+        let (sems, pending_alter, pending_const) = inner.field_mut();
+        let Some(sem) = sems.get_mut(sem_num) else {
+            return;
+        };
+
+        let val = sem.val().saturating_add(adjustment).clamp(0, SEMVMX);
+        sem.set_val(val);
+        sem.set_latest_modified_pid(pid);
+
+        let mut wake_queue = LinkedList::new();
+        let mut has_completed_op = false;
+        if val == 0 {
+            has_completed_op |= wake_const_ops(sems, pending_const, token, &mut wake_queue);
+        }
+        has_completed_op |=
+            update_pending_alter(sems, pending_alter, pending_const, token, &mut wake_queue);
+
+        for wake_op in wake_queue {
+            if let Some(waker) = wake_op.waker() {
+                waker.wake_up();
+            }
+        }
+
+        if has_completed_op || adjustment != 0 {
+            self.update_otime();
+        }
     }
 
     pub fn get<T>(&self, sem_num: usize, func: fn(&Semaphore) -> T) -> Result<T> {
@@ -230,6 +282,18 @@ impl SemaphoreSet {
         self.inner.lock()
     }
 
+    pub(in crate::ipc) fn sem_undo_token(&self) -> SemUndoToken {
+        SemUndoToken::new(
+            self.sem_undo_key,
+            self.sem_undo_epoch.load(Ordering::Relaxed),
+        )
+    }
+
+    fn advance_sem_undo_epoch(&self) -> SemUndoToken {
+        let epoch = self.sem_undo_epoch.fetch_add(1, Ordering::Relaxed);
+        SemUndoToken::new(self.sem_undo_key, epoch)
+    }
+
     pub(in crate::ipc) fn new(
         key: IpcKey,
         num_sems: usize,
@@ -261,6 +325,8 @@ impl SemaphoreSet {
             permission,
             sem_ctime: AtomicU64::new(RealTimeCoarseClock::get().read_time().as_secs()),
             sem_otime: AtomicU64::new(0),
+            sem_undo_key: NEXT_SEM_UNDO_KEY.fetch_add(1, Ordering::Relaxed),
+            sem_undo_epoch: AtomicU64::new(0),
         })
     }
 

--- a/kernel/src/ipc/semaphore/system_v/sem_undo.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_undo.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Tracks System V semaphore adjustments recorded by `SEM_UNDO`.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::{
+    ipc::{IpcId, IpcNamespace},
+    prelude::*,
+    process::Pid,
+};
+
+/// Identifies one logical lifetime of a semaphore set for `SEM_UNDO`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SemUndoToken {
+    key: u64,
+    epoch: u64,
+}
+
+impl SemUndoToken {
+    /// Creates a semaphore undo token.
+    pub fn new(key: u64, epoch: u64) -> Self {
+        Self { key, epoch }
+    }
+
+    /// Returns whether `self` belongs to an earlier or same epoch of `other`.
+    pub fn is_before_or_equal_to(self, other: Self) -> bool {
+        self.key == other.key && self.epoch <= other.epoch
+    }
+}
+
+/// A semaphore adjustment recorded for `SEM_UNDO`.
+#[derive(Clone, Copy, Debug)]
+pub struct SemUndoOp {
+    sem_num: usize,
+    adjustment: i32,
+}
+
+impl SemUndoOp {
+    /// Creates a semaphore undo adjustment.
+    pub fn new(sem_num: usize, adjustment: i32) -> Self {
+        Self {
+            sem_num,
+            adjustment,
+        }
+    }
+}
+
+struct SemUndoEntry {
+    ipc_ns: Arc<IpcNamespace>,
+    sem_id: IpcId,
+    token: SemUndoToken,
+    sem_num: usize,
+    adjustment: i32,
+}
+
+/// A System V semaphore undo list.
+pub struct SemUndoList {
+    entries: Mutex<Vec<SemUndoEntry>>,
+    holders: AtomicUsize,
+}
+
+impl SemUndoList {
+    /// Creates an empty semaphore undo list.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            entries: Mutex::new(Vec::new()),
+            holders: AtomicUsize::new(1),
+        })
+    }
+
+    /// Adds a process holder to the undo list.
+    pub fn add_holder(&self) {
+        self.holders.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Removes a process holder and applies undo entries if it was the last one.
+    pub fn remove_holder(&self, pid: Pid) {
+        let old_holders = self.holders.fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(old_holders > 0);
+        if old_holders == 1 {
+            self.apply(pid);
+        }
+    }
+
+    /// Records successful `SEM_UNDO` operations.
+    pub fn record(
+        self: &Arc<Self>,
+        ipc_ns: Arc<IpcNamespace>,
+        sem_id: IpcId,
+        token: SemUndoToken,
+        undo_ops: &[SemUndoOp],
+    ) {
+        if undo_ops.is_empty() {
+            return;
+        }
+
+        ipc_ns.register_sem_undo_list(self);
+
+        let mut entries = self.entries.lock();
+        if !ipc_ns.sem_undo_token_matches(sem_id, token) {
+            return;
+        }
+
+        for op in undo_ops {
+            if op.adjustment == 0 {
+                continue;
+            }
+
+            let Some(index) = entries.iter().position(|entry| {
+                Arc::ptr_eq(&entry.ipc_ns, &ipc_ns)
+                    && entry.sem_id == sem_id
+                    && entry.token == token
+                    && entry.sem_num == op.sem_num
+            }) else {
+                entries.push(SemUndoEntry {
+                    ipc_ns: ipc_ns.clone(),
+                    sem_id,
+                    token,
+                    sem_num: op.sem_num,
+                    adjustment: op.adjustment,
+                });
+                continue;
+            };
+
+            entries[index].adjustment += op.adjustment;
+            if entries[index].adjustment == 0 {
+                entries.remove(index);
+            }
+        }
+    }
+
+    /// Clears undo entries for one semaphore.
+    pub fn clear_sem(
+        &self,
+        ipc_ns: &IpcNamespace,
+        sem_id: IpcId,
+        token: SemUndoToken,
+        sem_num: usize,
+    ) {
+        self.entries.lock().retain(|entry| {
+            !(core::ptr::eq(entry.ipc_ns.as_ref(), ipc_ns)
+                && entry.sem_id == sem_id
+                && entry.token.is_before_or_equal_to(token)
+                && entry.sem_num == sem_num)
+        });
+    }
+
+    /// Clears undo entries for all semaphores in a set.
+    pub fn clear_set(&self, ipc_ns: &IpcNamespace, sem_id: IpcId, token: SemUndoToken) {
+        self.entries.lock().retain(|entry| {
+            !(core::ptr::eq(entry.ipc_ns.as_ref(), ipc_ns)
+                && entry.sem_id == sem_id
+                && entry.token.is_before_or_equal_to(token))
+        });
+    }
+
+    /// Applies and clears all undo entries.
+    fn apply(&self, pid: Pid) {
+        let entries = core::mem::take(&mut *self.entries.lock());
+
+        for entry in entries {
+            entry.ipc_ns.apply_sem_undo(
+                entry.sem_id,
+                entry.token,
+                entry.sem_num,
+                entry.adjustment,
+                pid,
+            );
+        }
+    }
+}

--- a/kernel/src/ipc/semaphore/system_v/sem_undo.rs
+++ b/kernel/src/ipc/semaphore/system_v/sem_undo.rs
@@ -98,10 +98,6 @@ impl SemUndoList {
         ipc_ns.register_sem_undo_list(self);
 
         let mut entries = self.entries.lock();
-        if !ipc_ns.sem_undo_token_matches(sem_id, token) {
-            return;
-        }
-
         for op in undo_ops {
             if op.adjustment == 0 {
                 continue;

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -378,9 +378,6 @@ fn clone_child_task(
         ..
     } = ctx;
 
-    // Clone system V semaphore
-    clone_sysvsem(clone_flags)?;
-
     // Clone VMAR
     let child_vmar = thread_local
         .vmar()
@@ -527,9 +524,6 @@ fn clone_child_process(
     // Clone signal dispositions
     let child_sig_dispositions = clone_sighand(process.sig_dispositions(), clone_flags);
 
-    // Clone System V semaphore
-    clone_sysvsem(clone_flags)?;
-
     // Clone FPU context
     let child_fpu_context = thread_local.supp_user_context().fpu().get();
 
@@ -619,6 +613,8 @@ fn clone_child_process(
             child_thread_builder,
         )
     };
+
+    clone_sysvsem(process, &child, clone_flags);
 
     clone_pidfd(ctx, &child, clone_flags, clone_args.pidfd)?;
 
@@ -760,11 +756,10 @@ fn clone_sighand(
     }
 }
 
-fn clone_sysvsem(clone_flags: CloneFlags) -> Result<()> {
+fn clone_sysvsem(parent: &Process, child: &Process, clone_flags: CloneFlags) {
     if clone_flags.contains(CloneFlags::CLONE_SYSVSEM) {
-        warn!("CLONE_SYSVSEM is not supported now");
+        child.set_sem_undo_list(parent.sem_undo_list());
     }
-    Ok(())
 }
 
 fn clone_pidfd(

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -17,6 +17,7 @@ use crate::{
 /// [`do_exit_group`]: crate::process::posix_thread::do_exit_group
 pub(super) fn exit_process(current_process: &Process) {
     current_process.status().set_vfork_child(false);
+    current_process.apply_sem_undo_on_exit();
 
     // Drop fields in `Process`.
     drop_after!(current_process.lock_vmar().set_vmar(None));

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -37,8 +37,7 @@ impl ContextUnshareAdminApi for Context<'_> {
     }
 
     fn unshare_sysvsem(&self) {
-        // TODO: Support unsharing System V semaphore.
-        warn!("unsharing System V semaphore is not supported");
+        self.process.unshare_sem_undo_list();
     }
 
     fn unshare_namespaces(&self, flags: CloneFlags) -> Result<()> {

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -24,6 +24,7 @@ use super::{
 use crate::{
     events::IoEvents,
     fs::cgroupfs::CgroupNode,
+    ipc::semaphore::system_v::sem_undo::SemUndoList,
     prelude::*,
     process::{
         UserNamespace, WaitOptions,
@@ -154,10 +155,13 @@ pub struct Process {
     // Namespaces
     /// The user namespace
     user_ns: Mutex<Arc<UserNamespace>>,
+    /// The System V semaphore undo list.
+    sem_undo_list: Mutex<Arc<SemUndoList>>,
 }
 
 impl Drop for Process {
     fn drop(&mut self) {
+        self.apply_sem_undo_on_exit();
         self.pidfile_pollee.notify(IoEvents::HUP);
     }
 }
@@ -268,6 +272,7 @@ impl Process {
                 timer_manager,
                 start_time: Jiffies::elapsed(),
                 user_ns: Mutex::new(user_ns),
+                sem_undo_list: Mutex::new(SemUndoList::new()),
             }
         })
     }
@@ -312,6 +317,30 @@ impl Process {
 
     pub fn resource_limits(&self) -> &ResourceLimits {
         &self.resource_limits
+    }
+
+    pub fn sem_undo_list(&self) -> Arc<SemUndoList> {
+        self.sem_undo_list.lock().clone()
+    }
+
+    pub(super) fn apply_sem_undo_on_exit(&self) {
+        let sem_undo_list = self.replace_sem_undo_list(SemUndoList::new());
+        sem_undo_list.remove_holder(self.pid);
+    }
+
+    pub(super) fn unshare_sem_undo_list(&self) {
+        let sem_undo_list = self.replace_sem_undo_list(SemUndoList::new());
+        sem_undo_list.remove_holder(self.pid);
+    }
+
+    pub(super) fn set_sem_undo_list(&self, sem_undo_list: Arc<SemUndoList>) {
+        sem_undo_list.add_holder();
+        let old_sem_undo_list = self.replace_sem_undo_list(sem_undo_list);
+        old_sem_undo_list.remove_holder(self.pid);
+    }
+
+    fn replace_sem_undo_list(&self, sem_undo_list: Arc<SemUndoList>) -> Arc<SemUndoList> {
+        core::mem::replace(&mut *self.sem_undo_list.lock(), sem_undo_list)
     }
 
     pub fn nice(&self) -> &AtomicNice {

--- a/kernel/src/syscall/semctl.rs
+++ b/kernel/src/syscall/semctl.rs
@@ -93,9 +93,10 @@ pub fn sys_semctl(
             // In `SEM_SETVAL`, the argument is parsed as an `i32`.
             let val = arg as i32;
 
-            ipc_ns.with_sem_set(semid, PermissionMode::ALTER, |sem_set| {
+            let cleared_token = ipc_ns.with_sem_set(semid, PermissionMode::ALTER, |sem_set| {
                 sem_set.setval(semnum as usize, val, ctx.process.pid())
             })?;
+            ipc_ns.clear_sem_undo_entries(semid, cleared_token, semnum as usize);
         }
     }
 

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -466,6 +466,33 @@ FN_TEST(semop_sem_undo)
 }
 END_TEST()
 
+FN_TEST(sem_undo_records_blocked_semop)
+{
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = -1,
+		.sem_flg = SEM_UNDO,
+	};
+	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t child = TEST_SUCC(fork());
+	int status;
+
+	if (child == 0) {
+		CHECK(semop(semid, &op, 1));
+		CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 0);
+		_exit(0);
+	}
+
+	sleep_ms(SETTLE_MS);
+	TEST_SUCC(set_sem_val(semid, 0, 1));
+	TEST_RES(waitpid(child, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 1);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
 FN_TEST(sem_undo_is_not_inherited_by_fork)
 {
 	struct sembuf op = {

--- a/test/initramfs/src/regression/ipc/sem/sem.c
+++ b/test/initramfs/src/regression/ipc/sem/sem.c
@@ -4,7 +4,9 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <sched.h>
 #include <signal.h>
+#include <stdlib.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
 #include <sys/syscall.h>
@@ -24,6 +26,7 @@
 #define SETTLE_MS 100
 #define SHORT_TIMEOUT_MS 1000
 #define LONG_TIMEOUT_MS 4000
+#define STACK_SIZE (1024 * 1024)
 
 union semun {
 	int val;
@@ -446,18 +449,245 @@ FN_TEST(semop_sem_undo)
 		.sem_flg = SEM_UNDO,
 	};
 	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t child = TEST_SUCC(fork());
+	int status;
 
-	/*
-	 * FIXME: Linux applies `SEM_UNDO`, but Asterinas rejects the flag as it
-	 * is not supported.
-	 */
-#ifdef __asterinas__
-	TEST_ERRNO(semop(semid, &op, 1), EINVAL);
+	if (child == 0) {
+		CHECK(semop(semid, &op, 1));
+		CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 1);
+		_exit(0);
+	}
+
+	TEST_RES(waitpid(child, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
 	TEST_RES(get_sem_val(semid, 0), _ret == 0);
-#else
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(sem_undo_is_not_inherited_by_fork)
+{
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t child;
+	int status;
+
 	TEST_SUCC(semop(semid, &op, 1));
 	TEST_RES(get_sem_val(semid, 0), _ret == 1);
-#endif
+
+	child = TEST_SUCC(fork());
+	if (child == 0)
+		_exit(0);
+
+	TEST_RES(waitpid(child, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 1);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+static int clone_sysvsem_child_fn(void *arg)
+{
+	int semid = *(int *)arg;
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+
+	CHECK(semop(semid, &op, 1));
+	CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 1);
+	return 0;
+}
+
+FN_TEST(sem_undo_is_shared_by_clone_sysvsem)
+{
+	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t owner = TEST_SUCC(fork());
+	int status;
+
+	if (owner == 0) {
+		char *stack = malloc(STACK_SIZE);
+		char *stack_top = stack + STACK_SIZE;
+		pid_t child = CHECK(clone(clone_sysvsem_child_fn, stack_top,
+					  CLONE_SYSVSEM | SIGCHLD, &semid));
+
+		CHECK_WITH(waitpid(child, &status, 0),
+			   _ret == child && WIFEXITED(status) &&
+				   WEXITSTATUS(status) == 0);
+		CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 1);
+		free(stack);
+		_exit(0);
+	}
+
+	TEST_RES(waitpid(owner, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+static int clone_sysvsem_delayed_exit_fn(void *arg)
+{
+	(void)arg;
+
+	sleep_ms(SETTLE_MS * 3);
+	return 0;
+}
+
+FN_TEST(sem_undo_shared_list_ignores_zombie_holder)
+{
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+	int pipe_fds[2];
+	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t owner;
+	char byte;
+	int status;
+
+	TEST_SUCC(pipe(pipe_fds));
+	owner = TEST_SUCC(fork());
+	if (owner == 0) {
+		char *stack = malloc(STACK_SIZE);
+		char *stack_top = stack + STACK_SIZE;
+
+		CHECK(close(pipe_fds[0]));
+		CHECK(semop(semid, &op, 1));
+		CHECK(clone(clone_sysvsem_delayed_exit_fn, stack_top,
+			    CLONE_SYSVSEM | SIGCHLD, NULL));
+		CHECK_WITH(write(pipe_fds[1], "x", 1), _ret == 1);
+		CHECK(close(pipe_fds[1]));
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pipe_fds[1]));
+	TEST_RES(read(pipe_fds[0], &byte, 1), _ret == 1);
+	TEST_SUCC(close(pipe_fds[0]));
+	sleep_ms(SETTLE_MS * 6);
+
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+	TEST_RES(waitpid(owner, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+static int unshare_sysvsem_child_fn(void *arg)
+{
+	int semid = *(int *)arg;
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+
+	CHECK(unshare(CLONE_SYSVSEM));
+	CHECK(semop(semid, &op, 1));
+	CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 2);
+	return 0;
+}
+
+FN_TEST(unshare_sysvsem_applies_last_sem_undo)
+{
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+	int semid = TEST_SUCC(create_sem_set(1));
+
+	TEST_SUCC(semop(semid, &op, 1));
+	TEST_RES(get_sem_val(semid, 0), _ret == 1);
+
+	TEST_SUCC(unshare(CLONE_SYSVSEM));
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(unshare_sysvsem_disassociates_sem_undo)
+{
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t owner = TEST_SUCC(fork());
+	int status;
+
+	if (owner == 0) {
+		char *stack = malloc(STACK_SIZE);
+		char *stack_top = stack + STACK_SIZE;
+		pid_t child;
+
+		CHECK(semop(semid, &op, 1));
+		CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 1);
+
+		child = CHECK(clone(unshare_sysvsem_child_fn, stack_top,
+				    CLONE_SYSVSEM | SIGCHLD, &semid));
+		CHECK_WITH(waitpid(child, &status, 0),
+			   _ret == child && WIFEXITED(status) &&
+				   WEXITSTATUS(status) == 0);
+		CHECK_WITH(semctl(semid, 0, GETVAL), _ret == 1);
+		free(stack);
+		_exit(0);
+	}
+
+	TEST_RES(waitpid(owner, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+	TEST_RES(get_sem_val(semid, 0), _ret == 0);
+
+	TEST_SUCC(remove_sem_set(semid));
+}
+END_TEST()
+
+FN_TEST(semctl_setval_clears_sem_undo)
+{
+	struct sembuf op = {
+		.sem_num = 0,
+		.sem_op = 1,
+		.sem_flg = SEM_UNDO,
+	};
+	int pipe_fds[2];
+	int semid = TEST_SUCC(create_sem_set(1));
+	pid_t child;
+	char byte;
+	int status;
+
+	TEST_SUCC(pipe(pipe_fds));
+	child = TEST_SUCC(fork());
+	if (child == 0) {
+		CHECK(close(pipe_fds[0]));
+		CHECK(semop(semid, &op, 1));
+		CHECK_WITH(write(pipe_fds[1], "x", 1), _ret == 1);
+		CHECK(close(pipe_fds[1]));
+		pause();
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pipe_fds[1]));
+	TEST_RES(read(pipe_fds[0], &byte, 1), _ret == 1);
+	TEST_SUCC(close(pipe_fds[0]));
+	TEST_RES(get_sem_val(semid, 0), _ret == 1);
+
+	TEST_SUCC(set_sem_val(semid, 0, 3));
+	TEST_SUCC(kill(child, SIGKILL));
+	TEST_RES(waitpid(child, &status, 0),
+		 WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL);
+	TEST_RES(get_sem_val(semid, 0), _ret == 3);
 
 	TEST_SUCC(remove_sem_set(semid));
 }


### PR DESCRIPTION
## Summary

This PR adds `SEM_UNDO` support for System V semaphore operations.

A successful `semop`/`semtimedop` with `SEM_UNDO` now records the inverse semaphore adjustment in the calling process's undo list. The undo entries are applied when the last process sharing that undo list exits. A normal fork starts with an empty undo list, while `clone(CLONE_SYSVSEM)` shares the parent's undo list. `unshare(CLONE_SYSVSEM)` disassociates the process from a shared undo list and applies the old undo list when it is the last holder. `SEM_SETVAL` and `IPC_RMID` clear the affected undo entries.

This builds on the existing IPC namespace and System V semaphore implementation. It does not add a new namespace implementation or new IPC object type.