### PR TITLE
Implement `clock_getres` syscall

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -249,7 +249,7 @@ which are summarized in the table below.
 | 226     | timer_delete           | ✅             | 💯 |
 | 227     | clock_settime          | ❌             | N/A |
 | 228     | clock_gettime          | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#clock_gettime) |
-| 229     | clock_getres           | ❌             | N/A |
+| 229     | clock_getres           | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#clock_getres) |
 | 230     | clock_nanosleep        | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#clock_nanosleep) |
 | 231     | exit_group             | ✅             | 💯 |
 | 232     | epoll_wait             | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/README.md
@@ -86,6 +86,26 @@ Unsupported predefined clock IDs:
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/clock_gettime.2.html).
 
+### `clock_getres`
+
+Supported functionality in SCML:
+
+```c
+{{#include clock_getres.scml}}
+```
+
+Unsupported predefined clock IDs:
+* `CLOCK_REALTIME_ALARM`
+* `CLOCK_BOOTTIME_ALARM`
+* `CLOCK_TAI`
+
+Unsupported dynamic clock IDs:
+* Dynamic file-descriptor clocks
+* Dynamic scheduling clocks
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/clock_getres.2.html).
+
 ### `clock_nanosleep`
 
 Supported functionality in SCML:

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/clock_getres.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/clock_getres.scml
@@ -1,0 +1,12 @@
+predefined_clockid = CLOCK_REALTIME | CLOCK_MONOTONIC | CLOCK_MONOTONIC_RAW |
+                     CLOCK_REALTIME_COARSE | CLOCK_MONOTONIC_COARSE | CLOCK_BOOTTIME |
+                     CLOCK_PROCESS_CPUTIME_ID | CLOCK_THREAD_CPUTIME_ID;
+
+// Get the resolution of a clock specified by a static ID
+clock_getres(clockid = <predefined_clockid>, res);
+
+// A null result pointer is allowed
+clock_getres(clockid = <predefined_clockid>, res = NULL);
+
+// Get the resolution of a supported CPU dynamic clock
+clock_getres(clockid = <INTEGER>, res);

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -21,7 +21,7 @@ macro_rules! import_generic_syscall_entries {
             chmod::{sys_fchmod, sys_fchmodat, sys_fchmodat2},
             chown::{sys_fchown, sys_fchownat},
             chroot::sys_chroot,
-            clock_gettime::sys_clock_gettime,
+            clock_gettime::{sys_clock_getres, sys_clock_gettime},
             clone::{sys_clone, sys_clone3},
             close::{sys_close, sys_close_range},
             connect::sys_connect,
@@ -296,6 +296,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_TIMER_SETTIME = 110          => sys_timer_settime(args[..4]);
             SYS_TIMER_DELETE = 111           => sys_timer_delete(args[..1]);
             SYS_CLOCK_GETTIME = 113          => sys_clock_gettime(args[..2]);
+            SYS_CLOCK_GETRES = 114           => sys_clock_getres(args[..2]);
             SYS_CLOCK_NANOSLEEP = 115        => sys_clock_nanosleep(args[..4]);
             SYS_PTRACE = 117                 => sys_ptrace(args[..4]);
             SYS_SCHED_SETPARAM = 118         => sys_sched_setparam(args[..2]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -15,7 +15,7 @@ use super::{
     chmod::{sys_chmod, sys_fchmod, sys_fchmodat, sys_fchmodat2},
     chown::{sys_chown, sys_fchown, sys_fchownat, sys_lchown},
     chroot::sys_chroot,
-    clock_gettime::sys_clock_gettime,
+    clock_gettime::{sys_clock_getres, sys_clock_gettime},
     clone::{sys_clone, sys_clone3},
     close::{sys_close, sys_close_range},
     connect::sys_connect,
@@ -353,6 +353,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_TIMER_GETTIME = 224    => sys_timer_gettime(args[..2]);
     SYS_TIMER_DELETE = 226     => sys_timer_delete(args[..1]);
     SYS_CLOCK_GETTIME = 228    => sys_clock_gettime(args[..2]);
+    SYS_CLOCK_GETRES = 229     => sys_clock_getres(args[..2]);
     SYS_CLOCK_NANOSLEEP = 230  => sys_clock_nanosleep(args[..4]);
     SYS_EXIT_GROUP = 231       => sys_exit_group(args[..1], &mut user_ctx);
     SYS_EPOLL_WAIT = 232       => sys_epoll_wait(args[..4]);

--- a/kernel/src/syscall/clock_gettime.rs
+++ b/kernel/src/syscall/clock_gettime.rs
@@ -3,7 +3,7 @@
 use core::time::Duration;
 
 use int_to_c_enum::TryFromInt;
-use ostd::{mm::VmIo, timer::TIMER_FREQ};
+use ostd::mm::VmIo;
 
 use super::SyscallReturn;
 use crate::{
@@ -126,15 +126,52 @@ fn clock_resolution(clockid: clockid_t, ctx: &Context) -> Result<Duration> {
     if clockid >= 0 {
         let clock_id = ClockId::try_from(clockid)?;
         return Ok(match clock_id {
-            ClockId::CLOCK_REALTIME_COARSE | ClockId::CLOCK_MONOTONIC_COARSE => {
-                Duration::from_nanos(1_000_000_000 / TIMER_FREQ)
-            }
-            _ => Duration::from_nanos(1),
+            ClockId::CLOCK_REALTIME => RealTimeClock::get().resolution(),
+            ClockId::CLOCK_MONOTONIC => MonotonicClock::get().resolution(),
+            ClockId::CLOCK_MONOTONIC_RAW => MonotonicRawClock::get().resolution(),
+            ClockId::CLOCK_REALTIME_COARSE => RealTimeCoarseClock::get().resolution(),
+            ClockId::CLOCK_MONOTONIC_COARSE => MonotonicCoarseClock::get().resolution(),
+            ClockId::CLOCK_BOOTTIME => BootTimeClock::get().resolution(),
+            ClockId::CLOCK_PROCESS_CPUTIME_ID => ctx.process.prof_clock().resolution(),
+            ClockId::CLOCK_THREAD_CPUTIME_ID => ctx.posix_thread.prof_clock().resolution(),
         });
     }
 
-    read_clock(clockid, ctx)?;
-    Ok(Duration::from_nanos(1))
+    let dynamic_clockid_info = DynamicClockIdInfo::try_from(clockid)?;
+    match dynamic_clockid_info {
+        DynamicClockIdInfo::Pid(pid, clock_type) => {
+            let process = pid_table::pid_table_mut()
+                .get_process(pid)
+                .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock ID"))?;
+            match clock_type {
+                DynamicClockType::Profiling => Ok(process.prof_clock().resolution()),
+                DynamicClockType::Virtual => Ok(process.prof_clock().user_clock().resolution()),
+                DynamicClockType::Scheduling => {
+                    return_errno_with_message!(Errno::EINVAL, "unsupported clock ID")
+                }
+                DynamicClockType::FD => unreachable!(),
+            }
+        }
+        DynamicClockIdInfo::Tid(tid, clock_type) => {
+            let thread = pid_table::pid_table_mut()
+                .get_thread(tid)
+                .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock ID"))?;
+            let posix_thread = thread.as_posix_thread().unwrap();
+            match clock_type {
+                DynamicClockType::Profiling => Ok(posix_thread.prof_clock().resolution()),
+                DynamicClockType::Virtual => {
+                    Ok(posix_thread.prof_clock().user_clock().resolution())
+                }
+                DynamicClockType::Scheduling => {
+                    return_errno_with_message!(Errno::EINVAL, "unsupported clock ID")
+                }
+                DynamicClockType::FD => unreachable!(),
+            }
+        }
+        DynamicClockIdInfo::Fd(_) => {
+            return_errno_with_message!(Errno::EINVAL, "unsupported clock ID")
+        }
+    }
 }
 
 /// Reads the time of a clock specified by the input clock ID.

--- a/kernel/src/syscall/clock_gettime.rs
+++ b/kernel/src/syscall/clock_gettime.rs
@@ -3,7 +3,7 @@
 use core::time::Duration;
 
 use int_to_c_enum::TryFromInt;
-use ostd::mm::VmIo;
+use ostd::{mm::VmIo, timer::TIMER_FREQ};
 
 use super::SyscallReturn;
 use crate::{
@@ -30,6 +30,22 @@ pub fn sys_clock_gettime(
 
     let timespec = timespec_t::from(time_duration);
     ctx.user_space().write_val(timespec_addr, &timespec)?;
+
+    Ok(SyscallReturn::Return(0))
+}
+
+pub fn sys_clock_getres(
+    clockid: clockid_t,
+    timespec_addr: Vaddr,
+    ctx: &Context,
+) -> Result<SyscallReturn> {
+    debug!("clockid = {:?}", clockid);
+
+    let resolution = clock_resolution(clockid, ctx)?;
+    if timespec_addr != 0 {
+        let timespec = timespec_t::from(resolution);
+        ctx.user_space().write_val(timespec_addr, &timespec)?;
+    }
 
     Ok(SyscallReturn::Return(0))
 }
@@ -104,6 +120,21 @@ pub enum DynamicClockType {
     Virtual = 1,
     Scheduling = 2,
     FD = 3,
+}
+
+fn clock_resolution(clockid: clockid_t, ctx: &Context) -> Result<Duration> {
+    if clockid >= 0 {
+        let clock_id = ClockId::try_from(clockid)?;
+        return Ok(match clock_id {
+            ClockId::CLOCK_REALTIME_COARSE | ClockId::CLOCK_MONOTONIC_COARSE => {
+                Duration::from_nanos(1_000_000_000 / TIMER_FREQ)
+            }
+            _ => Duration::from_nanos(1),
+        });
+    }
+
+    read_clock(clockid, ctx)?;
+    Ok(Duration::from_nanos(1))
 }
 
 /// Reads the time of a clock specified by the input clock ID.

--- a/kernel/src/time/clocks/cpu_clock.rs
+++ b/kernel/src/time/clocks/cpu_clock.rs
@@ -47,6 +47,10 @@ impl Clock for CpuClock {
     fn read_time(&self) -> Duration {
         self.read_jiffies().as_duration()
     }
+
+    fn resolution(&self) -> Duration {
+        Jiffies::new(1).as_duration()
+    }
 }
 
 impl ProfClock {
@@ -72,5 +76,9 @@ impl ProfClock {
 impl Clock for ProfClock {
     fn read_time(&self) -> Duration {
         self.user_clock.read_time() + self.kernel_clock.read_time()
+    }
+
+    fn resolution(&self) -> Duration {
+        Jiffies::new(1).as_duration()
     }
 }

--- a/kernel/src/time/clocks/system_wide.rs
+++ b/kernel/src/time/clocks/system_wide.rs
@@ -147,6 +147,10 @@ impl Clock for JiffiesClock {
     fn read_time(&self) -> Duration {
         Jiffies::elapsed().as_duration()
     }
+
+    fn resolution(&self) -> Duration {
+        Jiffies::new(1).as_duration()
+    }
 }
 
 impl Clock for RealTimeClock {
@@ -167,11 +171,19 @@ impl Clock for RealTimeCoarseClock {
     fn read_time(&self) -> Duration {
         *Self::current_ref().get().unwrap().disable_irq().lock()
     }
+
+    fn resolution(&self) -> Duration {
+        Jiffies::new(1).as_duration()
+    }
 }
 
 impl Clock for MonotonicCoarseClock {
     fn read_time(&self) -> Duration {
         RealTimeCoarseClock::get().read_time() - *START_TIME_AS_DURATION.get().unwrap()
+    }
+
+    fn resolution(&self) -> Duration {
+        Jiffies::new(1).as_duration()
     }
 }
 

--- a/kernel/src/time/core/mod.rs
+++ b/kernel/src/time/core/mod.rs
@@ -9,4 +9,9 @@ pub mod timer;
 pub trait Clock: Send + Sync {
     /// Read the current time of this clock.
     fn read_time(&self) -> Duration;
+
+    /// Returns the resolution of this clock.
+    fn resolution(&self) -> Duration {
+        Duration::from_nanos(1)
+    }
 }

--- a/test/initramfs/src/regression/time/Makefile
+++ b/test/initramfs/src/regression/time/Makefile
@@ -2,6 +2,7 @@
 
 SUBDIRS := \
 	alarm \
+	clock_getres \
 	clock_nanosleep \
 	gettimeofday \
 	itimer \

--- a/test/initramfs/src/regression/time/clock_getres/Makefile
+++ b/test/initramfs/src/regression/time/clock_getres/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/time/clock_getres/clock_getres.c
+++ b/test/initramfs/src/regression/time/clock_getres/clock_getres.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+
+#include <errno.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+FN_TEST(clock_getres_supported_clocks)
+{
+	struct timespec res = { 0 };
+
+	TEST_RES(syscall(SYS_clock_getres, CLOCK_MONOTONIC, &res),
+		 res.tv_sec >= 0 && res.tv_nsec > 0 &&
+			 res.tv_nsec < 1000000000L);
+
+	res.tv_sec = 0;
+	res.tv_nsec = 0;
+	TEST_RES(syscall(SYS_clock_getres, CLOCK_REALTIME, &res),
+		 res.tv_sec >= 0 && res.tv_nsec > 0 &&
+			 res.tv_nsec < 1000000000L);
+}
+END_TEST()
+
+FN_TEST(clock_getres_coarse_clocks)
+{
+	struct timespec res = { 0 };
+
+	TEST_RES(syscall(SYS_clock_getres, CLOCK_MONOTONIC_COARSE, &res),
+		 res.tv_sec == 0 && res.tv_nsec == 1000000L);
+
+	res.tv_sec = 0;
+	res.tv_nsec = 0;
+	TEST_RES(syscall(SYS_clock_getres, CLOCK_REALTIME_COARSE, &res),
+		 res.tv_sec == 0 && res.tv_nsec == 1000000L);
+}
+END_TEST()
+
+FN_TEST(clock_getres_null_res)
+{
+	TEST_SUCC(syscall(SYS_clock_getres, CLOCK_MONOTONIC, NULL));
+}
+END_TEST()
+
+FN_TEST(clock_getres_invalid_clock)
+{
+	struct timespec res = { 0 };
+
+	TEST_ERRNO(syscall(SYS_clock_getres, 0x7fffffff, &res), EINVAL);
+}
+END_TEST()

--- a/test/initramfs/src/regression/time/clock_getres/clock_getres.c
+++ b/test/initramfs/src/regression/time/clock_getres/clock_getres.c
@@ -9,6 +9,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#define FD_TO_CLOCKID(fd) ((~(clockid_t)(fd) << 3) | 3)
+
 FN_TEST(clock_getres_supported_clocks)
 {
 	struct timespec res = { 0 };
@@ -50,5 +52,13 @@ FN_TEST(clock_getres_invalid_clock)
 	struct timespec res = { 0 };
 
 	TEST_ERRNO(syscall(SYS_clock_getres, 0x7fffffff, &res), EINVAL);
+}
+END_TEST()
+
+FN_TEST(clock_getres_dynamic_fd_clock)
+{
+	struct timespec res = { 0 };
+
+	TEST_ERRNO(syscall(SYS_clock_getres, FD_TO_CLOCKID(0), &res), EINVAL);
 }
 END_TEST()

--- a/test/initramfs/src/regression/time/run_test.sh
+++ b/test/initramfs/src/regression/time/run_test.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+./clock_getres/clock_getres
+
 ./clock_nanosleep/nanosleep_err
 
 ./gettimeofday/gettimeofday


### PR DESCRIPTION
## Summary

- implement the `clock_getres` syscall and wire it into the x86 and generic syscall tables
- report 1ns for currently supported high-resolution clocks, and derive coarse-clock resolution from `ostd::timer::TIMER_FREQ`
- add time regression coverage for supported clocks, coarse clocks, a NULL result pointer, and an invalid clock ID

## Tests

- `cargo fmt --check` in the official Docker image `asterinas/asterinas:0.18.0-20260702`
- `make run_kernel AUTO_TEST=regression` in the official Docker image `asterinas/asterinas:0.18.0-20260702`
