### PR TITLE
fs/ext4: add read-only ext4 (mount, extent + directory reads)

### DIFF
--- a/kernel/src/fs/fs_impls/ext4/block_group.rs
+++ b/kernel/src/fs/fs_impls/ext4/block_group.rs
@@ -1,0 +1,787 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 block-group descriptors and the block-side read domain.
+//!
+//! Each block group owns its own block and inode bitmaps. At mount the parsed
+//! descriptor and both bitmaps are loaded; for a group flagged `BLOCK_UNINIT` /
+//! `INODE_UNINIT` the bitmap is reconstructed from the group's on-disk layout
+//! rather than read from disk. This is a read-only mount, so the descriptor and
+//! bitmaps are only read — never allocated against or written back.
+//!
+//! A per-group **inode cache** gives live inodes a stable identity (the same
+//! `Arc<Inode>` for a given inode number) so concurrent readers share one
+//! object.
+//!
+//! # Width invariant
+//!
+//! Group-relative bit indices and per-group counters are narrowed to `u16`
+//! throughout this file. That leans on one parse-time invariant: a group holds
+//! at most `block_size * 8 = 32768 < u16::MAX` blocks/inodes
+//! (`SuperBlock::try_from` rejects larger `s_{blocks,inodes}_per_group`), and
+//! counters never exceed the group capacity.
+//!
+//! # Locking
+//!
+//! `BlockGroup` uses two independent locks:
+//!
+//! - `metadata` — protects the group descriptor and the block and inode
+//!   bitmaps.
+//! - `inode_cache` — protects the per-group live inode map. Uses double-checked
+//!   locking (read then promote to write on miss).
+
+use core::fmt;
+
+use super::{
+    checksum::{self, FsCsumSeed},
+    fs::Ext4,
+    inode::{Inode, InodeDesc, RawInode},
+    prelude::*,
+    super_block::SuperBlock,
+    utils,
+};
+
+/// `bg_flags` bit: the group's inode bitmap and inode table are uninitialized
+/// (`EXT4_BG_INODE_UNINIT`). No inode has ever been allocated here; the on-disk
+/// inode bitmap is not maintained and the inode table is not zeroed.
+const BG_INODE_UNINIT: u16 = 0x0001;
+/// `bg_flags` bit: the group's block bitmap is uninitialized
+/// (`EXT4_BG_BLOCK_UNINIT`). No data block has ever been allocated here; the
+/// on-disk block bitmap is not maintained and must be reconstructed from the
+/// group layout (only the group's fixed metadata/backup overhead is in use).
+const BG_BLOCK_UNINIT: u16 = 0x0002;
+
+const_assert!(size_of::<RawBlockGroup>() == 32);
+
+/// On-disk block-group descriptor, 32 bytes (without the `64BIT` high halves).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawBlockGroup {
+    pub block_bitmap_lo: u32,
+    pub inode_bitmap_lo: u32,
+    pub inode_table_lo: u32,
+    pub free_blocks_count_lo: u16,
+    pub free_inodes_count_lo: u16,
+    pub used_dirs_count_lo: u16,
+    /// `bg_flags` (e.g. `INODE_UNINIT`, `BLOCK_UNINIT`, `INODE_ZEROED`).
+    pub flags: u16,
+    pub exclude_bitmap_lo: u32,
+    pub block_bitmap_csum_lo: u16,
+    pub inode_bitmap_csum_lo: u16,
+    pub itable_unused_lo: u16,
+    pub checksum: u16,
+}
+
+const_assert!(size_of::<RawBlockGroupHi>() == 32);
+
+/// The 32-byte high-half tail of a `64BIT` group descriptor (`ext4_group_desc`
+/// bytes 32..64). Present only when `s_desc_size == 64`; carries the block-number
+/// high halves plus the per-group checksums the `metadata_csum` feature adds.
+///
+/// The per-group counter high halves (`*_count_hi`, `itable_unused_hi`) are
+/// structurally zero in our geometry: a group holds at most `block_size * 8 =
+/// 32768 < u16::MAX` blocks/inodes, so the counters never overflow their low
+/// half. Only the block-number high halves can be non-zero (on volumes past
+/// `2^32` blocks), and they are the only tail fields the decoder splices.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawBlockGroupHi {
+    pub block_bitmap_hi: u32,
+    pub inode_bitmap_hi: u32,
+    pub inode_table_hi: u32,
+    pub free_blocks_count_hi: u16,
+    pub free_inodes_count_hi: u16,
+    pub used_dirs_count_hi: u16,
+    pub itable_unused_hi: u16,
+    pub exclude_bitmap_hi: u32,
+    pub block_bitmap_csum_hi: u16,
+    pub inode_bitmap_csum_hi: u16,
+    pub reserved: u32,
+}
+
+const_assert!(size_of::<RawBlockGroup64>() == 64);
+
+/// On-disk 64-byte `64BIT` group descriptor: the classic 32-byte low half
+/// ([`RawBlockGroup`]) followed by the 32-byte high-half tail
+/// ([`RawBlockGroupHi`]). Read whole when `s_desc_size == 64`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawBlockGroup64 {
+    pub lo: RawBlockGroup,
+    pub hi: RawBlockGroupHi,
+}
+
+/// Validated, Rust-typed block-group descriptor.
+///
+/// Block numbers are `Ext4Bid` (`u64`) so the `64BIT` high halves slot in later
+/// without widening; in Phase 2 they are the 32-bit low halves.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct BlockGroupDesc {
+    block_bitmap_bid: Ext4Bid,
+    inode_bitmap_bid: Ext4Bid,
+    inode_table_bid: Ext4Bid,
+    free_blocks_count: u32,
+    free_inodes_count: u32,
+    used_dirs_count: u32,
+    /// `bg_flags` — carries the `BLOCK_UNINIT`/`INODE_UNINIT` lazy-init bits. Kept
+    /// so the block side can reconstruct an uninitialized bitmap on load.
+    flags: u16,
+}
+
+impl BlockGroupDesc {
+    /// Decodes a group descriptor from its raw low half and, for `64BIT` volumes,
+    /// its high-half tail. This is the single parse-once boundary where the block
+    /// numbers combine `lo | (hi << 32)` (rust_rules #3); no caller splices high
+    /// halves itself, so a decode bug lives in exactly one place.
+    ///
+    /// The `(lo as u64) | ((hi as u64) << 32)` assembly is lossless: `lo` is
+    /// `u32`, `hi` is `u32`, and their union fits `u64` with no bits dropped. The
+    /// per-group counters are taken from the low half only — their high halves
+    /// are structurally zero (see [`RawBlockGroupHi`]).
+    fn from_raw(lo: &RawBlockGroup, hi: Option<&RawBlockGroupHi>) -> Self {
+        let (block_bitmap_hi, inode_bitmap_hi, inode_table_hi) = match hi {
+            Some(hi) => (hi.block_bitmap_hi, hi.inode_bitmap_hi, hi.inode_table_hi),
+            None => (0, 0, 0),
+        };
+        Self {
+            block_bitmap_bid: (lo.block_bitmap_lo as Ext4Bid)
+                | ((block_bitmap_hi as Ext4Bid) << 32),
+            inode_bitmap_bid: (lo.inode_bitmap_lo as Ext4Bid)
+                | ((inode_bitmap_hi as Ext4Bid) << 32),
+            inode_table_bid: (lo.inode_table_lo as Ext4Bid) | ((inode_table_hi as Ext4Bid) << 32),
+            free_blocks_count: lo.free_blocks_count_lo as u32,
+            free_inodes_count: lo.free_inodes_count_lo as u32,
+            used_dirs_count: lo.used_dirs_count_lo as u32,
+            flags: lo.flags,
+        }
+    }
+
+    /// Computes the crc32c group-descriptor checksum (`metadata_csum`), low 16
+    /// bits (Linux `ext4_group_desc_csum`). Seeded with the per-filesystem `seed`,
+    /// then folded over the 0-based `group` number, the descriptor bytes up to
+    /// `bg_checksum`, two zero bytes standing in for `bg_checksum` itself, and —
+    /// for a 64-byte (`64BIT`) descriptor — the 32-byte high-half tail.
+    fn group_desc_checksum(
+        lo: &RawBlockGroup,
+        hi: Option<&RawBlockGroupHi>,
+        group: u32,
+        seed: FsCsumSeed,
+    ) -> u16 {
+        // Byte offset of `bg_checksum` within the 32-byte low half.
+        const BG_CHECKSUM_OFFSET: usize = 30;
+        let mut crc = checksum::crc32c(seed.get(), &group.to_le_bytes());
+        crc = checksum::crc32c(crc, &lo.as_bytes()[..BG_CHECKSUM_OFFSET]);
+        crc = checksum::crc32c(crc, &[0u8, 0u8]); // bg_checksum, excluded from its own cover
+        if let Some(hi) = hi {
+            crc = checksum::crc32c(crc, hi.as_bytes());
+        }
+        (crc & 0xFFFF) as u16
+    }
+
+    /// Verifies a raw descriptor's stored `bg_checksum` for a `metadata_csum`
+    /// volume, at the descriptor read boundary.
+    fn verify_group_desc_checksum(
+        lo: &RawBlockGroup,
+        hi: Option<&RawBlockGroupHi>,
+        group: u32,
+        seed: FsCsumSeed,
+    ) -> Result<()> {
+        if lo.checksum != Self::group_desc_checksum(lo, hi, group, seed) {
+            return_errno_with_message!(Errno::EUCLEAN, "bad group descriptor checksum");
+        }
+        Ok(())
+    }
+
+    /// Returns the starting block of this group's inode table.
+    pub(super) const fn inode_table_bid(&self) -> Ext4Bid {
+        self.inode_table_bid
+    }
+
+    pub(super) const fn block_bitmap_bid(&self) -> Ext4Bid {
+        self.block_bitmap_bid
+    }
+
+    pub(super) const fn inode_bitmap_bid(&self) -> Ext4Bid {
+        self.inode_bitmap_bid
+    }
+
+    pub(super) const fn free_blocks_count(&self) -> u32 {
+        self.free_blocks_count
+    }
+
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn free_inodes_count(&self) -> u32 {
+        self.free_inodes_count
+    }
+
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn used_dirs_count(&self) -> u32 {
+        self.used_dirs_count
+    }
+
+    /// Whether this group's on-disk block bitmap is uninitialized and must be
+    /// reconstructed from the group layout (`EXT4_BG_BLOCK_UNINIT`).
+    pub(super) const fn is_block_uninit(&self) -> bool {
+        self.flags & BG_BLOCK_UNINIT != 0
+    }
+
+    /// Whether this group's inode bitmap and table are uninitialized
+    /// (`EXT4_BG_INODE_UNINIT`).
+    pub(super) const fn is_inode_uninit(&self) -> bool {
+        self.flags & BG_INODE_UNINIT != 0
+    }
+}
+
+/// One block group's metadata: the descriptor, the block bitmap, and the inode
+/// bitmap.
+///
+/// All three members carry dirty tracking, though a read-only mount never marks
+/// them dirty.
+pub(super) struct BlockGroupMetadata {
+    /// Group descriptor with dirty tracking.
+    pub desc: Dirty<BlockGroupDesc>,
+    /// Block bitmap cached in memory.
+    pub block_bitmap: Dirty<IdBitmap>,
+    /// Inode bitmap cached in memory.
+    pub inode_bitmap: Dirty<IdBitmap>,
+}
+
+impl Debug for BlockGroupMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BlockGroupMetadata")
+            .field("desc", &self.desc)
+            .field("block_bitmap_dirty", &self.block_bitmap.is_dirty())
+            .field("inode_bitmap_dirty", &self.inode_bitmap.is_dirty())
+            .finish()
+    }
+}
+
+/// A block group's read-side descriptor and bitmap cache.
+///
+/// Owns the cached block bitmap, inode bitmap, and group descriptor behind a
+/// single lock; on a read-only mount these are only read, never allocated
+/// against or written back.
+pub(super) struct BlockGroup {
+    /// Block group index (0-based).
+    group_idx: usize,
+    /// Group descriptor, block bitmap, and inode bitmap, protected by a single
+    /// lock.
+    metadata: RwMutex<BlockGroupMetadata>,
+    /// Backing block device (shared with `Ext4` and other groups).
+    block_device: Arc<dyn BlockDevice>,
+    /// Cached geometry: inodes per group.
+    nr_inodes_per_group: u32,
+    /// Cached geometry: inode size in bytes.
+    inode_size: usize,
+    /// Cached geometry: filesystem block size in bytes.
+    block_size: usize,
+    /// The per-filesystem crc32c seed when `metadata_csum` is on, else `None`
+    /// (checksums are a no-op). Cached from the superblock at load so the inode
+    /// read path can verify without holding a `SuperBlock`.
+    csum_seed: Option<FsCsumSeed>,
+    /// Per-group live inode cache keyed by group-local inode index.
+    ///
+    /// Ext4 keeps this cache locally because the VFS layer does not provide a
+    /// shared inode cache for filesystem implementations. It gives inodes a
+    /// stable identity: every lookup of one inode number returns the same
+    /// in-memory `Inode`, so concurrent readers share one object.
+    inode_cache: RwMutex<BTreeMap<u16, Arc<Inode>>>,
+}
+
+impl Debug for BlockGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BlockGroup")
+            .field("group_idx", &self.group_idx)
+            .finish()
+    }
+}
+
+impl BlockGroup {
+    /// Loads a block group from the descriptor table.
+    ///
+    /// Reads and decodes the group's descriptor at `gdt_base_offset + group_idx *
+    /// sb.desc_size()` (32 or 64 bytes wide per the `64BIT` feature), caches the
+    /// group's geometry from `sb`, and loads the block bitmap.
+    ///
+    /// Loading is lenient: strict validation that the system-metadata blocks are
+    /// marked allocated in the bitmap is deferred (the read-only fixtures carry
+    /// an all-zero bitmap and must still mount).
+    pub(super) fn load(
+        device: Arc<dyn BlockDevice>,
+        group_idx: usize,
+        sb: &SuperBlock,
+        gdt_base_offset: usize,
+    ) -> Result<Self> {
+        let desc_size = sb.desc_size();
+        let desc_offset = gdt_base_offset + group_idx * desc_size as usize;
+        let csum_seed = sb.has_metadata_csum().then(|| sb.metadata_csum_seed());
+        let desc = Self::read_desc(
+            device.as_ref(),
+            desc_offset,
+            desc_size,
+            group_idx as u32,
+            csum_seed,
+        )?;
+
+        // Cache geometry from `SuperBlock` at load time.
+        let nr_blocks_per_group = sb.nr_blocks_per_group() as Ext4Bid;
+        let first_block = sb.first_data_block() + (group_idx as Ext4Bid) * nr_blocks_per_group;
+        let nr_block_groups = sb.nr_block_groups() as usize;
+        let last_block = if group_idx == nr_block_groups - 1 {
+            sb.total_blocks() - 1
+        } else {
+            first_block + nr_blocks_per_group - 1
+        };
+        let nr_inodes_per_group = sb.nr_inodes_per_group();
+        let inode_size = sb.inode_size();
+        let block_size = sb.block_size();
+
+        // Load the block bitmap and the inode bitmap.
+        let block_bitmap =
+            Self::load_block_bitmap(device.as_ref(), first_block, last_block, &desc)?;
+        let inode_bitmap = Self::load_inode_bitmap(device.as_ref(), nr_inodes_per_group, &desc)?;
+
+        Ok(Self {
+            group_idx,
+            metadata: RwMutex::new(BlockGroupMetadata {
+                desc: Dirty::new(desc),
+                block_bitmap: Dirty::new(block_bitmap),
+                inode_bitmap: Dirty::new(inode_bitmap),
+            }),
+            block_device: device,
+            nr_inodes_per_group,
+            inode_size,
+            block_size,
+            csum_seed,
+            inode_cache: RwMutex::new(BTreeMap::new()),
+        })
+    }
+
+    /// Reads and decodes this group's descriptor from `device` at `desc_offset`,
+    /// sized by `desc_size`: the 64-byte `64BIT` layout — splicing the block-number
+    /// high halves via [`BlockGroupDesc::from_raw`] — when `desc_size` is 64, else
+    /// the classic 32-byte layout. The single decode path used by [`Self::load`],
+    /// so the high-half splice lives at one boundary.
+    /// `group` (0-based index) and `csum_seed` drive the `metadata_csum`
+    /// verify-on-read: when `csum_seed` is `Some`, the stored `bg_checksum` is
+    /// checked against a recomputation over this group's descriptor before the
+    /// decode is trusted (`EUCLEAN` on mismatch); when `None` the descriptor is
+    /// decoded as in Phases 1–5.
+    fn read_desc(
+        device: &dyn BlockDevice,
+        desc_offset: usize,
+        desc_size: u16,
+        group: u32,
+        csum_seed: Option<FsCsumSeed>,
+    ) -> Result<BlockGroupDesc> {
+        if desc_size as usize >= size_of::<RawBlockGroup64>() {
+            let raw = device
+                .read_val::<RawBlockGroup64>(desc_offset)
+                .map_err(|_| Error::with_message(Errno::EIO, "failed to read group descriptor"))?;
+            if let Some(seed) = csum_seed {
+                BlockGroupDesc::verify_group_desc_checksum(&raw.lo, Some(&raw.hi), group, seed)?;
+            }
+            Ok(BlockGroupDesc::from_raw(&raw.lo, Some(&raw.hi)))
+        } else {
+            let raw = device
+                .read_val::<RawBlockGroup>(desc_offset)
+                .map_err(|_| Error::with_message(Errno::EIO, "failed to read group descriptor"))?;
+            if let Some(seed) = csum_seed {
+                BlockGroupDesc::verify_group_desc_checksum(&raw, None, group, seed)?;
+            }
+            Ok(BlockGroupDesc::from_raw(&raw, None))
+        }
+    }
+
+    /// Returns the starting block of this group's inode table.
+    pub(super) fn inode_table_bid(&self) -> Ext4Bid {
+        self.metadata.read().desc.inode_table_bid()
+    }
+
+    /// Looks up an inode by inode number through this group's inode cache.
+    ///
+    /// Returns the same `Arc<Inode>` for repeated lookups of one inode number,
+    /// so concurrent users share one in-memory inode (and one set of dirty
+    /// state). The fast path hits the cache under the read lock; the slow path
+    /// promotes to the write lock, re-checks (another thread may have inserted
+    /// the inode in the gap), then loads the descriptor from disk and inserts it.
+    pub(super) fn lookup_inode(&self, ino: Ext4Ino, fs: Weak<Ext4>) -> Result<Arc<Inode>> {
+        let inode_idx = self.inode_idx_in_group(ino);
+
+        // Fast path: cache hit under the read lock.
+        if let Some(inode) = self.inode_cache.read().get(&inode_idx) {
+            return Ok(inode.clone());
+        }
+
+        // Slow path: revalidate under the write lock, since another thread may
+        // have inserted the inode between the read and write lock acquisition.
+        let mut inode_cache = self.inode_cache.write();
+        if let Some(inode) = inode_cache.get(&inode_idx) {
+            return Ok(inode.clone());
+        }
+
+        let desc = self.read_inode_desc(ino)?;
+        let type_ = desc.type_();
+        let inode = Inode::new(ino, type_, Dirty::new(desc), self.group_idx, fs)?;
+        inode_cache.insert(inode_idx, inode.clone());
+        Ok(inode)
+    }
+
+    /// Loads and decodes an inode's on-disk descriptor from the inode table.
+    ///
+    /// The inode-table block is read through [`utils::read_metadata_block`], the
+    /// single metadata-read funnel — a plain device read on this read-only,
+    /// non-journaled mount, where the device is authoritative (the seam a
+    /// journaling layer would later re-widen to consult its after-images).
+    ///
+    /// The fixed `size_of::<RawInode>()` (256-byte) read window never runs past
+    /// the block: mount admission currently accepts exactly 256-byte inodes
+    /// (`SuperBlock::try_from`), so each descriptor occupies one fixed slot and
+    /// `off_in_block + size_of::<RawInode>()` stays within the metadata block
+    /// that holds it.
+    pub(super) fn read_inode_desc(&self, ino: Ext4Ino) -> Result<InodeDesc> {
+        let idx_in_group = self.inode_idx_in_group(ino) as usize;
+        let byte_off = idx_in_group * self.inode_size;
+        let block_bid = self.inode_table_bid() + (byte_off / self.block_size) as Ext4Bid;
+        let off_in_block = byte_off % self.block_size;
+        let block = utils::read_metadata_block(self.block_device.as_ref(), block_bid)?;
+        let raw = RawInode::from_bytes(&block[off_in_block..off_in_block + size_of::<RawInode>()]);
+        if let Some(seed) = self.csum_seed {
+            InodeDesc::verify_inode_checksum(
+                &raw,
+                seed.derive_inode(ino, raw.generation),
+                self.inode_size,
+            )?;
+        }
+        InodeDesc::try_from(&raw)
+    }
+
+    /// Returns the 0-based group-local inode index for `ino`.
+    fn inode_idx_in_group(&self, ino: Ext4Ino) -> u16 {
+        debug_assert!(ino > 0);
+        debug_assert_eq!(
+            ((ino - 1) / self.nr_inodes_per_group) as usize,
+            self.group_idx
+        );
+        ((ino - 1) % self.nr_inodes_per_group) as u16
+    }
+
+    /// Loads the block bitmap for this group.
+    fn load_block_bitmap(
+        block_device: &dyn BlockDevice,
+        first_block: Ext4Bid,
+        last_block: Ext4Bid,
+        desc: &BlockGroupDesc,
+    ) -> Result<IdBitmap> {
+        let group_size = (last_block - first_block + 1) as u32;
+        let capacity = group_size as u16;
+        debug_assert!(capacity as u32 == group_size && capacity <= IdBitmap::capacity());
+
+        // A `BLOCK_UNINIT` group's on-disk block bitmap is not maintained, so the
+        // raw block is meaningless (often all-zero) — trusting it would present
+        // the group's backup superblock/GDT blocks as "free". Reconstruct the
+        // bitmap from the group layout instead: such a group holds no data, so its
+        // only used blocks are the fixed metadata/backup overhead at the group
+        // start — a contiguous prefix whose length the descriptor's authoritative
+        // free-block count gives us directly (Linux `ext4_init_block_bitmap`).
+        if desc.is_block_uninit() {
+            let overhead = group_size
+                .checked_sub(desc.free_blocks_count())
+                .ok_or_else(|| {
+                    Error::with_message(
+                        Errno::EUCLEAN,
+                        "uninit group free count exceeds group size",
+                    )
+                })?;
+            let mut bitmap = IdBitmap::from_buf(vec![0u8; BLOCK_SIZE].into_boxed_slice(), capacity);
+            if overhead > 0 {
+                // `capacity == group_size >= overhead`, so this cannot fail.
+                bitmap.alloc_consecutive(overhead as u16);
+            }
+            // Safety net for the prefix assumption: any of this group's own
+            // metadata blocks that fall within the group must lie inside the
+            // reconstructed prefix. If one sits beyond it the layout is not the
+            // prefix we assumed — refuse rather than risk presenting that block
+            // as free.
+            for bid in [
+                desc.block_bitmap_bid(),
+                desc.inode_bitmap_bid(),
+                desc.inode_table_bid(),
+            ] {
+                if (first_block..=last_block).contains(&bid)
+                    && bid - first_block >= overhead as Ext4Bid
+                {
+                    return_errno_with_message!(
+                        Errno::EUCLEAN,
+                        "uninit group metadata block outside reconstructed prefix"
+                    );
+                }
+            }
+            return Ok(bitmap);
+        }
+
+        let bitmap_bid = desc.block_bitmap_bid();
+        let mut buf = vec![0u8; BLOCK_SIZE];
+        if block_device
+            .read_bytes(Bid::new(bitmap_bid).to_offset(), &mut buf)
+            .is_err()
+        {
+            return_errno_with_message!(Errno::EIO, "failed to read block bitmap");
+        }
+
+        Ok(IdBitmap::from_buf(buf.into_boxed_slice(), capacity))
+    }
+
+    /// Loads the inode bitmap for this group.
+    ///
+    /// The bitmap's logical capacity is the number of inodes per group, capped
+    /// at the bitmap's physical capacity (a single block always holds at least
+    /// as many bits as inodes a group can have).
+    fn load_inode_bitmap(
+        block_device: &dyn BlockDevice,
+        nr_inodes_per_group: u32,
+        desc: &BlockGroupDesc,
+    ) -> Result<IdBitmap> {
+        let capacity = nr_inodes_per_group.min(u32::from(IdBitmap::capacity())) as u16;
+
+        // An `INODE_UNINIT` group has never had an inode allocated: its on-disk
+        // inode bitmap is not maintained (raw content is meaningless). Present an
+        // all-free bitmap rather than trusting the garbage, so any incidental
+        // read (e.g. via a bogus inode number) sees a consistent empty group
+        // instead of spurious allocated bits.
+        if desc.is_inode_uninit() {
+            return Ok(IdBitmap::from_buf(
+                vec![0u8; BLOCK_SIZE].into_boxed_slice(),
+                capacity,
+            ));
+        }
+
+        let bitmap_bid = desc.inode_bitmap_bid();
+        let mut buf = vec![0u8; BLOCK_SIZE];
+        if block_device
+            .read_bytes(Bid::new(bitmap_bid).to_offset(), &mut buf)
+            .is_err()
+        {
+            return_errno_with_message!(Errno::EIO, "failed to read inode bitmap");
+        }
+
+        Ok(IdBitmap::from_buf(buf.into_boxed_slice(), capacity))
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::{super::test_utils::Ext4MemoryDisk, *};
+
+    /// A `BLOCK_UNINIT` group reconstructs its block bitmap from the layout — the
+    /// leading `group_size - free_blocks_count` overhead blocks marked used, the
+    /// rest free — and does NOT trust the (garbage) on-disk bitmap block. This
+    /// prevents presenting a lazily-initialized group's backup metadata as
+    /// "free" space.
+    #[ktest]
+    fn block_uninit_reconstructs_prefix_bitmap() {
+        const GROUP_SIZE: u32 = 100;
+        const OVERHEAD: u32 = 10;
+
+        // Poison the on-disk block-bitmap block (bid 0) with all-ones: if the code
+        // trusted it, every block would read as used and the asserts below fail.
+        let disk = Ext4MemoryDisk::new(2);
+        disk.segment()
+            .write_bytes(0, &[0xFFu8; BLOCK_SIZE])
+            .unwrap();
+
+        let desc = BlockGroupDesc {
+            block_bitmap_bid: 0,
+            inode_bitmap_bid: 0,
+            inode_table_bid: 0,
+            free_blocks_count: GROUP_SIZE - OVERHEAD,
+            free_inodes_count: 0,
+            used_dirs_count: 0,
+            flags: BG_BLOCK_UNINIT,
+        };
+
+        let bitmap =
+            BlockGroup::load_block_bitmap(&disk, 0, (GROUP_SIZE - 1) as Ext4Bid, &desc).unwrap();
+
+        for bit in 0..OVERHEAD as u16 {
+            assert!(
+                bitmap.is_allocated(bit),
+                "overhead block {bit} must be used"
+            );
+        }
+        for bit in OVERHEAD as u16..GROUP_SIZE as u16 {
+            assert!(!bitmap.is_allocated(bit), "data block {bit} must be free");
+        }
+    }
+
+    /// A metadata block sitting beyond the reconstructed prefix breaks the
+    /// prefix assumption, so reconstruction refuses (fail-closed) rather than
+    /// risk handing that block out.
+    #[ktest]
+    fn block_uninit_rejects_metadata_past_prefix() {
+        let disk = Ext4MemoryDisk::new(2);
+        let desc = BlockGroupDesc {
+            block_bitmap_bid: 50, // in-range but past the 10-block prefix
+            inode_bitmap_bid: 0,
+            inode_table_bid: 0,
+            free_blocks_count: 90,
+            free_inodes_count: 0,
+            used_dirs_count: 0,
+            flags: BG_BLOCK_UNINIT,
+        };
+        assert!(BlockGroup::load_block_bitmap(&disk, 0, 99, &desc).is_err());
+    }
+
+    /// A 64-byte descriptor whose block-number high halves are non-zero decodes
+    /// to the correct `> 2^32` `Ext4Bid` — the red-line splice. The per-group
+    /// counters come from the low half untouched.
+    #[ktest]
+    fn decode_64byte_descriptor_high_halves() {
+        let raw = RawBlockGroup64 {
+            lo: RawBlockGroup {
+                block_bitmap_lo: 0x1111_2222,
+                inode_bitmap_lo: 0x3333_4444,
+                inode_table_lo: 0x5555_6666,
+                free_blocks_count_lo: 7,
+                free_inodes_count_lo: 9,
+                used_dirs_count_lo: 3,
+                ..Default::default()
+            },
+            hi: RawBlockGroupHi {
+                block_bitmap_hi: 0xA,
+                inode_bitmap_hi: 0xB,
+                inode_table_hi: 0xC,
+                ..Default::default()
+            },
+        };
+
+        let desc = BlockGroupDesc::from_raw(&raw.lo, Some(&raw.hi));
+        assert_eq!(desc.block_bitmap_bid(), 0x0000_000A_1111_2222);
+        assert_eq!(desc.inode_bitmap_bid(), 0x0000_000B_3333_4444);
+        assert_eq!(desc.inode_table_bid(), 0x0000_000C_5555_6666);
+        assert_eq!(desc.free_blocks_count(), 7);
+        assert_eq!(desc.free_inodes_count(), 9);
+        assert_eq!(desc.used_dirs_count(), 3);
+
+        // The 32-byte (no-hi) path leaves the block numbers at their low halves.
+        let desc32 = BlockGroupDesc::from_raw(&raw.lo, None);
+        assert_eq!(desc32.block_bitmap_bid(), 0x1111_2222);
+        assert_eq!(desc32.inode_bitmap_bid(), 0x3333_4444);
+        assert_eq!(desc32.inode_table_bid(), 0x5555_6666);
+    }
+
+    /// Two adjacent 64-byte descriptors in a GDT are read at their 64-byte-apart
+    /// offsets and each decodes to its own distinct (wide) block numbers — the
+    /// desc_size stride plus the wide read.
+    #[ktest]
+    fn read_desc_64byte_stride() {
+        let disk = Ext4MemoryDisk::new(4);
+        let gdt_base = BLOCK_SIZE; // GDT at block 1, as the fixture lays it out.
+        let desc_size: u16 = 64;
+
+        let g0 = RawBlockGroup64 {
+            lo: RawBlockGroup {
+                block_bitmap_lo: 0x10,
+                inode_bitmap_lo: 0x11,
+                inode_table_lo: 0x12,
+                ..Default::default()
+            },
+            hi: RawBlockGroupHi {
+                block_bitmap_hi: 1,
+                inode_table_hi: 2,
+                ..Default::default()
+            },
+        };
+        let g1 = RawBlockGroup64 {
+            lo: RawBlockGroup {
+                block_bitmap_lo: 0x20,
+                inode_bitmap_lo: 0x21,
+                inode_table_lo: 0x22,
+                ..Default::default()
+            },
+            hi: RawBlockGroupHi {
+                block_bitmap_hi: 3,
+                inode_table_hi: 4,
+                ..Default::default()
+            },
+        };
+
+        let off0 = gdt_base;
+        let off1 = gdt_base + desc_size as usize;
+        disk.segment().write_val(off0, &g0).unwrap();
+        disk.segment().write_val(off1, &g1).unwrap();
+
+        let d0 = BlockGroup::read_desc(&disk, off0, desc_size, 0, None).unwrap();
+        let d1 = BlockGroup::read_desc(&disk, off1, desc_size, 1, None).unwrap();
+        assert_eq!(d0.block_bitmap_bid(), (1u64 << 32) | 0x10);
+        assert_eq!(d0.inode_table_bid(), (2u64 << 32) | 0x12);
+        assert_eq!(d1.block_bitmap_bid(), (3u64 << 32) | 0x20);
+        assert_eq!(d1.inode_bitmap_bid(), 0x21);
+        assert_eq!(d1.inode_table_bid(), (4u64 << 32) | 0x22);
+    }
+
+    /// A 32-byte descriptor stamped with its crc32c `bg_checksum` verifies; a
+    /// corrupted field, a wrong group number, or a wrong seed each fail with
+    /// `EUCLEAN`. The checksum depends on the group number, so the same bytes at
+    /// a different group index do not verify.
+    #[ktest]
+    fn group_desc_checksum_round_trip() {
+        let seed = FsCsumSeed::new(0x1234_5678);
+        let mut lo = RawBlockGroup {
+            block_bitmap_lo: 0x10,
+            inode_bitmap_lo: 0x11,
+            inode_table_lo: 0x12,
+            free_blocks_count_lo: 100,
+            free_inodes_count_lo: 50,
+            used_dirs_count_lo: 3,
+            ..Default::default()
+        };
+        lo.checksum = BlockGroupDesc::group_desc_checksum(&lo, None, 7, seed);
+        BlockGroupDesc::verify_group_desc_checksum(&lo, None, 7, seed).unwrap();
+
+        // Wrong group number: the checksum folds it in.
+        assert_eq!(
+            BlockGroupDesc::verify_group_desc_checksum(&lo, None, 8, seed)
+                .unwrap_err()
+                .error(),
+            Errno::EUCLEAN
+        );
+        // Wrong seed.
+        assert!(
+            BlockGroupDesc::verify_group_desc_checksum(&lo, None, 7, FsCsumSeed::new(0x1234_5679))
+                .is_err()
+        );
+        // Corrupted body.
+        let mut bad = lo;
+        bad.free_blocks_count_lo = 101;
+        assert!(BlockGroupDesc::verify_group_desc_checksum(&bad, None, 7, seed).is_err());
+    }
+
+    /// The 64-byte descriptor folds its high-half tail (including the bitmap
+    /// checksum high halves) into `bg_checksum`, so a change there is caught.
+    #[ktest]
+    fn group_desc_checksum_covers_high_tail() {
+        let seed = FsCsumSeed::new(0xABCD);
+        let lo = RawBlockGroup {
+            block_bitmap_lo: 0x20,
+            ..Default::default()
+        };
+        let mut hi = RawBlockGroupHi {
+            block_bitmap_hi: 1,
+            block_bitmap_csum_hi: 0x9999,
+            ..Default::default()
+        };
+        let csum = BlockGroupDesc::group_desc_checksum(&lo, Some(&hi), 2, seed);
+        let mut lo_stamped = lo;
+        lo_stamped.checksum = csum;
+        BlockGroupDesc::verify_group_desc_checksum(&lo_stamped, Some(&hi), 2, seed).unwrap();
+
+        // A change in the high tail changes the checksum.
+        hi.block_bitmap_csum_hi = 0x8888;
+        assert_ne!(
+            BlockGroupDesc::group_desc_checksum(&lo, Some(&hi), 2, seed),
+            csum
+        );
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/checksum.rs
+++ b/kernel/src/fs/fs_impls/ext4/checksum.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! crc32c (Castagnoli) — the checksum kernel behind `metadata_csum` (Phase 6b)
+//! and, later, the JBD2 journal checksums (Phase 7).
+//!
+//! This is the *raw* reflected CRC-32C used by ext4: [`crc32c`] runs the
+//! reflected polynomial `0x82F63B78` over the bytes with `seed` as the running
+//! state and applies **no** pre- or post-inversion — exactly Linux's
+//! `__crc32c_le` and e2fsprogs' `crc32c_le`, which ext4's `ext4_chksum` wraps
+//! verbatim. Callers own the conventional `~0` seed (superblock) or the
+//! per-filesystem / per-inode seed (group descriptors, inodes, directory and
+//! extent blocks); ext4 stores the running value directly, so this function
+//! must not invert, or verify-on-read would reject every valid on-disk checksum.
+//!
+//! The well-known CRC-32C "check" constant `0xE3069283` (init and xorout both
+//! `~0`) therefore equals `!crc32c(!0, b"123456789")` here — the outer `!`
+//! being the caller-side xorout that ext4 does not use internally.
+
+use super::inode::Ext4Ino;
+
+/// The CRC-32C lookup table, one 32-bit residue per possible input byte,
+/// generated at compile time from the reflected polynomial `0x82F63B78`.
+const CRC32C_TABLE: [u32; 256] = {
+    const POLY: u32 = 0x82F63B78;
+    let mut table = [0u32; 256];
+    let mut i = 0;
+    while i < 256 {
+        let mut crc = i as u32;
+        let mut bit = 0;
+        while bit < 8 {
+            crc = if crc & 1 != 0 {
+                (crc >> 1) ^ POLY
+            } else {
+                crc >> 1
+            };
+            bit += 1;
+        }
+        table[i] = crc;
+        i += 1;
+    }
+    table
+};
+
+/// Folds `data` into the running CRC-32C `seed` and returns the new running
+/// value (no pre/post inversion — see the module docs).
+///
+/// Segments chain: `crc32c(crc32c(seed, a), b) == crc32c(seed, a ++ b)`, which
+/// is how ext4 checksums a structure across the gap left by its own (zeroed)
+/// checksum field.
+pub(super) fn crc32c(seed: u32, data: &[u8]) -> u32 {
+    let mut crc = seed;
+    for &byte in data {
+        crc = (crc >> 8) ^ CRC32C_TABLE[((crc ^ byte as u32) & 0xFF) as usize];
+    }
+    crc
+}
+
+/// The per-filesystem metadata_csum seed (`crc32c(!0, uuid)`): feeds the group
+/// descriptor and bitmap checksums directly, and folds into a per-inode seed for
+/// the inode, directory-block, and extent-node checksums.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct FsCsumSeed(u32);
+
+impl FsCsumSeed {
+    pub(super) fn new(seed: u32) -> Self {
+        Self(seed)
+    }
+
+    pub(super) fn get(self) -> u32 {
+        self.0
+    }
+
+    /// Folds `ino` and `generation` into the fs seed (Linux `ext4_inode_csum_seed`).
+    pub(super) fn derive_inode(self, ino: Ext4Ino, generation: u32) -> InodeCsumSeed {
+        let s = crc32c(self.0, &ino.to_le_bytes());
+        InodeCsumSeed(crc32c(s, &generation.to_le_bytes()))
+    }
+}
+
+/// The per-inode metadata_csum seed `crc32c(crc32c(fs_seed, ino), generation)`.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct InodeCsumSeed(u32);
+
+impl InodeCsumSeed {
+    pub(super) fn get(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::crc32c;
+
+    /// The canonical CRC-32C check vector: `0xE3069283` over `b"123456789"`
+    /// with the conventional `~0` init and `~0` xorout. Our raw function omits
+    /// the xorout, so the caller applies the outer `!`.
+    #[ktest]
+    fn crc32c_canonical_check_vector() {
+        assert_eq!(!crc32c(!0u32, b"123456789"), 0xE306_9283);
+    }
+
+    /// The empty input leaves the running state untouched (the identity of the
+    /// fold), so a `~0` seed over nothing xors back to zero.
+    #[ktest]
+    fn crc32c_empty_is_identity() {
+        assert_eq!(crc32c(0, &[]), 0);
+        assert_eq!(!crc32c(!0u32, &[]), 0);
+    }
+
+    /// Chaining two segments equals one pass over their concatenation — the
+    /// property ext4 relies on to checksum a struct around its checksum field.
+    #[ktest]
+    fn crc32c_segments_chain() {
+        let whole = crc32c(!0u32, b"123456789");
+        let split = crc32c(crc32c(!0u32, b"12345"), b"6789");
+        assert_eq!(whole, split);
+    }
+
+    /// A single-byte change flips the result (guards against a stuck table).
+    #[ktest]
+    fn crc32c_detects_single_bit() {
+        let a = crc32c(!0u32, b"metadata_csum");
+        let b = crc32c(!0u32, b"metadata_csun");
+        assert_ne!(a, b);
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/feature.rs
+++ b/kernel/src/fs/fs_impls/ext4/feature.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 feature flags and the masks of features this implementation supports.
+//!
+//! Features are split into three classes per the ext4 on-disk format: compatible
+//! (`s_feature_compat`), incompatible (`s_feature_incompat`), and read-only
+//! compatible (`s_feature_ro_compat`). Mount handling uses the `*_SUPP` masks to
+//! decide whether to reject a volume: an unsupported `incompat` feature is
+//! refused outright, and an unsupported `ro_compat` feature is refused with
+//! `EROFS` (this read-only port cannot interpret such a feature's on-disk
+//! semantics, so it refuses the volume rather than misread it).
+//!
+//! Naming follows ext2's de-prefixed style; each flag's doc comment cites the
+//! Linux `EXT4_FEATURE_*` constant for cross-reference.
+
+use super::prelude::*;
+
+bitflags! {
+    /// Compatible features. An unknown bit here does not affect mounting.
+    pub(super) struct FeatureCompatSet: u32 {
+        /// `COMPAT_DIR_PREALLOC`.
+        const DIR_PREALLOC = 1 << 0;
+        /// `COMPAT_IMAGIC_INODES`.
+        const IMAGIC_INODES = 1 << 1;
+        /// `COMPAT_HAS_JOURNAL`: the volume has a journal (inode 8).
+        const HAS_JOURNAL = 1 << 2;
+        /// `COMPAT_EXT_ATTR`: inodes have extended attributes.
+        const EXT_ATTR = 1 << 3;
+        /// `COMPAT_RESIZE_INODE`.
+        const RESIZE_INODE = 1 << 4;
+        /// `COMPAT_DIR_INDEX`: directories use an htree hash index.
+        const DIR_INDEX = 1 << 5;
+    }
+}
+
+bitflags! {
+    /// Incompatible features. An unknown bit not in `INCOMPAT_SUPP` makes the
+    /// volume unmountable.
+    pub(super) struct FeatureIncompatSet: u32 {
+        /// `INCOMPAT_COMPRESSION`.
+        const COMPRESSION = 1 << 0;
+        /// `INCOMPAT_FILETYPE`: directory entries record the file type.
+        const FILETYPE = 1 << 1;
+        /// `INCOMPAT_RECOVER`: the journal needs replay before writing.
+        const RECOVER = 1 << 2;
+        /// `INCOMPAT_JOURNAL_DEV`: journal is on an external device.
+        const JOURNAL_DEV = 1 << 3;
+        /// `INCOMPAT_META_BG`.
+        const META_BG = 1 << 4;
+        /// `INCOMPAT_EXTENTS`: inodes use extent block mapping (required).
+        const EXTENTS = 1 << 6;
+        /// `INCOMPAT_64BIT`: 64-bit block numbers and 64-byte group descriptors.
+        const IS_64BIT = 1 << 7;
+        /// `INCOMPAT_MMP`: multiple-mount protection.
+        const MMP = 1 << 8;
+        /// `INCOMPAT_FLEX_BG`: flexible block groups.
+        const FLEX_BG = 1 << 9;
+        /// `INCOMPAT_EA_INODE`.
+        const EA_INODE = 1 << 10;
+        /// `INCOMPAT_DIRDATA`.
+        const DIRDATA = 1 << 12;
+        /// `INCOMPAT_CSUM_SEED`: checksum seed stored in the superblock.
+        const CSUM_SEED = 1 << 13;
+        /// `INCOMPAT_LARGEDIR`.
+        const LARGEDIR = 1 << 14;
+        /// `INCOMPAT_INLINE_DATA`: small files stored inline in the inode.
+        const INLINE_DATA = 1 << 15;
+        /// `INCOMPAT_ENCRYPT`.
+        const ENCRYPT = 1 << 16;
+        /// `INCOMPAT_CASEFOLD`.
+        const CASEFOLD = 1 << 17;
+    }
+}
+
+bitflags! {
+    /// Read-only compatible features. A bit not in [`RO_COMPAT_SUPP`] refuses
+    /// the mount with `EROFS` — see the constant's doc.
+    pub(super) struct FeatureRoCompatSet: u32 {
+        /// `RO_COMPAT_SPARSE_SUPER`: sparse superblock and GDT backups.
+        const SPARSE_SUPER = 1 << 0;
+        /// `RO_COMPAT_LARGE_FILE`: 64-bit file sizes.
+        const LARGE_FILE = 1 << 1;
+        /// `RO_COMPAT_HUGE_FILE`: `i_blocks` counted in filesystem blocks.
+        const HUGE_FILE = 1 << 3;
+        /// `RO_COMPAT_GDT_CSUM`: legacy block-group descriptor checksums.
+        const GDT_CSUM = 1 << 4;
+        /// `RO_COMPAT_DIR_NLINK`: directory link counts may exceed 65000.
+        const DIR_NLINK = 1 << 5;
+        /// `RO_COMPAT_EXTRA_ISIZE`: inodes record their used extra size.
+        const EXTRA_ISIZE = 1 << 6;
+        /// `RO_COMPAT_QUOTA`.
+        const QUOTA = 1 << 8;
+        /// `RO_COMPAT_BIGALLOC`.
+        const BIGALLOC = 1 << 9;
+        /// `RO_COMPAT_METADATA_CSUM`: crc32c checksums on metadata.
+        const METADATA_CSUM = 1 << 10;
+        /// `RO_COMPAT_PROJECT`.
+        const PROJECT = 1 << 13;
+        /// `RO_COMPAT_VERITY`.
+        const VERITY = 1 << 15;
+    }
+}
+
+/// Incompatible features this implementation supports.
+///
+/// The reader understands typed directory entries (`FILETYPE`) and extent block
+/// mapping (`EXTENTS`). `RECOVER` is deliberately **not** in this mask: this
+/// read-only mount carries no journal-replay machinery, so a volume left with
+/// the journal needing replay is a dirty volume and must be rejected (its
+/// on-disk bytes may be a pre-crash inconsistent state the funnel would serve
+/// verbatim), not mounted and silently read without replay. Phase 6 adds
+/// `FLEX_BG`: flex_bg only relocates each group's bitmaps and inode table, and
+/// those block numbers already come from the descriptor getters
+/// (`block_bitmap_bid` etc.), never from geometry, so the read/write paths need
+/// no change beyond admitting the bit. Phase 6 also adds `IS_64BIT`: 64-byte
+/// group descriptors and the `s_*_count_hi` superblock halves are decoded wide
+/// (`BlockGroup::read_desc` strides by `s_desc_size` and splices the block-number
+/// high halves; `SuperBlock::try_from` splices the count high halves). This bit
+/// joins the mask **atomically with that decoder** — admitting it before the wide
+/// decode existed would misread every group descriptor as a truncated address.
+/// Other incompatible features (csum_seed, ...) are added in later phases and
+/// must stay out of this mask until then, so an image needing them is rejected
+/// rather than silently misread. (`HAS_JOURNAL` is a *compat* feature — an
+/// unknown/ignored compat bit on this no-journal read-only mount — so it does
+/// not belong in this incompat mask.)
+pub(super) const INCOMPAT_SUPP: FeatureIncompatSet = FeatureIncompatSet::FILETYPE
+    .union(FeatureIncompatSet::EXTENTS)
+    .union(FeatureIncompatSet::FLEX_BG)
+    .union(FeatureIncompatSet::IS_64BIT);
+
+/// Read-only compatible features this implementation handles.
+///
+/// Most need no extra code to read correctly. `METADATA_CSUM` is the
+/// exception: its crc32c is verified on read for the superblock, the group
+/// descriptors, and inodes. Bitmap, directory-block, and extent-node checksums
+/// are not verified on read (a known limitation); such a volume still mounts
+/// read-only. Known limitation: for an inode carrying `EXT4_HUGE_FILE_FL`,
+/// `i_blocks` is in filesystem-block units; this reader treats it as 512-byte
+/// sectors, so `st_blocks` may be under-reported for such inodes (normally
+/// files larger than 2 TiB, though a corrupt image could set the flag on any
+/// inode). The file data read back is unaffected. A volume carrying any
+/// `ro_compat` bit still outside this mask carries semantics this reader cannot
+/// interpret, so `SuperBlock::try_from` refuses the mount with `EROFS` (Linux
+/// `ext4_setup_super` parity).
+pub(super) const RO_COMPAT_SUPP: FeatureRoCompatSet = FeatureRoCompatSet::SPARSE_SUPER
+    .union(FeatureRoCompatSet::LARGE_FILE)
+    .union(FeatureRoCompatSet::HUGE_FILE)
+    .union(FeatureRoCompatSet::DIR_NLINK)
+    .union(FeatureRoCompatSet::EXTRA_ISIZE)
+    .union(FeatureRoCompatSet::METADATA_CSUM);

--- a/kernel/src/fs/fs_impls/ext4/fs.rs
+++ b/kernel/src/fs/fs_impls/ext4/fs.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The `Ext4` filesystem object: mount, geometry, and inode lookup.
+//!
+//! At mount the superblock and block-group descriptors are parsed and each group
+//! loads its block and inode bitmaps. `Ext4` resolves an inode number to its
+//! owning group and reads the inode on demand, caching live inodes per group.
+//! This is a read-only mount: there is no block/inode allocation, journaling, or
+//! metadata writeback.
+
+use device_id::DeviceId;
+
+use super::{
+    block_group::BlockGroup,
+    inode::{Inode, InodeDesc},
+    prelude::*,
+    super_block::{RawSuperBlock, SUPER_BLOCK_OFFSET, SuperBlock},
+};
+use crate::fs::vfs::file_system::FsEventSubscriberStats;
+
+/// Root directory inode number.
+pub(super) const ROOT_INO: Ext4Ino = 2;
+
+/// An ext4 filesystem instance.
+pub struct Ext4 {
+    block_device: Arc<dyn BlockDevice>,
+    /// Superblock with dirty tracking.
+    super_block: RwMutex<Dirty<SuperBlock>>,
+    /// Per-group block-side metadata (descriptor + block bitmap).
+    block_groups: Vec<BlockGroup>,
+    /// Inodes per group, cached once at mount to avoid locking `super_block` on
+    /// the inode read path.
+    nr_inodes_per_group: u32,
+    /// Total inode count, cached at mount like `nr_inodes_per_group` — the
+    /// corrupt-ino bound check sits on every inode load, so caching it here
+    /// avoids taking the `super_block` lock on that path.
+    total_inodes: u32,
+    fs_event_subscriber_stats: FsEventSubscriberStats,
+    self_ref: Weak<Ext4>,
+}
+
+impl Ext4 {
+    /// Mounts an ext4 volume from a block device.
+    pub(super) fn open(device: Arc<dyn BlockDevice>) -> Result<Arc<Self>> {
+        let raw_super_block = device.read_val::<RawSuperBlock>(SUPER_BLOCK_OFFSET)?;
+        let super_block = SuperBlock::try_from(raw_super_block)?;
+        let nr_inodes_per_group = super_block.nr_inodes_per_group();
+        let total_inodes = super_block.total_inodes();
+
+        let block_groups = Self::load_block_groups(device.clone(), &super_block)?;
+
+        let ext4 = Arc::new_cyclic(|weak| Ext4 {
+            block_device: device,
+            super_block: RwMutex::new(Dirty::new(super_block)),
+            block_groups,
+            nr_inodes_per_group,
+            total_inodes,
+            fs_event_subscriber_stats: FsEventSubscriberStats::new(),
+            self_ref: weak.clone(),
+        });
+
+        Ok(ext4)
+    }
+
+    pub(super) fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+        &self.fs_event_subscriber_stats
+    }
+
+    /// Returns the device ID of the backing block device.
+    pub(super) fn container_device_id(&self) -> DeviceId {
+        self.block_device.id()
+    }
+
+    /// Loads every block group from the descriptor table, which immediately
+    /// follows the block holding the superblock.
+    fn load_block_groups(
+        device: Arc<dyn BlockDevice>,
+        super_block: &SuperBlock,
+    ) -> Result<Vec<BlockGroup>> {
+        let nr_groups = super_block.nr_block_groups() as usize;
+        let gdt_base_offset =
+            (super_block.first_data_block() as usize + 1) * super_block.block_size();
+
+        let mut block_groups = Vec::with_capacity(nr_groups);
+        for group_idx in 0..nr_groups {
+            let group = BlockGroup::load(device.clone(), group_idx, super_block, gdt_base_offset)?;
+            block_groups.push(group);
+        }
+        Ok(block_groups)
+    }
+
+    /// Returns a read guard of the superblock.
+    pub(super) fn super_block(&self) -> RwMutexReadGuard<'_, Dirty<SuperBlock>> {
+        self.super_block.read()
+    }
+
+    pub(super) fn block_device(&self) -> &Arc<dyn BlockDevice> {
+        &self.block_device
+    }
+    /// Refuses a remount-time filesystem-flag change with `EOPNOTSUPP`.
+    ///
+    /// Ext4 processes no runtime change to the filesystem flags, so
+    /// `set_fs_flags` reports the change as unsupported rather than silently
+    /// answering `Ok(())` — a fake success that would pretend to honor a flag
+    /// transition it never performs.
+    pub(super) fn refuse_fs_flags_change(&self) -> Result<()> {
+        return_errno_with_message!(
+            Errno::EOPNOTSUPP,
+            "ext4 does not support changing filesystem flags at remount"
+        );
+    }
+
+    /// Submits an asynchronous read of one or more blocks starting at `bid`.
+    pub(super) fn read_blocks_async(
+        &self,
+        bid: Ext4Bid,
+        bio_segment: BioSegment,
+        complete_fn: Option<BioCompleteFn>,
+        io_batch: &mut IoBatch,
+    ) -> Result<()> {
+        self.block_device
+            .read_blocks_async(Bid::new(bid), bio_segment, complete_fn, io_batch)?;
+        Ok(())
+    }
+
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) fn this(&self) -> Weak<Ext4> {
+        self.self_ref.clone()
+    }
+
+    /// Locates and decodes an inode's metadata directly from the inode table.
+    ///
+    /// The owning group performs the on-disk load; this method only routes the
+    /// inode number to its group.
+    pub(super) fn read_inode_desc(&self, ino: Ext4Ino) -> Result<InodeDesc> {
+        self.find_group(ino)?.read_inode_desc(ino)
+    }
+
+    /// Returns the block group that owns `ino`.
+    fn find_group(&self, ino: Ext4Ino) -> Result<&BlockGroup> {
+        if ino == 0 {
+            return_errno_with_message!(Errno::ENOENT, "invalid inode number 0");
+        }
+        // A corrupt dirent can carry any 32-bit ino; bound it by the
+        // superblock's inode count, not just the group range (P1 review item,
+        // batch-fixed at P5). Uses the mount-time cache to avoid taking the
+        // `super_block` lock on every inode load.
+        if ino > self.total_inodes {
+            return_errno_with_message!(Errno::ENOENT, "inode number beyond s_inodes_count");
+        }
+        let group_idx = ((ino - 1) / self.nr_inodes_per_group) as usize;
+        self.block_groups
+            .get(group_idx)
+            .ok_or_else(|| Error::with_message(Errno::ENOENT, "inode block group out of range"))
+    }
+
+    /// Reads the root directory's inode metadata.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) fn root_inode_desc(&self) -> Result<InodeDesc> {
+        self.read_inode_desc(ROOT_INO)
+    }
+
+    /// Reads an inode, returning the cached `Arc<Inode>` if one already exists.
+    ///
+    /// Routing through the owning group's inode cache gives every reader of one
+    /// inode number the same in-memory inode (identity), so concurrent readers
+    /// share a single object.
+    pub(super) fn read_inode(&self, ino: Ext4Ino) -> Result<Arc<Inode>> {
+        self.find_group(ino)?
+            .lookup_inode(ino, self.self_ref.clone())
+    }
+
+    /// Reads the root directory inode.
+    pub(super) fn root_inode(&self) -> Result<Arc<Inode>> {
+        self.read_inode(ROOT_INO)
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::{
+        super::test_utils::{Ext4FixtureBuilder, make_empty_file_inode, make_file_inode},
+        *,
+    };
+
+    #[ktest]
+    fn mount_and_read_root() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let root = f.ext4.root_inode_desc().unwrap();
+        assert_eq!(root.type_(), InodeType::Dir);
+        assert_eq!(root.link_count(), 2);
+        assert!(root.is_extent_based());
+        assert_eq!(f.ext4.super_block().nr_block_groups(), 1);
+    }
+
+    #[ktest]
+    fn read_inode_zero_fails() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        assert!(f.ext4.read_inode_desc(0).is_err());
+    }
+
+    /// `statfs` reports usable capacity (raw blocks minus static metadata
+    /// overhead — a read-only mount consults no journal), a reserved-block
+    /// adjusted `bavail`, and a UUID-derived `fsid`.
+    #[ktest]
+    fn statfs_reports_usable_space() {
+        use crate::fs::vfs::file_system::FileSystem;
+
+        // 3 groups of 2048 blocks, non-zero reserved blocks and UUID. The fixture
+        // sets `first_data_block == 0`, `sparse_super`, and no reserved GDT, so
+        // only groups 0 and 1 carry a superblock/GDT copy.
+        let uuid = [
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+            0x77, 0x88,
+        ];
+        let f = Ext4FixtureBuilder::new(2048, 256, 3 * 2048)
+            .with_reserved_blocks(500)
+            .with_uuid(uuid)
+            .build()
+            .unwrap();
+        let sb = f.ext4.sb();
+
+        // Overhead = 3 groups * (16 inode-table + 2 bitmaps) + 2 super-bearing
+        // groups * (1 super + 1 GDT) = 58 blocks. A read-only mount adds no
+        // journal-log overhead (the journal is never loaded).
+        let expected_overhead = 3 * (16 + 2) + 2 * (1 + 1);
+        assert_eq!(sb.blocks, 3 * 2048 - expected_overhead);
+
+        // The read-only fixture declares no free blocks, so `bfree` is zero and
+        // `bavail` saturates at zero after subtracting the 500 reserved blocks.
+        assert_eq!(sb.bfree, 0);
+        assert_eq!(sb.bavail, 0);
+        // `fsid` is the UUID's low 8 bytes.
+        assert_eq!(sb.fsid, u64::from_le_bytes(uuid[..8].try_into().unwrap()));
+    }
+
+    /// A remount that asks to change filesystem flags is refused with
+    /// `EOPNOTSUPP` (ext4 honors no runtime change), not silently accepted.
+    #[ktest]
+    fn set_fs_flags_refuses_loudly() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let err = f.ext4.refuse_fs_flags_change().unwrap_err();
+        assert_eq!(err.error(), Errno::EOPNOTSUPP);
+    }
+
+    #[ktest]
+    fn read_small_file_end_to_end() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let data_block = 100u32;
+        let content = b"hello ext4 phase 1 read path!";
+        f.write_data_block(data_block, content);
+        f.write_raw_inode(11, &make_file_inode(data_block, content.len() as u32));
+
+        let inode = f.ext4.read_inode(11).unwrap();
+        assert_eq!(inode.inode_type(), InodeType::File);
+        assert_eq!(inode.size(), content.len());
+
+        let mut buf = vec![0u8; content.len()];
+        let mut writer = VmWriter::from(buf.as_mut_slice()).to_fallible();
+        let read = inode.read_at(0, &mut writer).unwrap();
+        assert_eq!(read, content.len());
+        assert_eq!(&buf[..], content);
+    }
+
+    /// Reading the same inode number twice returns the same cached `Arc`
+    /// (identity), while a different inode number is a distinct object.
+    #[ktest]
+    fn read_inode_returns_same_arc_identity() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        f.write_raw_inode(11, &make_empty_file_inode());
+
+        let a = f.ext4.read_inode(11).unwrap();
+        let b = f.ext4.read_inode(11).unwrap();
+        assert!(Arc::ptr_eq(&a, &b));
+
+        // A different inode is a different identity.
+        f.write_raw_inode(12, &make_empty_file_inode());
+        let c = f.ext4.read_inode(12).unwrap();
+        assert!(!Arc::ptr_eq(&a, &c));
+    }
+
+    /// Mount contract (report §4.5): a corrupt dirent can carry any 32-bit ino;
+    /// both the inode-count bound and the group-range check must answer ENOENT,
+    /// never panic.
+    #[ktest]
+    fn read_inode_rejects_out_of_range_ino() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        for ino in [u32::MAX, 1 << 20] {
+            let Err(err) = f.ext4.read_inode(ino) else {
+                panic!("out-of-range ino {ino} must not resolve");
+            };
+            assert_eq!(err.error(), Errno::ENOENT);
+        }
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/fs_type.rs
+++ b/kernel/src/fs/fs_impls/ext4/fs_type.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! VFS filesystem-type registration for ext4.
+//!
+//! `Ext4Type` implements the `FsType` trait so the VFS layer can discover and
+//! mount ext4 volumes by name (`"ext4"`).
+
+use aster_systree::SysNode;
+
+use super::Ext4;
+use crate::{
+    fs::vfs::{
+        file_system::FileSystem,
+        registry::{FsCreationCtx, FsProperties, FsType},
+    },
+    prelude::*,
+};
+
+/// VFS-visible ext4 filesystem type.
+pub(super) struct Ext4Type;
+
+impl FsType for Ext4Type {
+    fn name(&self) -> &'static str {
+        "ext4"
+    }
+
+    fn properties(&self) -> FsProperties {
+        FsProperties::NEED_DISK
+    }
+
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        let disk = fs_creation_ctx.resolve_block_device()?;
+        Ext4::open(disk).map(|fs| fs as Arc<dyn FileSystem>)
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn SysNode>> {
+        None
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/impl_for_vfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ext4/impl_for_vfs/fs.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! `FileSystem` trait implementation for `Ext4`.
+
+use aster_block::BLOCK_SIZE;
+
+use crate::{
+    fs::{
+        fs_impls::ext4::{Ext4, super_block::MAGIC_NUM},
+        utils::NAME_MAX,
+        vfs::{
+            file_system::{FileSystem, FsEventSubscriberStats, FsFlags, SuperBlock},
+            inode::Inode,
+        },
+    },
+    prelude::*,
+};
+
+impl FileSystem for Ext4 {
+    fn name(&self) -> &'static str {
+        "ext4"
+    }
+
+    fn sync(&self) -> Result<()> {
+        // Read-only mount: there is nothing to flush — no dirty inodes, no
+        // journal, no block-side metadata mutations — so sync(2) is a no-op.
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.root_inode().unwrap()
+    }
+
+    fn flags(&self) -> FsFlags {
+        // Read-only mount: the VFS refuses directory-entry mutations
+        // (create/unlink/rename/...) with `EROFS` via `check_mount_writable`.
+        FsFlags::RDONLY
+    }
+
+    fn sb(&self) -> SuperBlock {
+        let sb = self.super_block();
+        // `f_blocks` reports usable capacity, not the raw device size: the total
+        // block count minus the filesystem's metadata overhead — superblock/GDT
+        // copies, bitmaps, inode tables (`SuperBlock::metadata_overhead`) —
+        // matching Linux `ext4_statfs` (`ext4_blocks_count - s_overhead`). The
+        // journal's log blocks would add to this overhead, but this read-only
+        // mount consults no journal, so only the static metadata overhead counts.
+        let overhead = sb.metadata_overhead();
+        let usable_blocks = sb.total_blocks().saturating_sub(overhead);
+        // `bavail` excludes the root-reserved blocks (`s_r_blocks_count`), like
+        // Linux `ext4_statfs`, so unprivileged `df` sees the space it can use.
+        let bavail = sb
+            .free_blocks_count()
+            .saturating_sub(u64::from(sb.reserved_blocks_count()));
+        SuperBlock {
+            magic: MAGIC_NUM as u64,
+            bsize: BLOCK_SIZE,
+            blocks: usize::try_from(usable_blocks).unwrap(),
+            bfree: usize::try_from(sb.free_blocks_count()).unwrap(),
+            bavail: usize::try_from(bavail).unwrap(),
+            files: sb.total_inodes() as usize,
+            ffree: sb.free_inodes_count() as usize,
+            // The volume UUID's low 64 bits, so mounts are distinguishable
+            // (Linux folds the UUID into `f_fsid` too).
+            fsid: u64::from_le_bytes(sb.uuid()[..8].try_into().unwrap()),
+            namelen: NAME_MAX,
+            frsize: BLOCK_SIZE,
+            flags: FsFlags::RDONLY.bits() as u64,
+            container_dev_id: self.container_device_id(),
+        }
+    }
+
+    fn set_fs_flags(&self, _flags: FsFlags, _data: Option<CString>, _ctx: &Context) -> Result<()> {
+        // Refuse loudly instead of inheriting the VFS default, which logs a
+        // warning and returns `Ok(())` — a fake success that would pretend to
+        // honor a flag change this mount never performs. Ext4 here accepts no
+        // runtime filesystem-flag change, so any change is `EOPNOTSUPP`.
+        self.refuse_fs_flags_change()
+    }
+
+    fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+        self.fs_event_subscriber_stats()
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext4/impl_for_vfs/inode.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! VFS `FileOps` and `Inode` trait implementations for the ext4 `Inode`.
+//!
+//! Translates VFS read requests into ext4-internal operations: data reads
+//! through the page cache, attribute getters, `lookup`, `readdir`, and symlink
+//! reads; special files open into their live kernel objects. This is a
+//! read-only mount, so the write-side methods return `EROFS`.
+
+use core::time::Duration;
+
+use aster_block::BLOCK_SIZE;
+use device_id::DeviceId;
+
+use crate::{
+    device,
+    fs::{
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags},
+        fs_impls::ext4::Inode as Ext4Inode,
+        utils::DirentVisitor,
+        vfs::{
+            file_system::FileSystem,
+            inode::{
+                Extension, FallocMode, FileOps, HardLinkability, Inode, Metadata, MknodType,
+                RenameMode, SymbolicLink,
+            },
+            xattr::{XattrName, XattrSetFlags},
+        },
+    },
+    prelude::*,
+    process::{Gid, Uid},
+    vm::page_cache::PageCache,
+};
+
+impl FileOps for Ext4Inode {
+    fn read_at(
+        &self,
+        offset: usize,
+        writer: &mut VmWriter,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        // Read-only mount: serve reads (including O_DIRECT) through the page
+        // cache. Access-time updates are a write and are disabled.
+        self.read_at(offset, writer)
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _reader: &mut VmReader,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        // Read-only mount: all writes are refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: write is disabled");
+    }
+
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        // Read-only mount: no access-time update (a write).
+        self.readdir_at(offset, visitor)
+    }
+}
+
+impl Inode for Ext4Inode {
+    fn size(&self) -> usize {
+        self.size()
+    }
+
+    fn resize(&self, _new_size: usize) -> Result<()> {
+        // Read-only mount: truncation/extension is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: resize is disabled");
+    }
+
+    fn metadata(&self) -> Metadata {
+        let container_dev_id = self
+            .fs()
+            .map(|fs| fs.container_device_id())
+            .unwrap_or_else(|_| DeviceId::null());
+        Metadata {
+            ino: self.ino() as u64,
+            size: self.size(),
+            optimal_block_size: BLOCK_SIZE,
+            nr_sectors_allocated: self.sector_count() as usize,
+            last_access_at: self.atime(),
+            last_modify_at: self.mtime(),
+            last_meta_change_at: self.ctime(),
+            type_: self.inode_type(),
+            mode: self.mode(),
+            nr_hard_links: self.link_count() as usize,
+            uid: Uid::new(self.uid()),
+            gid: Gid::new(self.gid()),
+            container_dev_id,
+            self_dev_id: self.device_id().and_then(DeviceId::from_encoded_u64),
+            birth_at: Some(self.crtime()),
+        }
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino() as u64
+    }
+
+    fn type_(&self) -> InodeType {
+        self.inode_type()
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(self.mode())
+    }
+
+    fn set_mode(&self, _mode: InodeMode) -> Result<()> {
+        // Read-only mount: chmod is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: set_mode is disabled");
+    }
+
+    fn owner(&self) -> Result<Uid> {
+        Ok(Uid::new(self.uid()))
+    }
+
+    fn set_owner(&self, _uid: Uid) -> Result<()> {
+        // Read-only mount: chown is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: set_owner is disabled");
+    }
+
+    fn group(&self) -> Result<Gid> {
+        Ok(Gid::new(self.gid()))
+    }
+
+    fn set_group(&self, _gid: Gid) -> Result<()> {
+        // Read-only mount: chgrp is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: set_group is disabled");
+    }
+
+    fn atime(&self) -> Duration {
+        self.atime()
+    }
+
+    fn set_atime(&self, _time: Duration) {
+        // Read-only mount: timestamp updates are silently ignored (no-op).
+    }
+
+    fn mtime(&self) -> Duration {
+        self.mtime()
+    }
+
+    fn set_mtime(&self, _time: Duration) {
+        // Read-only mount: timestamp updates are silently ignored (no-op).
+    }
+
+    fn ctime(&self) -> Duration {
+        self.ctime()
+    }
+
+    fn set_ctime(&self, _time: Duration) {
+        // Read-only mount: timestamp updates are silently ignored (no-op).
+    }
+
+    fn page_cache(&self) -> Option<PageCache> {
+        self.page_cache()
+    }
+
+    fn create(&self, _name: &str, _type_: InodeType, _mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        // Read-only mount: namespace creation is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: create is disabled");
+    }
+
+    fn create_tmpfile(
+        &self,
+        _mode: InodeMode,
+        _hard_linkability: HardLinkability,
+    ) -> Result<Arc<dyn Inode>> {
+        // Read-only mount: unnamed file creation is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: create_tmpfile is disabled");
+    }
+
+    fn mknod(&self, _name: &str, _mode: InodeMode, _type_: MknodType) -> Result<Arc<dyn Inode>> {
+        // Read-only mount: device/FIFO/socket creation is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: mknod is disabled");
+    }
+
+    fn open(
+        &self,
+        access_mode: AccessMode,
+        status_flags: StatusFlags,
+    ) -> Option<Result<Box<dyn PerOpenFileOps>>> {
+        match self.inode_type() {
+            // Special files route to their live kernel objects, like ext2.
+            inode_type @ (InodeType::BlockDevice | InodeType::CharDevice) => {
+                let Some(device_id) = self.device_id().and_then(DeviceId::from_encoded_u64) else {
+                    return Some(Err(Error::with_message(
+                        Errno::ENODEV,
+                        "the device ID is invalid",
+                    )));
+                };
+                let device_type = inode_type
+                    .device_type()
+                    .expect("BlockDevice and CharDevice always have a device type");
+                let Some(device) = device::lookup(device_type, device_id) else {
+                    return Some(Err(Error::with_message(
+                        Errno::ENODEV,
+                        "the required device ID does not exist",
+                    )));
+                };
+                Some(device.open())
+            }
+            InodeType::NamedPipe => {
+                let pipe = self.pipe().expect("NamedPipe inode must have a pipe");
+                Some(pipe.open_named(access_mode, status_flags))
+            }
+            // Read-only mount: directories fall back to the direct inode path
+            // (the shutdown ioctl shim is a write-path feature and is cut).
+            _ => None,
+        }
+    }
+
+    fn link(&self, _old: &Arc<dyn Inode>, _name: &str) -> Result<()> {
+        // Read-only mount: hard-link creation is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: link is disabled");
+    }
+
+    fn unlink(&self, _name: &str) -> Result<()> {
+        // Read-only mount: unlink is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: unlink is disabled");
+    }
+
+    fn rmdir(&self, _name: &str) -> Result<()> {
+        // Read-only mount: directory removal is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: rmdir is disabled");
+    }
+
+    fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>> {
+        Ok(self.lookup(name)?)
+    }
+
+    fn rename(
+        &self,
+        _old_name: &str,
+        _target: &Arc<dyn Inode>,
+        _new_name: &str,
+        _mode: RenameMode,
+    ) -> Result<()> {
+        // Read-only mount: rename is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: rename is disabled");
+    }
+
+    fn read_link(&self) -> Result<SymbolicLink> {
+        self.read_link().map(SymbolicLink::Plain)
+    }
+
+    fn write_link(&self, _target: &str) -> Result<()> {
+        // Read-only mount: symlink-target updates are refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: write_link is disabled");
+    }
+
+    fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
+        // Read-only mount: preallocation and hole-punching are refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: fallocate is disabled");
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        self.fs().unwrap()
+    }
+
+    fn extension(&self) -> &Extension {
+        self.extension()
+    }
+
+    fn set_xattr(
+        &self,
+        _name: XattrName,
+        _value_reader: &mut VmReader,
+        _flags: XattrSetFlags,
+    ) -> Result<()> {
+        // Read-only mount: extended-attribute mutation is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: set_xattr is disabled");
+    }
+
+    fn remove_xattr(&self, _name: XattrName) -> Result<()> {
+        // Read-only mount: extended-attribute mutation is refused.
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: remove_xattr is disabled");
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use aster_block::BLOCK_SIZE;
+    use ostd::{
+        mm::{VmReader, VmWriter},
+        prelude::*,
+    };
+
+    use crate::{
+        fs::{
+            file::{InodeType, StatusFlags},
+            fs_impls::ext4::test_utils::{
+                Ext4FixtureBuilder, make_dir_block, make_dir_inode, make_file_inode,
+            },
+            vfs::{
+                file_system::{FileSystem, FsFlags},
+                inode::{FallocMode, Inode},
+                xattr::{XattrName, XattrSetFlags},
+            },
+        },
+        prelude::{Errno, Result},
+    };
+
+    fn assert_erofs<T>(result: Result<T>) {
+        let Err(err) = result else {
+            panic!("write-side operation must fail on read-only ext4");
+        };
+        assert_eq!(err.error(), Errno::EROFS);
+    }
+
+    /// Drives a mounted ext4 filesystem entirely through the VFS traits:
+    /// `FileSystem` for stat, and `Inode`/`FileOps` for type, lookup, metadata,
+    /// and reads.
+    #[ktest]
+    fn mount_via_vfs_and_read() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+
+        // A directory (ino 12) with an entry "data" pointing at a file (ino 11).
+        let dir_block = 102u32;
+        let block = make_dir_block(&[(2, ".", 2), (2, "..", 2), (11, "data", 1)]);
+        f.write_data_block(dir_block, &block);
+        f.write_raw_inode(12, &make_dir_inode(dir_block));
+        let content = b"vfs read works";
+        f.write_data_block(103, content);
+        f.write_raw_inode(11, &make_file_inode(103, content.len() as u32));
+
+        // `FileSystem` trait.
+        let fs: Arc<dyn FileSystem> = f.ext4.clone();
+        assert_eq!(fs.name(), "ext4");
+        assert_eq!(fs.sb().bsize, 4096);
+
+        // `Inode` trait via dynamic dispatch.
+        let dir_dyn: Arc<dyn Inode> = f.ext4.read_inode(12).unwrap();
+        assert_eq!(dir_dyn.type_(), InodeType::Dir);
+
+        let file_dyn = dir_dyn.lookup("data").unwrap();
+        assert_eq!(file_dyn.ino(), 11);
+        assert_eq!(file_dyn.size(), content.len());
+        assert_eq!(file_dyn.metadata().type_, InodeType::File);
+
+        // `FileOps::read_at` through the trait object.
+        let mut buf = [0u8; 64];
+        let mut writer = VmWriter::from(&mut buf[..content.len()]).to_fallible();
+        let read = file_dyn
+            .read_at(0, &mut writer, StatusFlags::empty())
+            .unwrap();
+        assert_eq!(read, content.len());
+        assert_eq!(&buf[..content.len()], content);
+    }
+
+    #[ktest]
+    fn fs_declares_read_only() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let fs: Arc<dyn FileSystem> = f.ext4.clone();
+
+        assert!(fs.flags().contains(FsFlags::RDONLY));
+        assert!(FsFlags::from_bits_truncate(fs.sb().flags as u32).contains(FsFlags::RDONLY));
+    }
+
+    #[ktest]
+    fn write_side_inode_ops_return_erofs() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let inode: Arc<dyn Inode> = f.ext4.read_inode(2).unwrap();
+
+        assert_erofs(inode.fallocate(FallocMode::Allocate, 0, BLOCK_SIZE));
+
+        let mut value_reader = VmReader::from(b"value".as_slice()).to_fallible();
+        let xattr_name = XattrName::try_from_full_name("user.ext4").unwrap();
+        assert_erofs(inode.set_xattr(xattr_name, &mut value_reader, XattrSetFlags::empty()));
+
+        let xattr_name = XattrName::try_from_full_name("user.ext4").unwrap();
+        assert_erofs(inode.remove_xattr(xattr_name));
+
+        assert_erofs(inode.write_link("target"));
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/impl_for_vfs/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/impl_for_vfs/mod.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Wires ext4 types into the VFS trait interfaces (`FileSystem`, `FileOps`,
+//! `Inode`): read entry points translate to ext4-internal operations, while the
+//! write-side methods return `EROFS` on this read-only mount.
+
+mod fs;
+mod inode;

--- a/kernel/src/fs/fs_impls/ext4/inode/dir/dir_entry.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/dir/dir_entry.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 linear directory entries (`ext4_dir_entry_2`), read path.
+//!
+//! A directory block is a sequence of variable-length records, each an 8-byte
+//! header followed by the name. `rec_len` gives the byte length of the whole
+//! record (header + name + padding to a 4-byte boundary); the last record's
+//! `rec_len` runs to the end of the block. Records never cross block
+//! boundaries. A zero `ino` marks a deleted slot.
+
+use super::super::super::prelude::*;
+use crate::fs::utils::NAME_MAX;
+
+const_assert!(size_of::<DirEntryHeader>() == 8);
+
+/// On-disk fixed part of a directory entry (`ext4_dir_entry_2`).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct DirEntryHeader {
+    pub ino: u32,
+    pub rec_len: u16,
+    pub name_len: u8,
+    pub file_type: u8,
+}
+
+impl DirEntryHeader {
+    const ALIGN_MASK: usize = 3;
+
+    /// The minimal record length that can hold a name of `name_len` bytes.
+    pub(super) const fn min_rec_len(name_len: usize) -> u16 {
+        ((name_len + size_of::<Self>()).next_multiple_of(4)) as u16
+    }
+}
+
+/// Directory entry file type (`ext4_dir_entry_2.file_type`).
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+pub(super) enum DirEntryFileType {
+    Unknown = 0,
+    File = 1,
+    Dir = 2,
+    CharDevice = 3,
+    BlockDevice = 4,
+    NamedPipe = 5,
+    Socket = 6,
+    SymLink = 7,
+}
+
+impl From<DirEntryFileType> for InodeType {
+    fn from(file_type: DirEntryFileType) -> Self {
+        match file_type {
+            DirEntryFileType::Unknown => Self::Unknown,
+            DirEntryFileType::File => Self::File,
+            DirEntryFileType::Dir => Self::Dir,
+            DirEntryFileType::CharDevice => Self::CharDevice,
+            DirEntryFileType::BlockDevice => Self::BlockDevice,
+            DirEntryFileType::NamedPipe => Self::NamedPipe,
+            DirEntryFileType::Socket => Self::Socket,
+            DirEntryFileType::SymLink => Self::SymLink,
+        }
+    }
+}
+
+impl From<InodeType> for DirEntryFileType {
+    fn from(type_: InodeType) -> Self {
+        match type_ {
+            InodeType::File => Self::File,
+            InodeType::Dir => Self::Dir,
+            InodeType::CharDevice => Self::CharDevice,
+            InodeType::BlockDevice => Self::BlockDevice,
+            InodeType::NamedPipe => Self::NamedPipe,
+            InodeType::Socket => Self::Socket,
+            InodeType::SymLink => Self::SymLink,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// A parsed directory entry; `name` borrows the iterator's reusable buffer.
+pub(super) struct DirEntry<'a> {
+    pub header: DirEntryHeader,
+    pub name: &'a [u8],
+}
+
+/// A bounded view of one directory block in the inode page cache.
+pub(super) struct DirBlockView<'a> {
+    page_cache: &'a PageCache,
+    /// Absolute byte offset of this block in the page cache.
+    offset: usize,
+    /// Valid data length within this block.
+    limit: usize,
+}
+
+impl<'a> DirBlockView<'a> {
+    pub(super) fn from_index(
+        page_cache: &'a PageCache,
+        block_idx: usize,
+        file_size: usize,
+    ) -> Self {
+        let offset = block_idx * BLOCK_SIZE;
+        // `saturating_sub` so a block index past EOF yields an empty view instead
+        // of underflowing (defence in depth against a corrupt htree leaf pointer).
+        let limit = file_size.saturating_sub(offset).min(BLOCK_SIZE);
+        Self {
+            page_cache,
+            offset,
+            limit,
+        }
+    }
+
+    /// Reads and validates an entry header at absolute page-cache `offset`.
+    fn read_header(&self, offset: usize) -> Result<DirEntryHeader> {
+        // The header itself must fit before it is read: on a malformed
+        // directory whose size is not block-aligned, a crafted rec_len chain
+        // can park `offset` close enough to the limit that the 8-byte header
+        // read crosses it (P1 review item, batch-fixed at P5).
+        if offset + size_of::<DirEntryHeader>() > self.offset + self.limit {
+            return_errno_with_message!(Errno::EIO, "dir entry header crosses the block limit");
+        }
+        let header: DirEntryHeader = self
+            .page_cache
+            .read_val(offset)
+            .map_err(|_| Error::with_message(Errno::EIO, "failed to read dir entry header"))?;
+
+        let end = self.offset + self.limit;
+        let rec_len = header.rec_len as usize;
+        if (rec_len & DirEntryHeader::ALIGN_MASK) != 0 {
+            return_errno_with_message!(Errno::EIO, "dir entry rec_len is not 4-byte aligned");
+        }
+        let name_len = header.name_len as usize;
+        if name_len > NAME_MAX {
+            return_errno_with_message!(Errno::EIO, "dir entry name_len exceeds NAME_MAX");
+        }
+        if header.ino != 0 && name_len == 0 {
+            return_errno_with_message!(Errno::EIO, "dir entry name_len is zero");
+        }
+        if rec_len < DirEntryHeader::min_rec_len(name_len) as usize {
+            return_errno_with_message!(Errno::EIO, "dir entry rec_len too small for name_len");
+        }
+        if offset + rec_len > end {
+            return_errno_with_message!(Errno::EIO, "dir entry extends beyond block limit");
+        }
+        Ok(header)
+    }
+
+    pub(super) fn iter_entries(&self) -> DirBlockViewIter<'_> {
+        DirBlockViewIter {
+            block: self,
+            cursor: self.offset,
+            name_buf: [0u8; NAME_MAX],
+        }
+    }
+}
+
+/// Iterates the entries of a [`DirBlockView`].
+pub(super) struct DirBlockViewIter<'a> {
+    block: &'a DirBlockView<'a>,
+    /// Absolute page-cache offset of the next entry.
+    cursor: usize,
+    /// Reusable buffer for the current entry's name.
+    name_buf: [u8; NAME_MAX],
+}
+
+impl DirBlockViewIter<'_> {
+    const HEADER_LEN: usize = size_of::<DirEntryHeader>();
+
+    /// Reads the next entry header and advances. Returns the entry's offset
+    /// within the block and the validated header.
+    pub(super) fn next_entry_header(&mut self) -> Result<Option<(usize, DirEntryHeader)>> {
+        let end = self.block.offset + self.block.limit;
+        if self.cursor >= end {
+            return Ok(None);
+        }
+
+        let header = self.block.read_header(self.cursor)?;
+        let rec_len = header.rec_len as usize;
+        let entry_offset = self.cursor - self.block.offset;
+        self.cursor += rec_len;
+
+        Ok(Some((entry_offset, header)))
+    }
+
+    /// Reads the next entry and advances. Returns the entry's offset within the
+    /// block and the entry. Deleted entries (`ino == 0`) yield an empty name.
+    pub(super) fn next_entry(&mut self) -> Result<Option<(usize, DirEntry<'_>)>> {
+        let Some((entry_offset, header)) = self.next_entry_header()? else {
+            return Ok(None);
+        };
+
+        let name: &[u8] = if header.ino != 0 {
+            let name_len = header.name_len as usize;
+            let name_abs_offset = self.block.offset + entry_offset + Self::HEADER_LEN;
+            self.block
+                .page_cache
+                .read_bytes(name_abs_offset, &mut self.name_buf[..name_len])?;
+            &self.name_buf[..name_len]
+        } else {
+            &[]
+        };
+
+        Ok(Some((entry_offset, DirEntry { header, name })))
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/dir/hash.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/dir/hash.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Directory-entry name hashing for htree (`dir_index`), ported from Linux 6.6
+//! `fs/ext4/hash.c` (`ext4fs_dirhash`).
+//!
+//! htree keys each directory entry by a hash of its name; `dx_probe` binary-
+//! searches the index by this value. The hash MUST match Linux bit-for-bit or a
+//! lookup lands on the wrong leaf and misses the name. Three versions are
+//! supported — the legacy hack hash,
+//! a cut-down half-MD4, and TEA — each in a signed- and unsigned-`char` variant
+//! (the historical ambiguity of `char`'s signedness on the hashed bytes).
+//! `siphash` (casefold) is not supported.
+//!
+//! All arithmetic is 32-bit wrapping, exactly as the C wraps `__u32`.
+
+/// Hash versions (`DX_HASH_*`, `ext4.h`). The `*_UNSIGNED` variants hash the
+/// name bytes as unsigned rather than signed `char`.
+pub(super) const DX_HASH_LEGACY: u8 = 0;
+pub(super) const DX_HASH_HALF_MD4: u8 = 1;
+pub(super) const DX_HASH_TEA: u8 = 2;
+pub(super) const DX_HASH_LEGACY_UNSIGNED: u8 = 3;
+pub(super) const DX_HASH_HALF_MD4_UNSIGNED: u8 = 4;
+pub(super) const DX_HASH_TEA_UNSIGNED: u8 = 5;
+
+/// The largest 32-bit hash value, reserved as the readdir end-of-file sentinel
+/// (`EXT4_HTREE_EOF_32BIT`); a name hashing to it is nudged down by one.
+const EXT4_HTREE_EOF_32BIT: u32 = (1 << 31) - 1;
+
+/// The result of hashing a directory entry name: `hash` keys the htree index;
+/// `minor_hash` disambiguates collisions in the readdir cursor (0 for the
+/// 32-bit legacy hash).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct DirHash {
+    pub hash: u32,
+    /// Feeds the hash-ordered readdir cursor, which stays linear (path C); the
+    /// lookup path keys only on `hash`. Kept for the on-disk hash's full result.
+    pub minor_hash: u32,
+}
+
+const DELTA: u32 = 0x9E37_79B9;
+
+/// TEA, 16 rounds (Linux `TEA_transform`).
+fn tea_transform(buf: &mut [u32; 4], input: &[u32; 4]) {
+    let mut sum: u32 = 0;
+    let (mut b0, mut b1) = (buf[0], buf[1]);
+    let (a, b, c, d) = (input[0], input[1], input[2], input[3]);
+
+    for _ in 0..16 {
+        sum = sum.wrapping_add(DELTA);
+        b0 = b0.wrapping_add(
+            ((b1 << 4).wrapping_add(a)) ^ b1.wrapping_add(sum) ^ ((b1 >> 5).wrapping_add(b)),
+        );
+        b1 = b1.wrapping_add(
+            ((b0 << 4).wrapping_add(c)) ^ b0.wrapping_add(sum) ^ ((b0 >> 5).wrapping_add(d)),
+        );
+    }
+
+    buf[0] = buf[0].wrapping_add(b0);
+    buf[1] = buf[1].wrapping_add(b1);
+}
+
+// MD4 basic functions (selection / majority / parity).
+fn md4_f(x: u32, y: u32, z: u32) -> u32 {
+    z ^ (x & (y ^ z))
+}
+fn md4_g(x: u32, y: u32, z: u32) -> u32 {
+    (x & y).wrapping_add((x ^ y) & z)
+}
+fn md4_h(x: u32, y: u32, z: u32) -> u32 {
+    x ^ y ^ z
+}
+
+/// One MD4 round step (`ROUND`): `a += f(b,c,d) + x; a = rol32(a, s)`.
+fn md4_round(f: fn(u32, u32, u32) -> u32, a: u32, b: u32, c: u32, d: u32, x: u32, s: u32) -> u32 {
+    a.wrapping_add(f(b, c, d)).wrapping_add(x).rotate_left(s)
+}
+
+/// Cut-down MD4, returning the "most hashed" word (Linux `half_md4_transform`).
+fn half_md4_transform(buf: &mut [u32; 4], input: &[u32; 8]) -> u32 {
+    // Octal round constants, verbatim from `hash.c` (K2/K3).
+    const K1: u32 = 0;
+    const K2: u32 = 0o13240474631;
+    const K3: u32 = 0o15666365641;
+
+    let (mut a, mut b, mut c, mut d) = (buf[0], buf[1], buf[2], buf[3]);
+
+    // Round 1 (F).
+    a = md4_round(md4_f, a, b, c, d, input[0].wrapping_add(K1), 3);
+    d = md4_round(md4_f, d, a, b, c, input[1].wrapping_add(K1), 7);
+    c = md4_round(md4_f, c, d, a, b, input[2].wrapping_add(K1), 11);
+    b = md4_round(md4_f, b, c, d, a, input[3].wrapping_add(K1), 19);
+    a = md4_round(md4_f, a, b, c, d, input[4].wrapping_add(K1), 3);
+    d = md4_round(md4_f, d, a, b, c, input[5].wrapping_add(K1), 7);
+    c = md4_round(md4_f, c, d, a, b, input[6].wrapping_add(K1), 11);
+    b = md4_round(md4_f, b, c, d, a, input[7].wrapping_add(K1), 19);
+
+    // Round 2 (G).
+    a = md4_round(md4_g, a, b, c, d, input[1].wrapping_add(K2), 3);
+    d = md4_round(md4_g, d, a, b, c, input[3].wrapping_add(K2), 5);
+    c = md4_round(md4_g, c, d, a, b, input[5].wrapping_add(K2), 9);
+    b = md4_round(md4_g, b, c, d, a, input[7].wrapping_add(K2), 13);
+    a = md4_round(md4_g, a, b, c, d, input[0].wrapping_add(K2), 3);
+    d = md4_round(md4_g, d, a, b, c, input[2].wrapping_add(K2), 5);
+    c = md4_round(md4_g, c, d, a, b, input[4].wrapping_add(K2), 9);
+    b = md4_round(md4_g, b, c, d, a, input[6].wrapping_add(K2), 13);
+
+    // Round 3 (H).
+    a = md4_round(md4_h, a, b, c, d, input[3].wrapping_add(K3), 3);
+    d = md4_round(md4_h, d, a, b, c, input[7].wrapping_add(K3), 9);
+    c = md4_round(md4_h, c, d, a, b, input[2].wrapping_add(K3), 11);
+    b = md4_round(md4_h, b, c, d, a, input[6].wrapping_add(K3), 15);
+    a = md4_round(md4_h, a, b, c, d, input[1].wrapping_add(K3), 3);
+    d = md4_round(md4_h, d, a, b, c, input[5].wrapping_add(K3), 9);
+    c = md4_round(md4_h, c, d, a, b, input[0].wrapping_add(K3), 11);
+    b = md4_round(md4_h, b, c, d, a, input[4].wrapping_add(K3), 15);
+
+    buf[0] = buf[0].wrapping_add(a);
+    buf[1] = buf[1].wrapping_add(b);
+    buf[2] = buf[2].wrapping_add(c);
+    buf[3] = buf[3].wrapping_add(d);
+
+    buf[1] // "most hashed" word
+}
+
+/// The old legacy hash (Linux `dx_hack_hash_{signed,unsigned}`). `signed`
+/// selects how each name byte is widened before the multiply.
+fn dx_hack_hash(name: &[u8], signed: bool) -> u32 {
+    let (mut hash0, mut hash1): (u32, u32) = (0x12a3_fe2d, 0x37ab_e8f9);
+    for &byte in name {
+        let widened = if signed {
+            (byte as i8 as i32).wrapping_mul(7_152_373) as u32
+        } else {
+            (byte as u32).wrapping_mul(7_152_373)
+        };
+        let mut hash = hash1.wrapping_add(hash0 ^ widened);
+        if hash & 0x8000_0000 != 0 {
+            hash = hash.wrapping_sub(0x7fff_ffff);
+        }
+        hash1 = hash0;
+        hash0 = hash;
+    }
+    hash0 << 1
+}
+
+/// Packs up to `num` 32-bit words from `msg` (Linux `str2hashbuf_{signed,unsigned}`).
+fn str2hashbuf(msg: &[u8], buf: &mut [u32; 8], mut num: usize, signed: bool) {
+    let len_full = msg.len();
+    let mut pad = (len_full as u32) | ((len_full as u32) << 8);
+    pad |= pad << 16;
+
+    let mut val = pad;
+    let len = len_full.min(num * 4);
+    let mut out = 0usize;
+    for (i, &byte) in msg[..len].iter().enumerate() {
+        let widened = if signed {
+            byte as i8 as i32 as u32
+        } else {
+            byte as u32
+        };
+        val = widened.wrapping_add(val << 8);
+        if i % 4 == 3 {
+            buf[out] = val;
+            out += 1;
+            val = pad;
+            num -= 1;
+        }
+    }
+    // `if (--num >= 0) *buf++ = val;` then `while (--num >= 0) *buf++ = pad;`
+    if num >= 1 {
+        buf[out] = val;
+        out += 1;
+        num -= 1;
+    }
+    while num >= 1 {
+        buf[out] = pad;
+        out += 1;
+        num -= 1;
+    }
+}
+
+/// Hashes directory entry `name` under `version` and `seed` (`s_hash_seed`),
+/// returning `None` for an unsupported version (e.g. `siphash`). Mirrors Linux
+/// `ext4fs_dirhash`: default seed unless `seed` has a nonzero word, the
+/// version-specific transform, then `hash &= ~1` and the EOF nudge.
+pub(super) fn ext4fs_dirhash(name: &[u8], version: u8, seed: &[u32; 4]) -> Option<DirHash> {
+    // Default seed for the checksum functions, overridden by a nonzero `seed`.
+    let mut buf: [u32; 4] = [0x6745_2301, 0xefcd_ab89, 0x98ba_dcfe, 0x1032_5476];
+    if seed.iter().any(|&w| w != 0) {
+        buf = *seed;
+    }
+
+    let mut minor_hash = 0u32;
+    let hash = match version {
+        DX_HASH_LEGACY_UNSIGNED => dx_hack_hash(name, false),
+        DX_HASH_LEGACY => dx_hack_hash(name, true),
+        DX_HASH_HALF_MD4 | DX_HASH_HALF_MD4_UNSIGNED => {
+            let signed = version == DX_HASH_HALF_MD4;
+            let mut input = [0u32; 8];
+            let mut p = name;
+            loop {
+                str2hashbuf(p, &mut input, 8, signed);
+                half_md4_transform(&mut buf, &input);
+                if p.len() <= 32 {
+                    break;
+                }
+                p = &p[32..];
+            }
+            minor_hash = buf[2];
+            buf[1]
+        }
+        DX_HASH_TEA | DX_HASH_TEA_UNSIGNED => {
+            let signed = version == DX_HASH_TEA;
+            let mut input8 = [0u32; 8];
+            let mut tea_in = [0u32; 4];
+            let mut p = name;
+            loop {
+                str2hashbuf(p, &mut input8, 4, signed);
+                tea_in.copy_from_slice(&input8[..4]);
+                tea_transform(&mut buf, &tea_in);
+                if p.len() <= 16 {
+                    break;
+                }
+                p = &p[16..];
+            }
+            minor_hash = buf[1];
+            buf[0]
+        }
+        _ => return None, // siphash / unknown
+    };
+
+    let mut hash = hash & !1;
+    if hash == EXT4_HTREE_EOF_32BIT << 1 {
+        hash = (EXT4_HTREE_EOF_32BIT - 1) << 1;
+    }
+    Some(DirHash { hash, minor_hash })
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    // Reference vectors captured from e2fsprogs 1.47 `debugfs htree_dump` on real
+    // `mke2fs -O dir_index` images (each with its own random `s_hash_seed`). The
+    // stored dx_root hash_version selects the transform; these images set
+    // SIGNED_HASH (s_flags bit 0), so the signed variants apply.
+
+    /// half_md4 (the mkfs default), seed from the sample image.
+    const MD4_SEED: [u32; 4] = [0xaec4_c740, 0x834c_e862, 0x09b5_3288, 0x34dc_d3db];
+
+    #[ktest]
+    fn half_md4_matches_e2fsprogs() {
+        let h = ext4fs_dirhash(b"file0", DX_HASH_HALF_MD4, &MD4_SEED).unwrap();
+        assert_eq!(h.hash, 0x1c3d_2670);
+        assert_eq!(h.minor_hash, 0xfca4_88c5);
+        assert_eq!(
+            ext4fs_dirhash(b"file3", DX_HASH_HALF_MD4, &MD4_SEED)
+                .unwrap()
+                .hash,
+            0x4f04_13ba
+        );
+        // The stored hash is always even (`hash & ~1`).
+        assert_eq!(h.hash & 1, 0);
+    }
+
+    /// A name with a high byte (0xE9) distinguishes the signed variant, which
+    /// this image uses, from the unsigned one.
+    #[ktest]
+    fn half_md4_signed_high_byte() {
+        let h = ext4fs_dirhash(b"x\xe9y", DX_HASH_HALF_MD4, &MD4_SEED).unwrap();
+        assert_eq!(h.hash, 0xb8a7_e90a);
+        assert_eq!(h.minor_hash, 0x3b68_6309);
+        // The unsigned variant differs on a high byte (no Linux vector, just the
+        // sign-widening path being distinct).
+        let u = ext4fs_dirhash(b"x\xe9y", DX_HASH_HALF_MD4_UNSIGNED, &MD4_SEED).unwrap();
+        assert_ne!(u.hash, h.hash);
+        // ASCII names are identical across the signedness split.
+        assert_eq!(
+            ext4fs_dirhash(b"file0", DX_HASH_HALF_MD4_UNSIGNED, &MD4_SEED)
+                .unwrap()
+                .hash,
+            0x1c3d_2670
+        );
+    }
+
+    #[ktest]
+    fn tea_matches_e2fsprogs() {
+        let seed = [0x79e2_f44a, 0x9449_4804, 0xd0aa_bea6, 0x8275_3d4e];
+        let h = ext4fs_dirhash(b"file0", DX_HASH_TEA, &seed).unwrap();
+        assert_eq!(h.hash, 0xd483_fcc4);
+        assert_eq!(h.minor_hash, 0x2166_1f2d);
+    }
+
+    #[ktest]
+    fn legacy_matches_e2fsprogs() {
+        let seed = [0x5001_7978, 0xb84a_f9d1, 0x3638_94a3, 0xe9cc_f611];
+        let h = ext4fs_dirhash(b"file0", DX_HASH_LEGACY, &seed).unwrap();
+        assert_eq!(h.hash, 0x9f12_3cc8);
+        assert_eq!(h.minor_hash, 0); // 32-bit legacy hash carries no minor hash
+    }
+
+    #[ktest]
+    fn unsupported_version_is_none() {
+        assert!(ext4fs_dirhash(b"file0", 6 /* siphash */, &MD4_SEED).is_none());
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/dir/htree.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/dir/htree.rs
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Read-side htree (`dir_index`) index traversal, ported from Linux 6.6
+//! `fs/ext4/namei.c` (`dx_probe`).
+//!
+//! An htree directory keeps a hash index in its first data blocks: a `dx_root`
+//! in logical block 0 and, for larger directories, one level of
+//! `dx_node` index blocks, each an array of `{ hash, block }` entries sorted by
+//! hash. To locate the leaf block that may hold a name, hash the name and, at
+//! each level, binary-search the entries for the last one whose hash does not
+//! exceed the target, then descend into the block it points at. The leaf block
+//! is then scanned linearly by the caller.
+//!
+//! This module only *decodes and descends* the index (path C of P6d): it never
+//! writes a dx block, so the per-block checksum trailer (`dx_tail`) is neither
+//! consulted nor produced here, matching the verify-on-read deferrals elsewhere
+//! in P6. Insert/build/flatten of the index is a later task.
+//!
+//! The byte layout is decoded field-by-field at the block boundary (never by
+//! overlaying a struct), because the count/limit of the first entry slot is
+//! overlaid onto the hash word of `entries[0]` — a struct view would misread it.
+
+use super::{super::super::prelude::*, hash, hash::DX_HASH_TEA};
+
+/// The filesystem-wide inputs to the htree name hash, snapshotted from the
+/// superblock so a directory lookup can probe the index without re-reading it.
+/// Built by the caller only for a `dir_index` volume; a directory that carries
+/// the `INDEX` flag is then probed, and any miss falls back to a linear scan.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct DxCtx {
+    /// The `s_hash_seed` words.
+    pub seed: [u32; 4],
+    /// Whether name bytes hash as unsigned `char` (`s_flags` bit).
+    pub unsigned: bool,
+}
+
+/// Size of one on-disk `struct dx_entry` (`{ __le32 hash, __le32 block }`).
+const DX_ENTRY_SIZE: usize = 8;
+
+/// Byte offset of `entries[]` within a `dx_root` block: two 12-byte fake dirents
+/// (`.` and `..`, each an 8-byte header plus a 4-byte name field) followed by the
+/// 8-byte `dx_root_info`. Production derives the offset from the parsed
+/// `info_length` (`DX_ROOT_INFO_OFF + info_length`); this named constant is the
+/// spec value the ktest fixtures build against.
+#[cfg_attr(not(ktest), expect(dead_code))]
+const DX_ROOT_ENTRIES_OFF: usize = 32;
+
+/// Byte offset of `entries[]` within a `dx_node` block: a single 8-byte fake
+/// dirent header (`inode == 0`, `rec_len == blocksize`).
+const DX_NODE_ENTRIES_OFF: usize = 8;
+
+/// Byte offset of `dx_root_info` within a `dx_root` block (after the two
+/// 12-byte fake dirents).
+const DX_ROOT_INFO_OFF: usize = 24;
+
+/// The mandated `dx_root_info.info_length` (`sizeof(struct dx_root_info)`).
+const DX_ROOT_INFO_LEN: u8 = 8;
+
+/// Largest `indirect_levels` an htree root may declare without the (unsupported)
+/// `largedir` feature: 0 (root points straight at leaf blocks) or 1 (root →
+/// one `dx_node` level → leaves). Linux `dx_probe` refuses more than
+/// `ext4_dir_htree_level() - 1` == 1 for a non-`largedir` volume; a deeper tree
+/// is refused here with `EUCLEAN`.
+const MAX_INDIRECT_LEVELS: u8 = 1;
+
+/// The low 28 bits of a `dx_entry.block` hold the logical block number; the top
+/// four are reserved (Linux `dx_get_block`).
+const DX_BLOCK_MASK: u32 = 0x0fff_ffff;
+
+/// Reads a little-endian `u32` at byte offset `off` in `buf`.
+///
+/// `buf` is always a full [`BLOCK_SIZE`] directory block and every caller keeps
+/// `off + 4` within it, so the slice is in range.
+fn read_le32(buf: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(buf[off..off + 4].try_into().unwrap())
+}
+
+/// Reads a little-endian `u16` at byte offset `off` in `buf`.
+fn read_le16(buf: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes(buf[off..off + 2].try_into().unwrap())
+}
+
+/// A validated view of one index block's `dx_entry` array (a `dx_root`'s or a
+/// `dx_node`'s), decoded once at `off` within a full-block buffer.
+///
+/// `entries[0]`'s hash word is overlaid by `{ limit, count }` (Linux
+/// `dx_countlimit`), so the real index entries are `1..count`; entry 0 carries
+/// only the hash-0 catch-all block. Construction validates the `{limit,count}`
+/// header and that the declared array fits the block, so every later
+/// [`hash`](Self::hash)/[`block`](Self::block) read is in bounds (a malformed
+/// index is rejected here rather than read off the end).
+struct DxEntries<'a> {
+    buf: &'a [u8],
+    off: usize,
+    count: usize,
+}
+
+impl<'a> DxEntries<'a> {
+    fn parse(buf: &'a [u8], off: usize) -> Result<Self> {
+        let limit = read_le16(buf, off) as usize;
+        let count = read_le16(buf, off + 2) as usize;
+        if count < 1 || count > limit || off + limit * DX_ENTRY_SIZE > BLOCK_SIZE {
+            return_errno_with_message!(Errno::EUCLEAN, "htree: dx entry count out of range");
+        }
+        Ok(Self { buf, off, count })
+    }
+
+    fn count(&self) -> usize {
+        self.count
+    }
+
+    /// The hash key of entry `i` (`dx_get_hash`); entry 0's slot is the overlaid
+    /// `{limit,count}`, so callers treat it as the implicit-0 floor.
+    fn hash(&self, i: usize) -> u32 {
+        read_le32(self.buf, self.off + i * DX_ENTRY_SIZE)
+    }
+
+    /// The child block of entry `i` (`dx_get_block`), masked to 28 bits.
+    fn block(&self, i: usize) -> Ext4Bid {
+        Ext4Bid::from(read_le32(self.buf, self.off + i * DX_ENTRY_SIZE + 4))
+            & Ext4Bid::from(DX_BLOCK_MASK)
+    }
+}
+
+/// The validated `dx_root_info` header of an htree directory's root block.
+#[derive(Debug)]
+pub(super) struct DxRootInfo {
+    /// Stored hash version (`DX_HASH_*`), before the unsigned-`char` adjustment.
+    hash_version: u8,
+    /// `info_length`; validated to equal [`DX_ROOT_INFO_LEN`].
+    info_length: u8,
+    /// Number of index levels below the root (0 or 1; a deeper tree needs the
+    /// unsupported `largedir` feature and is rejected — see
+    /// [`MAX_INDIRECT_LEVELS`]).
+    indirect_levels: u8,
+}
+
+/// Parses and validates the `dx_root_info` header from a directory's logical
+/// block 0 (Linux `dx_probe` prologue).
+///
+/// Rejects (`EUCLEAN`) a header whose `info_length` is not the mandated 8, whose
+/// `unused_flags` low bit is set (an on-disk hash flag we do not implement), or
+/// whose declared depth exceeds [`MAX_INDIRECT_LEVELS`]. The hash version is not
+/// validated here: an unrecognised or `siphash` version is handled downstream by
+/// [`super::hash::ext4fs_dirhash`] returning `None`, which the caller turns into a linear-scan
+/// fallback.
+pub(super) fn parse_dx_root(block0: &[u8]) -> Result<DxRootInfo> {
+    // dx_root_info: reserved_zero(4) hash_version(1) info_length(1)
+    // indirect_levels(1) unused_flags(1).
+    let hash_version = block0[DX_ROOT_INFO_OFF + 4];
+    let info_length = block0[DX_ROOT_INFO_OFF + 5];
+    let indirect_levels = block0[DX_ROOT_INFO_OFF + 6];
+    let unused_flags = block0[DX_ROOT_INFO_OFF + 7];
+
+    if info_length != DX_ROOT_INFO_LEN {
+        return_errno_with_message!(Errno::EUCLEAN, "htree: unexpected dx_root_info length");
+    }
+    if unused_flags & 1 != 0 {
+        return_errno_with_message!(Errno::EUCLEAN, "htree: unsupported hash flags");
+    }
+    if indirect_levels > MAX_INDIRECT_LEVELS {
+        return_errno_with_message!(Errno::EUCLEAN, "htree: index depth exceeds supported level");
+    }
+    Ok(DxRootInfo {
+        hash_version,
+        info_length,
+        indirect_levels,
+    })
+}
+
+/// Descends the htree index to the single leaf block that could hold `name`,
+/// returning its logical block number (Linux `dx_probe`).
+///
+/// `read_block` fetches a directory logical block through the page cache (the
+/// caller supplies it so this stays a pure, testable traversal over the on-disk
+/// bytes). `hash_seed` and `hash_unsigned` come from the superblock and, with the
+/// root's stored hash version, fix which hash the entries were indexed by.
+///
+/// Returns `Ok(None)` when the directory's hash version is one we cannot compute
+/// (e.g. `siphash`); the caller then falls back to a linear scan. Returns
+/// `EUCLEAN` on a malformed index (bad header, out-of-range entry count, or a
+/// block that points back at an ancestor — a cycle).
+pub(super) fn dx_lookup_leaf(
+    read_block: impl Fn(Ext4Bid) -> Result<[u8; BLOCK_SIZE]>,
+    name: &[u8],
+    hash_seed: &[u32; 4],
+    hash_unsigned: bool,
+) -> Result<Option<Ext4Bid>> {
+    let root_block = read_block(0)?;
+    let root = parse_dx_root(&root_block)?;
+
+    // Effective hash version: the `*_UNSIGNED` variants sit +3 above their signed
+    // twins, applied only to the three byte-hash versions (Linux `dx_probe`:
+    // `hinfo->hash_version += s_hash_unsigned`).
+    let version = if hash_unsigned && root.hash_version <= DX_HASH_TEA {
+        root.hash_version + 3
+    } else {
+        root.hash_version
+    };
+    let Some(dirhash) = hash::ext4fs_dirhash(name, version, hash_seed) else {
+        // Unsupported hash (e.g. siphash): let the caller scan linearly.
+        return Ok(None);
+    };
+    let target = dirhash.hash;
+
+    let indirect = root.indirect_levels;
+    // Blocks visited on the path from the root, indexed by level, for the cycle
+    // guard. `blocks[0]` is the root's own block (0); at most one entry per level
+    // and `indirect <= MAX_INDIRECT_LEVELS` (1), so the root + one `dx_node`
+    // level fit in three slots with room to spare.
+    let mut blocks: [Ext4Bid; 3] = [0; 3];
+    let mut level: u8 = 0;
+    // Root `entries[]` follow `dx_root_info` (Linux `&root->info + info_length`);
+    // `info_length` was validated to 8, so this is [`DX_ROOT_ENTRIES_OFF`].
+    let mut entries_off = DX_ROOT_INFO_OFF + root.info_length as usize;
+    let mut block_buf = root_block;
+
+    loop {
+        let entries = DxEntries::parse(&block_buf, entries_off)?;
+
+        // Binary search entries[1..count] for the last entry whose hash does not
+        // exceed the target; entry 0 (hash 0, the catch-all) is the floor, so
+        // `at` is 0 when every real entry sorts above the target.
+        let mut p: usize = 1;
+        let mut q: usize = entries.count() - 1;
+        while p <= q {
+            let m = p + (q - p) / 2;
+            if entries.hash(m) > target {
+                q = m - 1;
+            } else {
+                p = m + 1;
+            }
+        }
+        let block = entries.block(p - 1);
+
+        // A block that reappears on the path back to the root is a cycle.
+        if blocks[..=(level as usize)].contains(&block) {
+            return_errno_with_message!(Errno::EUCLEAN, "htree: index cycle");
+        }
+
+        // At the last index level `block` is the leaf to scan (Linux
+        // `if (++level > indirect) return frame`).
+        if level == indirect {
+            return Ok(Some(block));
+        }
+        level += 1;
+        blocks[level as usize] = block;
+        block_buf = read_block(block)?;
+        entries_off = DX_NODE_ENTRIES_OFF;
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    // Explicit `Result` shadows the two glob imports (kernel + ostd preludes),
+    // fixing the closure return type to the kernel `Result` `dx_lookup_leaf` uses.
+    use super::{
+        super::hash::{DX_HASH_HALF_MD4, ext4fs_dirhash},
+        Result, *,
+    };
+
+    /// Seed and known hashes reused from the `hash.rs` reference vectors (signed
+    /// half-MD4, the mkfs default): `ext4fs_dirhash(b"file0", HALF_MD4, seed)`.
+    const MD4_SEED: [u32; 4] = [0xaec4_c740, 0x834c_e862, 0x09b5_3288, 0x34dc_d3db];
+    const FILE0_HASH: u32 = 0x1c3d_2670;
+    const FILE3_HASH: u32 = 0x4f04_13ba;
+
+    /// Writes a `{ limit, count }` header plus the catch-all block and index
+    /// entries into `blk` at `entries_off`. `entries[0]` is `(_, catch_all_block)`
+    /// (its hash slot is the count/limit overlay); the rest are `(hash, block)`.
+    fn write_entries(blk: &mut [u8; BLOCK_SIZE], entries_off: usize, entries: &[(u32, u32)]) {
+        let count = entries.len() as u16;
+        let limit = count + 10; // headroom; only `count` entries are read
+        blk[entries_off..entries_off + 2].copy_from_slice(&limit.to_le_bytes());
+        blk[entries_off + 2..entries_off + 4].copy_from_slice(&count.to_le_bytes());
+        // entries[0]: catch-all block only (hash word is the overlay).
+        blk[entries_off + 4..entries_off + 8].copy_from_slice(&entries[0].1.to_le_bytes());
+        for (i, &(hash, block)) in entries.iter().enumerate().skip(1) {
+            let off = entries_off + i * DX_ENTRY_SIZE;
+            blk[off..off + 4].copy_from_slice(&hash.to_le_bytes());
+            blk[off + 4..off + 8].copy_from_slice(&block.to_le_bytes());
+        }
+    }
+
+    fn build_dx_root(
+        hash_version: u8,
+        indirect_levels: u8,
+        entries: &[(u32, u32)],
+    ) -> [u8; BLOCK_SIZE] {
+        let mut blk = [0u8; BLOCK_SIZE];
+        blk[DX_ROOT_INFO_OFF + 4] = hash_version;
+        blk[DX_ROOT_INFO_OFF + 5] = DX_ROOT_INFO_LEN;
+        blk[DX_ROOT_INFO_OFF + 6] = indirect_levels;
+        blk[DX_ROOT_INFO_OFF + 7] = 0; // unused_flags
+        write_entries(&mut blk, DX_ROOT_ENTRIES_OFF, entries);
+        blk
+    }
+
+    fn build_dx_node(entries: &[(u32, u32)]) -> [u8; BLOCK_SIZE] {
+        let mut blk = [0u8; BLOCK_SIZE];
+        write_entries(&mut blk, DX_NODE_ENTRIES_OFF, entries);
+        blk
+    }
+
+    /// The reference hashes this test file pins really are what the hasher
+    /// produces, so the entry layouts below bracket the right value.
+    #[ktest]
+    fn known_hash_vectors() {
+        assert_eq!(
+            ext4fs_dirhash(b"file0", DX_HASH_HALF_MD4, &MD4_SEED)
+                .unwrap()
+                .hash,
+            FILE0_HASH
+        );
+        assert_eq!(
+            ext4fs_dirhash(b"file3", DX_HASH_HALF_MD4, &MD4_SEED)
+                .unwrap()
+                .hash,
+            FILE3_HASH
+        );
+    }
+
+    /// A target below every real entry lands on `entries[0]`'s catch-all block.
+    #[ktest]
+    fn descent_lands_on_catch_all() {
+        // file0 hashes to 0x1c3d2670, below both real entries.
+        let root = build_dx_root(
+            DX_HASH_HALF_MD4,
+            0,
+            &[(0, 10), (0x2000_0000, 11), (0x3000_0000, 12)],
+        );
+        let leaf = dx_lookup_leaf(|b| single_block(b, &root), b"file0", &MD4_SEED, false).unwrap();
+        assert_eq!(leaf, Some(10));
+    }
+
+    /// A target sitting on a middle entry descends to that entry's block; the
+    /// entry immediately above (strictly greater hash) is not taken.
+    #[ktest]
+    fn descent_lands_on_middle_entry() {
+        let root = build_dx_root(
+            DX_HASH_HALF_MD4,
+            0,
+            &[
+                (0, 10),
+                (0x1000_0000, 11),
+                (FILE0_HASH, 12),
+                (0x3000_0000, 13),
+            ],
+        );
+        let leaf = dx_lookup_leaf(|b| single_block(b, &root), b"file0", &MD4_SEED, false).unwrap();
+        assert_eq!(leaf, Some(12));
+    }
+
+    /// A target above every entry lands on the last one.
+    #[ktest]
+    fn descent_lands_on_last_entry() {
+        // file3 hashes to 0x4f0413ba, above all three real entries.
+        let root = build_dx_root(
+            DX_HASH_HALF_MD4,
+            0,
+            &[
+                (0, 10),
+                (0x1000_0000, 11),
+                (0x2000_0000, 12),
+                (0x4000_0000, 13),
+            ],
+        );
+        let leaf = dx_lookup_leaf(|b| single_block(b, &root), b"file3", &MD4_SEED, false).unwrap();
+        assert_eq!(leaf, Some(13));
+    }
+
+    /// A one-level tree: the root's single catch-all points at a `dx_node`, whose
+    /// entries are searched for the leaf.
+    #[ktest]
+    fn descent_two_levels() {
+        let node = build_dx_node(&[
+            (0, 100),
+            (0x1000_0000, 101),
+            (FILE0_HASH, 102),
+            (0x3000_0000, 103),
+        ]);
+        // Root has one entry (catch-all) pointing at the node in block 5.
+        let root = build_dx_root(DX_HASH_HALF_MD4, 1, &[(0, 5)]);
+        let read = |b: Ext4Bid| match b {
+            0 => Ok(root),
+            5 => Ok(node),
+            other => panic!("unexpected block read {other}"),
+        };
+        let leaf = dx_lookup_leaf(read, b"file0", &MD4_SEED, false).unwrap();
+        assert_eq!(leaf, Some(102));
+    }
+
+    /// An unsupported hash version (siphash, 6) yields `None` so the caller can
+    /// fall back to a linear scan, rather than an error.
+    #[ktest]
+    fn unsupported_hash_falls_back() {
+        let root = build_dx_root(6 /* siphash */, 0, &[(0, 10), (0x2000_0000, 11)]);
+        let leaf = dx_lookup_leaf(|b| single_block(b, &root), b"file0", &MD4_SEED, false).unwrap();
+        assert_eq!(leaf, None);
+    }
+
+    /// A catch-all block that points back at the root (block 0) is a cycle.
+    #[ktest]
+    fn descent_rejects_cycle() {
+        let root = build_dx_root(DX_HASH_HALF_MD4, 0, &[(0, 0)]);
+        let err =
+            dx_lookup_leaf(|b| single_block(b, &root), b"file0", &MD4_SEED, false).unwrap_err();
+        assert_eq!(err.error(), Errno::EUCLEAN);
+    }
+
+    /// A zero entry count is rejected before any descent.
+    #[ktest]
+    fn descent_rejects_zero_count() {
+        let mut root = build_dx_root(DX_HASH_HALF_MD4, 0, &[(0, 10), (0x2000_0000, 11)]);
+        // Overwrite count (le16 at entries_off + 2) with 0.
+        root[DX_ROOT_ENTRIES_OFF + 2..DX_ROOT_ENTRIES_OFF + 4].copy_from_slice(&0u16.to_le_bytes());
+        let err =
+            dx_lookup_leaf(|b| single_block(b, &root), b"file0", &MD4_SEED, false).unwrap_err();
+        assert_eq!(err.error(), Errno::EUCLEAN);
+    }
+
+    /// A `limit` whose entry array cannot fit the block is rejected rather than
+    /// read off the end — a crafted index must not panic the kernel.
+    #[ktest]
+    fn descent_rejects_oversize_limit() {
+        let mut root = build_dx_root(DX_HASH_HALF_MD4, 0, &[(0, 10), (0x2000_0000, 11)]);
+        // Overwrite limit (le16 at entries_off) with a value far larger than the
+        // block can hold; count stays 2 (valid), so only the fit bound catches it.
+        root[DX_ROOT_ENTRIES_OFF..DX_ROOT_ENTRIES_OFF + 2]
+            .copy_from_slice(&60_000u16.to_le_bytes());
+        let err =
+            dx_lookup_leaf(|b| single_block(b, &root), b"file0", &MD4_SEED, false).unwrap_err();
+        assert_eq!(err.error(), Errno::EUCLEAN);
+    }
+
+    /// `parse_dx_root` rejects a bad `info_length`, an unimplemented hash flag,
+    /// and an over-deep tree.
+    #[ktest]
+    fn parse_dx_root_validation() {
+        let mut root = build_dx_root(DX_HASH_HALF_MD4, 0, &[(0, 10)]);
+        assert!(parse_dx_root(&root).is_ok());
+
+        let mut bad = root;
+        bad[DX_ROOT_INFO_OFF + 5] = 16; // info_length != 8
+        assert_eq!(parse_dx_root(&bad).unwrap_err().error(), Errno::EUCLEAN);
+
+        let mut bad = root;
+        bad[DX_ROOT_INFO_OFF + 7] = 1; // unused_flags & 1
+        assert_eq!(parse_dx_root(&bad).unwrap_err().error(), Errno::EUCLEAN);
+
+        root[DX_ROOT_INFO_OFF + 6] = MAX_INDIRECT_LEVELS + 1; // too deep
+        assert_eq!(parse_dx_root(&root).unwrap_err().error(), Errno::EUCLEAN);
+    }
+
+    /// Helper for the single-block (`indirect_levels == 0`) cases: only block 0 is
+    /// ever read, the leaf block being returned without a read.
+    fn single_block(b: Ext4Bid, root: &[u8; BLOCK_SIZE]) -> Result<[u8; BLOCK_SIZE]> {
+        assert_eq!(b, 0, "only the root block should be read at depth 0");
+        Ok(*root)
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/dir/mod.rs
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 linear directory read operations: `lookup` and `readdir`.
+//!
+//! A directory inode is page-cache-backed like a regular file; these methods
+//! read its data blocks through the page cache and parse linear directory
+//! entries. The htree index (Phase 6) only accelerates lookup; `readdir`
+//! always walks blocks in physical order.
+
+mod dir_entry;
+mod hash;
+mod htree;
+
+use self::{
+    dir_entry::{DirBlockView, DirEntryFileType, DirEntryHeader},
+    htree::DxCtx,
+};
+use super::{
+    super::{fs::Ext4, prelude::*},
+    FileFlags, Inode, InodeInner,
+};
+
+/// A located, live directory entry returned by [`InodeInner::find_entry_info`].
+#[derive(Clone, Copy, Debug)]
+struct DirEntryInfo {
+    /// Inode number of the located entry. Read by `lookup` to fetch the child
+    /// inode.
+    ino: Ext4Ino,
+}
+
+/// Builds the htree hash context for a lookup on `fs`, or `None` when the volume
+/// has no `dir_index` feature (so every directory is scanned linearly). A
+/// directory that carries the `INDEX` flag is then probed via this context.
+fn dx_ctx(fs: &Ext4) -> Option<DxCtx> {
+    let sb = fs.super_block();
+    sb.has_dir_index().then(|| DxCtx {
+        seed: *sb.hash_seed(),
+        unsigned: sb.hash_unsigned(),
+    })
+}
+
+impl InodeInner {
+    /// Iterates entries from byte `offset`, feeding each active entry to
+    /// `visitor`. Returns the number of bytes advanced.
+    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+        if self.desc.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        let size = self.file_size();
+        let min_rec_len = DirEntryHeader::min_rec_len(1) as usize;
+        if size < min_rec_len || offset > size - min_rec_len {
+            return Ok(0);
+        }
+
+        let start_block = offset / BLOCK_SIZE;
+        let mut current_offset = offset;
+        let mut advanced = 0usize;
+        let total_blocks = size.div_ceil(BLOCK_SIZE);
+        let page_cache = self.page_cache()?;
+
+        for block_idx in start_block..total_blocks {
+            let block_offset = block_idx * BLOCK_SIZE;
+            if block_offset >= size {
+                break;
+            }
+            let block = DirBlockView::from_index(page_cache, block_idx, size);
+            let mut iter = block.iter_entries();
+            while let Some((entry_offset_in_block, entry)) = iter.next_entry()? {
+                let entry_offset = block_offset + entry_offset_in_block;
+                let rec_len = entry.header.rec_len as usize;
+                let next_offset = entry_offset + rec_len;
+
+                // Skip entries already reported before `offset`.
+                if next_offset <= current_offset {
+                    continue;
+                }
+                if entry_offset < current_offset {
+                    current_offset = next_offset;
+                    continue;
+                }
+
+                let ino = entry.header.ino;
+                if ino != 0 {
+                    let name = core::str::from_utf8(entry.name)
+                        .map_err(|_| Error::with_message(Errno::EIO, "invalid dir entry name"))?;
+                    let file_type = DirEntryFileType::try_from(entry.header.file_type)
+                        .unwrap_or(DirEntryFileType::Unknown);
+                    let inode_type = InodeType::from(file_type);
+                    if visitor
+                        .visit(name, ino as u64, inode_type, next_offset)
+                        .is_err()
+                    {
+                        return Ok(current_offset - offset);
+                    }
+                }
+                current_offset = next_offset;
+            }
+            advanced = current_offset - offset;
+        }
+        Ok(advanced)
+    }
+
+    /// Scans one directory logical block for `name`, returning the located entry
+    /// or `None` if it is not in this block.
+    fn scan_block_for_name(
+        &self,
+        block_idx: usize,
+        name_bytes: &[u8],
+    ) -> Result<Option<DirEntryInfo>> {
+        let file_size = self.file_size();
+        let block = DirBlockView::from_index(self.page_cache()?, block_idx, file_size);
+        let mut iter = block.iter_entries();
+        while let Some((_, entry)) = iter.next_entry()? {
+            let ino = entry.header.ino;
+            if ino == 0 || entry.name != name_bytes {
+                continue;
+            }
+            return Ok(Some(DirEntryInfo { ino }));
+        }
+        Ok(None)
+    }
+
+    /// Locates a live entry by name and returns its inode number.
+    ///
+    /// On a `dir_index` volume `dx` carries the hash inputs; when this directory
+    /// also has the `INDEX` flag, the htree index is probed to the single leaf
+    /// block that may hold the name and only that block is scanned (O(log n)). A
+    /// probe miss — an unsupported hash, a corrupt index, or a hash collision
+    /// that spilled the name into a neighbouring leaf — falls through to the
+    /// linear scan, which is always correct: the index is an accelerator, never
+    /// the source of truth (Linux falls back the same way on `ERR_BAD_DX_DIR`).
+    fn find_entry_info(&self, name: &str, dx: Option<&DxCtx>) -> Result<DirEntryInfo> {
+        if self.desc.type_() != InodeType::Dir {
+            return_errno!(Errno::ENOTDIR);
+        }
+        let name_bytes = name.as_bytes();
+
+        if let Some(dx) = dx
+            && self.desc.flags().contains(FileFlags::INDEX)
+        {
+            let page_cache = self.page_cache()?;
+            let read_block = |logical: Ext4Bid| -> Result<[u8; BLOCK_SIZE]> {
+                page_cache
+                    .read_val(logical as usize * BLOCK_SIZE)
+                    .map_err(|_| {
+                        Error::with_message(Errno::EIO, "failed to read htree index block")
+                    })
+            };
+            if let Ok(Some(leaf)) =
+                htree::dx_lookup_leaf(read_block, name_bytes, &dx.seed, dx.unsigned)
+                // A corrupt index can point a leaf past EOF; validate the block
+                // against the directory size before scanning so a bad pointer
+                // falls through to the linear scan below rather than driving an
+                // out-of-range read (Linux rejects `block >= i_size` up front in
+                // `__ext4_read_dirblock`).
+                && leaf < self.file_size().div_ceil(BLOCK_SIZE) as Ext4Bid
+                && let Some(info) = self.scan_block_for_name(leaf as usize, name_bytes)?
+            {
+                return Ok(info);
+            }
+        }
+
+        let file_size = self.file_size();
+        for block_idx in 0..file_size.div_ceil(BLOCK_SIZE) {
+            if let Some(info) = self.scan_block_for_name(block_idx, name_bytes)? {
+                return Ok(info);
+            }
+        }
+        return_errno!(Errno::ENOENT)
+    }
+}
+
+impl Inode {
+    /// Looks up a child entry by name and reads its inode.
+    pub(in crate::fs::fs_impls::ext4) fn lookup(&self, name: &str) -> Result<Arc<Inode>> {
+        let fs = self
+            .fs
+            .upgrade()
+            .ok_or_else(|| Error::with_message(Errno::EIO, "filesystem dropped"))?;
+        let ino = self
+            .inner
+            .read()
+            .find_entry_info(name, dx_ctx(&fs).as_ref())?
+            .ino;
+        fs.read_inode(ino)
+    }
+
+    /// Iterates directory entries from `offset`, feeding them to `visitor`.
+    pub(in crate::fs::fs_impls::ext4) fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+    ) -> Result<usize> {
+        self.inner.read().readdir_at(offset, visitor)
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use alloc::{
+        string::{String, ToString},
+        vec::Vec,
+    };
+
+    use ostd::prelude::*;
+
+    use super::super::super::test_utils::{
+        Ext4FixtureBuilder, make_dir_block, make_dir_inode, make_file_inode,
+    };
+    use crate::{
+        fs::{file::InodeType, utils::DirentVisitor},
+        prelude::{Errno, Error, Result},
+    };
+
+    #[ktest]
+    fn lookup_and_readdir() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+
+        // A directory at ino 12 backed by data block 101 with three entries.
+        let dir_block = 101u32;
+        let block = make_dir_block(&[(2, ".", 2), (2, "..", 2), (11, "hello.txt", 1)]);
+        f.write_data_block(dir_block, &block);
+        f.write_raw_inode(12, &make_dir_inode(dir_block));
+        // The looked-up file inode must exist to be read back.
+        f.write_raw_inode(11, &make_file_inode(100, 0));
+
+        let dir = f.ext4.read_inode(12).unwrap();
+
+        let child = dir.lookup("hello.txt").unwrap();
+        assert_eq!(child.ino(), 11);
+        assert_eq!(child.inode_type(), InodeType::File);
+        assert!(dir.lookup("nonexistent").is_err());
+
+        let mut names: Vec<String> = Vec::new();
+        dir.readdir_at(0, &mut names).unwrap();
+        assert_eq!(names.len(), 3);
+        assert_eq!(names[0], ".");
+        assert_eq!(names[1], "..");
+        assert_eq!(names[2], "hello.txt");
+    }
+
+    /// A visitor that simulates a `getdents` buffer holding `cap` entries: it
+    /// records each entry, then fails (as a full user buffer would) once `cap`
+    /// entries have been accepted in the current call.
+    struct CappedVisitor {
+        cap: usize,
+        used: usize,
+        names: Vec<String>,
+    }
+
+    impl DirentVisitor for CappedVisitor {
+        fn visit(
+            &mut self,
+            name: &str,
+            _ino: u64,
+            _type_: InodeType,
+            _offset: usize,
+        ) -> Result<()> {
+            if self.used >= self.cap {
+                return Err(Error::with_message(Errno::EINVAL, "simulated buffer full"));
+            }
+            self.used += 1;
+            self.names.push(name.to_string());
+            Ok(())
+        }
+    }
+
+    /// Drives `readdir_at` exactly the way `InodeHandle::readdir` does — advancing
+    /// the directory offset by the returned byte count across multiple calls.
+    /// This exercises offset resumption that the single-call test above cannot,
+    /// mirroring a real mke2fs root layout (`.`, `..`, `lost+found`, files).
+    #[ktest]
+    fn readdir_resumes_across_getdents_calls() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let dir_block = 101u32;
+        let block = make_dir_block(&[
+            (2, ".", 2),
+            (2, "..", 2),
+            (11, "lost+found", 2),
+            (12, "hello.txt", 1),
+            (13, "subdir", 2),
+            (15, "big.txt", 1),
+        ]);
+        f.write_data_block(dir_block, &block);
+        f.write_raw_inode(12, &make_dir_inode(dir_block));
+        let dir = f.ext4.read_inode(12).unwrap();
+
+        let expected = [".", "..", "lost+found", "hello.txt", "subdir", "big.txt"];
+
+        // Including one entry per call, which forces the most resumption steps.
+        for cap in [1usize, 2, 3, 6] {
+            let mut all: Vec<String> = Vec::new();
+            let mut offset = 0usize;
+            loop {
+                let mut visitor = CappedVisitor {
+                    cap,
+                    used: 0,
+                    names: Vec::new(),
+                };
+                let read_cnt = dir.readdir_at(offset, &mut visitor).unwrap();
+                all.extend(visitor.names);
+                if read_cnt == 0 {
+                    break;
+                }
+                offset += read_cnt;
+                assert!(
+                    all.len() <= expected.len(),
+                    "readdir over-reported (cap={cap})"
+                );
+            }
+            assert_eq!(all, expected, "readdir mismatch at cap={cap}");
+        }
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/extent_manager/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/extent_manager/mod.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 extent block-mapping engine — the inode's logical→physical block
+//! translation for reads.
+//!
+//! This replaces ext2's indirect-block tree. The authoritative state is one
+//! [`ExtentTree`] per inode (the validated tree root + `i_blocks` accounting,
+//! defined in [`tree`]); [`ExtentManager`] wraps it in the position-③ lock
+//! (report §5.1), delegates every operation, and doubles as the `PageCache`
+//! backend, mirroring ext2's `InodeBlockManager` over `BlockPtrTree`.
+//!
+//! Interior tree nodes are read per lookup (through the metadata-read
+//! funnel); a frame cache (an allocation-free fast path for repeated lookups)
+//! is a P9 optimization.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use super::{super::prelude::*, RAW_BLOCK_PTRS_LEN};
+
+mod node;
+mod tree;
+
+pub(super) use self::tree::ExtentTree;
+
+/// State of a mapped logical block — the three-way view tests assert against
+/// (production code pattern-matches [`Mapping`] directly).
+#[cfg(ktest)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum MapState {
+    /// Backed by written data on disk.
+    Written,
+    /// Allocated but never written; reads as zeros.
+    Unwritten,
+    /// Not allocated; reads as zeros.
+    Hole,
+}
+
+/// The result of mapping a logical block. A hole carries no physical block at
+/// all — there is no in-band "pblock 0" to misread as block 0.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum Mapping {
+    /// A contiguous mapped physical run.
+    Mapped {
+        pblock: Ext4Bid,
+        /// Contiguous logical blocks from the queried one to the run's end.
+        #[cfg_attr(not(ktest), expect(dead_code))]
+        len: u32,
+        /// `false` = preallocated-unwritten: allocated, but reads as zeros.
+        written: bool,
+    },
+    /// Not allocated; reads as zeros.
+    Hole {
+        /// Logical blocks known to be unmapped (currently always 1). Only the
+        /// test view reads it today; the read path zero-fills a hole one block
+        /// at a time.
+        #[cfg_attr(not(ktest), expect(dead_code))]
+        len: u32,
+    },
+}
+
+impl Mapping {
+    /// Returns the three-way state view (see [`MapState`]).
+    #[cfg(ktest)]
+    pub(super) const fn state(&self) -> MapState {
+        match self {
+            Mapping::Mapped { written: true, .. } => MapState::Written,
+            Mapping::Mapped { written: false, .. } => MapState::Unwritten,
+            Mapping::Hole { .. } => MapState::Hole,
+        }
+    }
+
+    /// Returns the number of contiguous logical blocks this mapping describes.
+    #[cfg(ktest)]
+    pub(super) const fn len(&self) -> u32 {
+        match self {
+            Mapping::Mapped { len, .. } | Mapping::Hole { len } => *len,
+        }
+    }
+
+    /// Returns the physical block backing the run, `None` for a hole.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn mapped_pblock(&self) -> Option<Ext4Bid> {
+        match self {
+            Mapping::Mapped { pblock, .. } => Some(*pblock),
+            Mapping::Hole { .. } => None,
+        }
+    }
+
+    /// Returns whether reading these blocks must return zeros without device I/O.
+    #[cfg(ktest)]
+    pub(super) const fn reads_as_zeros(&self) -> bool {
+        !matches!(self, Mapping::Mapped { written: true, .. })
+    }
+}
+
+/// Maps an inode's logical blocks to physical blocks via its [`ExtentTree`],
+/// which owns the authoritative tree + `i_blocks` accounting.
+///
+/// Thin delegation over the tree: this type contributes the lock (position ③
+/// in the global order, report §5.1), the filesystem back-reference, and the
+/// `PageCache` backend surface — mirroring ext2's `InodeBlockManager` over
+/// `BlockPtrTree`.
+pub(super) struct ExtentManager {
+    /// The authoritative extent tree (the ③ "ExtentTree" lock).
+    state: RwMutex<ExtentTree>,
+    /// Cached page count for the `PageCache` backend.
+    npages: AtomicUsize,
+    /// Back-reference to the filesystem, for the block device (metadata and
+    /// data reads).
+    fs: Weak<super::super::fs::Ext4>,
+}
+
+impl ExtentManager {
+    /// Validates `root` (see [`ExtentTree::try_new`]) and builds the manager.
+    pub(super) fn try_new(
+        root: [u32; RAW_BLOCK_PTRS_LEN],
+        sector_count: u64,
+        fs: Weak<super::super::fs::Ext4>,
+        npages: usize,
+    ) -> Result<Self> {
+        Ok(Self {
+            state: RwMutex::new(ExtentTree::try_new(root, sector_count)?),
+            npages: AtomicUsize::new(npages),
+            fs,
+        })
+    }
+
+    /// Returns a strong reference to the owning filesystem.
+    fn fs(&self) -> Result<Arc<super::super::fs::Ext4>> {
+        self.fs
+            .upgrade()
+            .ok_or_else(|| Error::with_message(Errno::EIO, "filesystem dropped"))
+    }
+
+    /// Maps logical block `iblock` to a physical run.
+    ///
+    /// The returned length spans from `iblock` to the end of the covering
+    /// extent, so callers can batch contiguous reads.
+    pub(super) fn map_blocks(&self, iblock: Iblock) -> Result<Mapping> {
+        let fs = self.fs()?;
+        let tree = self.state.read();
+
+        match tree.lookup(&fs, iblock)? {
+            Some(extent) => {
+                let offset_in_extent = iblock - extent.block();
+                Ok(Mapping::Mapped {
+                    pblock: extent.start() + offset_in_extent as Ext4Bid,
+                    len: extent.len() as u32 - offset_in_extent,
+                    written: !extent.is_unwritten(),
+                })
+            }
+            None => Ok(Mapping::Hole { len: 1 }),
+        }
+    }
+
+    /// Returns the inode's `i_blocks` (512-byte sectors) accounting.
+    pub(super) fn sector_count(&self) -> u64 {
+        self.state.read().sector_count()
+    }
+}
+
+impl BlockAsPageCacheBackend for ExtentManager {
+    fn submit_read_bio(
+        &self,
+        idx: usize,
+        bio_segment: BioSegment,
+        complete_fn: BioCompleteFn,
+        io_batch: &mut IoBatch,
+    ) -> Result<()> {
+        if idx >= self.npages.load(Ordering::Acquire) {
+            return_errno_with_message!(Errno::EINVAL, "read past end of inode");
+        }
+        let iblock = Iblock::try_from(idx)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
+
+        let Mapping::Mapped {
+            pblock,
+            written: true,
+            ..
+        } = self.map_blocks(iblock)?
+        else {
+            // Holes and unwritten extents read as zeros without device I/O.
+            complete_fn(BioStatus::Zeros);
+            return Ok(());
+        };
+
+        let fs = self
+            .fs
+            .upgrade()
+            .ok_or_else(|| Error::with_message(Errno::EIO, "filesystem dropped"))?;
+        fs.read_blocks_async(pblock, bio_segment, Some(complete_fn), io_batch)
+    }
+
+    fn submit_write_bio(
+        &self,
+        _idx: usize,
+        _bio_segment: BioSegment,
+        _complete_fn: BioCompleteFn,
+        _io_batch: &mut IoBatch,
+    ) -> Result<()> {
+        // Read-only mount: the `PageCache` backend trait requires this method,
+        // but no dirty page can reach it (all write paths return `EROFS`).
+        return_errno_with_message!(Errno::EROFS, "read-only ext4: block writeback disabled");
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::{
+        super::super::test_utils::Ext4FixtureBuilder,
+        node::{EXTENT_MAGIC, RawExtent, RawExtentHeader},
+        *,
+    };
+
+    fn inline_root(extents: &[RawExtent]) -> [u32; RAW_BLOCK_PTRS_LEN] {
+        let mut block = [0u32; RAW_BLOCK_PTRS_LEN];
+        let bytes = block.as_mut_bytes();
+        let header = RawExtentHeader {
+            magic: EXTENT_MAGIC,
+            entries: extents.len() as u16,
+            max: 4,
+            depth: 0,
+            generation: 0,
+        };
+        bytes[0..12].copy_from_slice(header.as_bytes());
+        for (i, extent) in extents.iter().enumerate() {
+            let off = 12 * (1 + i);
+            bytes[off..off + 12].copy_from_slice(extent.as_bytes());
+        }
+        block
+    }
+
+    #[ktest]
+    fn map_written_extent() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let root = inline_root(&[RawExtent {
+            block: 0,
+            len: 4,
+            start_hi: 0,
+            start_lo: 100,
+        }]);
+        let em = ExtentManager::try_new(root, 4 * 8, f.ext4.this(), 4).unwrap();
+
+        let m0 = em.map_blocks(0).unwrap();
+        assert_eq!(m0.state(), MapState::Written);
+        assert_eq!(m0.mapped_pblock(), Some(100));
+        assert_eq!(m0.len(), 4);
+
+        // Mapping from the middle returns the remaining run.
+        let m2 = em.map_blocks(2).unwrap();
+        assert_eq!(m2.mapped_pblock(), Some(102));
+        assert_eq!(m2.len(), 2);
+
+        // Past the extent: a hole.
+        let m4 = em.map_blocks(4).unwrap();
+        assert_eq!(m4.state(), MapState::Hole);
+        assert!(m4.reads_as_zeros());
+    }
+
+    #[ktest]
+    fn map_unwritten_extent_reads_as_zeros() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let root = inline_root(&[RawExtent {
+            block: 0,
+            len: 32768 + 2, // unwritten, length 2
+            start_hi: 0,
+            start_lo: 500,
+        }]);
+        let em = ExtentManager::try_new(root, 2 * 8, f.ext4.this(), 2).unwrap();
+        let m = em.map_blocks(0).unwrap();
+        assert_eq!(m.state(), MapState::Unwritten);
+        assert!(m.reads_as_zeros());
+        assert_eq!(m.mapped_pblock(), Some(500));
+    }
+
+    // A1-B0 read regression: the two `journaled_*` tests that formerly lived
+    // here (`journaled_tree_read_sees_uncheckpointed_leaf`,
+    // `journaled_reserialize_captures_reused_leaf`) staged a
+    // committed-but-un-checkpointed leaf via `ensure_allocated` + a journal
+    // commit, then asserted the read was served from the journal's after-image.
+    // That stale-read window cannot exist on a read-only, journal-less mount —
+    // the device is always authoritative — so the tests are cut. The multi-node
+    // *device-parse* read they also exercised is preserved by
+    // `tree::tests::descends_into_external_leaf`, which builds a depth-1 index
+    // root over an external leaf laid down on the device and descends into it
+    // through `lookup`.
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/extent_manager/node.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/extent_manager/node.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! On-disk ext4 extent structures and their decoded forms.
+//!
+//! An extent tree node is a 12-byte header followed by 12-byte entries: index
+//! entries (`RawExtentIdx`) in interior nodes, leaf entries (`RawExtent`) in
+//! depth-0 nodes. The tree root lives inline in the inode's 60-byte `i_block`.
+
+use super::super::super::prelude::*;
+
+/// Extent header magic (`eh_magic`).
+pub(super) const EXTENT_MAGIC: u16 = 0xF30A;
+
+/// Maximum logical length encodable in a single extent. A length above this
+/// marks the extent as unwritten (preallocated but not yet written).
+pub(super) const MAX_WRITTEN_LEN: u16 = 32768;
+
+/// Maximum logical length of a single *unwritten* extent. An unwritten extent
+/// bias-encodes its length as `len + MAX_WRITTEN_LEN` in the 16-bit `ee_len`
+/// field, so the pre-bias length must stay strictly below `MAX_WRITTEN_LEN` or
+/// the sum wraps to a bogus (often zero-length) written extent on decode. This
+/// mirrors Linux `EXT_UNWRITTEN_MAX_LEN = EXT_INIT_MAX_LEN - 1`.
+#[cfg_attr(not(ktest), expect(dead_code))]
+pub(super) const MAX_UNWRITTEN_LEN: u16 = MAX_WRITTEN_LEN - 1;
+
+const_assert!(size_of::<RawExtentHeader>() == 12);
+const_assert!(size_of::<RawExtentIdx>() == 12);
+const_assert!(size_of::<RawExtent>() == 12);
+
+/// On-disk extent-tree node header (`ext4_extent_header`).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawExtentHeader {
+    pub magic: u16,
+    pub entries: u16,
+    pub max: u16,
+    pub depth: u16,
+    pub generation: u32,
+}
+
+/// On-disk interior index entry (`ext4_extent_idx`).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawExtentIdx {
+    /// First logical block this child covers (`ei_block`).
+    pub block: u32,
+    /// Lower 32 bits of the child node's physical block (`ei_leaf_lo`).
+    pub leaf_lo: u32,
+    /// Upper 16 bits of the child node's physical block (`ei_leaf_hi`).
+    pub leaf_hi: u16,
+    pub unused: u16,
+}
+
+/// On-disk leaf entry (`ext4_extent`).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawExtent {
+    /// First logical block this extent covers (`ee_block`).
+    pub block: u32,
+    /// Length; the top bit (`> 32768`) marks the extent unwritten (`ee_len`).
+    pub len: u16,
+    /// Upper 16 bits of the starting physical block (`ee_start_hi`).
+    pub start_hi: u16,
+    /// Lower 32 bits of the starting physical block (`ee_start_lo`).
+    pub start_lo: u32,
+}
+
+/// A validated extent-tree node header.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ExtentHeader {
+    entries: u16,
+    max: u16,
+    depth: u16,
+}
+
+impl ExtentHeader {
+    pub(super) const fn entries(&self) -> u16 {
+        self.entries
+    }
+
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn max(&self) -> u16 {
+        self.max
+    }
+
+    pub(super) const fn is_leaf(&self) -> bool {
+        self.depth == 0
+    }
+}
+
+impl ExtentHeader {
+    /// Decodes a header from bytes that are already trusted — the in-memory
+    /// root of a constructed [`ExtentTree`](super::tree::ExtentTree), which was
+    /// validated once at construction and never rewritten afterward on this
+    /// read-only mount. Freshly read device bytes are a parse boundary and must
+    /// go through `TryFrom` instead.
+    pub(super) const fn from_trusted(raw: &RawExtentHeader) -> Self {
+        Self {
+            entries: raw.entries,
+            max: raw.max,
+            depth: raw.depth,
+        }
+    }
+}
+
+impl TryFrom<&RawExtentHeader> for ExtentHeader {
+    type Error = Error;
+
+    fn try_from(raw: &RawExtentHeader) -> Result<Self> {
+        if raw.magic != EXTENT_MAGIC {
+            return_errno_with_message!(Errno::EUCLEAN, "bad extent header magic");
+        }
+        if raw.entries > raw.max {
+            return_errno_with_message!(Errno::EUCLEAN, "extent header entries exceed max");
+        }
+        if raw.depth > 5 {
+            return_errno_with_message!(Errno::EUCLEAN, "extent tree too deep");
+        }
+        Ok(Self {
+            entries: raw.entries,
+            max: raw.max,
+            depth: raw.depth,
+        })
+    }
+}
+
+/// A decoded interior index entry.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ExtentIdx {
+    block: Iblock,
+    leaf: Ext4Bid,
+}
+
+impl ExtentIdx {
+    /// Returns the first logical block this child covers.
+    pub(super) const fn block(&self) -> Iblock {
+        self.block
+    }
+
+    /// Returns the physical block of the child node (48-bit).
+    pub(super) const fn leaf(&self) -> Ext4Bid {
+        self.leaf
+    }
+}
+
+impl From<&RawExtentIdx> for ExtentIdx {
+    fn from(raw: &RawExtentIdx) -> Self {
+        Self {
+            block: raw.block,
+            leaf: (raw.leaf_lo as Ext4Bid) | ((raw.leaf_hi as Ext4Bid) << 32),
+        }
+    }
+}
+
+/// A decoded leaf extent: a contiguous run mapping `len` logical blocks starting
+/// at logical `block` to physical `start`.
+/// Whether an extent is backed by written data, or is preallocated but
+/// unwritten (reads as zeros until written).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ExtentKind {
+    Written,
+    Unwritten,
+}
+
+impl ExtentKind {
+    /// Returns whether this is an unwritten (preallocated) extent.
+    pub(super) const fn is_unwritten(self) -> bool {
+        matches!(self, ExtentKind::Unwritten)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct Extent {
+    block: Iblock,
+    len: u16,
+    start: Ext4Bid,
+    kind: ExtentKind,
+}
+
+impl Extent {
+    /// Builds a leaf extent mapping `len` logical blocks from logical `block` to
+    /// physical `start`, written or unwritten per `kind`.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn new(block: Iblock, len: u16, start: Ext4Bid, kind: ExtentKind) -> Self {
+        Self {
+            block,
+            len,
+            start,
+            kind,
+        }
+    }
+
+    /// Returns the first logical block this extent covers.
+    pub(super) const fn block(&self) -> Iblock {
+        self.block
+    }
+
+    /// Returns the number of logical blocks covered.
+    pub(super) const fn len(&self) -> u16 {
+        self.len
+    }
+
+    /// Returns the starting physical block (48-bit).
+    pub(super) const fn start(&self) -> Ext4Bid {
+        self.start
+    }
+
+    /// Returns whether this extent is unwritten (allocated, reads as zeros).
+    pub(super) const fn is_unwritten(&self) -> bool {
+        self.kind.is_unwritten()
+    }
+
+    /// Returns whether `iblock` falls within this extent.
+    pub(super) const fn covers(&self, iblock: Iblock) -> bool {
+        iblock >= self.block && (iblock as u64) < self.block as u64 + self.len as u64
+    }
+}
+
+impl From<&RawExtent> for Extent {
+    fn from(raw: &RawExtent) -> Self {
+        let unwritten = raw.len > MAX_WRITTEN_LEN;
+        let len = if unwritten {
+            raw.len - MAX_WRITTEN_LEN
+        } else {
+            raw.len
+        };
+        Self {
+            block: raw.block,
+            len,
+            start: (raw.start_lo as Ext4Bid) | ((raw.start_hi as Ext4Bid) << 32),
+            kind: if unwritten {
+                ExtentKind::Unwritten
+            } else {
+                ExtentKind::Written
+            },
+        }
+    }
+}
+
+impl From<&Extent> for RawExtent {
+    fn from(ext: &Extent) -> Self {
+        // Unwritten extents encode their length biased by `MAX_WRITTEN_LEN`; the
+        // physical block splits into a 32-bit low half and a 16-bit high half.
+        let unwritten = ext.kind.is_unwritten();
+        debug_assert!(
+            !unwritten || ext.len < MAX_WRITTEN_LEN,
+            "unwritten extent length must be < MAX_WRITTEN_LEN to bias-encode"
+        );
+        let len = if unwritten {
+            ext.len + MAX_WRITTEN_LEN
+        } else {
+            ext.len
+        };
+        // The on-disk format caps physical blocks at 48 bits (16-bit hi +
+        // 32-bit lo); every physical block is < 2^32 on a no-64bit mount, so
+        // the split below is lossless.
+        debug_assert!(ext.start < 1 << 48);
+        Self {
+            block: ext.block,
+            len,
+            start_hi: (ext.start >> 32) as u16,
+            start_lo: ext.start as u32,
+        }
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    #[ktest]
+    fn parse_leaf_header() {
+        let raw = RawExtentHeader {
+            magic: EXTENT_MAGIC,
+            entries: 1,
+            max: 4,
+            depth: 0,
+            generation: 0,
+        };
+        let hdr = ExtentHeader::try_from(&raw).unwrap();
+        assert!(hdr.is_leaf());
+        assert_eq!(hdr.entries(), 1);
+        assert_eq!(hdr.max(), 4);
+    }
+
+    #[ktest]
+    fn reject_bad_magic() {
+        let raw = RawExtentHeader {
+            magic: 0x1234,
+            entries: 0,
+            max: 4,
+            depth: 0,
+            generation: 0,
+        };
+        assert!(ExtentHeader::try_from(&raw).is_err());
+    }
+
+    #[ktest]
+    fn decode_extent_pblock_and_len() {
+        let raw = RawExtent {
+            block: 0,
+            len: 5,
+            start_hi: 0x0001,
+            start_lo: 0x0000_0002,
+        };
+        let ext = Extent::from(&raw);
+        assert_eq!(ext.block(), 0);
+        assert_eq!(ext.len(), 5);
+        assert_eq!(ext.start(), (1u64 << 32) | 2);
+        assert!(!ext.is_unwritten());
+        assert!(ext.covers(4));
+        assert!(!ext.covers(5));
+    }
+
+    #[ktest]
+    fn decode_unwritten_extent() {
+        let raw = RawExtent {
+            block: 10,
+            len: MAX_WRITTEN_LEN + 3, // unwritten, real len 3
+            start_hi: 0,
+            start_lo: 100,
+        };
+        let ext = Extent::from(&raw);
+        assert!(ext.is_unwritten());
+        assert_eq!(ext.len(), 3);
+        assert_eq!(ext.start(), 100);
+    }
+
+    #[ktest]
+    fn max_unwritten_extent_round_trips() {
+        // Regression: a full-group unwritten run must encode within `ee_len`.
+        // `MAX_UNWRITTEN_LEN` (32767) bias-encodes to 65535 (still non-zero) and
+        // decodes back to an unwritten extent of the same length. One more block
+        // (32768) would encode to 65536, wrap the u16 to 0, and decode as a bogus
+        // zero-length *written* extent — so an unwritten extent's length must
+        // stay <= `MAX_UNWRITTEN_LEN` to bias-encode losslessly.
+        let ext = Extent::new(0, MAX_UNWRITTEN_LEN, 1000, ExtentKind::Unwritten);
+        let raw = RawExtent::from(&ext);
+        assert_eq!(raw.len, u16::MAX); // 32767 + 32768, no wrap
+        let decoded = Extent::from(&raw);
+        assert!(decoded.is_unwritten());
+        assert_eq!(decoded.len(), MAX_UNWRITTEN_LEN);
+        assert_eq!(decoded.start(), 1000);
+    }
+
+    #[ktest]
+    fn decode_index_leaf_pblock() {
+        let raw = RawExtentIdx {
+            block: 7,
+            leaf_lo: 0x0000_0005,
+            leaf_hi: 0x0002,
+            unused: 0,
+        };
+        let idx = ExtentIdx::from(&raw);
+        assert_eq!(idx.block(), 7);
+        assert_eq!(idx.leaf(), (2u64 << 32) | 5);
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/extent_manager/tree.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/extent_manager/tree.rs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! [`ExtentTree`] — the validated, read-only extent tree of one inode.
+//!
+//! The tree root lives inline in the inode's 60-byte `i_block`; interior nodes
+//! hold index entries pointing to child blocks read from the device, and leaf
+//! nodes hold the extents mapping logical blocks to physical runs. The type
+//! owns the root (validated once at construction — the parse-once boundary) and
+//! the inode's `i_blocks` sector accounting; every tree operation is a method,
+//! so only a constructed (i.e. proven well-formed) tree can be searched.
+//! Mirrors ext2's `BlockPtrTree`.
+
+use super::{
+    super::{
+        super::{fs::Ext4, prelude::*, utils},
+        RAW_BLOCK_PTRS_LEN,
+    },
+    node::{
+        EXTENT_MAGIC, Extent, ExtentHeader, ExtentIdx, RawExtent, RawExtentHeader, RawExtentIdx,
+    },
+};
+
+/// Size of one extent-tree entry (header, index, or leaf), in bytes.
+const ENTRY_SIZE: usize = 12;
+
+/// Maximum extent-tree depth, mirroring `EXT4_MAX_EXTENT_DEPTH`.
+const MAX_DEPTH: u32 = 5;
+
+/// Maximum extents in the inline (depth-0) root: the 60-byte `i_block` holds a
+/// 12-byte header plus four 12-byte entries.
+const INLINE_MAX: usize = 4;
+
+/// The validated, read-only extent tree of one inode, plus the `i_blocks`
+/// sector accounting it exposes for reads.
+///
+/// `root` is the inode's 60-byte `i_block` in its on-disk layout, **validated
+/// at construction** ([`try_new`](Self::try_new)) and thereafter only read — so
+/// methods trust it without re-validating (rule: parse once at the boundary).
+/// `sector_count` mirrors the inode's `i_blocks` (data + extent-tree metadata,
+/// in 512-byte sectors).
+///
+/// This struct is the "ExtentTree" lock content at position ③ in the global
+/// lock order (report §5.1); [`ExtentManager`](super::ExtentManager) wraps it
+/// in the `RwMutex` and delegates.
+pub(in crate::fs::fs_impls::ext4::inode) struct ExtentTree {
+    root: [u32; RAW_BLOCK_PTRS_LEN],
+    sector_count: u64,
+}
+
+impl ExtentTree {
+    /// Validates `root`'s extent header once and takes ownership of the tree.
+    ///
+    /// This is the parse boundary: a bad magic / entry count / depth is
+    /// rejected here, and every later method call trusts the root.
+    pub(super) fn try_new(root: [u32; RAW_BLOCK_PTRS_LEN], sector_count: u64) -> Result<Self> {
+        ExtentHeader::try_from(&RawExtentHeader::from_bytes(
+            &root.as_bytes()[0..ENTRY_SIZE],
+        ))?;
+        Ok(Self { root, sector_count })
+    }
+
+    /// A valid empty tree: a depth-0 header (magic, 0 entries, max 4) followed
+    /// by zeros — what a freshly created regular file or directory carries, so
+    /// the extent reader sees a well-formed (empty) tree from the first byte.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(in crate::fs::fs_impls::ext4::inode) const fn empty() -> Self {
+        let mut root = [0u32; RAW_BLOCK_PTRS_LEN];
+        // Each `i_block` word packs two 16-bit fields, little-endian: word 0 is
+        // `eh_magic | eh_entries(=0)`, word 1 is `eh_max(=4) | eh_depth(=0)`.
+        root[0] = EXTENT_MAGIC as u32;
+        root[1] = INLINE_MAX as u32;
+        Self {
+            root,
+            sector_count: 0,
+        }
+    }
+
+    /// Returns the inode's `i_blocks` (512-byte sectors) accounting.
+    pub(super) const fn sector_count(&self) -> u64 {
+        self.sector_count
+    }
+
+    /// Returns the root's header, decoded from the trusted
+    /// (construction-validated) bytes.
+    fn header(&self) -> ExtentHeader {
+        ExtentHeader::from_trusted(&RawExtentHeader::from_bytes(
+            &self.root.as_bytes()[0..ENTRY_SIZE],
+        ))
+    }
+
+    /// Walks the tree to find the extent covering `iblock`, returning `None`
+    /// for a hole.
+    ///
+    /// External nodes are read through [`utils::read_metadata_block`], the
+    /// single metadata-read funnel — a plain device read on this read-only,
+    /// non-journaled mount (the seam a journaling layer would later re-widen).
+    pub(super) fn lookup(&self, fs: &Ext4, iblock: Iblock) -> Result<Option<Extent>> {
+        let root_bytes = self.root.as_bytes();
+        let mut next_bid = match search_entries(&self.header(), root_bytes, iblock)? {
+            Step::Found(extent) => return Ok(Some(extent)),
+            Step::Hole => return Ok(None),
+            Step::Descend(bid) => bid,
+        };
+
+        let device = fs.block_device().as_ref();
+        for _ in 0..MAX_DEPTH {
+            let block = utils::read_metadata_block(device, next_bid)?;
+            match search_node(&block, iblock)? {
+                Step::Found(extent) => return Ok(Some(extent)),
+                Step::Hole => return Ok(None),
+                Step::Descend(bid) => next_bid = bid,
+            }
+        }
+        return_errno_with_message!(Errno::EUCLEAN, "extent tree deeper than maximum depth");
+    }
+}
+
+/// The outcome of searching a single extent-tree node for `iblock`.
+enum Step {
+    /// A leaf extent that covers `iblock`.
+    Found(Extent),
+    /// No extent covers `iblock`: a hole.
+    Hole,
+    /// An interior node points to a child at this physical block.
+    Descend(Ext4Bid),
+}
+
+/// Parses and searches one freshly read (untrusted) node — the parse boundary
+/// for device bytes.
+fn search_node(bytes: &[u8], iblock: Iblock) -> Result<Step> {
+    let header = ExtentHeader::try_from(&RawExtentHeader::from_bytes(&bytes[0..ENTRY_SIZE]))?;
+    search_entries(&header, bytes, iblock)
+}
+
+/// Searches one node's entries for `iblock`, `header` already decoded.
+///
+/// Entries are sorted by logical block, so the covering entry is the last one
+/// whose starting block is `<= iblock`. Phase 1 scans linearly (nodes hold at
+/// most a few hundred entries); a binary search is a later optimization.
+fn search_entries(header: &ExtentHeader, bytes: &[u8], iblock: Iblock) -> Result<Step> {
+    let nr_entries = header.entries() as usize;
+
+    let entries_end = ENTRY_SIZE * (1 + nr_entries);
+    if entries_end > bytes.len() {
+        return_errno_with_message!(Errno::EUCLEAN, "extent node entries overrun node");
+    }
+
+    if header.is_leaf() {
+        let mut covering: Option<Extent> = None;
+        for i in 0..nr_entries {
+            let off = ENTRY_SIZE * (1 + i);
+            let extent = Extent::from(&RawExtent::from_bytes(&bytes[off..off + ENTRY_SIZE]));
+            if extent.block() <= iblock {
+                covering = Some(extent);
+            } else {
+                break;
+            }
+        }
+        match covering {
+            Some(extent) if extent.covers(iblock) => Ok(Step::Found(extent)),
+            _ => Ok(Step::Hole),
+        }
+    } else {
+        let mut chosen: Option<ExtentIdx> = None;
+        for i in 0..nr_entries {
+            let off = ENTRY_SIZE * (1 + i);
+            let idx = ExtentIdx::from(&RawExtentIdx::from_bytes(&bytes[off..off + ENTRY_SIZE]));
+            if idx.block() <= iblock {
+                chosen = Some(idx);
+            } else {
+                break;
+            }
+        }
+        match chosen {
+            Some(idx) => Ok(Step::Descend(idx.leaf())),
+            // `iblock` lies before the first index entry. Linux descends into
+            // the first child anyway and then finds no covering extent; we
+            // short-circuit to the same answer. On a well-formed tree the two
+            // are equivalent (no leaf under index 0 maps anything below its
+            // `first_block`); on a corrupt tree the short-circuit is the safer
+            // degradation — a hole read instead of chasing a bogus subtree
+            // (P1 review item, judged & documented at P5).
+            None => Ok(Step::Hole),
+        }
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+    use crate::fs::fs_impls::ext4::test_utils::Ext4FixtureBuilder;
+
+    /// Builds a validated tree over a depth-0 root (header + extents).
+    fn inline_tree(extents: &[RawExtent]) -> ExtentTree {
+        let mut block = [0u32; RAW_BLOCK_PTRS_LEN];
+        let bytes = block.as_mut_bytes();
+        let header = RawExtentHeader {
+            magic: EXTENT_MAGIC,
+            entries: extents.len() as u16,
+            max: 4,
+            depth: 0,
+            generation: 0,
+        };
+        bytes[0..ENTRY_SIZE].copy_from_slice(header.as_bytes());
+        for (i, extent) in extents.iter().enumerate() {
+            let off = ENTRY_SIZE * (1 + i);
+            bytes[off..off + ENTRY_SIZE].copy_from_slice(extent.as_bytes());
+        }
+        ExtentTree::try_new(block, 0).unwrap()
+    }
+
+    #[ktest]
+    fn inline_single_extent_lookup() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        // One extent mapping logical 0..4 to physical 100..104.
+        let tree = inline_tree(&[RawExtent {
+            block: 0,
+            len: 4,
+            start_hi: 0,
+            start_lo: 100,
+        }]);
+
+        let mapped = tree.lookup(&f.ext4, 2).unwrap().unwrap();
+        assert_eq!(mapped.start(), 100);
+        assert_eq!(mapped.block(), 0);
+
+        // Block 4 is beyond the extent: a hole.
+        assert!(tree.lookup(&f.ext4, 4).unwrap().is_none());
+    }
+
+    #[ktest]
+    fn inline_multiple_extents_lookup() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let tree = inline_tree(&[
+            RawExtent {
+                block: 0,
+                len: 2,
+                start_hi: 0,
+                start_lo: 200,
+            },
+            RawExtent {
+                block: 5,
+                len: 3,
+                start_hi: 0,
+                start_lo: 300,
+            },
+        ]);
+
+        // Logical 6 → second extent, physical 300 + (6 - 5) = 301.
+        let mapped = tree.lookup(&f.ext4, 6).unwrap().unwrap();
+        assert_eq!(mapped.start() + (6 - mapped.block()) as u64, 301);
+
+        // Logical 3 falls in the gap between the two extents: a hole.
+        assert!(tree.lookup(&f.ext4, 3).unwrap().is_none());
+    }
+
+    #[ktest]
+    fn empty_root_is_all_holes() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let tree = ExtentTree::empty();
+        assert!(tree.lookup(&f.ext4, 0).unwrap().is_none());
+    }
+
+    #[ktest]
+    fn rejects_bad_root_magic() {
+        let root = [0u32; RAW_BLOCK_PTRS_LEN];
+        assert!(ExtentTree::try_new(root, 0).is_err());
+    }
+
+    /// Builds a validated tree over a depth-1 index root pointing at a single
+    /// external leaf node at physical block `leaf_block`.
+    fn index_tree(leaf_block: u32) -> ExtentTree {
+        let mut block = [0u32; RAW_BLOCK_PTRS_LEN];
+        let bytes = block.as_mut_bytes();
+        let header = RawExtentHeader {
+            magic: EXTENT_MAGIC,
+            entries: 1,
+            max: 4,
+            depth: 1,
+            generation: 0,
+        };
+        bytes[0..ENTRY_SIZE].copy_from_slice(header.as_bytes());
+        let idx = RawExtentIdx {
+            block: 0,
+            leaf_lo: leaf_block,
+            leaf_hi: 0,
+            unused: 0,
+        };
+        bytes[ENTRY_SIZE..2 * ENTRY_SIZE].copy_from_slice(idx.as_bytes());
+        ExtentTree::try_new(block, 0).unwrap()
+    }
+
+    /// Builds a full-block external leaf node (depth 0) from `extents`.
+    fn leaf_node(extents: &[RawExtent]) -> [u8; BLOCK_SIZE] {
+        let mut block = [0u8; BLOCK_SIZE];
+        let header = RawExtentHeader {
+            magic: EXTENT_MAGIC,
+            entries: extents.len() as u16,
+            max: ((BLOCK_SIZE / ENTRY_SIZE) - 1) as u16,
+            depth: 0,
+            generation: 0,
+        };
+        block[0..ENTRY_SIZE].copy_from_slice(header.as_bytes());
+        for (i, extent) in extents.iter().enumerate() {
+            let off = ENTRY_SIZE * (1 + i);
+            block[off..off + ENTRY_SIZE].copy_from_slice(extent.as_bytes());
+        }
+        block
+    }
+
+    /// A depth-1 tree (index root → external leaf read from the device) must be
+    /// descended into. This exercises the interior-node read path that inline
+    /// (depth-0) roots never reach — the real-image counterpart is a fragmented
+    /// file whose extents overflow the inline root.
+    #[ktest]
+    fn descends_into_external_leaf() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+
+        let leaf_block = 200u32;
+        let leaf = leaf_node(&[
+            RawExtent {
+                block: 0,
+                len: 2,
+                start_hi: 0,
+                start_lo: 300,
+            },
+            RawExtent {
+                block: 5,
+                len: 3,
+                start_hi: 0,
+                start_lo: 400,
+            },
+        ]);
+        f.write_data_block(leaf_block, &leaf);
+        let tree = index_tree(leaf_block);
+
+        // Logical 1 → descend to the leaf → first extent (0..2) → physical 301.
+        let m0 = tree.lookup(&f.ext4, 1).unwrap().unwrap();
+        assert_eq!(m0.start() + (1 - m0.block()) as u64, 301);
+        // Logical 6 → second extent (5..8) → physical 401.
+        let m1 = tree.lookup(&f.ext4, 6).unwrap().unwrap();
+        assert_eq!(m1.start() + (6 - m1.block()) as u64, 401);
+        // Logical 3 → gap between the leaf's extents → hole.
+        assert!(tree.lookup(&f.ext4, 3).unwrap().is_none());
+        // Logical 100 → beyond all extents → hole.
+        assert!(tree.lookup(&f.ext4, 100).unwrap().is_none());
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/mod.rs
@@ -1,0 +1,844 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Ext4 inodes: shared type aliases, the on-disk inode, its validated in-memory
+//! form, and read access.
+//!
+//! An inode decodes its on-disk metadata (type, permissions, owners, size,
+//! times, flags) into `InodeDesc` and maps its data through an extent tree
+//! (`extent_manager`). Reads go through `Inode`; this is a read-only mount, so
+//! the write-side methods return `EROFS`.
+//!
+//! # Locking
+//!
+//! Data-backed inodes nest the extent tree under `inner`:
+//!
+//! ```text
+//! Inode::inner → ExtentManager::state
+//! ```
+//!
+//! `BlockGroup::inode_cache` is independent of that nesting: repeated lookups of
+//! the same inode number return the same in-memory `Inode`, giving concurrent
+//! readers a shared object.
+
+use super::{
+    checksum::{self, InodeCsumSeed},
+    fs::Ext4,
+    prelude::*,
+};
+
+mod dir;
+mod extent_manager;
+mod symlink;
+
+use self::{extent_manager::ExtentManager, symlink::FastSymlinkTarget};
+use crate::fs::{file::InodeMode, vfs::inode::Extension};
+
+/// Number of 32-bit slots in `i_block` (60 bytes total).
+///
+/// In ext4 these 60 bytes hold the inline extent-tree root rather than the
+/// direct/indirect block pointers of ext2.
+pub(super) const RAW_BLOCK_PTRS_LEN: usize = 15;
+
+/// Byte capacity of the inline `i_block` area used to store a fast symlink
+/// target (`RAW_BLOCK_PTRS_LEN * 4` = 60). A target strictly shorter than this
+/// is stored inline (one byte is reserved for the Linux trailing NUL); a longer
+/// one is stored in an extent-mapped data block (a slow symlink).
+pub(super) const MAX_FAST_SYMLINK_LEN: usize = RAW_BLOCK_PTRS_LEN * 4;
+
+/// Logical (file-relative) block index (Linux `ext4_lblk_t`, 32-bit).
+pub(super) type Iblock = u32;
+
+/// Physical block number on the device. 64-bit from day one so enabling the
+/// `64BIT` feature later needs no widening (report §3.3); the on-disk extent
+/// encodes a 48-bit physical block.
+pub(super) type Ext4Bid = u64;
+
+/// Inode number.
+pub(super) type Ext4Ino = u32;
+
+/// `i_flags` value marking an inode with inline data (Linux
+/// `EXT4_INLINE_DATA_FL`); unsupported in Phase 1.
+#[expect(dead_code)]
+pub(super) const INLINE_DATA_FL: u32 = 0x1000_0000;
+
+/// File permission bits (the low 12 bits of `i_mode`).
+#[derive(Clone, Copy, Debug)]
+pub struct FilePerm(u16);
+
+impl FilePerm {
+    /// Constructs a `FilePerm` from raw mode bits, keeping only the low 12.
+    pub(super) fn from_bits_truncate(bits: u16) -> Self {
+        Self(bits & 0o7777)
+    }
+
+    /// Returns the raw permission bits.
+    pub(super) const fn bits(&self) -> u16 {
+        self.0
+    }
+}
+
+bitflags! {
+    /// Inode flags (`i_flags`).
+    pub(super) struct FileFlags: u32 {
+        const SECURE_DEL = 1 << 0;
+        const UNDELETE = 1 << 1;
+        const COMPRESS = 1 << 2;
+        const SYNC = 1 << 3;
+        const IMMUTABLE = 1 << 4;
+        const APPEND = 1 << 5;
+        const NODUMP = 1 << 6;
+        const NOATIME = 1 << 7;
+        /// Directory uses an htree hash index.
+        const INDEX = 1 << 12;
+        /// `i_blocks` is counted in filesystem blocks, not 512-byte sectors.
+        const HUGE_FILE = 1 << 18;
+        /// `i_block` holds an extent tree (`EXT4_EXTENTS_FL`).
+        const EXTENTS = 1 << 19;
+        const EA_INODE = 1 << 21;
+        /// The inode has inline data.
+        const INLINE_DATA = 1 << 28;
+    }
+}
+
+/// Validated, Rust-typed in-memory inode metadata.
+///
+/// The raw `i_block` bytes are retained in `block`; they are parsed into an
+/// `ExtentTree` when the inode's payload is built (`InodePayload::new`).
+#[derive(Clone, Debug)]
+pub(super) struct InodeDesc {
+    type_: InodeType,
+    perm: FilePerm,
+    uid: u32,
+    gid: u32,
+    size: u64,
+    atime: Duration,
+    ctime: Duration,
+    mtime: Duration,
+    crtime: Duration,
+    link_count: u16,
+    /// `i_blocks` in 512-byte sectors (48-bit: low 32 + high 16).
+    sector_count: u64,
+    flags: FileFlags,
+    #[expect(dead_code)]
+    file_acl: u64,
+    generation: u32,
+    /// Raw `i_block` (60 bytes) — the inline extent-tree root.
+    block: [u32; RAW_BLOCK_PTRS_LEN],
+}
+
+/// Decodes the ext4 special-file device encoding stored in `i_block`: 8-bit
+/// major/minor pairs use the old `(major << 8) | minor` form in word 0,
+/// anything wider the `new_encode_dev` form in word 1.
+fn decode_device_block(block: &[u32; RAW_BLOCK_PTRS_LEN]) -> u64 {
+    let (major, minor) = if block[0] != 0 {
+        ((block[0] >> 8) & 0xFF, block[0] & 0xFF)
+    } else {
+        let dev = block[1];
+        ((dev & 0xFFF00) >> 8, (dev & 0xFF) | ((dev >> 12) & 0xFFF00))
+    };
+    device_id::encode_device_numbers(major, minor)
+}
+
+impl InodeDesc {
+    /// Returns the device id encoded in `i_block`, for character/block device
+    /// inodes (`None` for every other type — their `i_block` is not a device
+    /// encoding).
+    pub(super) fn device_id(&self) -> Option<u64> {
+        match self.type_ {
+            InodeType::CharDevice | InodeType::BlockDevice => {
+                Some(decode_device_block(&self.block))
+            }
+            _ => None,
+        }
+    }
+
+    pub(super) const fn type_(&self) -> InodeType {
+        self.type_
+    }
+
+    pub(super) const fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub(super) const fn link_count(&self) -> u16 {
+        self.link_count
+    }
+
+    pub(super) const fn flags(&self) -> FileFlags {
+        self.flags
+    }
+
+    pub(super) const fn sector_count(&self) -> u64 {
+        self.sector_count
+    }
+
+    pub(super) const fn perm(&self) -> FilePerm {
+        self.perm
+    }
+
+    pub(super) const fn uid(&self) -> u32 {
+        self.uid
+    }
+
+    pub(super) const fn gid(&self) -> u32 {
+        self.gid
+    }
+
+    pub(super) const fn atime(&self) -> Duration {
+        self.atime
+    }
+
+    pub(super) const fn mtime(&self) -> Duration {
+        self.mtime
+    }
+
+    pub(super) const fn ctime(&self) -> Duration {
+        self.ctime
+    }
+
+    pub(super) const fn crtime(&self) -> Duration {
+        self.crtime
+    }
+
+    /// Returns the inode generation (`i_generation`).
+    pub(super) const fn generation(&self) -> u32 {
+        self.generation
+    }
+
+    /// Returns the raw `i_block` bytes holding the extent-tree root.
+    pub(super) const fn raw_block(&self) -> &[u32; RAW_BLOCK_PTRS_LEN] {
+        &self.block
+    }
+
+    /// Returns whether this inode's data is mapped by an extent tree.
+    pub(super) fn is_extent_based(&self) -> bool {
+        self.flags.contains(FileFlags::EXTENTS)
+    }
+}
+
+/// Decodes an ext4 timestamp from its seconds field and the `*_extra` field.
+///
+/// The extra field packs a 2-bit epoch (extending seconds past 2038) in its low
+/// bits and nanoseconds in the upper bits (report §4.3).
+fn decode_time(secs: u32, extra: u32) -> Duration {
+    let epoch = (extra & 0x3) as i64;
+    let nsec = extra >> 2;
+    // Linux `ext4_decode_extra_time`: the base seconds are SIGNED and the
+    // 2-bit epoch extends them upward, so epoch 0 spans 1901..2038 and epoch 1
+    // continues seamlessly at 2^31. Decoding the base as unsigned misread
+    // foreign images' pre-1970 timestamps as far-future (P1 review item).
+    // `Duration` cannot express pre-1970 at all; clamp those to the epoch.
+    let secs = (secs as i32) as i64 + (epoch << 32);
+    Duration::new(u64::try_from(secs).unwrap_or(0), nsec)
+}
+
+impl TryFrom<&RawInode> for InodeDesc {
+    type Error = Error;
+
+    fn try_from(raw: &RawInode) -> Result<Self> {
+        if raw.link_count == 0 {
+            return_errno_with_message!(Errno::ESTALE, "inode is not in use");
+        }
+
+        let type_ = InodeType::from_raw_mode(raw.mode)
+            .map_err(|_| Error::with_message(Errno::EUCLEAN, "invalid inode mode"))?;
+        let perm = FilePerm::from_bits_truncate(raw.mode);
+
+        let uid = (raw.uid as u32) | ((raw.uid_high as u32) << 16);
+        let gid = (raw.gid as u32) | ((raw.gid_high as u32) << 16);
+
+        let mut size = raw.size_lo as u64;
+        if type_ == InodeType::File {
+            size |= (raw.size_high as u64) << 32;
+        }
+        if type_ == InodeType::SymLink && size >= BLOCK_SIZE as u64 {
+            return_errno_with_message!(Errno::EUCLEAN, "symlink size too large");
+        }
+        if size > i64::MAX as u64 {
+            return_errno_with_message!(Errno::EUCLEAN, "inode size too large");
+        }
+
+        let flags = FileFlags::from_bits_truncate(raw.flags);
+        // NB: not rescaled for `EXT4_HUGE_FILE_FL` inodes (known limitation,
+        // see `feature.rs`); `st_blocks` may under-report for huge files.
+        let sector_count = (raw.sector_count as u64) | ((raw.blocks_high as u64) << 32);
+        let file_acl = (raw.file_acl_lo as u64) | ((raw.file_acl_high as u64) << 32);
+
+        Ok(Self {
+            type_,
+            perm,
+            uid,
+            gid,
+            size,
+            atime: decode_time(raw.atime, raw.atime_extra),
+            ctime: decode_time(raw.ctime, raw.ctime_extra),
+            mtime: decode_time(raw.mtime, raw.mtime_extra),
+            crtime: decode_time(raw.crtime, raw.crtime_extra),
+            link_count: raw.link_count,
+            sector_count,
+            flags,
+            file_acl,
+            generation: raw.generation,
+            block: raw.block,
+        })
+    }
+}
+
+/// Byte offset of `i_checksum_lo` in [`RawInode`] (0x7C, inside osd2); the low
+/// half of the inode checksum, present in every inode.
+const I_CHECKSUM_LO_OFFSET: usize = 0x7C;
+
+/// Byte offset of `i_checksum_hi` in [`RawInode`] (0x82, just past
+/// `i_extra_isize`); the high half, present only when the inode carries the
+/// extra-size region (`s_inode_size > 128`).
+const I_CHECKSUM_HI_OFFSET: usize = 0x82;
+
+impl InodeDesc {
+    /// Computes the full 32-bit crc32c of `raw` over the whole `inode_size`, with
+    /// both checksum fields treated as zero (Linux `ext4_inode_csum`). The caller
+    /// splits it into `i_checksum_lo` (low 16 bits) and, when the inode has the
+    /// extra region, `i_checksum_hi` (high 16 bits). `seed` is this inode's
+    /// per-inode seed (ino and generation already folded in).
+    fn inode_checksum(raw: &RawInode, seed: InodeCsumSeed, inode_size: usize) -> u32 {
+        let bytes = raw.as_bytes();
+        let mut crc = checksum::crc32c(seed.get(), &bytes[..I_CHECKSUM_LO_OFFSET]);
+        crc = checksum::crc32c(crc, &[0u8, 0u8]); // i_checksum_lo
+        if inode_size > 128 {
+            // The extra region carries i_checksum_hi: checksum the gap between
+            // the two fields, then the zeroed hi, then the remainder.
+            crc = checksum::crc32c(crc, &bytes[I_CHECKSUM_LO_OFFSET + 2..I_CHECKSUM_HI_OFFSET]);
+            crc = checksum::crc32c(crc, &[0u8, 0u8]); // i_checksum_hi
+            crc = checksum::crc32c(crc, &bytes[I_CHECKSUM_HI_OFFSET + 2..inode_size]);
+        } else {
+            crc = checksum::crc32c(crc, &bytes[I_CHECKSUM_LO_OFFSET + 2..inode_size]);
+        }
+        crc
+    }
+
+    /// Verifies `raw`'s stored `i_checksum_lo` (and `i_checksum_hi` when the
+    /// inode has the extra region) for a `metadata_csum` volume, at the inode
+    /// read boundary. `seed` is this inode's per-inode seed.
+    pub(super) fn verify_inode_checksum(
+        raw: &RawInode,
+        seed: InodeCsumSeed,
+        inode_size: usize,
+    ) -> Result<()> {
+        let crc = Self::inode_checksum(raw, seed, inode_size);
+        if raw.checksum_lo != (crc & 0xFFFF) as u16 {
+            return_errno_with_message!(Errno::EUCLEAN, "bad inode checksum (lo)");
+        }
+        if inode_size > 128 && raw.checksum_hi != ((crc >> 16) & 0xFFFF) as u16 {
+            return_errno_with_message!(Errno::EUCLEAN, "bad inode checksum (hi)");
+        }
+        Ok(())
+    }
+}
+
+const_assert!(size_of::<RawInode>() == 256);
+
+/// The on-disk ext4 inode (256 bytes for the default `s_inode_size`).
+///
+/// The first 128 bytes match ext2's layout; the trailing fields are ext4's
+/// extra-size region (nanosecond timestamps, creation time) followed by space
+/// reserved for inline extended attributes.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawInode {
+    pub mode: u16,
+    pub uid: u16,
+    pub size_lo: u32,
+    pub atime: u32,
+    pub ctime: u32,
+    pub mtime: u32,
+    pub dtime: u32,
+    pub gid: u16,
+    pub link_count: u16,
+    /// `i_blocks` low 32 bits (512-byte sectors).
+    pub sector_count: u32,
+    pub flags: u32,
+    pub osd1: u32,
+    /// `i_block`: 60 bytes holding the inline extent-tree root.
+    pub block: [u32; RAW_BLOCK_PTRS_LEN],
+    pub generation: u32,
+    pub file_acl_lo: u32,
+    pub size_high: u32,
+    pub obso_faddr: u32,
+    // osd2 (Linux ext4 layout).
+    pub blocks_high: u16,
+    pub file_acl_high: u16,
+    pub uid_high: u16,
+    pub gid_high: u16,
+    pub checksum_lo: u16,
+    pub osd2_reserved: u16,
+    // ext4 extra-size region (present when `s_inode_size` > 128).
+    pub extra_isize: u16,
+    pub checksum_hi: u16,
+    pub ctime_extra: u32,
+    pub mtime_extra: u32,
+    pub atime_extra: u32,
+    pub crtime: u32,
+    pub crtime_extra: u32,
+    pub version_hi: u32,
+    pub projid: u32,
+    /// Space reserved for inline extended attributes (unused in Phase 1).
+    pub tail: InodeTail,
+}
+
+/// Padding from the end of the ext4 inode fields (offset 160) to the 256-byte
+/// on-disk inode size; in ext4 this holds inline extended attributes.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct InodeTail([u8; 96]);
+
+impl Default for InodeTail {
+    fn default() -> Self {
+        Self([0u8; 96])
+    }
+}
+
+/// A single ext4 inode: shared metadata plus type-specific payload.
+pub struct Inode {
+    ino: Ext4Ino,
+    type_: InodeType,
+    inner: RwMutex<InodeInner>,
+    block_group_idx: usize,
+    fs: Weak<Ext4>,
+    /// The in-memory pipe object backing a named-pipe (FIFO) inode; `None`
+    /// for every other type. Created with the inode, like ext2's.
+    pipe: Option<crate::fs::pipe::Pipe>,
+    /// The VFS extension slot (flock, POSIX locks, inotify); must exist from
+    /// day one or the VFS layer panics on inodes that use these features.
+    extension: Extension,
+}
+
+impl Inode {
+    /// Builds a live inode; fails if a data-backed extent root does not parse
+    /// (see [`InodePayload::new`]).
+    pub(super) fn new(
+        ino: Ext4Ino,
+        type_: InodeType,
+        desc: Dirty<InodeDesc>,
+        block_group_idx: usize,
+        fs: Weak<Ext4>,
+    ) -> Result<Arc<Self>> {
+        // With `metadata_csum`, external extent-tree nodes carry a tail checksum
+        // seeded per inode (ino + generation folded into the fs seed). Derive it
+        // once here; `None` when the feature is off. The read path does not
+        // verify external extent-node checksums, so the payload only holds it.
+        let csum_seed = fs.upgrade().and_then(|f| {
+            let sb = f.super_block();
+            sb.has_metadata_csum()
+                .then(|| sb.metadata_csum_seed().derive_inode(ino, desc.generation()))
+        });
+        let payload = InodePayload::new(&desc, fs.clone(), csum_seed)?;
+        let pipe = match type_ {
+            InodeType::NamedPipe => Some(crate::fs::pipe::Pipe::new()),
+            _ => None,
+        };
+        // The only fallible step (payload parsing) runs before the closure,
+        // which just assembles the inode.
+        Ok(Arc::new_cyclic(|_self_weak| Self {
+            ino,
+            type_,
+            inner: RwMutex::new(InodeInner { desc, payload }),
+            block_group_idx,
+            fs,
+            pipe,
+            extension: Extension::new(),
+        }))
+    }
+
+    pub(super) fn ino(&self) -> Ext4Ino {
+        self.ino
+    }
+
+    pub(super) fn inode_type(&self) -> InodeType {
+        self.type_
+    }
+
+    pub(super) fn size(&self) -> usize {
+        self.inner.read().file_size()
+    }
+
+    /// Reads file data at `offset` through the inode's page cache.
+    pub(super) fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        self.inner.read().read_at(offset, writer)
+    }
+
+    pub(super) fn perm(&self) -> FilePerm {
+        self.inner.read().desc.perm()
+    }
+
+    /// Returns the permission bits as a VFS `InodeMode`.
+    pub(super) fn mode(&self) -> InodeMode {
+        InodeMode::from_bits_truncate(self.perm().bits() as _)
+    }
+
+    pub(super) fn uid(&self) -> u32 {
+        self.inner.read().desc.uid()
+    }
+
+    pub(super) fn gid(&self) -> u32 {
+        self.inner.read().desc.gid()
+    }
+
+    pub(super) fn link_count(&self) -> u16 {
+        self.inner.read().desc.link_count()
+    }
+
+    pub(super) fn sector_count(&self) -> u64 {
+        self.inner.read().sector_count()
+    }
+
+    pub(super) fn atime(&self) -> Duration {
+        self.inner.read().desc.atime()
+    }
+
+    pub(super) fn mtime(&self) -> Duration {
+        self.inner.read().desc.mtime()
+    }
+
+    pub(super) fn ctime(&self) -> Duration {
+        self.inner.read().desc.ctime()
+    }
+
+    pub(super) fn crtime(&self) -> Duration {
+        self.inner.read().desc.crtime()
+    }
+
+    #[expect(dead_code)]
+    pub(super) fn block_group_idx(&self) -> usize {
+        self.block_group_idx
+    }
+
+    /// Returns a clone of the inode's page cache, if it is data-backed.
+    pub(super) fn page_cache(&self) -> Option<PageCache> {
+        self.inner.read().page_cache().ok().cloned()
+    }
+
+    /// Returns the pipe object backing a named-pipe (FIFO) inode.
+    pub(super) fn pipe(&self) -> Option<&crate::fs::pipe::Pipe> {
+        self.pipe.as_ref()
+    }
+
+    /// Returns the device id of a character/block device inode (`None`
+    /// otherwise).
+    pub(super) fn device_id(&self) -> Option<u64> {
+        self.inner.read().desc.device_id()
+    }
+
+    /// Returns the owning filesystem, or an error if it has been dropped.
+    pub(super) fn fs(&self) -> Result<Arc<Ext4>> {
+        self.fs
+            .upgrade()
+            .ok_or_else(|| Error::with_message(Errno::EIO, "filesystem dropped"))
+    }
+
+    pub(super) fn extension(&self) -> &Extension {
+        &self.extension
+    }
+}
+
+impl Drop for Inode {
+    fn drop(&mut self) {
+        // Read-only mount: inode reclaim is a write path and is cut. A read-only
+        // volume's link counts never reach 0 in memory, so `Drop` is a natural
+        // no-op (the on-disk inode is never freed here).
+    }
+}
+
+struct InodeInner {
+    desc: Dirty<InodeDesc>,
+    payload: InodePayload,
+}
+
+impl InodeInner {
+    fn file_size(&self) -> usize {
+        self.desc.size() as usize
+    }
+
+    fn page_cache(&self) -> Result<&PageCache> {
+        match &self.payload {
+            InodePayload::DataBacked { page_cache, .. } => Ok(page_cache),
+            _ => return_errno_with_message!(Errno::EINVAL, "inode has no page cache"),
+        }
+    }
+
+    fn extent_manager(&self) -> Result<&Arc<ExtentManager>> {
+        match &self.payload {
+            InodePayload::DataBacked { extent_manager, .. } => Ok(extent_manager),
+            _ => return_errno_with_message!(Errno::EINVAL, "inode has no block manager"),
+        }
+    }
+
+    /// Returns `i_blocks` (512-byte sectors). For data-backed inodes the block
+    /// manager owns the authoritative count; otherwise the descriptor's value.
+    fn sector_count(&self) -> u64 {
+        match self.extent_manager() {
+            Ok(bm) => bm.sector_count(),
+            Err(_) => self.desc.sector_count(),
+        }
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        if writer.avail() == 0 {
+            return Ok(0);
+        }
+        let file_size = self.file_size();
+        if offset >= file_size {
+            return Ok(0);
+        }
+        let read_len = writer.avail().min(file_size - offset);
+        writer.limit(read_len);
+        self.page_cache()?.read(offset, writer)?;
+        Ok(read_len)
+    }
+}
+
+/// Type-specific inode contents.
+enum InodePayload {
+    /// Regular files and directories: page-cached data mapped by extents. Also
+    /// slow (block-backed) symlinks, whose target lives in a data block.
+    DataBacked {
+        page_cache: PageCache,
+        /// The authoritative extent tree + `i_blocks`, and the page-cache
+        /// backend (the page cache holds only a `Weak` to it).
+        extent_manager: Arc<ExtentManager>,
+    },
+    /// Fast (inline) symlinks: the target bytes sit in the 60-byte `i_block`
+    /// area without any data block, and the `EXTENTS` flag is cleared.
+    FastSymlink { target: FastSymlinkTarget },
+    /// Inline data (small files stored in the inode); not supported (volumes are
+    /// mounted `^inline_data`).
+    #[expect(dead_code)]
+    Inline,
+    /// Devices, FIFOs, and sockets: no in-memory payload — a device node's id is
+    /// decoded from the descriptor's `i_block` on demand (`InodeDesc::device_id`).
+    NoPayload,
+}
+
+impl InodePayload {
+    /// Builds the payload for `desc`; fails if a data-backed inode's extent
+    /// root does not parse (`ExtentTree::try_new` — the parse-once boundary).
+    fn new(desc: &InodeDesc, fs: Weak<Ext4>, csum_seed: Option<InodeCsumSeed>) -> Result<Self> {
+        Ok(match desc.type_() {
+            // Regular files and directories are both data-backed: page-cached
+            // data mapped by an extent tree.
+            InodeType::File => Self::new_data_backed(
+                desc.size() as usize,
+                *desc.raw_block(),
+                desc.sector_count(),
+                fs,
+                csum_seed,
+            )?,
+            InodeType::Dir => Self::new_data_backed(
+                desc.size() as usize,
+                *desc.raw_block(),
+                desc.sector_count(),
+                fs,
+                csum_seed,
+            )?,
+            // A symlink is fast (inline) when it is not extent-based and its
+            // target fits strictly within the 60-byte `i_block` area (one byte
+            // is reserved for the Linux-compatible trailing NUL). Otherwise it
+            // is a slow, extent-mapped data block.
+            InodeType::SymLink => {
+                let size = desc.size() as usize;
+                if !desc.is_extent_based() && size < MAX_FAST_SYMLINK_LEN {
+                    Self::FastSymlink {
+                        target: FastSymlinkTarget::new(*desc.raw_block()),
+                    }
+                } else {
+                    Self::new_data_backed(
+                        size,
+                        *desc.raw_block(),
+                        desc.sector_count(),
+                        fs,
+                        csum_seed,
+                    )?
+                }
+            }
+            // Devices, FIFOs, and sockets carry no payload (a device id lives in
+            // the descriptor's `i_block`, decoded on demand).
+            _ => Self::NoPayload,
+        })
+    }
+
+    fn new_data_backed(
+        size: usize,
+        root: [u32; RAW_BLOCK_PTRS_LEN],
+        sector_count: u64,
+        fs: Weak<Ext4>,
+        _csum_seed: Option<InodeCsumSeed>,
+    ) -> Result<Self> {
+        let page_cache_size = size.align_up(PAGE_SIZE);
+        let page_count = page_cache_size / PAGE_SIZE;
+        let extent_manager = Arc::new(ExtentManager::try_new(root, sector_count, fs, page_count)?);
+        let backend: Weak<dyn PageCacheBackend> = Arc::downgrade(&extent_manager) as _;
+        let page_cache = PageCache::new_with_backend(page_cache_size, backend)
+            .expect("ext4 inode page cache allocation failed");
+        Ok(Self::DataBacked {
+            page_cache,
+            extent_manager,
+        })
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    /// Builds a raw root-directory inode: one data block via an (unparsed here)
+    /// extent root, link count 2, `EXT4_EXTENTS_FL` set.
+    fn raw_root_dir() -> RawInode {
+        RawInode {
+            mode: 0o040755, // S_IFDIR | 0755
+            size_lo: BLOCK_SIZE as u32,
+            link_count: 2,
+            sector_count: (BLOCK_SIZE / SECTOR_SIZE) as u32,
+            flags: FileFlags::EXTENTS.bits(),
+            extra_isize: 32,
+            ..Default::default()
+        }
+    }
+
+    /// An inode stamped with its crc32c `i_checksum_lo`/`i_checksum_hi` verifies;
+    /// a body change, a wrong inode number, or a wrong generation each fail with
+    /// `EUCLEAN`. The seed folds in the inode number and generation, so identical
+    /// bytes at a different inode number do not verify.
+    #[ktest]
+    fn inode_checksum_round_trip() {
+        const INODE_SIZE: usize = 256;
+        let fs_seed = 0xFEED_BEEF;
+        let ino: Ext4Ino = 12;
+        let mut raw = raw_root_dir();
+        raw.generation = 0x55AA;
+        let iseed = checksum::FsCsumSeed::new(fs_seed).derive_inode(ino, raw.generation);
+
+        let crc = InodeDesc::inode_checksum(&raw, iseed, INODE_SIZE);
+        raw.checksum_lo = (crc & 0xFFFF) as u16;
+        raw.checksum_hi = ((crc >> 16) & 0xFFFF) as u16;
+        InodeDesc::verify_inode_checksum(&raw, iseed, INODE_SIZE).unwrap();
+
+        // Wrong inode number / generation are folded into the seed.
+        let wrong_ino_seed =
+            checksum::FsCsumSeed::new(fs_seed).derive_inode(ino + 1, raw.generation);
+        assert_eq!(
+            InodeDesc::verify_inode_checksum(&raw, wrong_ino_seed, INODE_SIZE)
+                .unwrap_err()
+                .error(),
+            Errno::EUCLEAN
+        );
+        // A regenerated inode changes the covered body (its `generation` field),
+        // so it no longer verifies against the original seed.
+        let mut regen = raw;
+        regen.generation = 0x55AB;
+        assert!(InodeDesc::verify_inode_checksum(&regen, iseed, INODE_SIZE).is_err());
+
+        // Corrupted body (the covered range excludes the checksum fields).
+        let mut bad = raw;
+        bad.size_lo += 1;
+        assert!(InodeDesc::verify_inode_checksum(&bad, iseed, INODE_SIZE).is_err());
+
+        // Storing the checksum back does not change the covered result.
+        let recheck = InodeDesc::inode_checksum(&raw, iseed, INODE_SIZE);
+        assert_eq!(recheck, crc);
+    }
+
+    #[ktest]
+    fn decode_root_dir_inode() {
+        let raw = raw_root_dir();
+        let desc = InodeDesc::try_from(&raw).unwrap();
+        assert_eq!(desc.type_(), InodeType::Dir);
+        assert_eq!(desc.size(), BLOCK_SIZE as u64);
+        assert_eq!(desc.link_count(), 2);
+        assert!(desc.is_extent_based());
+        assert_eq!(desc.sector_count(), (BLOCK_SIZE / SECTOR_SIZE) as u64);
+    }
+
+    #[ktest]
+    fn decode_combines_uid_gid_high() {
+        let mut raw = raw_root_dir();
+        raw.uid = 0x1111;
+        raw.uid_high = 0x2222;
+        raw.gid = 0x3333;
+        raw.gid_high = 0x4444;
+        let desc = InodeDesc::try_from(&raw).unwrap();
+        assert_eq!(desc.uid, 0x2222_1111);
+        assert_eq!(desc.gid, 0x4444_3333);
+    }
+
+    #[ktest]
+    fn decode_combines_size_high_for_file() {
+        let mut raw = raw_root_dir();
+        raw.mode = 0o100644; // S_IFREG | 0644
+        raw.link_count = 1;
+        raw.size_lo = 0x0000_1000;
+        raw.size_high = 0x0000_0001; // 4 GiB + 4 KiB
+        let desc = InodeDesc::try_from(&raw).unwrap();
+        assert_eq!(desc.type_(), InodeType::File);
+        assert_eq!(desc.size(), (1u64 << 32) | 0x1000);
+    }
+
+    #[ktest]
+    fn decode_nanosecond_time() {
+        let mut raw = raw_root_dir();
+        raw.mtime = 1000;
+        raw.mtime_extra = 500 << 2; // nsec=500, epoch=0
+        let desc = InodeDesc::try_from(&raw).unwrap();
+        assert_eq!(desc.mtime, Duration::new(1000, 500));
+    }
+
+    #[ktest]
+    fn reject_unused_inode() {
+        let mut raw = raw_root_dir();
+        raw.link_count = 0;
+        assert!(InodeDesc::try_from(&raw).is_err());
+    }
+}
+
+#[cfg(ktest)]
+mod read_tests {
+    use ostd::prelude::*;
+
+    use super::{
+        super::test_utils::{Ext4FixtureBuilder, make_unwritten_file_inode},
+        *,
+    };
+
+    const FILE_INO: u32 = 11;
+
+    /// A preallocated (unwritten) extent reads back as zeros end-to-end through
+    /// `Inode::read_at`: the page-cache read path serves an unwritten mapping as
+    /// `BioStatus::Zeros` with no device I/O (the Unwritten-first read half). The
+    /// blocks count toward `i_blocks` but hold no committed data yet.
+    #[ktest]
+    fn read_unwritten_extent_reads_as_zeros() {
+        let len = 4u16;
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        // A file with a single 4-block unwritten (preallocated) extent at pblock
+        // 200 and logical size 4 blocks.
+        f.write_raw_inode(
+            FILE_INO,
+            &make_unwritten_file_inode(200, len, (len as u32) * BLOCK_SIZE as u32),
+        );
+
+        let inode = f.ext4.read_inode(FILE_INO).unwrap();
+        assert_eq!(inode.size(), len as usize * BLOCK_SIZE);
+        assert_eq!(
+            inode.sector_count(),
+            len as u64 * (BLOCK_SIZE / SECTOR_SIZE) as u64
+        );
+
+        // The whole extent reads as zeros while unwritten — the pre-filled buffer
+        // is fully overwritten with zeros, proving the read did not skip it.
+        let total = len as usize * BLOCK_SIZE;
+        let mut buf = vec![0xAAu8; total];
+        let mut writer = VmWriter::from(buf.as_mut_slice()).to_fallible();
+        let read = inode.read_at(0, &mut writer).unwrap();
+        assert_eq!(read, total);
+        assert_eq!(buf, vec![0u8; total]);
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/inode/symlink.rs
+++ b/kernel/src/fs/fs_impls/ext4/inode/symlink.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Symlink read for ext4 inodes.
+//!
+//! Ext4 distinguishes two storage strategies for symbolic link targets:
+//!
+//! - **Fast symlink** — targets shorter than 60 bytes are stored inline in the
+//!   60-byte `i_block` area of the inode without allocating any data block. One
+//!   byte is reserved for the Linux-compatible trailing NUL. Unlike a regular
+//!   file or directory, a fast symlink must *not* carry the `EXTENTS` flag: its
+//!   `i_block` holds raw target bytes, not an extent-tree root, so the extent
+//!   reader must never parse it.
+//! - **Slow symlink** — longer targets are written to an extent-mapped data
+//!   block through the normal page-cache path, exactly like a small file.
+
+use super::{
+    super::prelude::*, Inode, InodeInner, InodePayload, MAX_FAST_SYMLINK_LEN, RAW_BLOCK_PTRS_LEN,
+};
+
+/// Inline fast-symlink target stored in the raw `i_block` byte area.
+#[derive(Debug)]
+pub(super) struct FastSymlinkTarget {
+    block_ptrs: [u32; RAW_BLOCK_PTRS_LEN],
+}
+
+impl FastSymlinkTarget {
+    pub(super) fn new(block_ptrs: [u32; RAW_BLOCK_PTRS_LEN]) -> Self {
+        Self { block_ptrs }
+    }
+
+    fn read(&self, len: usize) -> Vec<u8> {
+        self.block_ptrs.as_bytes()[..len].to_vec()
+    }
+}
+
+impl Inode {
+    /// Reads symbolic link target bytes and decodes them as UTF-8.
+    pub(in crate::fs::fs_impls::ext4) fn read_link(&self) -> Result<String> {
+        if self.type_ != InodeType::SymLink {
+            return_errno!(Errno::EINVAL);
+        }
+        self.inner.read().read_link()
+    }
+}
+
+impl InodeInner {
+    /// Returns whether this symlink uses fast (inline) storage.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) fn is_fast_symlink(&self) -> bool {
+        matches!(self.payload, InodePayload::FastSymlink { .. })
+    }
+
+    fn read_link(&self) -> Result<String> {
+        let link_size = self.file_size();
+
+        if let InodePayload::FastSymlink { target } = &self.payload {
+            // Exclude the Linux-compatible trailing NUL byte from the target.
+            let read_len = link_size.min(MAX_FAST_SYMLINK_LEN - 1);
+            let target_bytes = target.read(read_len);
+            return String::from_utf8(target_bytes)
+                .map_err(|_| Error::with_message(Errno::EIO, "symlink target is not valid UTF-8"));
+        }
+
+        let mut buf = vec![0u8; link_size];
+        let mut writer = VmWriter::from(buf.as_mut_slice()).to_fallible();
+        self.page_cache()?.read(0, &mut writer).map_err(|_| {
+            Error::with_message(Errno::EIO, "failed to read symlink target from page cache")
+        })?;
+
+        String::from_utf8(buf)
+            .map_err(|_| Error::with_message(Errno::EIO, "symlink target is not valid UTF-8"))
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use aster_block::{BLOCK_SIZE, SECTOR_SIZE};
+    use ostd::prelude::*;
+
+    use super::super::{
+        super::test_utils::{Ext4Fixture, Ext4FixtureBuilder},
+        FileFlags, MAX_FAST_SYMLINK_LEN, RawInode,
+    };
+    use crate::{fs::file::InodeType, prelude::Errno};
+
+    const LINK_INO: u32 = 11;
+
+    /// Lays down a non-extent symlink at `ino`: its `i_block` holds raw target
+    /// bytes rather than an extent-tree root.
+    fn write_non_extent_symlink(f: &Ext4Fixture, ino: u32, target: &str) {
+        debug_assert!(target.len() <= MAX_FAST_SYMLINK_LEN);
+        let mut raw = RawInode {
+            mode: 0o120777, // S_IFLNK | 0777
+            size_lo: target.len() as u32,
+            link_count: 1,
+            sector_count: 0,
+            flags: 0, // a fast symlink carries no EXTENTS flag; i_block is raw bytes
+            extra_isize: 32,
+            ..Default::default()
+        };
+        // Pack the target into the 60-byte `i_block` area, little-endian words —
+        // the same on-disk layout `FastSymlinkTarget::read` decodes.
+        for (i, chunk) in target.as_bytes().chunks(4).enumerate() {
+            let mut word = [0u8; 4];
+            word[..chunk.len()].copy_from_slice(chunk);
+            raw.block[i] = u32::from_le_bytes(word);
+        }
+        f.write_raw_inode(ino, &raw);
+    }
+
+    /// Lays down a *fast* (inline) symlink at `ino`. This helper accepts only
+    /// targets that fit strictly within the 60-byte `i_block` area.
+    fn write_fast_symlink(f: &Ext4Fixture, ino: u32, target: &str) {
+        debug_assert!(target.len() < MAX_FAST_SYMLINK_LEN);
+        write_non_extent_symlink(f, ino, target);
+    }
+
+    /// Lays down a *slow* (block-backed) symlink at `ino`: an extent-mapped
+    /// symlink inode whose single data block holds the target, exactly how a
+    /// long target is stored on disk.
+    fn write_slow_symlink(f: &Ext4Fixture, ino: u32, data_block: u32, target: &str) {
+        let mut raw = RawInode {
+            mode: 0o120777, // S_IFLNK | 0777
+            size_lo: target.len() as u32,
+            link_count: 1,
+            sector_count: (BLOCK_SIZE / SECTOR_SIZE) as u32,
+            flags: FileFlags::EXTENTS.bits(),
+            extra_isize: 32,
+            ..Default::default()
+        };
+        // Inline extent root mapping logical block 0 to `data_block`, length 1.
+        raw.block[0] = 0xF30A | (1 << 16); // eh_magic | eh_entries
+        raw.block[1] = 4; // eh_max=4, eh_depth=0
+        raw.block[3] = 0; // ee_block = 0
+        raw.block[4] = 1; // ee_len=1, ee_start_hi=0
+        raw.block[5] = data_block; // ee_start_lo
+        f.write_data_block(data_block, target.as_bytes());
+        f.write_raw_inode(ino, &raw);
+    }
+
+    /// A short target (< 60 bytes) stored inline in `i_block` is decoded as a
+    /// fast symlink and `read_link` round-trips it. The inode is not
+    /// extent-based, so the extent reader never parses the raw target bytes.
+    #[ktest]
+    fn fast_symlink_reads_inline_target() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let target = "x".repeat(MAX_FAST_SYMLINK_LEN - 1);
+        write_fast_symlink(&f, LINK_INO, &target);
+
+        let link = f.ext4.read_inode(LINK_INO).unwrap();
+        assert_eq!(link.inode_type(), InodeType::SymLink);
+        assert_eq!(link.size(), target.len());
+        {
+            let inner = link.inner.read();
+            assert!(inner.is_fast_symlink());
+            // No EXTENTS flag: the target is raw bytes, never an extent root.
+            assert!(!inner.desc.is_extent_based());
+        }
+        // A fast symlink consumes no sectors.
+        assert_eq!(link.sector_count(), 0);
+        assert_eq!(link.read_link().unwrap(), target);
+    }
+
+    /// A non-extent symlink with size exactly 60 is not a fast symlink: ext4
+    /// reserves one byte for the trailing NUL. It therefore falls through to the
+    /// data-backed path, where the raw target bytes fail extent-root parsing.
+    #[ktest]
+    fn symlink_size_60_is_rejected_as_malformed_slow_symlink() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let target = "x".repeat(MAX_FAST_SYMLINK_LEN);
+        write_non_extent_symlink(&f, LINK_INO, &target);
+
+        let Err(err) = f.ext4.read_inode(LINK_INO) else {
+            panic!("non-extent size-60 symlink must not decode as fast");
+        };
+        assert_eq!(err.error(), Errno::EUCLEAN);
+    }
+
+    /// A long target (> 60 bytes, < BLOCK_SIZE) stored in an extent-mapped data
+    /// block is decoded as a slow symlink and `read_link` round-trips it through
+    /// the page-cache read path.
+    #[ktest]
+    fn slow_symlink_reads_data_block_target() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        let target = "x".repeat(200); // > MAX_FAST_SYMLINK_LEN, < BLOCK_SIZE
+        assert!(target.len() >= MAX_FAST_SYMLINK_LEN && target.len() < BLOCK_SIZE);
+        write_slow_symlink(&f, LINK_INO, 100, &target);
+
+        let link = f.ext4.read_inode(LINK_INO).unwrap();
+        assert_eq!(link.inode_type(), InodeType::SymLink);
+        assert_eq!(link.size(), target.len());
+        {
+            let inner = link.inner.read();
+            assert!(!inner.is_fast_symlink());
+            // A block-backed symlink keeps the EXTENTS flag.
+            assert!(inner.desc.is_extent_based());
+        }
+        assert_eq!(link.sector_count(), (BLOCK_SIZE / SECTOR_SIZE) as u64);
+        assert_eq!(link.read_link().unwrap(), target);
+    }
+
+    /// `read_link` rejects a non-symlink inode (the root directory) with an error.
+    #[ktest]
+    fn rejects_read_link_on_non_symlink() {
+        let f = Ext4FixtureBuilder::new(2048, 256, 2048).build().unwrap();
+        // The root (ino 2) is a directory, not a symlink.
+        let dir = f.ext4.read_inode(2).unwrap();
+        assert!(dir.read_link().is_err());
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/mod.rs
+++ b/kernel/src/fs/fs_impls/ext4/mod.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Read-only ext4 filesystem implementation.
+//!
+//! A read-only ext4 built as a sibling to `ext2`, mirroring its layering and
+//! visibility discipline. It mounts a clean, fully-checkpointed ext4 image and
+//! serves reads: superblock parse and feature gating; extent-mapped file reads
+//! (extent trees up to depth 2, Unwritten extents read as zeros); the linear
+//! and htree directory read paths (`readdir`/`lookup`); and read-time
+//! verification for the `metadata_csum`, `64bit`, and `flex_bg` features.
+//!
+//! Writing is not supported: the write-side `Inode`/`FileSystem` methods return
+//! `EROFS`, and a volume that needs recovery (the `RECOVER` feature bit set, or
+//! a non-empty orphan list) is refused at mount so that reads never observe a
+//! crash-inconsistent on-disk state. The metadata-read funnel
+//! ([`utils::read_metadata_block`]) is the seam at
+//! which a journaling layer is later reintroduced.
+
+// Set this module's log prefix for `ostd::log`.
+macro_rules! __log_prefix {
+    () => {
+        "ext4: "
+    };
+}
+
+pub use fs::Ext4;
+pub use inode::Inode;
+
+use self::fs_type::Ext4Type;
+use crate::fs::vfs::registry;
+
+mod block_group;
+mod checksum;
+mod feature;
+mod fs;
+mod fs_type;
+mod impl_for_vfs;
+mod inode;
+mod prelude;
+mod super_block;
+mod utils;
+
+#[cfg(ktest)]
+mod test_utils;
+
+/// Registers the ext4 filesystem type with the VFS registry.
+pub(super) fn init() {
+    registry::register(&Ext4Type).unwrap();
+}

--- a/kernel/src/fs/fs_impls/ext4/prelude.rs
+++ b/kernel/src/fs/fs_impls/ext4/prelude.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Re-exports used throughout the ext4 module.
+
+pub(super) use core::{
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
+
+pub(super) use align_ext::AlignExt;
+#[cfg(ktest)]
+pub(super) use aster_block::SECTOR_SIZE;
+pub(super) use aster_block::{
+    BLOCK_SIZE, BlockDevice,
+    bio::{BioCompleteFn, BioSegment, BioStatus},
+    id::Bid,
+};
+pub(super) use io_util::batch::IoBatch;
+#[cfg(ktest)]
+pub(super) use ostd::mm::{FrameAllocOptions, Segment};
+pub(super) use ostd::{
+    const_assert,
+    mm::{PAGE_SIZE, VmIo, VmWriter},
+    sync::{RwMutex, RwMutexReadGuard},
+};
+
+pub(super) use super::{
+    inode::{Ext4Bid, Ext4Ino, Iblock},
+    utils::Dirty,
+};
+pub(super) use crate::{
+    fs::{
+        file::InodeType,
+        utils::{DirentVisitor, IdBitmap, Str16, Str64},
+    },
+    prelude::*,
+    time::UnixTime,
+    vm::page_cache::{BlockAsPageCacheBackend, PageCache, PageCacheBackend},
+};

--- a/kernel/src/fs/fs_impls/ext4/super_block.rs
+++ b/kernel/src/fs/fs_impls/ext4/super_block.rs
@@ -1,0 +1,1148 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! On-disk ext4 superblock parsing and the validated in-memory representation.
+//!
+//! The ext4 superblock shares its first 264 bytes of layout with ext2; the
+//! ext4-specific fields live in the trailing reserved area. The group
+//! descriptor size (`s_desc_size`) is parsed here so `flex_bg` images mount
+//! (their bitmaps/tables come from the descriptor getters, so relocating them
+//! needs no geometry change), and the `64BIT` high halves of the block counts
+//! (`s_blocks_count_hi` / `s_free_blocks_count_hi`) are spliced at the parse
+//! boundary so `> 2^32`-block volumes count correctly. The metadata-checksum
+//! fields are parsed and, for a `metadata_csum` volume, the superblock checksum
+//! is verified at this boundary.
+
+use super::{
+    checksum::{self, FsCsumSeed},
+    feature::{
+        FeatureCompatSet, FeatureIncompatSet, FeatureRoCompatSet, INCOMPAT_SUPP, RO_COMPAT_SUPP,
+    },
+    inode::RawInode,
+    prelude::*,
+};
+
+/// Magic signature (`s_magic`).
+pub(super) const MAGIC_NUM: u16 = 0xef53;
+
+/// The main superblock is located at byte 1024 from the start of the device.
+pub(super) const SUPER_BLOCK_OFFSET: usize = 1024;
+
+const SUPER_BLOCK_SIZE: usize = 1024;
+
+/// Classic group-descriptor size in bytes, and the size forced when the `64BIT`
+/// feature is absent (Linux `EXT4_MIN_DESC_SIZE`).
+const MIN_DESC_SIZE: u16 = 32;
+
+/// Smallest group descriptor a `64BIT` volume may declare (Linux
+/// `EXT4_MIN_DESC_SIZE_64BIT`). With `64BIT` set, `s_desc_size` must be at
+/// least this — a smaller value contradicts the wide on-disk GDT stride.
+const MIN_DESC_SIZE_64BIT: u16 = 64;
+
+/// Widest group descriptor the `64BIT` feature defines (Linux
+/// `EXT4_MAX_DESC_SIZE`); the 64-byte descriptor carries the high halves and
+/// per-group checksums.
+const MAX_DESC_SIZE: u16 = 64;
+
+/// `s_flags` bit recording that the on-disk htree hashes were computed treating
+/// name bytes as signed `char` (`EXT2_FLAGS_SIGNED_HASH`). Present here for
+/// documentation of the two-bit signedness encoding; the reader only needs the
+/// unsigned bit, defaulting to signed when neither is set.
+#[expect(dead_code)]
+const EXT2_FLAGS_SIGNED_HASH: u32 = 0x1;
+
+/// `s_flags` bit recording that the on-disk htree hashes were computed treating
+/// name bytes as unsigned `char` (`EXT2_FLAGS_UNSIGNED_HASH`); selects the
+/// `*_UNSIGNED` hash variants in `dx_probe`.
+const EXT2_FLAGS_UNSIGNED_HASH: u32 = 0x2;
+
+/// Validated, Rust-typed in-memory representation of the ext4 superblock.
+///
+/// Counts that the `64BIT` feature widens are stored as `u64`, and the parse
+/// boundary splices in their high halves for a `64BIT` volume (the high halves
+/// are zero on a 32-bit volume).
+#[derive(Clone, Copy, Debug)]
+pub(super) struct SuperBlock {
+    inodes_count: u32,
+    blocks_count: u64,
+    free_blocks_count: u64,
+    free_inodes_count: u32,
+    first_data_block: Ext4Bid,
+    block_size: usize,
+    nr_blocks_per_group: u32,
+    /// Number of block groups, computed once at parse from the geometry above
+    /// (rounding up the last partial group).
+    nr_block_groups: u32,
+    nr_inodes_per_group: u32,
+    // The fields below are decoded from the raw superblock and consumed by the
+    // read, statfs, and checksum-verify paths. A few not yet read by any path
+    // (e.g. `rev_level`, `state`) still carry an `#[expect(dead_code)]` marker on
+    // their accessor.
+    nr_inode_table_blocks_per_group: u32,
+    inode_size: usize,
+    /// Effective group-descriptor size in bytes (32 or 64), already resolved
+    /// from the raw `s_desc_size` sentinel by [`parse_desc_size`].
+    desc_size: u16,
+    first_ino: u32,
+    rev_level: RevLevel,
+    state: FsState,
+    feature_compat: FeatureCompatSet,
+    feature_incompat: FeatureIncompatSet,
+    feature_ro_compat: FeatureRoCompatSet,
+    uuid: [u8; 16],
+    last_orphan: Option<Ext4Ino>,
+    reserved_blocks_count: u32,
+    /// `s_reserved_gdt_blocks` widened once at parse; consumed only by
+    /// [`Self::metadata_overhead`] (an image built with `^resize_inode` has none).
+    reserved_gdt_blocks: u32,
+    /// `s_hash_seed`: the four seed words feeding the htree name hash. Consumed
+    /// by `dx_probe` (P6d) to reproduce the hashes the entries were indexed by.
+    hash_seed: [u32; 4],
+    /// Whether the on-disk htree hashes treat name bytes as unsigned `char`
+    /// (`s_flags & EXT2_FLAGS_UNSIGNED_HASH`); picks the `*_UNSIGNED` hash
+    /// variant. Defaults to signed (`false`) when neither signedness bit is set.
+    hash_unsigned: bool,
+}
+
+impl TryFrom<RawSuperBlock> for SuperBlock {
+    type Error = Error;
+
+    fn try_from(sb: RawSuperBlock) -> Result<Self> {
+        if sb.magic != MAGIC_NUM {
+            return_errno_with_message!(Errno::EINVAL, "bad ext4 magic number");
+        }
+
+        // Only the 4 KiB block size the page-cache model assumes (page index ==
+        // logical block) is supported.
+        if sb.log_block_size != 2 {
+            return_errno_with_message!(Errno::EINVAL, "unsupported block size (4 KiB only)");
+        }
+        if sb.log_frag_size != sb.log_block_size {
+            return_errno_with_message!(Errno::EINVAL, "invalid fragment size");
+        }
+        let block_size = BLOCK_SIZE;
+
+        let state = FsState::from_bits_truncate(sb.state);
+
+        let errors_behavior = ErrorsBehavior::try_from(sb.errors)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "invalid errors behavior"))?;
+        if errors_behavior != ErrorsBehavior::Continue {
+            return_errno_with_message!(Errno::EINVAL, "unsupported errors behavior");
+        }
+
+        let creator_os = OsId::try_from(sb.creator_os)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "invalid creator os"))?;
+        if creator_os != OsId::Linux {
+            return_errno_with_message!(Errno::EINVAL, "unsupported creator os");
+        }
+
+        let rev_level = RevLevel::try_from(sb.rev_level)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "invalid revision level"))?;
+        let (first_ino, inode_size) = match rev_level {
+            RevLevel::GoodOld => (11, 128usize),
+            RevLevel::Dynamic => {
+                let inode_size = sb.inode_size as usize;
+                // Must divide the 4 KiB block (power of two, not exceeding it) so no
+                // inode straddles a block boundary.
+                if inode_size > block_size || !inode_size.is_power_of_two() {
+                    return_errno_with_message!(Errno::EINVAL, "invalid inode size");
+                }
+                (sb.first_ino, inode_size)
+            }
+        };
+
+        // The inode decode reads a fixed `size_of::<RawInode>()`
+        // (256-byte) slot, and the metadata-csum path checks exactly that raw
+        // slot. This 256-centric port therefore admits exactly 256-byte inodes:
+        // a narrower legacy slot would make the fixed read window cross inode
+        // boundaries, while a wider slot would make checksum verification slice
+        // past the fixed `RawInode` buffer.
+        // Checked after the rev-level match so it also covers the `GoodOld` path,
+        // which forces 128 and skips the `Dynamic` size validation above.
+        if inode_size != size_of::<RawInode>() {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "unsupported inode size: this read-only port handles only 256-byte inodes"
+            );
+        }
+
+        // Reject any incompatible feature this phase cannot honor, rather than
+        // silently misreading the volume.
+        let unsupported_incompat = sb.feature_incompat & !INCOMPAT_SUPP.bits();
+        if unsupported_incompat != 0 {
+            return_errno_with_message!(Errno::EINVAL, "unsupported incompatible feature");
+        }
+        let feature_incompat = FeatureIncompatSet::from_bits_truncate(sb.feature_incompat);
+        if !feature_incompat.contains(FeatureIncompatSet::EXTENTS) {
+            return_errno_with_message!(Errno::EINVAL, "ext4 image without the extents feature");
+        }
+
+        // Read-only fail-closed (dirty-volume policy): this mount carries no
+        // journal-replay machinery, so a volume that still needs recovery must be
+        // refused, not read verbatim as a possibly pre-crash inconsistent state.
+        // The RECOVER incompat bit is already rejected above (dropped from
+        // `INCOMPAT_SUPP`); a pending orphan list (`s_last_orphan != 0`) is the
+        // other half of `needs_recovery` and is refused here.
+        if sb.last_orphan != 0 {
+            return_errno_with_message!(
+                Errno::EROFS,
+                "dirty ext4 volume needs recovery; refusing read-only mount"
+            );
+        }
+        let feature_compat = FeatureCompatSet::from_bits_truncate(sb.feature_compat);
+
+        // Resolve `s_desc_size` at this boundary into the effective descriptor
+        // size the group-descriptor decoder strides by: `EXT4_DESC_SIZE =
+        // has_64bit ? s_desc_size : 32`. With `64BIT` now supported, a 64-byte
+        // descriptor is admitted and decoded wide by `BlockGroup::read_desc`.
+        let desc_size = parse_desc_size(
+            sb.desc_size,
+            feature_incompat.contains(FeatureIncompatSet::IS_64BIT),
+        )?;
+
+        // A ro_compat feature outside `RO_COMPAT_SUPP` (e.g. `GDT_CSUM` or
+        // `BIGALLOC`) may carry on-disk layout or semantics this reader cannot
+        // interpret, so mounting the volume would risk misreading it. Refuse
+        // the mount with `EROFS` (Linux `ext4_setup_super` refuses `MS_RDWR`
+        // the same way). Checked on the raw bits so bits unknown to
+        // `FeatureRoCompatSet` are caught too.
+        if sb.feature_ro_compat & !RO_COMPAT_SUPP.bits() != 0 {
+            return_errno_with_message!(
+                Errno::EROFS,
+                "unsupported read-only-compatible feature; refusing mount"
+            );
+        }
+        let feature_ro_compat = FeatureRoCompatSet::from_bits_truncate(sb.feature_ro_compat);
+
+        // Verify the superblock's own checksum at the parse boundary (Linux
+        // `ext4_superblock_csum_verify`). `METADATA_CSUM` is in `RO_COMPAT_SUPP`,
+        // so a checksummed volume passes the `EROFS` gate above and reaches here
+        // on every mount.
+        if feature_ro_compat.contains(FeatureRoCompatSet::METADATA_CSUM) {
+            Self::verify_superblock_checksum(&sb)?;
+        }
+
+        let nr_inodes_per_group = sb.inodes_per_group;
+        let nr_blocks_per_group = sb.blocks_per_group;
+        if nr_inodes_per_group == 0 || nr_blocks_per_group == 0 {
+            return_errno_with_message!(Errno::EINVAL, "invalid group sizes");
+        }
+
+        let inodes_per_block = (block_size / inode_size) as u32;
+        let max_bits_per_group = (block_size as u32) * 8;
+        if nr_inodes_per_group < inodes_per_block || nr_inodes_per_group > max_bits_per_group {
+            return_errno_with_message!(Errno::EINVAL, "invalid inodes per group");
+        }
+        if nr_blocks_per_group > max_bits_per_group {
+            return_errno_with_message!(Errno::EINVAL, "blocks per group is too large");
+        }
+
+        let nr_inode_table_blocks_per_group = nr_inodes_per_group / inodes_per_block;
+        if nr_blocks_per_group <= nr_inode_table_blocks_per_group + 3 {
+            return_errno_with_message!(Errno::EINVAL, "blocks per group is too small");
+        }
+
+        // Splice the 64-bit block counts at this one parse boundary: the high
+        // halves are honored only with the `64BIT` feature, and a non-64bit image
+        // carrying a non-zero high half is malformed (rejected inside the helper).
+        let is_64bit = feature_incompat.contains(FeatureIncompatSet::IS_64BIT);
+        let blocks_count = splice_count_hi(sb.blocks_count, sb.blocks_count_hi, is_64bit)?;
+        let free_blocks_count =
+            splice_count_hi(sb.free_blocks_count, sb.free_blocks_count_hi, is_64bit)?;
+
+        let first_data_block = sb.first_data_block as u64;
+        if blocks_count <= first_data_block + 1 {
+            return_errno_with_message!(Errno::EINVAL, "invalid blocks count");
+        }
+        let nr_block_groups =
+            (blocks_count - first_data_block - 1) / nr_blocks_per_group as u64 + 1;
+        let nr_block_groups = u32::try_from(nr_block_groups)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "block group count exceeds 32 bits"))?;
+
+        let max_inodes = nr_block_groups as u64 * nr_inodes_per_group as u64;
+        let min_inodes = (nr_block_groups as u64 - 1) * nr_inodes_per_group as u64;
+        let inodes_count = sb.inodes_count as u64;
+        if inodes_count <= min_inodes || inodes_count > max_inodes {
+            return_errno_with_message!(Errno::EINVAL, "invalid inodes count");
+        }
+        if free_blocks_count > blocks_count {
+            return_errno_with_message!(Errno::EINVAL, "free blocks count exceeds blocks count");
+        }
+        if sb.free_inodes_count > sb.inodes_count {
+            return_errno_with_message!(Errno::EINVAL, "free inodes count exceeds inodes count");
+        }
+
+        Ok(Self {
+            inodes_count: sb.inodes_count,
+            blocks_count,
+            free_blocks_count,
+            free_inodes_count: sb.free_inodes_count,
+            first_data_block,
+            block_size,
+            nr_blocks_per_group,
+            nr_block_groups,
+            nr_inodes_per_group,
+            nr_inode_table_blocks_per_group,
+            inode_size,
+            desc_size,
+            first_ino,
+            rev_level,
+            state,
+            feature_compat,
+            feature_incompat,
+            feature_ro_compat,
+            uuid: sb.uuid,
+            // `0 = empty` is the on-disk convention; in memory the head is an
+            // `Option` and the sentinel stops at this parse boundary.
+            last_orphan: (sb.last_orphan != 0).then_some(sb.last_orphan),
+            reserved_blocks_count: sb.reserved_blocks_count,
+            reserved_gdt_blocks: u32::from(sb.reserved_gdt_blocks),
+            hash_seed: sb.hash_seed,
+            // Neither signedness bit set means signed `char` (the historical
+            // default); only `UNSIGNED_HASH` flips it (Linux `ext4_fill_super`).
+            hash_unsigned: sb.flags & EXT2_FLAGS_UNSIGNED_HASH != 0,
+        })
+    }
+}
+
+impl SuperBlock {
+    pub(super) const fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    pub(super) const fn inode_size(&self) -> usize {
+        self.inode_size
+    }
+
+    /// Returns the effective group-descriptor size in bytes (`EXT4_DESC_SIZE`):
+    /// the raw `s_desc_size` when the `64BIT` feature is set, else the classic
+    /// 32. Drives the GDT stride and the 32-vs-64-byte descriptor decode in
+    /// [`BlockGroup::load`](super::block_group::BlockGroup).
+    pub(super) const fn desc_size(&self) -> u16 {
+        self.desc_size
+    }
+
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn first_ino(&self) -> u32 {
+        self.first_ino
+    }
+
+    pub(super) const fn nr_inodes_per_group(&self) -> u32 {
+        self.nr_inodes_per_group
+    }
+
+    pub(super) const fn nr_blocks_per_group(&self) -> u32 {
+        self.nr_blocks_per_group
+    }
+
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn nr_inode_table_blocks_per_group(&self) -> u32 {
+        self.nr_inode_table_blocks_per_group
+    }
+
+    pub(super) const fn first_data_block(&self) -> Ext4Bid {
+        self.first_data_block
+    }
+
+    pub(super) const fn total_inodes(&self) -> u32 {
+        self.inodes_count
+    }
+
+    pub(super) const fn total_blocks(&self) -> u64 {
+        self.blocks_count
+    }
+
+    pub(super) const fn free_blocks_count(&self) -> u64 {
+        self.free_blocks_count
+    }
+
+    pub(super) const fn free_inodes_count(&self) -> u32 {
+        self.free_inodes_count
+    }
+
+    /// Returns the number of block groups (computed once at parse, rounding up
+    /// the last partial group).
+    pub(super) const fn nr_block_groups(&self) -> u32 {
+        self.nr_block_groups
+    }
+
+    /// Returns the number of inodes stored per block.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn inodes_per_block(&self) -> u32 {
+        (self.block_size / self.inode_size) as u32
+    }
+
+    #[expect(dead_code)]
+    pub(super) const fn rev_level(&self) -> RevLevel {
+        self.rev_level
+    }
+
+    #[expect(dead_code)]
+    pub(super) const fn state(&self) -> FsState {
+        self.state
+    }
+
+    pub(super) const fn uuid(&self) -> &[u8; 16] {
+        &self.uuid
+    }
+
+    /// Returns whether this volume carries crc32c metadata checksums
+    /// (`metadata_csum`). When false, every checksum compute/verify site is a
+    /// no-op, so a checksum-free image is handled byte-for-byte as in Phases 1–5.
+    pub(super) fn has_metadata_csum(&self) -> bool {
+        self.feature_ro_compat
+            .contains(FeatureRoCompatSet::METADATA_CSUM)
+    }
+
+    /// Returns the per-filesystem checksum seed feeding the group-descriptor,
+    /// inode, bitmap, directory, and extent checksums: `crc32c(!0, uuid)`. (A
+    /// `csum_seed`-incompat volume, which would override this with an on-disk
+    /// seed word, is refused at the incompat gate, so the UUID is authoritative.)
+    /// The superblock's own checksum does not use this seed.
+    pub(super) fn metadata_csum_seed(&self) -> FsCsumSeed {
+        FsCsumSeed::new(checksum::crc32c(!0, &self.uuid))
+    }
+
+    /// Computes the crc32c of `raw`'s first [`S_CHECKSUM_OFFSET`] bytes: the
+    /// superblock's own checksum. Seeded with `!0` — the superblock, unlike group
+    /// descriptors and inodes, does not use the per-filesystem seed (Linux
+    /// `ext4_superblock_csum`). The covered range stops short of `s_checksum`, so
+    /// the result does not depend on the field's current value; a writer stores
+    /// it straight back.
+    pub(super) fn superblock_checksum(raw: &RawSuperBlock) -> u32 {
+        checksum::crc32c(!0, &raw.as_bytes()[..S_CHECKSUM_OFFSET])
+    }
+
+    /// Verifies `raw`'s stored `s_checksum` (and that `s_checksum_type` names
+    /// crc32c), for a `metadata_csum` volume at the parse boundary.
+    pub(super) fn verify_superblock_checksum(raw: &RawSuperBlock) -> Result<()> {
+        if raw.as_bytes()[S_CHECKSUM_TYPE_OFFSET] != CHECKSUM_TYPE_CRC32C {
+            return_errno_with_message!(Errno::EUCLEAN, "superblock checksum type is not crc32c");
+        }
+        if raw.checksum != Self::superblock_checksum(raw) {
+            return_errno_with_message!(Errno::EUCLEAN, "bad superblock checksum");
+        }
+        Ok(())
+    }
+
+    /// Returns the blocks reserved for privileged processes
+    /// (`s_r_blocks_count`); `statfs` subtracts them from `bfree` to report
+    /// `bavail`.
+    pub(super) const fn reserved_blocks_count(&self) -> u32 {
+        self.reserved_blocks_count
+    }
+
+    /// Returns whether block group `group` carries a copy of the superblock and
+    /// group-descriptor table (Linux `ext4_bg_has_super`).
+    ///
+    /// Without `sparse_super` every group has one. With it, only groups 0 and 1
+    /// and the odd powers of 3, 5, and 7 do; the rest carry data only. The
+    /// unsupported `sparse_super2` layout (not in `RO_COMPAT_SUPP`) is refused at
+    /// the mount gate, so this mirrors the sparse/dense split alone.
+    fn bg_has_super(&self, group: u32) -> bool {
+        if group <= 1 {
+            return true;
+        }
+        if !self
+            .feature_ro_compat
+            .contains(FeatureRoCompatSet::SPARSE_SUPER)
+        {
+            return true;
+        }
+        if group.is_multiple_of(2) {
+            return false;
+        }
+        is_power_of(group, 3) || is_power_of(group, 5) || is_power_of(group, 7)
+    }
+
+    /// Computes the on-disk metadata overhead in blocks, excluding the journal
+    /// (Linux `ext4_calculate_overhead`, non-`bigalloc` path; `bigalloc` is not
+    /// in `RO_COMPAT_SUPP`, so every mounted volume takes this path).
+    ///
+    /// The sum is: the blocks before `first_data_block`, plus per group the block
+    /// bitmap, inode bitmap, and inode-table blocks — and, in each group that
+    /// carries a superblock/GDT copy, the superblock block, the group-descriptor
+    /// blocks, and the reserved GDT-growth blocks. `flex_bg` only relocates these
+    /// within a flex group without changing their count, so the geometry sum is
+    /// unchanged. `statfs` reports `f_blocks = total_blocks - overhead`,
+    /// so unprivileged `df` sees usable capacity rather than the raw device size.
+    pub(super) fn metadata_overhead(&self) -> u64 {
+        // Number of group descriptors that fit in one block (`EXT4_DESC_PER_BLOCK`),
+        // hence the count of primary GDT blocks. `meta_bg` (not in `INCOMPAT_SUPP`)
+        // would spread the GDT differently, so its absence keeps this contiguous.
+        let desc_per_block = u64::try_from(self.block_size / usize::from(self.desc_size)).unwrap();
+        let gdt_blocks = u64::from(self.nr_block_groups).div_ceil(desc_per_block);
+
+        let per_group_data = u64::from(self.nr_inode_table_blocks_per_group) + 2;
+        let per_super_group = 1 + gdt_blocks + u64::from(self.reserved_gdt_blocks);
+
+        let groups_with_super = u64::try_from(
+            (0..self.nr_block_groups)
+                .filter(|&group| self.bg_has_super(group))
+                .count(),
+        )
+        .unwrap();
+
+        self.first_data_block
+            + per_group_data * u64::from(self.nr_block_groups)
+            + per_super_group * groups_with_super
+    }
+
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) const fn feature_incompat(&self) -> FeatureIncompatSet {
+        self.feature_incompat
+    }
+
+    #[expect(dead_code)]
+    pub(super) const fn feature_ro_compat(&self) -> FeatureRoCompatSet {
+        self.feature_ro_compat
+    }
+
+    /// Returns the four-word htree name-hash seed (`s_hash_seed`).
+    pub(super) fn hash_seed(&self) -> &[u32; 4] {
+        &self.hash_seed
+    }
+
+    /// Returns whether the on-disk htree hashes treat name bytes as unsigned
+    /// `char` (`s_flags & EXT2_FLAGS_UNSIGNED_HASH`); `dx_probe` adds this to the
+    /// root's hash version to pick the matching variant.
+    pub(super) fn hash_unsigned(&self) -> bool {
+        self.hash_unsigned
+    }
+
+    /// Returns whether the volume carries htree directory indexes
+    /// (`COMPAT_DIR_INDEX`); a directory can only be probed as an htree when set.
+    pub(super) fn has_dir_index(&self) -> bool {
+        self.feature_compat.contains(FeatureCompatSet::DIR_INDEX)
+    }
+
+    /// Returns whether the volume still needs journal replay (the `RECOVER` bit
+    /// is set or an orphan list is pending). A read-only mount refuses such a
+    /// volume at parse time rather than reading a possibly pre-crash state.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(super) fn needs_recovery(&self) -> bool {
+        self.feature_incompat.contains(FeatureIncompatSet::RECOVER) || self.last_orphan.is_some()
+    }
+}
+
+/// Resolves and validates the raw `s_desc_size` into the effective
+/// group-descriptor size in bytes.
+///
+/// Mirrors Linux ext4 `super.c`: the on-disk field is honored only with the
+/// `64BIT` feature (`EXT4_DESC_SIZE = has_64bit ? s_desc_size : 32`); a `0` on
+/// disk means the classic 32-byte descriptor either way. When honored the size
+/// must be a power of two within `[MIN_DESC_SIZE, MAX_DESC_SIZE]`.
+///
+/// The classic-layout branch is deliberately strict: without `64BIT` the
+/// descriptor is 32 bytes, so a raw value other than the unset sentinel or the
+/// classic size would be silently misread, and we reject it instead.
+fn parse_desc_size(raw: u16, has_64bit: bool) -> Result<u16> {
+    if !has_64bit {
+        // Without the 64bit feature `s_desc_size` is not authoritative: `0`
+        // (unset) or the classic `32` both mean 32-byte descriptors, and any
+        // other value is a malformed superblock. The sentinel `0` stops here.
+        if raw != 0 && raw != MIN_DESC_SIZE {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "group descriptor size set without the 64bit feature"
+            );
+        }
+        return Ok(MIN_DESC_SIZE);
+    }
+
+    // With 64bit, `s_desc_size` is authoritative and MUST describe a 64-bit
+    // descriptor. Mirror Linux `super.c` (EXT4_MIN_DESC_SIZE_64BIT): it does NOT
+    // fold `0` to a default here and rejects anything below 64. Otherwise a
+    // 64bit image whose `s_desc_size` disagrees with its physical 64-byte GDT
+    // stride would mount and read every group's descriptor at the wrong offset —
+    // the refused-mount → silent-cross-linked-corruption the red-line forbids.
+    if raw < MIN_DESC_SIZE_64BIT || raw > MAX_DESC_SIZE || !raw.is_power_of_two() {
+        return_errno_with_message!(Errno::EINVAL, "invalid 64bit group descriptor size");
+    }
+    // `read_desc` strides by this size and decodes the 64-byte layout's high
+    // halves; it stays in lockstep with `IS_64BIT ∈ INCOMPAT_SUPP`.
+    Ok(raw)
+}
+
+/// Whether `value` is a positive integer power of `base` (`value == base^k`,
+/// `k >= 1`), mirroring Linux `test_root`. Sparse-super backups live in groups
+/// that are powers of 3, 5, or 7, so [`SuperBlock::bg_has_super`] tests each base.
+fn is_power_of(value: u32, base: u32) -> bool {
+    let mut remaining = value;
+    while remaining > base {
+        if !remaining.is_multiple_of(base) {
+            return false;
+        }
+        remaining /= base;
+    }
+    remaining == base
+}
+
+/// Splices a superblock 64-bit block count's low and high halves into a `u64`.
+///
+/// The one read-side boundary for `s_{blocks,free_blocks}_count{,_hi}`
+/// (rust_rules #3). `(lo as u64) | ((hi as u64) << 32)` is lossless. The high
+/// half is honored only with the `64BIT` feature; a non-64bit image with a
+/// non-zero high half is malformed — that field is defined only under `64BIT` —
+/// and is rejected rather than silently folded in.
+fn splice_count_hi(lo: u32, hi: u32, has_64bit: bool) -> Result<u64> {
+    if !has_64bit {
+        if hi != 0 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "64-bit count high half set without the 64bit feature"
+            );
+        }
+        return Ok(lo as u64);
+    }
+    Ok((lo as u64) | ((hi as u64) << 32))
+}
+
+/// The ext4 revision level (`s_rev_level`).
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+pub(super) enum RevLevel {
+    /// Original format with a fixed 128-byte inode.
+    GoodOld = 0,
+    /// V2 format with a dynamic inode size (ext4 uses this).
+    Dynamic = 1,
+}
+
+bitflags! {
+    /// Filesystem state (`s_state`).
+    pub(super) struct FsState: u16 {
+        /// Unmounted cleanly.
+        const VALID = 1 << 0;
+        /// Errors detected.
+        const ERROR = 1 << 1;
+        /// Orphan inodes are being recovered.
+        const ORPHAN = 1 << 2;
+    }
+}
+
+/// Action taken when an error is detected (`s_errors`).
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, TryFromInt)]
+pub(super) enum ErrorsBehavior {
+    /// Continues execution.
+    #[default]
+    Continue = 1,
+    /// Remounts the filesystem read-only.
+    RemountReadonly = 2,
+    /// Panics.
+    Panic = 3,
+}
+
+/// OS that created the filesystem (`s_creator_os`).
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
+pub(super) enum OsId {
+    Linux = 0,
+    Hurd = 1,
+    Masix = 2,
+    FreeBSD = 3,
+    Lites = 4,
+}
+
+const_assert!(size_of::<RawSuperBlock>() == SUPER_BLOCK_SIZE);
+
+/// The on-disk superblock structure (exactly 1024 bytes).
+///
+/// Convert to `SuperBlock` via `TryFrom` for the validated representation.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct RawSuperBlock {
+    pub inodes_count: u32,
+    pub blocks_count: u32,
+    pub reserved_blocks_count: u32,
+    pub free_blocks_count: u32,
+    pub free_inodes_count: u32,
+    pub first_data_block: u32,
+    /// The number to left-shift 1024 by to obtain the block size.
+    pub log_block_size: u32,
+    /// The number to left-shift 1024 by to obtain the fragment size.
+    pub log_frag_size: u32,
+    pub blocks_per_group: u32,
+    pub frags_per_group: u32,
+    pub inodes_per_group: u32,
+    pub mtime: UnixTime,
+    pub wtime: UnixTime,
+    pub mnt_count: u16,
+    pub max_mnt_count: u16,
+    pub magic: u16,
+    pub state: u16,
+    pub errors: u16,
+    pub min_rev_level: u16,
+    pub last_check_time: UnixTime,
+    pub check_interval: u32,
+    pub creator_os: u32,
+    pub rev_level: u32,
+    pub default_reserved_uid: u16,
+    pub default_reserved_gid: u16,
+    pub first_ino: u32,
+    pub inode_size: u16,
+    pub block_group_idx: u16,
+    pub feature_compat: u32,
+    pub feature_incompat: u32,
+    pub feature_ro_compat: u32,
+    pub uuid: [u8; 16],
+    pub volume_name: Str16,
+    pub last_mounted_dir: Str64,
+    pub algorithm_usage_bitmap: u32,
+    pub prealloc_file_blocks: u8,
+    pub prealloc_dir_blocks: u8,
+    /// `s_reserved_gdt_blocks` (0xCE): blocks reserved after the group-descriptor
+    /// table so the GDT can grow on an online resize. They are filesystem
+    /// overhead in every group that carries a superblock/GDT copy, so
+    /// [`SuperBlock::metadata_overhead`] counts them there (Linux `count_overhead`).
+    pub reserved_gdt_blocks: u16,
+    pub journal_uuid: [u8; 16],
+    pub journal_ino: u32,
+    pub journal_dev: u32,
+    pub last_orphan: u32,
+    pub hash_seed: [u32; 4],
+    pub def_hash_version: u8,
+    pub(super) reserved_char_pad: u8,
+    /// `s_desc_size`: on-disk group-descriptor size in bytes (offset 0xFE).
+    /// Honored only with the `64BIT` feature; `0` means the classic 32-byte
+    /// descriptor. Validated at the parse boundary by [`parse_desc_size`].
+    pub(super) desc_size: u16,
+    pub default_mount_opts: u32,
+    pub first_meta_bg: u32,
+    /// `s_mkfs_time` (0x108): filesystem creation time.
+    pub mkfs_time: UnixTime,
+    /// `s_jnl_blocks` (0x10C): backup of the journal inode's block map.
+    pub jnl_blocks: [u32; 17],
+    /// `s_blocks_count_hi` (0x150): high 32 bits of the total block count.
+    /// Honored only with the `64BIT` feature; spliced with `blocks_count` at the
+    /// parse boundary ([`SuperBlock::try_from`]).
+    pub blocks_count_hi: u32,
+    /// `s_r_blocks_count_hi` (0x154): high 32 bits of the reserved block count.
+    /// Named for correct field placement; `reserved_blocks_count` stays 32-bit
+    /// (a >2^32-block reserve is beyond the supported geometry).
+    pub r_blocks_count_hi: u32,
+    /// `s_free_blocks_count_hi` (0x158): high 32 bits of the free block count.
+    /// Honored only with the `64BIT` feature; spliced with `free_blocks_count` at
+    /// the parse boundary.
+    pub free_blocks_count_hi: u32,
+    /// `s_min_extra_isize` (0x15C, u16) + `s_want_extra_isize` (0x15E, u16),
+    /// carved out only to place `flags` at the correct offset; not consumed.
+    pub(super) extra_isize_hints: u32,
+    /// `s_flags` (0x160): miscellaneous filesystem flags. The two low bits record
+    /// which `char` signedness the on-disk htree hashes were computed with
+    /// ([`EXT2_FLAGS_SIGNED_HASH`] / [`EXT2_FLAGS_UNSIGNED_HASH`]); `dx_probe`
+    /// reads them to pick the matching hash variant.
+    pub flags: u32,
+    pub(super) reserved: Reserved,
+    /// `s_checksum` (0x3FC): crc32c of the superblock over its first
+    /// [`S_CHECKSUM_OFFSET`] bytes — the last word of the 1024-byte block.
+    /// Meaningful only with `metadata_csum`; computed by
+    /// [`SuperBlock::superblock_checksum`] and verified at the parse boundary.
+    pub checksum: u32,
+}
+
+/// Byte offset of `s_checksum` in the on-disk superblock (0x3FC): the crc32c
+/// covers exactly `[0, S_CHECKSUM_OFFSET)`, stopping short of the field itself.
+const S_CHECKSUM_OFFSET: usize = 0x3FC;
+
+/// Byte offset of `s_checksum_type` (0x175); `metadata_csum` requires it to name
+/// crc32c ([`CHECKSUM_TYPE_CRC32C`]).
+const S_CHECKSUM_TYPE_OFFSET: usize = 0x175;
+
+/// The only `s_checksum_type` ext4 defines: crc32c.
+const CHECKSUM_TYPE_CRC32C: u8 = 1;
+
+/// Reserved padding filling the on-disk superblock up to `s_checksum` at 0x3FC.
+/// In ext4 this region also holds the checksum-seed and mount-option fields; the
+/// checksum seed is derived from the UUID instead (a `csum_seed`-incompat volume
+/// is refused at the feature gate, so the on-disk seed word is never consulted).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub(super) struct Reserved([u32; 166]);
+
+impl Default for Reserved {
+    fn default() -> Self {
+        Self([0u32; 166])
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    /// Builds a minimal-feature (extent + filetype) raw superblock for a small
+    /// 4 KiB-block image with the given geometry.
+    fn minimal_raw(
+        blocks_count: u32,
+        blocks_per_group: u32,
+        inodes_per_group: u32,
+    ) -> RawSuperBlock {
+        let nr_groups = (blocks_count - 1) / blocks_per_group + 1;
+        RawSuperBlock {
+            inodes_count: nr_groups * inodes_per_group,
+            blocks_count,
+            free_blocks_count: 0,
+            free_inodes_count: 0,
+            first_data_block: 0,
+            log_block_size: 2,
+            log_frag_size: 2,
+            blocks_per_group,
+            frags_per_group: blocks_per_group,
+            inodes_per_group,
+            magic: MAGIC_NUM,
+            state: FsState::VALID.bits(),
+            errors: ErrorsBehavior::Continue as u16,
+            creator_os: OsId::Linux as u32,
+            rev_level: RevLevel::Dynamic as u32,
+            first_ino: 11,
+            inode_size: 256,
+            feature_incompat: (FeatureIncompatSet::FILETYPE | FeatureIncompatSet::EXTENTS).bits(),
+            feature_ro_compat: FeatureRoCompatSet::SPARSE_SUPER.bits(),
+            ..Default::default()
+        }
+    }
+
+    #[ktest]
+    fn parse_minimal_superblock() {
+        let raw = minimal_raw(2048, 2048, 256);
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert_eq!(sb.block_size(), 4096);
+        assert_eq!(sb.inode_size(), 256);
+        assert_eq!(sb.first_ino(), 11);
+        assert_eq!(sb.inodes_per_block(), 16);
+        assert_eq!(sb.nr_inode_table_blocks_per_group(), 16);
+        assert_eq!(sb.nr_block_groups(), 1);
+        assert!(sb.feature_incompat().contains(FeatureIncompatSet::EXTENTS));
+        assert!(!sb.needs_recovery());
+    }
+
+    #[ktest]
+    fn reject_bad_magic() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.magic = 0x1234;
+        assert!(SuperBlock::try_from(raw).is_err());
+    }
+
+    #[ktest]
+    fn reject_non_4k_block() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.log_block_size = 0; // 1 KiB
+        assert!(SuperBlock::try_from(raw).is_err());
+    }
+
+    /// A legacy 128-byte inode is refused at admission. The inode decode reads a
+    /// fixed 256-byte `RawInode`, so this 256-centric port admits exactly that
+    /// slot width rather than misreading old-style inode tables.
+    #[ktest]
+    fn reject_inode_size_below_256() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.inode_size = 128;
+        assert!(SuperBlock::try_from(raw).is_err());
+    }
+
+    /// Wider inode slots are refused too: the read path currently fetches only
+    /// the 256-byte `RawInode` and metadata-csum verification must not slice
+    /// beyond that fixed buffer.
+    #[ktest]
+    fn reject_inode_size_not_256() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.inode_size = 512;
+        let Err(err) = SuperBlock::try_from(raw) else {
+            panic!("wider inode size must be refused at mount");
+        };
+        assert_eq!(err.error(), Errno::EINVAL);
+    }
+
+    #[ktest]
+    fn reject_unsupported_incompat() {
+        // `MMP` is a genuine incompatible feature this implementation does not
+        // support (it is not in `INCOMPAT_SUPP`), so it must refuse the mount.
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.feature_incompat |= FeatureIncompatSet::MMP.bits();
+        assert!(SuperBlock::try_from(raw).is_err());
+    }
+
+    /// A ro_compat feature outside `RO_COMPAT_SUPP` must refuse the mount with
+    /// `EROFS` — its semantics are ones this reader cannot interpret (Linux
+    /// `ext4_setup_super` parity).
+    #[ktest]
+    fn reject_unsupported_ro_compat() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        // `GDT_CSUM` (legacy crc16 group-descriptor checksums) is a known but
+        // unimplemented ro_compat feature — mutually exclusive with the
+        // `METADATA_CSUM` we do support — so it is refused with `EROFS`.
+        raw.feature_ro_compat |= FeatureRoCompatSet::GDT_CSUM.bits();
+        let Err(err) = SuperBlock::try_from(raw) else {
+            panic!("unsupported ro_compat must be refused at mount");
+        };
+        assert_eq!(err.error(), Errno::EROFS);
+
+        // A bit unknown to `FeatureRoCompatSet` entirely (raw-bits check).
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.feature_ro_compat |= 1 << 12; // RO_COMPAT_READONLY
+        assert!(SuperBlock::try_from(raw).is_err());
+    }
+
+    /// Fail-closed dirty-volume policy: a superblock with a pending orphan list
+    /// (`s_last_orphan != 0`) is `needs_recovery`, which this read-only,
+    /// journal-less mount cannot perform. It is refused with `EROFS` rather than
+    /// silently exposing the crash-time inconsistent state behind it — the same
+    /// fail-closed stance as dropping `RECOVER` from `INCOMPAT_SUPP`.
+    #[ktest]
+    fn reject_dirty_volume_pending_orphan() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.last_orphan = 5;
+        let Err(err) = SuperBlock::try_from(raw) else {
+            panic!("a volume needing orphan recovery must not mount");
+        };
+        assert_eq!(err.error(), Errno::EROFS);
+    }
+
+    /// `superblock_checksum` covers exactly the first `S_CHECKSUM_OFFSET` bytes,
+    /// so recomputing after only the `s_checksum` field changes is stable, and a
+    /// change anywhere in the covered range flips it.
+    #[ktest]
+    fn superblock_checksum_covers_body_not_field() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        let csum = SuperBlock::superblock_checksum(&raw);
+
+        // Storing the checksum (the excluded last word) does not change it.
+        raw.checksum = csum;
+        assert_eq!(SuperBlock::superblock_checksum(&raw), csum);
+        raw.checksum = 0xDEAD_BEEF;
+        assert_eq!(SuperBlock::superblock_checksum(&raw), csum);
+
+        // A change inside the covered body does change it.
+        raw.blocks_count += 1;
+        assert_ne!(SuperBlock::superblock_checksum(&raw), csum);
+    }
+
+    /// `verify_superblock_checksum` accepts a correctly stamped superblock and
+    /// rejects a corrupted one or a non-crc32c checksum type with `EUCLEAN`.
+    #[ktest]
+    fn verify_superblock_checksum_round_trip() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        // `s_checksum_type` (0x175) must name crc32c (== 1).
+        raw.as_mut_bytes()[S_CHECKSUM_TYPE_OFFSET] = CHECKSUM_TYPE_CRC32C;
+        raw.checksum = SuperBlock::superblock_checksum(&raw);
+        SuperBlock::verify_superblock_checksum(&raw).unwrap();
+
+        // Corrupt the stored checksum.
+        let mut bad = raw;
+        bad.checksum ^= 1;
+        assert_eq!(
+            SuperBlock::verify_superblock_checksum(&bad)
+                .unwrap_err()
+                .error(),
+            Errno::EUCLEAN
+        );
+
+        // Wrong checksum type is rejected even with a matching value.
+        let mut wrong_type = raw;
+        wrong_type.as_mut_bytes()[S_CHECKSUM_TYPE_OFFSET] = 0;
+        wrong_type.checksum = SuperBlock::superblock_checksum(&wrong_type);
+        assert_eq!(
+            SuperBlock::verify_superblock_checksum(&wrong_type)
+                .unwrap_err()
+                .error(),
+            Errno::EUCLEAN
+        );
+    }
+
+    #[ktest]
+    fn reject_without_extents() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.feature_incompat = FeatureIncompatSet::FILETYPE.bits();
+        assert!(SuperBlock::try_from(raw).is_err());
+    }
+
+    #[ktest]
+    fn multi_group_geometry() {
+        // 3 full groups of 2048 blocks: blocks_count = 3*2048.
+        let raw = minimal_raw(3 * 2048, 2048, 256);
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert_eq!(sb.nr_block_groups(), 3);
+        assert_eq!(sb.total_blocks(), 3 * 2048);
+    }
+
+    /// `test_root`/`is_power_of` picks out the sparse-super backup groups.
+    #[ktest]
+    fn is_power_of_matches_test_root() {
+        assert!(is_power_of(3, 3) && is_power_of(9, 3) && is_power_of(81, 3));
+        assert!(is_power_of(5, 5) && is_power_of(125, 5));
+        assert!(is_power_of(7, 7) && is_power_of(49, 7));
+        // Not powers: composites and the identity/zero cases.
+        assert!(!is_power_of(15, 3) && !is_power_of(15, 5));
+        assert!(!is_power_of(1, 3) && !is_power_of(6, 3));
+    }
+
+    /// The `ext4_calculate_overhead` (non-bigalloc) geometry sum. `minimal_raw`
+    /// sets `sparse_super`, `first_data_block == 0`, inode size 256 (16 inodes
+    /// per 4 KiB block → 16 inode-table blocks per group), and no reserved GDT.
+    #[ktest]
+    fn metadata_overhead_sparse_super() {
+        // 10 groups of 2048 blocks. GDT fits in one block (10 <= 4096/32). The
+        // groups carrying a superblock/GDT copy are 0, 1 and the odd powers of
+        // 3/5/7 below 10 — i.e. 3, 5, 7, 9 — so six of the ten.
+        let raw = minimal_raw(10 * 2048, 2048, 256);
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert_eq!(sb.nr_block_groups(), 10);
+        // 10 * (16 inode-table + 2 bitmaps) + 6 * (1 super + 1 GDT + 0 reserved).
+        assert_eq!(sb.metadata_overhead(), 10 * (16 + 2) + 6 * (1 + 1));
+    }
+
+    /// Reserved GDT-growth blocks add to every superblock-bearing group.
+    #[ktest]
+    fn metadata_overhead_reserved_gdt() {
+        let mut raw = minimal_raw(10 * 2048, 2048, 256);
+        raw.reserved_gdt_blocks = 100;
+        let sb = SuperBlock::try_from(raw).unwrap();
+        // The six super-bearing groups each also carry 100 reserved GDT blocks.
+        assert_eq!(sb.metadata_overhead(), 10 * (16 + 2) + 6 * (1 + 1 + 100));
+    }
+
+    /// Without `sparse_super`, every group carries a superblock/GDT copy.
+    #[ktest]
+    fn metadata_overhead_dense_super() {
+        let mut raw = minimal_raw(10 * 2048, 2048, 256);
+        raw.feature_ro_compat = 0; // clear SPARSE_SUPER
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert_eq!(sb.metadata_overhead(), 10 * (16 + 2) + 10 * (1 + 1));
+    }
+
+    /// A GDT spanning more than one block: with 130 groups the primary GDT needs
+    /// `ceil(130 / (4096/32)) = 2` blocks, charged to each super-bearing group.
+    #[ktest]
+    fn metadata_overhead_multi_gdt_block() {
+        let raw = minimal_raw(130 * 2048, 2048, 256);
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert_eq!(sb.nr_block_groups(), 130);
+        // Super-bearing groups: 0, 1 plus powers of 3 (3,9,27,81), 5 (5,25,125),
+        // 7 (7,49) below 130 — eleven groups; each carries 1 super + 2 GDT blocks.
+        assert_eq!(sb.metadata_overhead(), 130 * (16 + 2) + 11 * (1 + 2));
+    }
+
+    /// A `0` on-disk `s_desc_size` (the mkfs default for non-64bit images)
+    /// resolves to the classic 32-byte descriptor.
+    #[ktest]
+    fn desc_size_defaults_to_classic() {
+        let raw = minimal_raw(2048, 2048, 256);
+        assert_eq!(raw.desc_size, 0);
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert_eq!(sb.desc_size(), MIN_DESC_SIZE);
+    }
+
+    /// An explicit `s_desc_size == 32` resolves to 32.
+    #[ktest]
+    fn desc_size_explicit_classic() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.desc_size = MIN_DESC_SIZE;
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert_eq!(sb.desc_size(), MIN_DESC_SIZE);
+    }
+
+    /// Without `64BIT`, any `s_desc_size` other than 0 or 32 is rejected rather
+    /// than silently misread by the 32-byte decoder.
+    #[ktest]
+    fn reject_out_of_range_desc_size() {
+        for bad in [16u16, 33, 48, 64, 128] {
+            let mut raw = minimal_raw(2048, 2048, 256);
+            raw.desc_size = bad;
+            let Err(err) = SuperBlock::try_from(raw) else {
+                panic!("desc_size {bad} must be rejected without 64bit");
+            };
+            assert_eq!(err.error(), Errno::EINVAL);
+        }
+    }
+
+    /// The `EXT4_DESC_SIZE = has_64bit ? s_desc_size : 32` gating, exercised at
+    /// the parse boundary directly (the mount-level `IS_64BIT` gate rejects the
+    /// feature earlier today, so the 64bit branch is only reachable here).
+    #[ktest]
+    fn parse_desc_size_gating() {
+        // Without 64BIT: 0 and 32 resolve to 32; anything else is rejected.
+        assert_eq!(parse_desc_size(0, false).unwrap(), MIN_DESC_SIZE);
+        assert_eq!(parse_desc_size(32, false).unwrap(), MIN_DESC_SIZE);
+        assert!(parse_desc_size(64, false).is_err());
+        assert!(parse_desc_size(48, false).is_err());
+
+        // With 64BIT: `s_desc_size` is authoritative and must be >= 64 (Linux
+        // EXT4_MIN_DESC_SIZE_64BIT); 0 and 32 are REJECTED — they would
+        // contradict the wide 64-byte GDT stride — as are non-power-of-two and
+        // out-of-range. Only 64 is admitted.
+        assert_eq!(parse_desc_size(MAX_DESC_SIZE, true).unwrap(), MAX_DESC_SIZE);
+        assert!(parse_desc_size(0, true).is_err());
+        assert!(parse_desc_size(32, true).is_err());
+        assert!(parse_desc_size(48, true).is_err());
+        assert!(parse_desc_size(16, true).is_err());
+        assert!(parse_desc_size(128, true).is_err());
+    }
+
+    /// A `flex_bg` image mounts now that `FLEX_BG` is in `INCOMPAT_SUPP` (the
+    /// read side already locates bitmaps/tables through the descriptor getters).
+    #[ktest]
+    fn accept_flex_bg() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.feature_incompat |= FeatureIncompatSet::FLEX_BG.bits();
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert!(sb.feature_incompat().contains(FeatureIncompatSet::FLEX_BG));
+    }
+
+    /// The `s_*_count_hi` splice boundary: the high half is honored only under
+    /// `64BIT`, and a non-64bit high half is rejected rather than folded in. A
+    /// genuine `> 2^32`-block image cannot be built here (the fixture's `u32`
+    /// `inodes_count` cannot express that geometry), so the wide decode itself is
+    /// verified at this boundary.
+    #[ktest]
+    fn splice_count_hi_gating() {
+        // Without 64BIT: the low half passes through; any high half is rejected.
+        assert_eq!(splice_count_hi(0x1234, 0, false).unwrap(), 0x1234);
+        assert!(splice_count_hi(0, 1, false).is_err());
+        assert!(splice_count_hi(5, 7, false).is_err());
+
+        // With 64BIT: `lo | (hi << 32)`, lossless.
+        assert_eq!(splice_count_hi(0xDEAD_BEEF, 0, true).unwrap(), 0xDEAD_BEEF);
+        assert_eq!(splice_count_hi(0, 1, true).unwrap(), 1u64 << 32);
+        assert_eq!(
+            splice_count_hi(0x8000_0001, 2, true).unwrap(),
+            (2u64 << 32) | 0x8000_0001
+        );
+    }
+
+    /// A non-64bit image carrying a non-zero `s_blocks_count_hi` or
+    /// `s_free_blocks_count_hi` is malformed and rejected at parse time.
+    #[ktest]
+    fn reject_high_count_without_64bit() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.blocks_count_hi = 1;
+        assert_eq!(
+            SuperBlock::try_from(raw).unwrap_err().error(),
+            Errno::EINVAL
+        );
+
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.free_blocks_count_hi = 1;
+        assert_eq!(
+            SuperBlock::try_from(raw).unwrap_err().error(),
+            Errno::EINVAL
+        );
+    }
+
+    /// A `64BIT` image (feature bit + `s_desc_size == 64`) mounts, records the
+    /// wide descriptor size, and round-trips the (here `< 2^32`) free-block count
+    /// through the u64 splice.
+    #[ktest]
+    fn accept_64bit_image() {
+        let mut raw = minimal_raw(2048, 2048, 256);
+        raw.feature_incompat |= FeatureIncompatSet::IS_64BIT.bits();
+        raw.desc_size = MAX_DESC_SIZE;
+        raw.free_blocks_count = 500;
+        // High halves zero (this small image fits in 32 bits).
+        let sb = SuperBlock::try_from(raw).unwrap();
+        assert!(sb.feature_incompat().contains(FeatureIncompatSet::IS_64BIT));
+        assert_eq!(sb.desc_size(), MAX_DESC_SIZE);
+        assert_eq!(sb.free_blocks_count(), 500u64);
+        assert_eq!(sb.total_blocks(), 2048u64);
+    }
+}

