### PR TITLE
Implement `times` syscall

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -120,7 +120,7 @@ which are summarized in the table below.
 | 97      | getrlimit              | ✅             | 💯 |
 | 98      | getrusage              | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#getrusage) |
 | 99      | sysinfo                | ✅             | 💯 |
-| 100     | times                  | ❌             | N/A |
+| 100     | times                  | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#times) |
 | 101     | ptrace                 | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#ptrace) |
 | 102     | getuid                 | ✅             | 💯 |
 | 103     | syslog                 | ❌             | N/A |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/README.md
@@ -50,6 +50,17 @@ Silently-ignored flags:
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/getrandom.2.html).
 
+### `times`
+
+Supported functionality in SCML:
+
+```c
+{{#include times.scml}}
+```
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/times.2.html).
+
 ### `reboot`
 
 Supported functionality in SCML:

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/times.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/times.scml
@@ -1,0 +1,5 @@
+// Store process times in the user buffer and return elapsed clock ticks
+times(buf);
+
+// Return elapsed clock ticks without storing process times
+times(buf = NULL);

--- a/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/stat.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{sync::atomic::Ordering, time::Duration};
+use core::sync::atomic::Ordering;
 
 use aster_util::printer::VmPrinter;
-use ostd::timer::TIMER_FREQ;
 
 use super::{super::PidDirOps, TidDirOps};
 use crate::{
@@ -20,7 +19,7 @@ use crate::{
     },
     sched::{LinuxSchedPolicy, RealTimePriority, SchedPolicy},
     thread::Thread,
-    time::NSEC_PER_SEC,
+    time::util::duration_to_jiffies,
     vm::vmar::RssType,
 };
 
