### PR TITLE
Add the `Groups` field to `/proc/[pid]/status`

### DIFF
--- a/kernel/core/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -154,6 +154,14 @@ impl ProcFileOps for StatusFileOps {
                 .unwrap_or(0)
         )?;
 
+        write!(printer, "Groups:\t")?;
+        for (i, gid) in credentials.groups().iter().enumerate() {
+            let separator = if i == 0 { "" } else { " " };
+            write!(printer, "{}{}", separator, u32::from(*gid))?;
+        }
+        // Linux appends this space unconditionally, so an empty group list still prints one.
+        writeln!(printer, " ")?;
+
         if let Some(vmar_ref) = process.lock_vmar().as_ref() {
             let vsize = vmar_ref.get_mappings_total_size();
             let anon = vmar_ref.get_rss_counter(RssType::Anon) * (PAGE_SIZE / 1024);

--- a/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/status.rs
@@ -150,6 +150,14 @@ impl ProcFileOps for StatusFileOps {
                 .unwrap_or(0)
         )?;
 
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/array.c#L199>
+        write!(printer, "Groups:\t")?;
+        for gid in credentials.groups().iter() {
+            write!(printer, "{} ", u32::from(*gid))?;
+        }
+        writeln!(printer)?;
+
         if let Some(vmar_ref) = process.lock_vmar().as_ref() {
             let vsize = vmar_ref.get_mappings_total_size();
             let anon = vmar_ref.get_rss_counter(RssType::Anon) * (PAGE_SIZE / 1024);

--- a/test/initramfs/src/conformance/gvisor/blocklists/proc_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/proc_test
@@ -16,7 +16,6 @@ ProcPidMem.DifferentUserAttached
 ProcPidFile.SubprocessRunning
 ProcPidFile.SubprocessZombie
 ProcPidFile.SubprocessExited
-ProcPidStatusTest.HasBasicFields
 ProcPidStatTest.VmStats
 ProcPidSymlink.SubprocessRunning
 ProcPidSymlink.SubprocessZombied


### PR DESCRIPTION
## What

Add the missing `Groups:` line to `/proc/[pid]/status` (and the per-thread
`/proc/[pid]/task/[tid]/status`), listing the process's supplementary group IDs.

## Why

`Groups:` is a standard field of `/proc/[pid]/status`. Its absence is the only
reason the gVisor `proc` conformance test `ProcPidStatusTest.HasBasicFields`
fails: the test reads `/proc/[tid]/status` for a thread and asserts, among other
already-present fields (`Name`, `Tgid`, `Pid`, `PPid`, `Uid`, `Gid`), that the
`Groups` value starts with the process's supplementary GID list (from
`getgroups(2)`). Every other field the test checks is already emitted, so this
one-line addition unblocks it.

## How

After the `FDSize:` line (matching Linux's field order), the handler writes
`Groups:\t` followed by each supplementary GID and a trailing space, iterating
the credentials' supplementary group set (`credentials.groups()`). Asterinas
stores these GIDs in a sorted set, which matches the ordering returned by its own
`getgroups(2)`, so the two views are consistent. When there are no supplementary
groups the value is empty, exactly as on Linux.

The gVisor case is removed from
`test/initramfs/src/conformance/gvisor/blocklists/proc_test`.

## Reference

- `Groups:` emission in `task_state`: [`fs/proc/array.c#L199`](https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/array.c#L199)

## Testing

- `rustfmt` (pinned `nightly-2026-04-03`) reports the changed file as clean.
- The previously-blocklisted gVisor `ProcPidStatusTest.HasBasicFields` case is now
  enabled and will be exercised by CI. (Secondary-thread `/proc/[tid]` lookup is
  already supported, so the missing `Groups` line was the sole gap.)

Note: I could not run the full kernel build or the gVisor suite locally (the
build OOMs in my WSL environment). The change is a small extension of the existing
`/proc/[pid]/status` handler.