--- a/kernel/src/fs/fs_impls/ext4/test_utils.rs
+++ b/kernel/src/fs/fs_impls/ext4/test_utils.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! In-memory block device and image fixtures for ext4 kernel-mode tests.
+//!
+//! These fixtures hand-build a minimal-feature image (extent + filetype, no
+//! checksums/64-bit/flex_bg) directly in memory, since `mke2fs` cannot run
+//! inside a kernel test. This read-only build only lays down the on-disk state
+//! the read paths consume — a superblock, per-group descriptors, a root inode,
+//! and (via [`Ext4Fixture::write_data_block`] / [`Ext4Fixture::write_raw_inode`])
+//! whatever data blocks and inodes a test wants to read back.
+
+use core::fmt;
+
+use aster_block::{
+    BlockDeviceMeta,
+    bio::{BioEnqueueError, BioType, SubmittedBio},
+};
+use device_id::{DeviceId, MajorId, MinorId};
+use ostd::mm::{HasSize, io::util::HasVmReaderWriter};
+
+use super::{
+    block_group::RawBlockGroup,
+    fs::{Ext4, ROOT_INO},
+    inode::{FileFlags, RawInode},
+    prelude::*,
+    super_block::{MAGIC_NUM, RawSuperBlock, SUPER_BLOCK_OFFSET, SuperBlock},
+};
+
+/// An in-memory block device backed by a zeroed frame segment.
+///
+/// Read-only: only read bios are serviced. `build()` seeds the image by writing
+/// straight into the backing [`Segment`], never through a write bio, so no write
+/// path is needed.
+pub(super) struct Ext4MemoryDisk {
+    segment: Segment<()>,
+}
+
+impl Ext4MemoryDisk {
+    pub(super) fn new(nblocks: usize) -> Self {
+        let npages = (nblocks * BLOCK_SIZE).div_ceil(PAGE_SIZE);
+        let segment = FrameAllocOptions::new()
+            .zeroed(true)
+            .alloc_segment(npages)
+            .unwrap();
+        Self { segment }
+    }
+
+    pub(super) fn segment(&self) -> &Segment<()> {
+        &self.segment
+    }
+}
+
+impl Debug for Ext4MemoryDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ext4MemoryDisk")
+            .field("bytes", &self.segment.size())
+            .finish()
+    }
+}
+
+impl BlockDevice for Ext4MemoryDisk {
+    fn enqueue(&self, bio: SubmittedBio) -> core::result::Result<(), BioEnqueueError> {
+        let mut cur_device_ofs = bio.sid_range().start.to_raw() as usize * SECTOR_SIZE;
+        for seg in bio.segments() {
+            let io_size = match bio.type_() {
+                BioType::Read => seg
+                    .inner_dma_slice()
+                    .writer()
+                    .unwrap()
+                    .write(self.segment.reader().skip(cur_device_ofs)),
+                // Read-only mount: no write or flush bio can reach here (all
+                // write paths return `EROFS`), so anything else is unsupported.
+                _ => {
+                    bio.complete(BioStatus::NotSupported);
+                    return Ok(());
+                }
+            };
+            cur_device_ofs += io_size;
+        }
+
+        bio.complete(BioStatus::Complete);
+        Ok(())
+    }
+
+    fn metadata(&self) -> BlockDeviceMeta {
+        BlockDeviceMeta {
+            max_nr_segments_per_bio: usize::MAX,
+            nr_sectors: self.segment.size() / SECTOR_SIZE,
+        }
+    }
+
+    fn name(&self) -> &str {
+        "ext4-memory-disk"
+    }
+
+    fn id(&self) -> DeviceId {
+        DeviceId::new(MajorId::new(1), MinorId::new(0))
+    }
+}
+
+/// Fixed group-0 layout used by the fixture builder.
+const INODE_SIZE: usize = 256;
+const INODE_TABLE_BID: u32 = 4;
+
+/// A mounted ext4 filesystem over an in-memory disk, for tests.
+pub(super) struct Ext4Fixture {
+    pub disk: Arc<Ext4MemoryDisk>,
+    pub ext4: Arc<Ext4>,
+    #[expect(dead_code)]
+    pub sb: SuperBlock,
+}
+
+impl Ext4Fixture {
+    /// Writes raw bytes into data block `block`.
+    pub(super) fn write_data_block(&self, block: u32, data: &[u8]) {
+        self.disk
+            .segment()
+            .write_bytes(block as usize * BLOCK_SIZE, data)
+            .unwrap();
+    }
+
+    /// Writes a raw inode into the group-0 inode table at inode number `ino`.
+    pub(super) fn write_raw_inode(&self, ino: u32, raw: &RawInode) {
+        let offset = INODE_TABLE_BID as usize * BLOCK_SIZE + (ino - 1) as usize * INODE_SIZE;
+        self.disk.segment().write_val(offset, raw).unwrap();
+    }
+}
+
+/// Builds a minimal single-purpose ext4 image with a fixed group-0 layout:
+/// block 0 = superblock, block 1 = GDT, 2 = block bitmap, 3 = inode bitmap,
+/// 4.. = inode table.
+///
+/// Read-only: the free-block/inode counters are left at zero and the bitmaps are
+/// left all-zero. The read paths never consult them (statfs only echoes the
+/// superblock counters), so there is no allocator state to seed.
+pub(super) struct Ext4FixtureBuilder {
+    blocks_per_group: u32,
+    inodes_per_group: u32,
+    nblocks: usize,
+    /// Blocks reserved for privileged processes (`s_r_blocks_count`); `statfs`
+    /// subtracts them from `bfree` to report `bavail`.
+    reserved_blocks: u32,
+    /// Volume UUID (`s_uuid`); `statfs` folds its low 8 bytes into `f_fsid`.
+    uuid: [u8; 16],
+}
+
+impl Ext4FixtureBuilder {
+    pub(super) fn new(blocks_per_group: u32, inodes_per_group: u32, nblocks: usize) -> Self {
+        Self {
+            blocks_per_group,
+            inodes_per_group,
+            nblocks,
+            reserved_blocks: 0,
+            uuid: [0; 16],
+        }
+    }
+
+    /// Sets `s_r_blocks_count` so `statfs` has reserved blocks to subtract from
+    /// `bfree` when reporting `bavail`.
+    pub(super) fn with_reserved_blocks(mut self, blocks: u32) -> Self {
+        self.reserved_blocks = blocks;
+        self
+    }
+
+    /// Sets `s_uuid` so `statfs` has a non-zero `f_fsid` (its low 8 bytes).
+    pub(super) fn with_uuid(mut self, uuid: [u8; 16]) -> Self {
+        self.uuid = uuid;
+        self
+    }
+
+    pub(super) fn build(self) -> Result<Ext4Fixture> {
+        let nr_groups = (self.nblocks as u32 - 1) / self.blocks_per_group + 1;
+        let inodes_count = nr_groups * self.inodes_per_group;
+
+        let raw_sb = RawSuperBlock {
+            inodes_count,
+            blocks_count: self.nblocks as u32,
+            reserved_blocks_count: self.reserved_blocks,
+            free_blocks_count: 0,
+            free_inodes_count: 0,
+            first_data_block: 0,
+            log_block_size: 2,
+            log_frag_size: 2,
+            blocks_per_group: self.blocks_per_group,
+            frags_per_group: self.blocks_per_group,
+            inodes_per_group: self.inodes_per_group,
+            magic: MAGIC_NUM,
+            state: 1,      // VALID
+            errors: 1,     // Continue
+            creator_os: 0, // Linux
+            rev_level: 1,  // Dynamic
+            first_ino: 11,
+            inode_size: INODE_SIZE as u16,
+            // Read-only fixture: no journal.
+            feature_compat: 0,
+            feature_incompat: 0x2 | 0x40, // FILETYPE | EXTENTS
+            feature_ro_compat: 0x1,       // SPARSE_SUPER
+            uuid: self.uuid,
+            journal_ino: 0,
+            ..Default::default()
+        };
+        let sb = SuperBlock::try_from(raw_sb)?;
+
+        let disk = Arc::new(Ext4MemoryDisk::new(self.nblocks));
+        disk.segment()
+            .write_val(SUPER_BLOCK_OFFSET, &raw_sb)
+            .unwrap();
+
+        // Lay out a descriptor per group. Each group `g` keeps its metadata at
+        // fixed in-group offsets: block bitmap at +2, inode bitmap at +3, inode
+        // table at +4. The bitmaps and free counters are left zeroed — the read
+        // paths never consult them.
+        for g in 0..nr_groups {
+            let group_first = g * self.blocks_per_group; // first_data_block == 0
+            let raw_gd = RawBlockGroup {
+                block_bitmap_lo: group_first + 2,
+                inode_bitmap_lo: group_first + 3,
+                inode_table_lo: group_first + INODE_TABLE_BID,
+                free_blocks_count_lo: 0,
+                free_inodes_count_lo: 0,
+                ..Default::default()
+            };
+            disk.segment()
+                .write_val(
+                    BLOCK_SIZE + g as usize * size_of::<RawBlockGroup>(),
+                    &raw_gd,
+                )
+                .unwrap();
+        }
+
+        let root = make_root_dir_inode();
+        let root_offset =
+            INODE_TABLE_BID as usize * BLOCK_SIZE + (ROOT_INO - 1) as usize * INODE_SIZE;
+        disk.segment().write_val(root_offset, &root).unwrap();
+
+        let ext4 = Ext4::open(disk.clone() as Arc<dyn BlockDevice>)?;
+        Ok(Ext4Fixture { disk, ext4, sb })
+    }
+}
+
+/// A root-directory inode: link count 2, `EXT4_EXTENTS_FL` set, and a valid
+/// **empty** extent root.
+fn make_root_dir_inode() -> RawInode {
+    let mut raw = RawInode {
+        mode: 0o040755,
+        size_lo: BLOCK_SIZE as u32,
+        link_count: 2,
+        sector_count: (BLOCK_SIZE / SECTOR_SIZE) as u32,
+        flags: FileFlags::EXTENTS.bits(),
+        extra_isize: 32,
+        ..Default::default()
+    };
+    // A valid **empty** extent root — the root must parse, since
+    // `ExtentTree::try_new` validates it when the inode is loaded. Tests that
+    // read actual root-directory data overwrite ino 2 with a populated inode.
+    raw.block[0] = 0xF30A; // eh_magic | eh_entries(=0)
+    raw.block[1] = 4; // eh_max=4, eh_depth=0
+    raw
+}
+
+/// Builds a regular-file inode mapping logical block 0 to `data_block` via a
+/// depth-0 inline extent.
+pub(super) fn make_file_inode(data_block: u32, size: u32) -> RawInode {
+    let mut raw = RawInode {
+        mode: 0o100644, // S_IFREG | 0644
+        size_lo: size,
+        link_count: 1,
+        sector_count: (BLOCK_SIZE / SECTOR_SIZE) as u32,
+        flags: FileFlags::EXTENTS.bits(),
+        extra_isize: 32,
+        ..Default::default()
+    };
+    // Inline extent root in `i_block`: a 12-byte header (magic 0xF30A, 1 entry,
+    // max 4, depth 0) followed by one extent mapping logical block 0 to
+    // `data_block` with length 1. Each `i_block` word packs two 16-bit fields.
+    raw.block[0] = 0xF30A | (1 << 16); // eh_magic | eh_entries
+    raw.block[1] = 4; // eh_max=4, eh_depth=0
+    raw.block[2] = 0; // eh_generation
+    raw.block[3] = 0; // ee_block = 0
+    raw.block[4] = 1; // ee_len=1, ee_start_hi=0
+    raw.block[5] = data_block; // ee_start_lo
+    raw
+}
+
+/// Builds an empty regular-file inode: size 0, `i_blocks` 0, and an empty
+/// inline extent root (header with 0 entries).
+pub(super) fn make_empty_file_inode() -> RawInode {
+    let mut raw = RawInode {
+        mode: 0o100644, // S_IFREG | 0644
+        size_lo: 0,
+        link_count: 1,
+        sector_count: 0,
+        flags: FileFlags::EXTENTS.bits(),
+        extra_isize: 32,
+        ..Default::default()
+    };
+    // Empty extent root: 12-byte header (magic 0xF30A, 0 entries, max 4, depth
+    // 0), no extents. Each `i_block` word packs two 16-bit fields.
+    raw.block[0] = 0xF30A; // eh_magic | eh_entries(=0)
+    raw.block[1] = 4; // eh_max=4, eh_depth=0
+    raw.block[2] = 0; // eh_generation
+    raw
+}
+
+/// Builds a regular-file inode whose `i_block` holds a single *unwritten*
+/// (preallocated) inline extent mapping logical blocks `[0, len)` to physical
+/// `[data_block, data_block + len)`. The blocks count toward `i_blocks`, but the
+/// extent is flagged unwritten, so the read path serves them as zeros. `size` is
+/// the logical file size in bytes.
+pub(super) fn make_unwritten_file_inode(data_block: u32, len: u16, size: u32) -> RawInode {
+    let mut raw = RawInode {
+        mode: 0o100644, // S_IFREG | 0644
+        size_lo: size,
+        link_count: 1,
+        sector_count: (len as u32) * (BLOCK_SIZE / SECTOR_SIZE) as u32,
+        flags: FileFlags::EXTENTS.bits(),
+        extra_isize: 32,
+        ..Default::default()
+    };
+    // Inline extent root: header (magic, 1 entry, max 4, depth 0) + one extent.
+    // An unwritten extent encodes its length biased by 32768 (`MAX_WRITTEN_LEN`).
+    raw.block[0] = 0xF30A | (1 << 16); // eh_magic | eh_entries
+    raw.block[1] = 4; // eh_max=4, eh_depth=0
+    raw.block[2] = 0; // eh_generation
+    raw.block[3] = 0; // ee_block = 0
+    // ee_len (low 16, biased for unwritten) | ee_start_hi (high 16, = 0).
+    raw.block[4] = (len + 32768) as u32;
+    raw.block[5] = data_block; // ee_start_lo
+    raw
+}
+
+/// Builds a directory inode (type Dir, one block) mapping logical block 0 to
+/// `data_block`.
+pub(super) fn make_dir_inode(data_block: u32) -> RawInode {
+    let mut raw = make_file_inode(data_block, BLOCK_SIZE as u32);
+    raw.mode = 0o040755; // S_IFDIR | 0755
+    raw.link_count = 2;
+    raw
+}
+
+/// Builds one directory data block holding `entries` of `(ino, name,
+/// file_type)`. The last entry's `rec_len` is extended to fill the block.
+pub(super) fn make_dir_block(entries: &[(u32, &str, u8)]) -> Vec<u8> {
+    let mut block = vec![0u8; BLOCK_SIZE];
+    let mut offset = 0;
+    for (i, (ino, name, file_type)) in entries.iter().enumerate() {
+        let name_bytes = name.as_bytes();
+        let rec_len = if i + 1 == entries.len() {
+            BLOCK_SIZE - offset
+        } else {
+            (name_bytes.len() + 8).next_multiple_of(4)
+        };
+        block[offset..offset + 4].copy_from_slice(&ino.to_le_bytes());
+        block[offset + 4..offset + 6].copy_from_slice(&(rec_len as u16).to_le_bytes());
+        block[offset + 6] = name_bytes.len() as u8;
+        block[offset + 7] = *file_type;
+        block[offset + 8..offset + 8 + name_bytes.len()].copy_from_slice(name_bytes);
+        offset += rec_len;
+    }
+    block
+}