@@ -189,8 +188,8 @@ impl ProcFileOps for StatFileOps {
         let (cutime, cstime) = {
             let (user_time, kernel_time) = process.reaped_children_stats().lock().get();
             (
-                duration_to_jiffies(user_time),
-                duration_to_jiffies(kernel_time),
+                duration_to_jiffies(user_time).as_u64(),
+                duration_to_jiffies(kernel_time).as_u64(),
             )
         };
 
@@ -198,7 +197,7 @@ impl ProcFileOps for StatFileOps {
         let nice = process.nice().load(Ordering::Relaxed).value().get();
         let num_threads = process.tasks().lock().as_slice().len();
         let itrealvalue =
-            duration_to_jiffies(process.timer_manager().alarm_timer().lock().remain());
+            duration_to_jiffies(process.timer_manager().alarm_timer().lock().remain()).as_u64();
         let starttime = process.start_time().as_u64();
 
         let (
@@ -343,16 +342,6 @@ impl ProcFileOps for StatFileOps {
 
         Ok(printer.bytes_written())
     }
-}
-
-/// Converts a duration into kernel clock ticks.
-fn duration_to_jiffies(duration: Duration) -> u64 {
-    const NSEC_PER_JIFFY: u64 = NSEC_PER_SEC as u64 / TIMER_FREQ;
-    const { assert!((NSEC_PER_SEC as u64).is_multiple_of(TIMER_FREQ)) };
-
-    let sec_jiffies = duration.as_secs().saturating_mul(TIMER_FREQ);
-    let subsec_jiffies = u64::from(duration.subsec_nanos()) / NSEC_PER_JIFFY;
-    sec_jiffies.saturating_add(subsec_jiffies)
 }
 
 /// Returns the `priority`, `rt_priority`, and `policy` values for `/proc/<pid>/stat`.

--- a/kernel/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/src/process/program_loader/elf/load_elf.rs
@@ -17,6 +17,7 @@ use crate::{
         process_vm::{AuxKey, AuxVec},
         program_loader::check_executable_inode,
     },
+    time::util::USER_HZ,
     util::random::getrandom,
     vm::{
         perms::VmPerms,
@@ -455,6 +456,7 @@ fn init_aux_vec(
     let mut aux_vec = AuxVec::new();
 
     aux_vec.set(AuxKey::AT_PAGESZ, PAGE_SIZE as _);
+    aux_vec.set(AuxKey::AT_CLKTCK, USER_HZ);
 
     let Some(ph_vaddr) = elf_map_range.relocated_addr_of(elf.find_vaddr_of_phdrs()?) else {
         return_errno_with_message!(

--- a/kernel/src/process/signal/c_types.rs
+++ b/kernel/src/process/signal/c_types.rs
@@ -7,6 +7,7 @@ use inherit_methods_macro::inherit_methods;
 use ostd::arch::cpu::context::UserContext;
 
 use super::sig_num::SigNum;
+pub use crate::time::util::clock_t;
 use crate::{
     arch::cpu::SigContext,
     prelude::*,
@@ -14,8 +15,6 @@ use crate::{
 };
 
 pub type sigset_t = u64;
-// FIXME: this type should be put at suitable place
-pub type clock_t = i64;
 
 #[padding_struct]
 #[repr(C)]

--- a/kernel/src/syscall/arch/generic.rs
+++ b/kernel/src/syscall/arch/generic.rs
@@ -163,6 +163,7 @@ macro_rules! import_generic_syscall_entries {
             timerfd_create::sys_timerfd_create,
             timerfd_gettime::sys_timerfd_gettime,
             timerfd_settime::sys_timerfd_settime,
+            times::sys_times,
             truncate::{sys_ftruncate, sys_truncate},
             umask::sys_umask,
             umount::sys_umount,
@@ -330,6 +331,7 @@ macro_rules! define_syscalls_with_generic_syscall_table {
             SYS_GETRESGID = 150              => sys_getresgid(args[..3]);
             SYS_SETFSUID = 151               => sys_setfsuid(args[..1]);
             SYS_SETFSGID = 152               => sys_setfsgid(args[..1]);
+            SYS_TIMES = 153                  => sys_times(args[..1]);
             SYS_SETPGID = 154                => sys_setpgid(args[..2]);
             SYS_GETPGID = 155                => sys_getpgid(args[..1]);
             SYS_GETSID = 156                 => sys_getsid(args[..1]);

--- a/kernel/src/syscall/arch/x86.rs
+++ b/kernel/src/syscall/arch/x86.rs
@@ -168,6 +168,7 @@ use super::{
     timerfd_create::sys_timerfd_create,
     timerfd_gettime::sys_timerfd_gettime,
     timerfd_settime::sys_timerfd_settime,
+    times::sys_times,
     truncate::{sys_ftruncate, sys_truncate},
     umask::sys_umask,
     umount::sys_umount,
@@ -272,6 +273,7 @@ impl_syscall_nums_and_dispatch_fn! {
     SYS_GETRLIMIT = 97         => sys_getrlimit(args[..2]);
     SYS_GETRUSAGE = 98         => sys_getrusage(args[..2]);
     SYS_SYSINFO = 99           => sys_sysinfo(args[..1]);
+    SYS_TIMES = 100            => sys_times(args[..1]);
     SYS_PTRACE = 101           => sys_ptrace(args[..4]);
     SYS_GETUID = 102           => sys_getuid(args[..0]);
     SYS_GETGID = 104           => sys_getgid(args[..0]);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -181,6 +181,7 @@ mod timer_settime;
 mod timerfd_create;
 mod timerfd_gettime;
 mod timerfd_settime;
+mod times;
 mod truncate;
 mod umask;
 mod umount;

--- a/kernel/src/syscall/times.rs
+++ b/kernel/src/syscall/times.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::time::Duration;
+
+use ostd::{
+    mm::VmIo,
+    timer::{Jiffies, TIMER_FREQ},
+};
+
+use super::SyscallReturn;
+use crate::{prelude::*, time::NSEC_PER_SEC};
+
+pub fn sys_times(tms_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
+    debug!("tms_addr = 0x{:x}", tms_addr);
+
+    if tms_addr != 0 {
+        let process = ctx.process.as_ref();
+        let prof_clock = process.prof_clock();
+        let (child_user_time, child_kernel_time) = process.reaped_children_stats().lock().get();
+        let tms = Tms {
+            tms_utime: clock_t_from_jiffies(prof_clock.user_clock().read_jiffies().as_u64()),
+            tms_stime: clock_t_from_jiffies(prof_clock.kernel_clock().read_jiffies().as_u64()),
+            tms_cutime: clock_t_from_jiffies(duration_to_jiffies(child_user_time)),
+            tms_cstime: clock_t_from_jiffies(duration_to_jiffies(child_kernel_time)),
+        };
+
+        ctx.user_space().write_val(tms_addr, &tms)?;
+    }
+
+    Ok(SyscallReturn::Return(
+        clock_t_from_jiffies(Jiffies::elapsed().as_u64()) as isize,
+    ))
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+struct Tms {
+    tms_utime: i64,
+    tms_stime: i64,
+    tms_cutime: i64,
+    tms_cstime: i64,
+}
+
+/// Converts a duration into kernel clock ticks.
+fn duration_to_jiffies(duration: Duration) -> u64 {
+    const NSEC_PER_JIFFY: u64 = NSEC_PER_SEC as u64 / TIMER_FREQ;
+    const { assert!((NSEC_PER_SEC as u64).is_multiple_of(TIMER_FREQ)) };
+
+    let sec_jiffies = duration.as_secs().saturating_mul(TIMER_FREQ);
+    let subsec_jiffies = u64::from(duration.subsec_nanos()) / NSEC_PER_JIFFY;
+    sec_jiffies.saturating_add(subsec_jiffies)
+}
+
+fn clock_t_from_jiffies(jiffies: u64) -> i64 {
+    jiffies.min(i64::MAX as u64) as i64
+}

--- a/kernel/src/syscall/times.rs
+++ b/kernel/src/syscall/times.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::time::Duration;
-
-use ostd::{
-    mm::VmIo,
-    timer::{Jiffies, TIMER_FREQ},
-};
+use ostd::{mm::VmIo, timer::Jiffies};
 
 use super::SyscallReturn;
-use crate::{prelude::*, time::NSEC_PER_SEC};
+use crate::{
+    prelude::*,
+    time::util::{clock_t, duration_to_clock_t, jiffies_to_clock_t},
+};
 
 pub fn sys_times(tms_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     debug!("tms_addr = 0x{:x}", tms_addr);
@@ -18,39 +16,25 @@ pub fn sys_times(tms_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
         let prof_clock = process.prof_clock();
         let (child_user_time, child_kernel_time) = process.reaped_children_stats().lock().get();
         let tms = Tms {
-            tms_utime: clock_t_from_jiffies(prof_clock.user_clock().read_jiffies().as_u64()),
-            tms_stime: clock_t_from_jiffies(prof_clock.kernel_clock().read_jiffies().as_u64()),
-            tms_cutime: clock_t_from_jiffies(duration_to_jiffies(child_user_time)),
-            tms_cstime: clock_t_from_jiffies(duration_to_jiffies(child_kernel_time)),
+            tms_utime: jiffies_to_clock_t(prof_clock.user_clock().read_jiffies()),
+            tms_stime: jiffies_to_clock_t(prof_clock.kernel_clock().read_jiffies()),
+            tms_cutime: duration_to_clock_t(child_user_time),
+            tms_cstime: duration_to_clock_t(child_kernel_time),
         };
 
         ctx.user_space().write_val(tms_addr, &tms)?;
     }
 
     Ok(SyscallReturn::Return(
-        clock_t_from_jiffies(Jiffies::elapsed().as_u64()) as isize,
+        jiffies_to_clock_t(Jiffies::elapsed()) as isize,
     ))
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod)]
 struct Tms {
-    tms_utime: i64,
-    tms_stime: i64,
-    tms_cutime: i64,
-    tms_cstime: i64,
-}
-
-/// Converts a duration into kernel clock ticks.
-fn duration_to_jiffies(duration: Duration) -> u64 {
-    const NSEC_PER_JIFFY: u64 = NSEC_PER_SEC as u64 / TIMER_FREQ;
-    const { assert!((NSEC_PER_SEC as u64).is_multiple_of(TIMER_FREQ)) };
-
-    let sec_jiffies = duration.as_secs().saturating_mul(TIMER_FREQ);
-    let subsec_jiffies = u64::from(duration.subsec_nanos()) / NSEC_PER_JIFFY;
-    sec_jiffies.saturating_add(subsec_jiffies)
-}
-
-fn clock_t_from_jiffies(jiffies: u64) -> i64 {
-    jiffies.min(i64::MAX as u64) as i64
+    tms_utime: clock_t,
+    tms_stime: clock_t,
+    tms_cutime: clock_t,
+    tms_cstime: clock_t,
 }

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -16,6 +16,7 @@ pub mod cpu_time_stats;
 mod softirq;
 mod system_time;
 pub mod timerfd;
+pub mod util;
 pub mod wait;
 
 pub type clockid_t = i32;

--- a/kernel/src/time/util.rs
+++ b/kernel/src/time/util.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#![expect(non_camel_case_types)]
+
+use core::time::Duration;
+
+use ostd::timer::{Jiffies, TIMER_FREQ};
+
+use crate::time::NSEC_PER_SEC;
+
+pub type clock_t = i64;
+
+/// The user-space clock tick frequency exposed by Linux ABIs such as `times(2)`.
+pub const USER_HZ: u64 = 100;
+
+/// Converts a duration into kernel clock ticks.
+pub fn duration_to_jiffies(duration: Duration) -> Jiffies {
+    const NSEC_PER_JIFFY: u64 = NSEC_PER_SEC as u64 / TIMER_FREQ;
+    const { assert!((NSEC_PER_SEC as u64).is_multiple_of(TIMER_FREQ)) };
+
+    let sec_jiffies = duration.as_secs().saturating_mul(TIMER_FREQ);
+    let subsec_jiffies = u64::from(duration.subsec_nanos()) / NSEC_PER_JIFFY;
+    Jiffies::new(sec_jiffies.saturating_add(subsec_jiffies))
+}
+
+/// Converts kernel jiffies into the `clock_t` unit observed by user space.
+pub fn jiffies_to_clock_t(jiffies: Jiffies) -> clock_t {
+    let clock_ticks = jiffies.as_u64().saturating_mul(USER_HZ) / TIMER_FREQ;
+    clock_ticks.min(clock_t::MAX as u64) as clock_t
+}
+
+/// Converts a duration directly into the `clock_t` unit observed by user space.
+pub fn duration_to_clock_t(duration: Duration) -> clock_t {
+    jiffies_to_clock_t(duration_to_jiffies(duration))
+}

--- a/test/initramfs/src/regression/time/Makefile
+++ b/test/initramfs/src/regression/time/Makefile
@@ -5,5 +5,6 @@ SUBDIRS := \
 	clock_nanosleep \
 	gettimeofday \
 	itimer \
+	times \
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/time/run_test.sh
+++ b/test/initramfs/src/regression/time/run_test.sh
@@ -10,3 +10,5 @@ set -e
 
 ./itimer/setitimer
 ./itimer/timer_create
+
+./times/times

--- a/test/initramfs/src/regression/time/times/Makefile
+++ b/test/initramfs/src/regression/time/times/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+TESTS := times
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/time/times/times.c
+++ b/test/initramfs/src/regression/time/times/times.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+
+#include <errno.h>
+#include <sys/syscall.h>
+#include <sys/times.h>
+#include <unistd.h>
+
+FN_TEST(times_valid_tms)
+{
+	struct tms tms = { 0 };
+
+	TEST_RES(syscall(SYS_times, &tms),
+		 _ret >= 0 && tms.tms_utime >= 0 && tms.tms_stime >= 0 &&
+			 tms.tms_cutime >= 0 && tms.tms_cstime >= 0);
+}
+END_TEST()
+
+FN_TEST(times_null_tms)
+{
+	TEST_RES(syscall(SYS_times, NULL), _ret >= 0);
+}
+END_TEST()
+
+FN_TEST(times_bad_tms)
+{
+	TEST_ERRNO(syscall(SYS_times, (void *)0xDEAD0000), EFAULT);
+}
+END_TEST()

--- a/test/initramfs/src/regression/time/times/times.c
+++ b/test/initramfs/src/regression/time/times/times.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <sys/syscall.h>
 #include <sys/times.h>
+#include <time.h>
 #include <unistd.h>
 
 FN_TEST(times_valid_tms)
@@ -28,5 +29,42 @@ END_TEST()
 FN_TEST(times_bad_tms)
 {
 	TEST_ERRNO(syscall(SYS_times, (void *)0xDEAD0000), EFAULT);
+}
+END_TEST()
+
+FN_TEST(times_matches_sysconf_clk_tck)
+{
+	struct tms start_tms = { 0 };
+	struct tms end_tms = { 0 };
+	struct timespec start = { 0 };
+	struct timespec now = { 0 };
+	long clk_tck = sysconf(_SC_CLK_TCK);
+	long elapsed_ns = 0;
+	clock_t start_ticks;
+	clock_t end_ticks;
+	clock_t elapsed_ticks;
+	clock_t delta;
+	volatile unsigned long sink = 0;
+
+	TEST_RES(clk_tck, clk_tck == 100);
+	TEST_SUCC(clock_gettime(CLOCK_MONOTONIC, &start));
+	start_ticks = TEST_RES(syscall(SYS_times, &start_tms), _ret >= 0);
+
+	do {
+		for (unsigned long i = 0; i < 10000UL; i++) {
+			sink += i;
+		}
+		TEST_SUCC(clock_gettime(CLOCK_MONOTONIC, &now));
+		elapsed_ns = (now.tv_sec - start.tv_sec) * 1000000000L +
+			     (now.tv_nsec - start.tv_nsec);
+	} while (elapsed_ns < 200000000L);
+
+	end_ticks = TEST_RES(syscall(SYS_times, &end_tms), _ret >= 0);
+	elapsed_ticks = end_ticks - start_ticks;
+	delta = (end_tms.tms_utime + end_tms.tms_stime) -
+		(start_tms.tms_utime + start_tms.tms_stime);
+	TEST_RES(elapsed_ticks,
+		 elapsed_ticks > 0 && elapsed_ticks <= clk_tck + 2);
+	TEST_RES(delta, delta >= 0 && delta <= clk_tck + 2);
 }
 END_TEST()


### PR DESCRIPTION
## Summary
- add the `times(2)` syscall handler and wire it into x86_64 and generic syscall tables
- report process user/system CPU ticks from `ProfClock`, reaped-child ticks from `ReapedChildrenStats`, and elapsed ticks from `Jiffies::elapsed()`
- add regression coverage for valid `struct tms`, NULL `tms`, and bad user pointers

## Test plan
- `cargo fmt --check`
- `make run_kernel AUTO_TEST=regression`