--- a/kernel/src/fs/fs_impls/ext4/utils.rs
+++ b/kernel/src/fs/fs_impls/ext4/utils.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Small helpers shared across the ext4 module.
+//!
+//! - `Dirty` — a wrapper that tracks whether its inner value has been mutated
+//!   since construction; it warns if dropped while dirty. Retained from the
+//!   writable design — nothing is flushed on a read-only mount.
+//! - `IsPowerOf` — a trait for testing whether a number is a power of another;
+//!   currently unused (kept for sparse-superblock backup-group detection —
+//!   backups live in groups that are powers of 3/5/7 — though the block-side
+//!   lazy-group reconstruction derives its overhead from the descriptor's free
+//!   count instead).
+//! - `read_metadata_block` — the single funnel for metadata-block reads.
+
+use core::ops::MulAssign;
+
+use super::prelude::*;
+use crate::prelude::warn;
+
+#[expect(dead_code)] // Currently unused; kept for sparse-superblock backup-group detection.
+pub(super) trait IsPowerOf: Copy + Sized + MulAssign + PartialOrd {
+    /// Returns whether `self` equals `x^k` for some `k > 0`.
+    ///
+    /// `x` must be greater than 1.
+    fn is_power_of(&self, x: Self) -> bool {
+        let mut power = x;
+        while power < *self {
+            power *= x;
+        }
+
+        power == *self
+    }
+}
+
+macro_rules! impl_ipo_for {
+    ($($ipo_ty:ty),*) => {
+        $(impl IsPowerOf for $ipo_ty {})*
+    };
+}
+
+impl_ipo_for!(
+    u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, isize, usize
+);
+
+/// A value with dirty tracking.
+pub(super) struct Dirty<T: Debug> {
+    value: T,
+    dirty: bool,
+}
+
+impl<T: Debug> Dirty<T> {
+    /// Creates a new `Dirty` value without setting the dirty flag.
+    pub(super) fn new(val: T) -> Dirty<T> {
+        Dirty {
+            value: val,
+            dirty: false,
+        }
+    }
+
+    /// Returns whether the value is dirty.
+    pub(super) fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+}
+
+impl<T: Debug> Deref for Dirty<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T: Debug> DerefMut for Dirty<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.dirty = true;
+        &mut self.value
+    }
+}
+
+impl<T: Debug> Drop for Dirty<T> {
+    fn drop(&mut self) {
+        if self.is_dirty() {
+            warn!("dropped while dirty: {:?}", self.value);
+        }
+    }
+}
+
+impl<T: Debug> Debug for Dirty<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let tag = if self.dirty { "Dirty" } else { "Clean" };
+        write!(f, "[{}] {:?}", tag, self.value)
+    }
+}
+
+/// Reads a metadata block from the device.
+///
+/// All ext4 metadata-block reads (extent-tree interior/leaf nodes, inode-table
+/// blocks) go through this single funnel. On a read-only, non-journaled mount
+/// the on-disk block is authoritative — a clean, fully-checkpointed volume is
+/// required at mount time — so this is a plain device read. Routing every
+/// reader through one entry point is the seam at which a journaling layer would
+/// consult its in-memory after-images (the running/committing transaction's
+/// captures and any not-yet-checkpointed image) before falling through to the
+/// device, without having to hunt down scattered device reads.
+pub(super) fn read_metadata_block(
+    device: &dyn BlockDevice,
+    blocknr: Ext4Bid,
+) -> Result<[u8; BLOCK_SIZE]> {
+    Ok(device.read_val(Bid::new(blocknr).to_offset())?)
+}

--- a/kernel/src/fs/fs_impls/mod.rs
+++ b/kernel/src/fs/fs_impls/mod.rs
@@ -9,6 +9,7 @@ pub mod configfs;
 pub mod devpts;
 pub mod exfat;
 pub mod ext2;
+pub mod ext4;
 pub mod overlayfs;
 pub mod procfs;
 pub mod pseudofs;
@@ -28,6 +29,7 @@ pub(super) fn init() {
     pseudofs::init();
 
     ext2::init();
+    ext4::init();
     exfat::init();
     overlayfs::init();
     virtiofs::init();


### PR DESCRIPTION
## Summary

Adds a read-only ext4 filesystem, built as a sibling to `ext2` and following its
layering and visibility discipline. It mounts a clean, fully-checkpointed ext4
image (the modern `mke2fs` default feature set) and serves reads:

- superblock parse + feature gating;
- extent-mapped file reads (extent trees up to depth 2; unwritten extents read as zeros);
- linear and htree directory reads (`readdir`/`lookup`), directory hash verified against e2fsprogs vectors;
- read-time verification for `metadata_csum` (superblock, group descriptors, inodes), plus `64bit`, `flex_bg`, and `BLOCK_UNINIT`/`INODE_UNINIT` bitmap reconstruction.

Disk format and algorithms follow Linux 6.6.

## Scope

- **No writes, no journal.** Write-side `Inode`/`FileSystem` methods return `EROFS`, and the filesystem declares `FsFlags::RDONLY` so the VFS refuses mutations at the path layer.
- **Dirty volumes are refused at mount** (the `RECOVER` incompat bit, or a non-empty orphan list), so reads never observe a crash-inconsistent on-disk state.
- The only change outside the ext4 module is registering it in `fs/fs_impls/mod.rs`.
- Metadata reads go through a single funnel (`utils::read_metadata_block`) — a plain device read here, and the seam at which a journaling layer is reintroduced in a follow-up.

## Testing

- `make ktest` — aster-kernel passes, including the ext4 read tests (mount, extent read incl. unwritten-as-zero, linear + htree lookup, dirhash vectors, `metadata_csum` verify, 64bit descriptor decode, `BLOCK_UNINIT` reconstruction, statfs, read-only enforcement, dirty-volume rejection, inode-size admission, symlink boundary).
- `make check` — clippy (both cfgs) + rustfmt clean.
- `make docs` — clean.

## Known limitations

- Bitmap, directory-block, and extent-node `metadata_csum` checksums are not verified on read yet.
- `st_blocks` may be under-reported for inodes carrying `EXT4_HUGE_FILE_FL`.
- `O_DIRECT` reads fall back to the page cache.

Volumes needing features this reader cannot interpret (fast_commit, bigalloc, inline_data, encryption/verity, external journal, `data=journal`, …) are refused at mount.
