### PR TITLE
Implement Smack policy ABI and mount labels

### DIFF
--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -57,6 +57,46 @@ virtio_mmio.device=0x200@0x5950f000:10
 virtio_mmio.device=1K@0x1001e000:74
 ```
 
+### `lsm`
+
+Select the optional Linux Security Modules (LSMs) to enable,
+in the order they should run after mandatory capability checks.
+
+Valid module names:
+- `yama`
+- `smack`
+
+If omitted,
+Asterinas enables the default optional module stack,
+which currently contains `yama`.
+Unknown names are ignored with a warning.
+Duplicate names are ignored after their first occurrence.
+If multiple exclusive major modules are listed,
+only the first one is enabled.
+
+Examples:
+```text
+lsm=smack
+lsm=yama,smack
+```
+
+### `security`
+
+Select one legacy major LSM.
+
+Valid values:
+- `smack`
+
+If `lsm=` is also specified,
+`security=` is ignored.
+If only `security=smack` is specified,
+the default optional module stack remains enabled and Smack is added.
+
+Example:
+```text
+security=smack
+```
+
 ## Asterinas-specific
 ### `earlycon`
 

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -7,8 +7,8 @@ use core::{fmt::Display, sync::atomic::Ordering};
 use aster_rights::Rights;
 
 use super::{
-    AccessMode, AtomicStatusFlags, CreationFlags, FileLike, InodeType, Mappable, StatusFlags,
-    file_table::FdFlags, flock::FlockItem,
+    AccessMode, AtomicStatusFlags, CreationFlags, FileLike, InodeType, Mappable, Permission,
+    StatusFlags, file_table::FdFlags, flock::FlockItem,
 };
 use crate::{
     events::IoEvents,
@@ -24,6 +24,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
+    security,
     util::ioctl::RawIoctl,
 };
 
@@ -45,7 +46,9 @@ impl InodeHandle {
             // "Opening a file or directory with the O_PATH flag requires no permissions on the
             // object itself".
             // Reference: <https://man7.org/linux/man-pages/man2/openat.2.html>
-            inode.check_permission(access_mode.into())?;
+            let permission = access_mode.into();
+            inode.check_permission(permission)?;
+            security::inode_permission(inode.as_ref(), permission)?;
         }
 
         Self::new_unchecked_access(path, access_mode, status_flags)
@@ -122,6 +125,7 @@ impl InodeHandle {
         if !self.rights.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
+        security::file_permission(&self.path, Permission::MAY_READ)?;
 
         let file_ops: &dyn FileOps = if let Some(ref open_file) = self.open_file {
             open_file.as_ref()
@@ -259,6 +263,7 @@ impl FileLike for InodeHandle {
         if !self.rights.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
+        security::file_permission(&self.path, Permission::MAY_READ)?;
 
         let (file_ops, is_offset_aware) = self.file_ops_and_is_offset_aware();
         let status_flags = self.status_flags();
@@ -282,6 +287,7 @@ impl FileLike for InodeHandle {
 
         let (file_ops, is_offset_aware) = self.file_ops_and_is_offset_aware();
         let status_flags = self.status_flags();
+        security::file_permission(&self.path, write_permission(status_flags))?;
 
         if !is_offset_aware {
             return file_ops.write_at(0, reader, status_flags);
@@ -307,6 +313,7 @@ impl FileLike for InodeHandle {
         if !self.rights.contains(Rights::READ) {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
+        security::file_permission(&self.path, Permission::MAY_READ)?;
 
         let status_flags = self.status_flags();
 
@@ -320,6 +327,7 @@ impl FileLike for InodeHandle {
         }
 
         let status_flags = self.status_flags();
+        security::file_permission(&self.path, write_permission(status_flags))?;
 
         // FIXME: How can we deal with the `O_APPEND` flag if `open_file` is set?
         if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
@@ -375,6 +383,7 @@ impl FileLike for InodeHandle {
             // FIXME: It's allowed to `ftruncate` an append-only file on Linux.
             return_errno_with_message!(Errno::EPERM, "can not resize append-only file");
         }
+        security::path_setattr(&self.path)?;
         self.path.inode().resize(new_size)
     }
 
@@ -464,6 +473,7 @@ impl FileLike for InodeHandle {
             );
         }
 
+        security::file_permission(&self.path, Permission::MAY_WRITE)?;
         inode.fallocate(mode, offset, len)
     }
 
@@ -495,6 +505,14 @@ impl FileLike for InodeHandle {
             inner: self,
             fd_flags,
         })
+    }
+}
+
+fn write_permission(status_flags: StatusFlags) -> Permission {
+    if status_flags.contains(StatusFlags::O_APPEND) {
+        Permission::MAY_APPEND
+    } else {
+        Permission::MAY_WRITE
     }
 }
 

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -33,7 +33,7 @@ use super::{
 use crate::{
     fs::{ext2::utils, vfs::file_system::FsEventSubscriberStats},
     process::{Gid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
-    security::lsm::hooks as lsm_hooks,
+    security::{self, SmackMountLabels, lsm::hooks as lsm_hooks},
     thread::Thread,
 };
 
@@ -59,6 +59,8 @@ pub struct Ext2 {
     group_descriptors_segment: USegment,
     /// Runtime mount options that affect block-count reporting.
     mount_options: Ext2MountOptions,
+    /// Smack labels supplied through mount options.
+    smack_mount_labels: SmackMountLabels,
     /// FS event stats for VFS.
     fs_event_subscriber_stats: FsEventSubscriberStats,
     /// Per-filesystem inode generation counter.
@@ -122,6 +124,7 @@ impl Ext2 {
         }
 
         let mount_options = Ext2MountOptions::parse(data);
+        let smack_mount_labels = security::smack_mount_labels_from_options(data)?;
 
         let nr_inodes_per_group = super_block.nr_inodes_per_group();
 
@@ -174,10 +177,13 @@ impl Ext2 {
             nr_inodes_per_group,
             group_descriptors_segment,
             mount_options,
+            smack_mount_labels,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
             next_generation: AtomicU32::new(utils::duration_to_ext2_secs(utils::now())),
             self_ref: weak_self.clone(),
         });
+
+        security::apply_smack_mount_labels(ext2.as_ref())?;
 
         Ok(ext2)
     }
@@ -218,6 +224,11 @@ impl Ext2 {
     /// Returns the fs event subscriber stats.
     pub(super) fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
         &self.fs_event_subscriber_stats
+    }
+
+    /// Returns Smack labels supplied through mount options.
+    pub(super) fn smack_mount_labels(&self) -> SmackMountLabels {
+        self.smack_mount_labels.clone()
     }
 
     /// Returns the root inode.

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
@@ -58,6 +58,7 @@ impl FileSystem for Ext2 {
             frsize: sb.fragment_size(),
             flags: 0,
             container_dev_id: self.container_device_id(),
+            smack: self.smack_mount_labels(),
         }
     }
 

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -16,6 +16,7 @@ use self::{
     mounts::MountsSymOps,
     pid::{PidDirOps, TidDirOps},
     self_::SelfSymOps,
+    smack::SmackDirOps,
     sys::SysDirOps,
     thread_self::ThreadSelfSymOps,
     uptime::UptimeFileOps,
@@ -38,6 +39,7 @@ use crate::{
         Pid,
         pid_table::{self, PidEntryType},
     },
+    security,
 };
 
 mod cmdline;
@@ -48,6 +50,7 @@ mod meminfo;
 mod mounts;
 mod pid;
 mod self_;
+mod smack;
 mod stat;
 mod sys;
 mod template;
@@ -199,6 +202,10 @@ impl ProcDirOps for RootDirOps {
             return Ok(child);
         }
 
+        if name == "smack" && security::is_smack_enabled() {
+            return Ok(SmackDirOps::new_inode(this_dir.this_weak().clone()));
+        }
+
         return_errno_with_message!(Errno::ENOENT, "the file does not exist");
     }
 
@@ -211,6 +218,16 @@ impl ProcDirOps for RootDirOps {
             sequential_readdir_entries(offset, 2, listed_entries_from_table(Self::STATIC_ENTRIES)),
             &mut visit_fn,
         )?;
+        if security::is_smack_enabled() {
+            visit_readdir_entries(
+                sequential_readdir_entries(
+                    offset,
+                    2 + RootDirOps::STATIC_ENTRIES.len(),
+                    [ListedEntry::new("smack", InodeType::Dir)],
+                ),
+                &mut visit_fn,
+            )?;
+        }
 
         // Collect PIDs before visiting entries, as `visit_fn` may copy data to user memory.
         let process_pids = {

--- a/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
@@ -32,8 +32,13 @@ impl AttrDirOps {
         ProcDir::new(Self(dir.clone()), parent, mkmod!(a+rx))
     }
 
-    const STATIC_ENTRIES: &'static [StaticEntryWithOps<AttrDirOps>] =
-        &[("current", InodeType::File, CurrentFileOps::new_inode)];
+    const STATIC_ENTRIES: &'static [StaticEntryWithOps<AttrDirOps>] = &[
+        ("current", InodeType::File, CurrentFileOps::new_inode),
+        ("exec", InodeType::File, ExecFileOps::new_inode),
+        ("prev", InodeType::File, PrevFileOps::new_inode),
+        ("fscreate", InodeType::File, FscreateFileOps::new_inode),
+        ("sockcreate", InodeType::File, SockcreateFileOps::new_inode),
+    ];
 }
 
 impl ProcDirOps for AttrDirOps {
@@ -158,6 +163,146 @@ impl ProcFileOps for CurrentFileOps {
 
         let (label, read_bytes) = read_label_from(reader)?;
         security::set_current_smack_label(&label)?;
+
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/exec`.
+struct ExecFileOps(TidDirOps);
+
+impl ExecFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for ExecFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        if let Some(label) = task_state_of(&self.0)?.exec_label() {
+            write!(printer, "{}", label.as_str())?;
+        }
+        writeln!(printer)?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        ensure_current_thread(&thread)?;
+
+        let (label, read_bytes) = read_label_from(reader)?;
+        security::set_current_smack_exec_label(&label)?;
+
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/prev`.
+struct PrevFileOps(TidDirOps);
+
+impl PrevFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r))
+    }
+}
+
+impl ProcFileOps for PrevFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        if let Some(label) = task_state_of(&self.0)?.previous_label() {
+            write!(printer, "{}", label.as_str())?;
+        }
+        writeln!(printer)?;
+
+        Ok(printer.bytes_written())
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/fscreate`.
+struct FscreateFileOps(TidDirOps);
+
+impl FscreateFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for FscreateFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        if let Some(label) = task_state_of(&self.0)?.fscreate_label() {
+            write!(printer, "{}", label.as_str())?;
+        }
+        writeln!(printer)?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        ensure_current_thread(&thread)?;
+
+        let (label, read_bytes) = read_label_from(reader)?;
+        security::set_current_smack_fscreate_label(&label)?;
+
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/sockcreate`.
+struct SockcreateFileOps(TidDirOps);
+
+impl SockcreateFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for SockcreateFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        if let Some(label) = task_state_of(&self.0)?.sockcreate_label() {
+            write!(printer, "{}", label.as_str())?;
+        }
+        writeln!(printer)?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        ensure_current_thread(&thread)?;
+
+        let (label, read_bytes) = read_label_from(reader)?;
+        security::set_current_smack_sockcreate_label(&label)?;
 
         Ok(read_bytes)
     }

--- a/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::{
+            StaticEntryWithOps,
+            template::{
+                ListedEntry, ProcDir, ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry,
+                listed_entries_from_table, lookup_child_from_table, visit_listed_entries,
+            },
+        },
+        vfs::inode::{Inode, RevalidationPolicy},
+    },
+    prelude::*,
+    process::posix_thread::AsPosixThread,
+    security,
+    thread::Thread,
+};
+
+const MAX_WRITTEN_LABEL_LEN: usize = 256;
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr`.
+pub(super) struct AttrDirOps(TidDirOps);
+
+impl AttrDirOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L2850>
+        ProcDir::new(Self(dir.clone()), parent, mkmod!(a+rx))
+    }
+
+    const STATIC_ENTRIES: &'static [StaticEntryWithOps<AttrDirOps>] =
+        &[("current", InodeType::File, CurrentFileOps::new_inode)];
+}
+
+impl ProcDirOps for AttrDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if self.0.thread().is_none() {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
+        }
+
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(self, this_dir.this_weak().clone())
+        }) {
+            return Ok(child);
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the file does not exist");
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        if self.0.thread().is_none() {
+            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
+        }
+
+        visit_listed_entries(offset, self.static_listed_entries(), visit_fn)
+    }
+
+    fn revalidation_policy(&self) -> RevalidationPolicy {
+        RevalidationPolicy::REVALIDATE_EXISTS
+    }
+
+    fn revalidate_exists(&self, _name: &str, _child: &dyn Inode) -> bool {
+        self.0.thread().is_some()
+    }
+}
+
+impl AttrDirOps {
+    fn static_listed_entries(&self) -> impl Iterator<Item = ListedEntry<'_>> + '_ {
+        listed_entries_from_table(Self::STATIC_ENTRIES)
+    }
+}
+
+fn task_state_of(dir: &TidDirOps) -> Result<security::SmackTaskState> {
+    let Some(thread) = dir.thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+    };
+    let Some(posix_thread) = thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the thread is not a POSIX thread");
+    };
+    let Some(task_state) = security::smack_task_state(posix_thread) else {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    };
+
+    Ok(task_state)
+}
+
+fn ensure_current_thread(thread: &Arc<Thread>) -> Result<()> {
+    let Some(current_thread) = Thread::current() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread does not exist");
+    };
+    if !Arc::ptr_eq(&current_thread, thread) {
+        return_errno_with_message!(
+            Errno::EPERM,
+            "the Smack task attribute is only writable by the current thread"
+        );
+    }
+
+    Ok(())
+}
+
+fn read_label_from(reader: &mut VmReader) -> Result<(String, usize)> {
+    let (label, read_bytes) = reader.read_cstring_until_end(MAX_WRITTEN_LABEL_LEN)?;
+    if reader.has_remain() {
+        return_errno_with_message!(Errno::E2BIG, "the Smack label is too large");
+    }
+
+    let label = label
+        .to_str()
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the Smack label is not valid UTF-8"))?
+        .trim();
+    if label.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the Smack label is empty");
+    }
+
+    Ok((label.to_string(), read_bytes))
+}
+
+/// Represents the inode at `/proc/[pid]/task/[tid]/attr/current`.
+struct CurrentFileOps(TidDirOps);
+
+impl CurrentFileOps {
+    pub fn new_inode(dir: &AttrDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/base.c#L2775>
+        ProcFile::new(Self(dir.0.clone()), parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for CurrentFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let mut printer = VmPrinter::new_skip(writer, offset);
+
+        let task_state = task_state_of(&self.0)?;
+        writeln!(printer, "{}", task_state.current_label().as_str())?;
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let Some(thread) = self.0.thread() else {
+            return_errno_with_message!(Errno::ESRCH, "the thread does not exist");
+        };
+        ensure_current_thread(&thread)?;
+
+        let (label, read_bytes) = read_label_from(reader)?;
+        security::set_current_smack_label(&label)?;
+
+        Ok(read_bytes)
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -7,12 +7,12 @@ use crate::{
         procfs::{
             StaticEntryWithOps,
             pid::task::{
-                auxv::AuxvFileOps, cgroup::CgroupFileOps, cmdline::CmdlineFileOps,
-                comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
-                gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
-                mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
-                ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
-                status::StatusFileOps, uid_map::UidMapFileOps,
+                attr::AttrDirOps, auxv::AuxvFileOps, cgroup::CgroupFileOps,
+                cmdline::CmdlineFileOps, comm::CommFileOps, environ::EnvironFileOps,
+                exe::ExeSymOps, fd::FdDirOps, gid_map::GidMapFileOps, maps::MapsFileOps,
+                mem::MemFileOps, mountinfo::MountInfoFileOps, mounts::MountsFileOps,
+                mountstats::MountStatsFileOps, ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps,
+                stat::StatFileOps, status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
                 ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, keyed_readdir_entries,
@@ -27,6 +27,7 @@ use crate::{
     thread::{Thread, Tid},
 };
 
+mod attr;
 mod auxv;
 mod cgroup;
 mod cmdline;
@@ -100,6 +101,7 @@ impl TidDirOps {
     }
 
     const STATIC_ENTRIES: &'static [StaticEntryWithOps<TidDirOps>] = &[
+        ("attr", InodeType::Dir, AttrDirOps::new_inode),
         ("auxv", InodeType::File, AuxvFileOps::new_inode),
         ("cgroup", InodeType::File, CgroupFileOps::new_inode),
         ("cmdline", InodeType::File, CmdlineFileOps::new_inode),

--- a/kernel/src/fs/fs_impls/procfs/smack.rs
+++ b/kernel/src/fs/fs_impls/procfs/smack.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::{
+            StaticEntry,
+            template::{
+                ProcDir, ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry,
+                listed_entries_from_table, lookup_child_from_table, visit_listed_entries,
+            },
+        },
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    security,
+};
+
+const MAX_POLICY_WRITE_LEN: usize = 64 * 1024;
+
+/// Represents the inode at `/proc/smack`.
+pub struct SmackDirOps;
+
+impl SmackDirOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcDir::new(Self, parent, mkmod!(a+rx))
+    }
+
+    const STATIC_ENTRIES: &'static [StaticEntry] = &[
+        ("load", InodeType::File, LoadFileOps::new_inode),
+        ("accesses", InodeType::File, AccessesFileOps::new_inode),
+    ];
+}
+
+impl ProcDirOps for SmackDirOps {
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if let Some(child) = lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| {
+            (f)(this_dir.this_weak().clone())
+        }) {
+            return Ok(child);
+        }
+
+        return_errno_with_message!(Errno::ENOENT, "the file does not exist");
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            listed_entries_from_table(Self::STATIC_ENTRIES),
+            visit_fn,
+        )
+    }
+}
+
+/// Represents the inode at `/proc/smack/load`.
+struct LoadFileOps;
+
+impl LoadFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for LoadFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        write_rules_at(offset, writer)
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        read_and_load_rules(reader)
+    }
+}
+
+/// Represents the inode at `/proc/smack/accesses`.
+struct AccessesFileOps;
+
+impl AccessesFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r))
+    }
+}
+
+impl ProcFileOps for AccessesFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        write_rules_at(offset, writer)
+    }
+}
+
+fn write_rules_at(offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    let rules = security::smack_rules_as_text()?;
+    let mut printer = VmPrinter::new_skip(writer, offset);
+    write!(printer, "{}", rules)?;
+    Ok(printer.bytes_written())
+}
+
+fn read_and_load_rules(reader: &mut VmReader) -> Result<usize> {
+    let read_bytes = reader.remain();
+    if read_bytes > MAX_POLICY_WRITE_LEN {
+        return_errno_with_message!(Errno::E2BIG, "the Smack policy write is too large");
+    }
+
+    let mut policy = vec![0u8; read_bytes];
+    reader.read_fallible(&mut VmWriter::from(policy.as_mut_slice()))?;
+    let policy = core::str::from_utf8(&policy)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "the Smack policy is not UTF-8"))?;
+    security::load_smack_rules(policy)?;
+
+    Ok(read_bytes)
+}

--- a/kernel/src/fs/fs_impls/procfs/smack.rs
+++ b/kernel/src/fs/fs_impls/procfs/smack.rs
@@ -30,7 +30,19 @@ impl SmackDirOps {
 
     const STATIC_ENTRIES: &'static [StaticEntry] = &[
         ("load", InodeType::File, LoadFileOps::new_inode),
+        ("load2", InodeType::File, LoadFileOps::new_inode),
+        ("access", InodeType::File, AccessFileOps::new_inode),
+        ("access2", InodeType::File, AccessFileOps::new_inode),
         ("accesses", InodeType::File, AccessesFileOps::new_inode),
+        ("change-rule", InodeType::File, ChangeRuleFileOps::new_inode),
+        (
+            "revoke-subject",
+            InodeType::File,
+            RevokeSubjectFileOps::new_inode,
+        ),
+        ("ambient", InodeType::File, AmbientFileOps::new_inode),
+        ("onlycap", InodeType::File, OnlycapFileOps::new_inode),
+        ("logging", InodeType::File, LoggingFileOps::new_inode),
     ];
 }
 
@@ -76,6 +88,31 @@ impl ProcFileOps for LoadFileOps {
     }
 }
 
+/// Represents the inode at `/proc/smack/access`.
+struct AccessFileOps;
+
+impl AccessFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for AccessFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        write_text_at(
+            offset,
+            writer,
+            security::smack_access_query_result_as_text()?,
+        )
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let (query, read_bytes) = read_policy_text(reader)?;
+        security::query_smack_access(&query)?;
+        Ok(read_bytes)
+    }
+}
+
 /// Represents the inode at `/proc/smack/accesses`.
 struct AccessesFileOps;
 
@@ -91,14 +128,129 @@ impl ProcFileOps for AccessesFileOps {
     }
 }
 
+/// Represents the inode at `/proc/smack/change-rule`.
+struct ChangeRuleFileOps;
+
+impl ChangeRuleFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(u+w))
+    }
+}
+
+impl ProcFileOps for ChangeRuleFileOps {
+    fn read_at(&self, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "the Smack change-rule file is write-only");
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let (rule, read_bytes) = read_policy_text(reader)?;
+        security::change_smack_rule(&rule)?;
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/smack/revoke-subject`.
+struct RevokeSubjectFileOps;
+
+impl RevokeSubjectFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(u+w))
+    }
+}
+
+impl ProcFileOps for RevokeSubjectFileOps {
+    fn read_at(&self, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "the Smack revoke-subject file is write-only");
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let (subject, read_bytes) = read_policy_text(reader)?;
+        security::revoke_smack_subject(&subject)?;
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/smack/ambient`.
+struct AmbientFileOps;
+
+impl AmbientFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for AmbientFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        write_text_at(offset, writer, security::smack_ambient_label_as_text()?)
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let (label, read_bytes) = read_policy_text(reader)?;
+        security::set_smack_ambient_label(&label)?;
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/smack/onlycap`.
+struct OnlycapFileOps;
+
+impl OnlycapFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for OnlycapFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        write_text_at(offset, writer, security::smack_onlycap_labels_as_text()?)
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let (labels, read_bytes) = read_policy_text(reader)?;
+        security::set_smack_onlycap_labels(&labels)?;
+        Ok(read_bytes)
+    }
+}
+
+/// Represents the inode at `/proc/smack/logging`.
+struct LoggingFileOps;
+
+impl LoggingFileOps {
+    pub fn new_inode(parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self, parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for LoggingFileOps {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        write_text_at(offset, writer, security::smack_logging_mode_as_text()?)
+    }
+
+    fn write_at(&self, _offset: usize, reader: &mut VmReader) -> Result<usize> {
+        let (mode, read_bytes) = read_policy_text(reader)?;
+        security::set_smack_logging_mode(&mode)?;
+        Ok(read_bytes)
+    }
+}
+
 fn write_rules_at(offset: usize, writer: &mut VmWriter) -> Result<usize> {
-    let rules = security::smack_rules_as_text()?;
+    write_text_at(offset, writer, security::smack_rules_as_text()?)
+}
+
+fn write_text_at(offset: usize, writer: &mut VmWriter, text: String) -> Result<usize> {
     let mut printer = VmPrinter::new_skip(writer, offset);
-    write!(printer, "{}", rules)?;
+    write!(printer, "{}", text)?;
     Ok(printer.bytes_written())
 }
 
 fn read_and_load_rules(reader: &mut VmReader) -> Result<usize> {
+    let (policy, read_bytes) = read_policy_text(reader)?;
+    security::load_smack_rules(&policy)?;
+
+    Ok(read_bytes)
+}
+
+fn read_policy_text(reader: &mut VmReader) -> Result<(String, usize)> {
     let read_bytes = reader.remain();
     if read_bytes > MAX_POLICY_WRITE_LEN {
         return_errno_with_message!(Errno::E2BIG, "the Smack policy write is too large");
@@ -108,7 +260,5 @@ fn read_and_load_rules(reader: &mut VmReader) -> Result<usize> {
     reader.read_fallible(&mut VmWriter::from(policy.as_mut_slice()))?;
     let policy = core::str::from_utf8(&policy)
         .map_err(|_| Error::with_message(Errno::EINVAL, "the Smack policy is not UTF-8"))?;
-    security::load_smack_rules(policy)?;
-
-    Ok(read_bytes)
+    Ok((policy.to_string(), read_bytes))
 }

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -44,6 +44,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::{Extension, FileOps, Inode, Metadata},
+            xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
     prelude::*,
@@ -192,6 +193,7 @@ impl From<PseudoInodeType> for InodeType {
 pub struct PseudoInode {
     metadata: SpinLock<Metadata>,
     extension: Extension,
+    xattrs: RwMutex<BTreeMap<String, Vec<u8>>>,
     fs: Weak<NaivePseudoFs>,
     is_anon: bool,
 }
@@ -230,6 +232,7 @@ impl PseudoInode {
         PseudoInode {
             metadata: SpinLock::new(metadata),
             extension: Extension::new(),
+            xattrs: RwMutex::new(BTreeMap::new()),
             fs,
             is_anon: type_ == InodeType::Unknown,
         }
@@ -365,8 +368,85 @@ impl Inode for PseudoInode {
     fn fs(&self) -> Arc<dyn FileSystem> {
         self.fs.upgrade().unwrap()
     }
+
+    fn set_xattr(
+        &self,
+        name: XattrName,
+        value_reader: &mut VmReader,
+        flags: XattrSetFlags,
+    ) -> Result<()> {
+        let mut xattrs = self.xattrs.write();
+        let name = name.full_name();
+        if flags.contains(XattrSetFlags::CREATE_ONLY) && xattrs.contains_key(name) {
+            return_errno_with_message!(Errno::EEXIST, "the target xattr already exists");
+        }
+        if flags.contains(XattrSetFlags::REPLACE_ONLY) && !xattrs.contains_key(name) {
+            return_errno_with_message!(Errno::ENODATA, "the target xattr does not exist");
+        }
+
+        let mut value = vec![0u8; value_reader.remain()];
+        value_reader.read_fallible(&mut VmWriter::from(value.as_mut_slice()))?;
+        xattrs.insert(name.to_string(), value);
+        Ok(())
+    }
+
+    fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize> {
+        let xattrs = self.xattrs.read();
+        let value = xattrs.get(name.full_name()).ok_or_else(|| {
+            Error::with_message(Errno::ENODATA, "the target xattr does not exist")
+        })?;
+        let value_len = value.len();
+
+        let value_avail_len = value_writer.avail();
+        if value_avail_len == 0 {
+            return Ok(value_len);
+        }
+        if value_len > value_avail_len {
+            return_errno_with_message!(Errno::ERANGE, "the xattr value buffer is too small");
+        }
+
+        value_writer.write_fallible(&mut VmReader::from(value.as_slice()))?;
+        Ok(value_len)
+    }
+
+    fn list_xattr(&self, namespace: XattrNamespace, list_writer: &mut VmWriter) -> Result<usize> {
+        let xattrs = self.xattrs.read();
+        let list_len = xattrs
+            .keys()
+            .filter(|name| xattr_namespace_matches(name, namespace))
+            .map(|name| name.len() + 1)
+            .sum();
+        let list_avail_len = list_writer.avail();
+        if list_avail_len == 0 {
+            return Ok(list_len);
+        }
+        if list_len > list_avail_len {
+            return_errno_with_message!(Errno::ERANGE, "the xattr list buffer is too small");
+        }
+
+        for name in xattrs
+            .keys()
+            .filter(|name| xattr_namespace_matches(name, namespace))
+        {
+            list_writer.write_fallible(&mut VmReader::from(name.as_bytes()))?;
+            list_writer.write_val(&0u8)?;
+        }
+        Ok(list_len)
+    }
+
+    fn remove_xattr(&self, name: XattrName) -> Result<()> {
+        self.xattrs
+            .write()
+            .remove(name.full_name())
+            .ok_or_else(|| Error::with_message(Errno::ENODATA, "the target xattr does not exist"))
+            .map(|_| ())
+    }
 }
 
 fn now() -> Duration {
     RealTimeCoarseClock::get().read_time()
+}
+
+fn xattr_namespace_matches(full_name: &str, namespace: XattrNamespace) -> bool {
+    XattrNamespace::try_from_full_name(full_name) == Some(namespace)
 }

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    security,
 };
 
 pub(super) fn init() {
@@ -36,7 +37,7 @@ impl SockFs {
     }
 
     /// Creates a pseudo `Path` for a socket.
-    pub fn new_path() -> Path {
+    pub fn new_path() -> Result<Path> {
         let socket_inode = Arc::new(Self::singleton().alloc_inode(
             PseudoInodeType::Socket,
             mkmod!(a+rwx),
@@ -44,9 +45,12 @@ impl SockFs {
             Gid::new_root(),
         ));
 
-        Path::new_pseudo(Self::mount_node().clone(), socket_inode, |inode| {
+        let path = Path::new_pseudo(Self::mount_node().clone(), socket_inode, |inode| {
             format!("socket:[{}]", inode.ino())
-        })
+        });
+        security::socket_create(&path)?;
+
+        Ok(path)
     }
 
     /// Returns the pseudo mount node of the socket file system.

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -37,6 +37,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid, posix_thread::AsPosixThread},
+    security::{self, SmackMountLabels},
     thread::Thread,
     time::clocks::RealTimeCoarseClock,
     vm::page_cache::PageCache,
@@ -61,17 +62,36 @@ impl RamFs {
         Self::new_internal("ramfs")
     }
 
+    pub(in crate::fs) fn new_with_mount_args(args: Option<&CStr>) -> Result<Arc<Self>> {
+        let smack_mount_labels = security::smack_mount_labels_from_options(args)?;
+        let fs = Self::new_internal_with_smack_labels("ramfs", smack_mount_labels);
+        security::apply_smack_mount_labels(fs.as_ref())?;
+        Ok(fs)
+    }
+
     pub(in crate::fs) fn new_rootfs() -> Arc<Self> {
         Self::new_internal("rootfs")
     }
 
     // TODO: Remove this tmpfs-specific constructor once `TmpFs` no longer
     // aliases `RamFs`.
-    pub fn new_tmpfs() -> Arc<Self> {
+    pub(in crate::fs) fn new_tmpfs() -> Arc<Self> {
+        Self::new_tmpfs_with_smack_labels(SmackMountLabels::default())
+    }
+
+    pub(in crate::fs) fn new_tmpfs_with_mount_args(args: Option<&CStr>) -> Result<Arc<Self>> {
+        let smack_mount_labels = security::smack_mount_labels_from_options(args)?;
+        let fs = Self::new_tmpfs_with_smack_labels(smack_mount_labels);
+        security::apply_smack_mount_labels(fs.as_ref())?;
+        Ok(fs)
+    }
+
+    fn new_tmpfs_with_smack_labels(smack_mount_labels: SmackMountLabels) -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for tmpfs");
         let sb = {
             let mut super_block =
                 SuperBlock::new(TMPFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+            super_block.smack = smack_mount_labels;
             let max_blocks = tmpfs::default_max_blocks();
             let max_inodes = tmpfs::default_max_inodes();
             super_block.blocks = max_blocks;
@@ -85,8 +105,16 @@ impl RamFs {
     }
 
     fn new_internal(name: &'static str) -> Arc<Self> {
+        Self::new_internal_with_smack_labels(name, SmackMountLabels::default())
+    }
+
+    fn new_internal_with_smack_labels(
+        name: &'static str,
+        smack_mount_labels: SmackMountLabels,
+    ) -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for ramfs");
-        let sb = SuperBlock::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let mut sb = SuperBlock::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        sb.smack = smack_mount_labels;
         Self::new_internal_with_sb(name, anon_device_id, sb)
     }
 
@@ -1474,8 +1502,8 @@ impl FsType for RamFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(RamFs::new())
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(RamFs::new_with_mount_args(fs_creation_ctx.args())?)
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/fs.rs
@@ -40,8 +40,8 @@ impl FsType for TmpFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(TmpFs::new_tmpfs())
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(TmpFs::new_tmpfs_with_mount_args(fs_creation_ctx.args())?)
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/vfs/fs_apis/file_system.rs
+++ b/kernel/src/fs/vfs/fs_apis/file_system.rs
@@ -6,7 +6,7 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 use device_id::DeviceId;
 
 use super::inode::Inode;
-use crate::prelude::*;
+use crate::{prelude::*, security::SmackMountLabels};
 
 /// Common interface implemented by each concrete file system instance.
 pub trait FileSystem: Any + Sync + Send {
@@ -79,6 +79,7 @@ pub struct SuperBlock {
     pub frsize: usize,
     pub flags: u64,
     pub container_dev_id: DeviceId,
+    pub smack: SmackMountLabels,
 }
 
 impl SuperBlock {
@@ -96,6 +97,7 @@ impl SuperBlock {
             frsize: block_size,
             flags: 0,
             container_dev_id: dev_id,
+            smack: SmackMountLabels::default(),
         }
     }
 }

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -639,12 +639,23 @@ impl DirDentry<'_> {
 
     /// Deletes a `Dentry` by `unlink()` the inner inode.
     pub(super) fn unlink(&self, name: &str) -> Result<()> {
+        self.unlink_with_check(name, |_| Ok(()))
+    }
+
+    /// Deletes a `Dentry` after checking the child selected under the dentry lock.
+    pub(super) fn unlink_with_check(
+        &self,
+        name: &str,
+        check_child_fn: impl FnOnce(&Arc<dyn Inode>) -> Result<()>,
+    ) -> Result<()> {
         if is_dot_or_dotdot(name) {
             return_errno_with_message!(Errno::EISDIR, "unlink on . or ..");
         }
 
         let dir_inode = self.inode();
-        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.unlink(name))?;
+        let child_inode = self.remove_child(name, check_child_fn, |dir_inode, name| {
+            dir_inode.unlink(name)
+        })?;
 
         let nlinks = child_inode.metadata().nr_hard_links;
         fs::vfs::notify::on_link_count(&child_inode);
@@ -669,6 +680,15 @@ impl DirDentry<'_> {
 
     /// Deletes a directory `Dentry` by `rmdir()` the inner inode.
     pub(super) fn rmdir(&self, name: &str) -> Result<()> {
+        self.rmdir_with_check(name, |_| Ok(()))
+    }
+
+    /// Deletes a directory after checking the child selected under the dentry lock.
+    pub(super) fn rmdir_with_check(
+        &self,
+        name: &str,
+        check_child_fn: impl FnOnce(&Arc<dyn Inode>) -> Result<()>,
+    ) -> Result<()> {
         if is_dot(name) {
             return_errno_with_message!(Errno::EINVAL, "rmdir on .");
         }
@@ -677,7 +697,9 @@ impl DirDentry<'_> {
         }
 
         let dir_inode = self.inode();
-        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.rmdir(name))?;
+        let child_inode = self.remove_child(name, check_child_fn, |dir_inode, name| {
+            dir_inode.rmdir(name)
+        })?;
 
         let nlinks = child_inode.metadata().nr_hard_links;
         if nlinks == 0 {
@@ -702,6 +724,7 @@ impl DirDentry<'_> {
     fn remove_child(
         &self,
         name: &str,
+        check_child_fn: impl FnOnce(&Arc<dyn Inode>) -> Result<()>,
         remove_child_fn: impl FnOnce(&dyn Inode, &str) -> Result<()>,
     ) -> Result<Arc<dyn Inode>> {
         let dir_inode = self.inode();
@@ -733,6 +756,7 @@ impl DirDentry<'_> {
             None => dir_inode.lookup(name)?,
         };
 
+        check_child_fn(&child_inode)?;
         remove_child_fn(dir_inode.as_ref(), name)?;
         if cached_child.is_some() {
             children.upgrade().delete(name);
@@ -748,6 +772,18 @@ impl DirDentry<'_> {
         new_dir: &DirDentry,
         new_name: &str,
         mode: RenameMode,
+    ) -> Result<()> {
+        self.rename_with_check(old_name, new_dir, new_name, mode, |_, _| Ok(()))
+    }
+
+    /// Renames a `Dentry` after checking selected children under the dentry locks.
+    pub(super) fn rename_with_check(
+        &self,
+        old_name: &str,
+        new_dir: &DirDentry,
+        new_name: &str,
+        mode: RenameMode,
+        check_rename_fn: impl FnOnce(&dyn Inode, Option<&dyn Inode>) -> Result<()>,
     ) -> Result<()> {
         if is_dot_or_dotdot(old_name) {
             return_errno_with_message!(Errno::EBUSY, "old_name is . or ..");
@@ -797,6 +833,11 @@ impl DirDentry<'_> {
                 }
             }
 
+            check_rename_fn(
+                old_dentry.inode().as_ref(),
+                new_dentry.as_ref().map(|dentry| dentry.inode().as_ref()),
+            )?;
+
             old_dir_inode.rename(old_name, old_dir_inode, new_name, mode)?;
 
             match mode {
@@ -845,6 +886,11 @@ impl DirDentry<'_> {
             {
                 new_dir.check_sticky_bit_permission(new_dentry.inode())?;
             }
+
+            check_rename_fn(
+                old_dentry.inode().as_ref(),
+                new_dentry.as_ref().map(|dentry| dentry.inode().as_ref()),
+            )?;
 
             old_dir_inode.rename(old_name, new_dir_inode, new_name, mode)?;
 

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     process::{
         Gid, Uid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
     },
-    security::lsm::hooks as lsm_hooks,
+    security::{self, lsm::hooks as lsm_hooks},
 };
 
 mod dentry;
@@ -67,8 +67,14 @@ impl Path {
     pub fn new_fs_child(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Self> {
         let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
         self.check_dir_entry_mutation()?;
+        security::path_create(self)?;
         let new_child_dentry = dir_dentry.create(name, type_, mode)?;
-        Ok(Self::new(self.mount.clone(), new_child_dentry))
+        let new_child = Self::new(self.mount.clone(), new_child_dentry);
+        if let Err(error) = security::path_post_create(self, &new_child) {
+            self.remove_child_after_failed_post_create(name, type_.is_directory());
+            return Err(error);
+        }
+        Ok(new_child)
     }
 
     /// Creates a new `Path` to represent an unnamed temporary file.
@@ -83,9 +89,12 @@ impl Path {
     ) -> Result<Self> {
         let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
         self.check_dir_entry_mutation()?;
+        security::path_create(self)?;
         let tmp_inode = self.inode().create_tmpfile(mode, hard_linkability)?;
         let tmp_dentry = Dentry::new_anonymous(tmp_inode, &dir_dentry);
-        Ok(Self::new(self.mount.clone(), tmp_dentry))
+        let tmpfile_path = Self::new(self.mount.clone(), tmp_dentry);
+        security::path_post_create(self, &tmpfile_path)?;
+        Ok(tmpfile_path)
     }
 
     /// Creates a new pseudo `Path`.
@@ -593,8 +602,14 @@ impl Path {
     pub fn mknod(&self, name: &str, mode: InodeMode, type_: MknodType) -> Result<Self> {
         let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
         self.check_dir_entry_mutation()?;
+        security::path_create(self)?;
         let inner = dir_dentry.mknod(name, mode, type_)?;
-        Ok(Self::new(self.mount.clone(), inner))
+        let new_child = Self::new(self.mount.clone(), inner);
+        if let Err(error) = security::path_post_create(self, &new_child) {
+            self.remove_child_after_failed_post_create(name, false);
+            return Err(error);
+        }
+        Ok(new_child)
     }
 
     /// Links a new name for the `Path`.
@@ -606,6 +621,7 @@ impl Path {
         let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
         old.check_hardlink_source()?;
         self.check_dir_entry_mutation()?;
+        security::path_link(old, self)?;
         dir_dentry.link(old.inode(), name)
     }
 
@@ -613,14 +629,16 @@ impl Path {
     pub fn unlink(&self, name: &str) -> Result<()> {
         let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
         self.check_dir_entry_mutation()?;
-        dir_dentry.unlink(name)
+        dir_dentry
+            .unlink_with_check(name, |child| security::path_unlink(self, child.as_ref()))
     }
 
     /// Removes a directory by `rmdir()` the inner inode.
     pub fn rmdir(&self, name: &str) -> Result<()> {
         let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
         self.check_dir_entry_mutation()?;
-        dir_dentry.rmdir(name)
+        dir_dentry
+            .rmdir_with_check(name, |child| security::path_unlink(self, child.as_ref()))
     }
 
     /// Renames a `Path` to the new `Path` by `rename()` the inner inode.
@@ -643,7 +661,76 @@ impl Path {
             new_dir.check_dir_entry_mutation()?;
         }
 
-        old_dir_dentry.rename(old_name, &new_dir_dentry, new_name, mode)
+        old_dir_dentry.rename_with_check(
+            old_name,
+            &new_dir_dentry,
+            new_name,
+            mode,
+            |old_child, new_child| security::path_rename(self, old_child, new_dir, new_child),
+        )
+    }
+
+    fn remove_child_after_failed_post_create(&self, name: &str, is_dir: bool) {
+        let Ok(parent) = self.dentry.as_dir_dentry_or_err() else {
+            return;
+        };
+
+        let result = if is_dir {
+            parent.rmdir(name)
+        } else {
+            parent.unlink(name)
+        };
+        if let Err(error) = result {
+            warn!(
+                "failed to clean up `{}` after security post-create failure: {:?}",
+                name, error
+            );
+        }
+    }
+}
+
+impl Path {
+    /// Sets the inode mode after LSM metadata checks.
+    pub fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        security::path_setattr(self)?;
+        self.inode().set_mode(mode)
+    }
+
+    /// Resizes the inode after LSM metadata checks.
+    pub fn resize(&self, size: usize) -> Result<()> {
+        let inode = self.inode();
+        inode.check_permission(Permission::MAY_WRITE)?;
+        security::path_setattr(self)?;
+        inode.resize(size)
+    }
+
+    /// Sets the inode owner after LSM metadata checks.
+    pub fn set_owner(&self, uid: Uid) -> Result<()> {
+        security::path_setattr(self)?;
+        self.inode().set_owner(uid)
+    }
+
+    /// Sets the inode group after LSM metadata checks.
+    pub fn set_group(&self, gid: Gid) -> Result<()> {
+        security::path_setattr(self)?;
+        self.inode().set_group(gid)
+    }
+
+    /// Sets an xattr after LSM metadata checks.
+    pub fn set_xattr(
+        &self,
+        name: XattrName,
+        value_reader: &mut VmReader,
+        flags: XattrSetFlags,
+    ) -> Result<()> {
+        security::path_setattr(self)?;
+        self.inode().set_xattr(name, value_reader, flags)
+    }
+
+    /// Removes an xattr after LSM metadata checks.
+    pub fn remove_xattr(&self, name: XattrName) -> Result<()> {
+        security::path_setattr(self)?;
+        self.inode().remove_xattr(name)
     }
 }
 
@@ -655,38 +742,21 @@ impl Path {
     pub fn sync_data(&self) -> Result<()>;
     pub fn metadata(&self) -> Metadata;
     pub fn mode(&self) -> Result<InodeMode>;
-    pub fn set_mode(&self, mode: InodeMode) -> Result<()>;
     pub fn size(&self) -> usize;
     pub fn owner(&self) -> Result<Uid>;
-    pub fn set_owner(&self, uid: Uid) -> Result<()>;
     pub fn group(&self) -> Result<Gid>;
-    pub fn set_group(&self, gid: Gid) -> Result<()>;
     pub fn atime(&self) -> Duration;
     pub fn set_atime(&self, time: Duration);
     pub fn mtime(&self) -> Duration;
     pub fn set_mtime(&self, time: Duration);
     pub fn ctime(&self) -> Duration;
     pub fn set_ctime(&self, time: Duration);
-    pub fn set_xattr(
-        &self,
-        name: XattrName,
-        value_reader: &mut VmReader,
-        flags: XattrSetFlags,
-    ) -> Result<()>;
     pub fn get_xattr(&self, name: XattrName, value_writer: &mut VmWriter) -> Result<usize>;
     pub fn list_xattr(
         &self,
         namespace: XattrNamespace,
         list_writer: &mut VmWriter,
     ) -> Result<usize>;
-    pub fn remove_xattr(&self, name: XattrName) -> Result<()>;
-
-    /// Resizes the file.
-    pub fn resize(&self, size: usize) -> Result<()> {
-        let inode = self.inode();
-        inode.check_permission(Permission::MAY_WRITE)?;
-        inode.resize(size)
-    }
 }
 
 /// Checks if the file name is ".", indicating it's the current directory.

--- a/kernel/src/fs/vfs/path/resolver.rs
+++ b/kernel/src/fs/vfs/path/resolver.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     prelude::*,
     process::{pid_table::PidTable, posix_thread::AsPosixThread},
+    security,
 };
 
 /// The file descriptor of the current working directory.
@@ -558,6 +559,7 @@ impl PathResolver {
         if path.inode().check_permission(Permission::MAY_EXEC).is_err() {
             return_errno_with_message!(Errno::EACCES, "the path cannot be looked up");
         }
+        security::inode_permission(path.inode().as_ref(), Permission::MAY_EXEC)?;
         if name.len() > NAME_MAX {
             return_errno_with_message!(Errno::ENAMETOOLONG, "the path name is too long");
         }

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -59,15 +59,15 @@ impl OptionSet {
 }
 
 impl DatagramSocket {
-    pub fn new(is_nonblocking: bool) -> Arc<Self> {
+    pub fn new(is_nonblocking: bool) -> Result<Arc<Self>> {
         let unbound_datagram = UnboundDatagram::new();
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             inner: RwMutex::new(Inner::Unbound(unbound_datagram)),
             options: RwLock::new(OptionSet::new()),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
-        })
+            pseudo_path: SockFs::new_path()?,
+        }))
     }
 
     fn try_recv(

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -104,18 +104,21 @@ impl OptionSet {
 }
 
 impl StreamSocket {
-    pub fn new(is_nonblocking: bool, family: IpAddressFamily) -> Arc<Self> {
+    pub fn new(is_nonblocking: bool, family: IpAddressFamily) -> Result<Arc<Self>> {
         let init_stream = InitStream::new(family);
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Init(init_stream))),
             options: RwLock::new(OptionSet::new()),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
-        })
+            pseudo_path: SockFs::new_path()?,
+        }))
     }
 
-    fn new_accepted(connected_stream: ConnectedStream, listener_options: &OptionSet) -> Arc<Self> {
+    fn new_accepted(
+        connected_stream: ConnectedStream,
+        listener_options: &OptionSet,
+    ) -> Result<Arc<Self>> {
         let options = connected_stream.raw_with(|raw_tcp_socket| {
             let mut options = OptionSet::new();
 
@@ -150,13 +153,13 @@ impl StreamSocket {
         let pollee = Pollee::new();
         connected_stream.init_observer(StreamObserver::new(pollee.clone()));
 
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
             options: RwLock::new(options),
             is_nonblocking: AtomicBool::new(false),
             pollee,
-            pseudo_path: SockFs::new_path(),
-        })
+            pseudo_path: SockFs::new_path()?,
+        }))
     }
 
     /// Ensures that the socket state is up to date and obtains a read lock on it.
@@ -319,11 +322,11 @@ impl StreamSocket {
             return_errno_with_message!(Errno::EINVAL, "the socket is not listening");
         };
 
-        let accepted = listen_stream.try_accept().map(|connected_stream| {
+        let accepted = listen_stream.try_accept().and_then(|connected_stream| {
             let remote_endpoint = connected_stream.remote_endpoint();
             let listener_options = self.options.read();
-            let accepted_socket = Self::new_accepted(connected_stream, &listener_options);
-            (accepted_socket as _, remote_endpoint.into())
+            let accepted_socket = Self::new_accepted(connected_stream, &listener_options)?;
+            Ok((accepted_socket as _, remote_endpoint.into()))
         });
         let iface_to_poll = listen_stream.iface().clone();
 

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -7,11 +7,12 @@ use util::{MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr};
 
 use crate::{
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileLike, Permission, StatusFlags, file_table::FdFlags},
         pseudofs::SockFs,
         vfs::path::Path,
     },
     prelude::*,
+    security,
     util::{MultiRead, MultiWrite},
 };
 
@@ -136,12 +137,14 @@ impl<T: Socket + 'static> FileLike for T {
             return Ok(0);
         }
 
+        security::socket_message(self.pseudo_path(), Permission::MAY_READ)?;
         // TODO: Set correct flags
         self.recvmsg(writer, SendRecvFlags::empty())
             .map(|(len, _)| len)
     }
 
     fn write(&self, reader: &mut VmReader) -> Result<usize> {
+        security::socket_message(self.pseudo_path(), Permission::MAY_WRITE)?;
         // TODO: Set correct flags
         self.sendmsg(
             reader,

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -58,18 +58,18 @@ impl<P: SupportedNetlinkProtocol> NetlinkSocket<P>
 where
     BoundNetlink<P::Message>: Bound<Endpoint = NetlinkSocketAddr>,
 {
-    pub fn new(is_nonblocking: bool, socket_type: SockType) -> Arc<Self> {
+    pub fn new(is_nonblocking: bool, socket_type: SockType) -> Result<Arc<Self>> {
         debug_assert!(socket_type == SockType::SOCK_RAW || socket_type == SockType::SOCK_DGRAM);
 
         let unbound = UnboundNetlink::new();
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             inner: RwMutex::new(Inner::Unbound(unbound)),
             options: RwLock::new(OptionSet::new()),
             socket_type,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
-        })
+            pseudo_path: SockFs::new_path()?,
+        }))
     }
 
     fn try_send(

--- a/kernel/src/net/socket/netlink/kobject_uevent/message/test.rs
+++ b/kernel/src/net/socket/netlink/kobject_uevent/message/test.rs
@@ -54,7 +54,7 @@ fn multicast_synthetic_uevent() {
     crate::net::socket::netlink::init();
 
     // Creates a new netlink uevent socket and joins the group for kobject uevents.
-    let socket = NetlinkUeventSocket::new(true, SockType::SOCK_DGRAM);
+    let socket = NetlinkUeventSocket::new(true, SockType::SOCK_DGRAM).unwrap();
     let socket_addr = SocketAddr::Netlink(NetlinkSocketAddr::new(100, GroupIdSet::new(0x1)));
     socket.bind(socket_addr).unwrap();
 

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -51,13 +51,13 @@ impl OptionSet {
 }
 
 impl UnixDatagramSocket {
-    pub fn new(is_nonblocking: bool) -> Arc<Self> {
-        Arc::new(Self::new_raw(is_nonblocking))
+    pub fn new(is_nonblocking: bool) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self::new_raw(is_nonblocking)?))
     }
 
-    pub fn new_pair(is_nonblocking: bool) -> (Arc<Self>, Arc<Self>) {
-        let mut socket_a = Self::new_raw(is_nonblocking);
-        let mut socket_b = Self::new_raw(is_nonblocking);
+    pub fn new_pair(is_nonblocking: bool) -> Result<(Arc<Self>, Arc<Self>)> {
+        let mut socket_a = Self::new_raw(is_nonblocking)?;
+        let mut socket_b = Self::new_raw(is_nonblocking)?;
 
         let cred = SocketCred::<ReadDupOp>::new_current();
         socket_a.peer_cred = Some(cred.dup().restrict());
@@ -69,19 +69,19 @@ impl UnixDatagramSocket {
         *remote_queue_a = Some(socket_b.local_receiver.queue().clone());
         *remote_queue_b = Some(socket_a.local_receiver.queue().clone());
 
-        (Arc::new(socket_a), Arc::new(socket_b))
+        Ok((Arc::new(socket_a), Arc::new(socket_b)))
     }
 
-    fn new_raw(is_nonblocking: bool) -> Self {
-        Self {
+    fn new_raw(is_nonblocking: bool) -> Result<Self> {
+        Ok(Self {
             local_receiver: MessageReceiver::new(),
             remote_queue: RwLock::new(None),
             options: RwLock::new(OptionSet::new()),
             peer_cred: None,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             is_write_shutdown: AtomicBool::new(false),
-            pseudo_path: SockFs::new_path(),
-        }
+            pseudo_path: SockFs::new_path()?,
+        })
     }
 
     fn do_send(

--- a/kernel/src/net/socket/unix/ns/path.rs
+++ b/kernel/src/net/socket/unix/ns/path.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::path::{FsPath, Path},
     },
     prelude::*,
+    security,
 };
 
 pub fn lookup_socket_file(path: &str) -> Result<Path> {
@@ -26,6 +27,10 @@ pub fn lookup_socket_file(path: &str) -> Result<Path> {
     {
         return_errno_with_message!(Errno::EACCES, "the socket file cannot be read or written")
     }
+    security::inode_permission(
+        path.inode().as_ref(),
+        Permission::MAY_READ | Permission::MAY_WRITE,
+    )?;
 
     if path.type_() != InodeType::Socket {
         return_errno_with_message!(

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -69,7 +69,7 @@ impl Listener {
         let peer_addr = connected.peer_addr().into();
         let options = OptionSet::new_accepted(connected.is_pass_cred());
 
-        let socket = UnixStreamSocket::new_connected(connected, options, false, socket_type);
+        let socket = UnixStreamSocket::new_connected(connected, options, false, socket_type)?;
         Ok((socket, peer_addr))
     }
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -163,7 +163,7 @@ impl OptionSet {
 }
 
 impl UnixStreamSocket {
-    pub fn new(is_nonblocking: bool, socket_type: SockType) -> Arc<Self> {
+    pub fn new(is_nonblocking: bool, socket_type: SockType) -> Result<Arc<Self>> {
         debug_assert!(
             socket_type == SockType::SOCK_STREAM || socket_type == SockType::SOCK_SEQPACKET
         );
@@ -171,18 +171,21 @@ impl UnixStreamSocket {
         Self::new_init(Init::new(), is_nonblocking, socket_type)
     }
 
-    fn new_init(init: Init, is_nonblocking: bool, socket_type: SockType) -> Arc<Self> {
-        Arc::new(Self {
+    fn new_init(init: Init, is_nonblocking: bool, socket_type: SockType) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
             state: RwMutex::new(Takeable::new(State::Init(init))),
             options: RwLock::new(OptionSet::new()),
             pollee: Pollee::new(),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             socket_type,
-            pseudo_path: SockFs::new_path(),
-        })
+            pseudo_path: SockFs::new_path()?,
+        }))
     }
 
-    pub fn new_pair(is_nonblocking: bool, socket_type: SockType) -> (Arc<Self>, Arc<Self>) {
+    pub fn new_pair(
+        is_nonblocking: bool,
+        socket_type: SockType,
+    ) -> Result<(Arc<Self>, Arc<Self>)> {
         debug_assert!(
             socket_type == SockType::SOCK_STREAM || socket_type == SockType::SOCK_SEQPACKET
         );
@@ -197,10 +200,9 @@ impl UnixStreamSocket {
             cred.dup().restrict(),
             cred.restrict(),
         );
-        (
-            Self::new_connected(conn_a, OptionSet::new(), is_nonblocking, socket_type),
-            Self::new_connected(conn_b, OptionSet::new(), is_nonblocking, socket_type),
-        )
+        let socket_a = Self::new_connected(conn_a, OptionSet::new(), is_nonblocking, socket_type)?;
+        let socket_b = Self::new_connected(conn_b, OptionSet::new(), is_nonblocking, socket_type)?;
+        Ok((socket_a, socket_b))
     }
 
     pub(super) fn new_connected(
@@ -208,16 +210,16 @@ impl UnixStreamSocket {
         options: OptionSet,
         is_nonblocking: bool,
         socket_type: SockType,
-    ) -> Arc<Self> {
+    ) -> Result<Arc<Self>> {
         let cloned_pollee = connected.cloned_pollee();
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             state: RwMutex::new(Takeable::new(State::Connected(connected))),
             options: RwLock::new(options),
             pollee: cloned_pollee,
             is_nonblocking: AtomicBool::new(is_nonblocking),
             socket_type,
-            pseudo_path: SockFs::new_path(),
-        })
+            pseudo_path: SockFs::new_path()?,
+        }))
     }
 
     fn try_send(

--- a/kernel/src/net/socket/vsock/stream/mod.rs
+++ b/kernel/src/net/socket/vsock/stream/mod.rs
@@ -50,7 +50,7 @@ impl VsockStreamSocket {
             state: Mutex::new(Takeable::new(State::Init(InitStream::new()))),
             is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
+            pseudo_path: SockFs::new_path()?,
         }))
     }
 
@@ -151,7 +151,7 @@ impl VsockStreamSocket {
             state: Mutex::new(Takeable::new(State::Connected(connected))),
             is_nonblocking: AtomicBool::new(false),
             pollee,
-            pseudo_path: SockFs::new_path(),
+            pseudo_path: SockFs::new_path()?,
         });
 
         Ok((accepted, peer_addr))

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -9,7 +9,11 @@ use super::{
 };
 use crate::{
     prelude::*,
-    process::credentials::capabilities::{AtomicCapSet, CapSet},
+    process::credentials::{
+        AMBIENT_CAPSET,
+        capabilities::{AtomicCapSet, CapSet},
+    },
+    security::SmackTaskState,
 };
 
 #[derive(Debug)]
@@ -75,6 +79,9 @@ pub(super) struct Credentials_ {
 
     /// Secure bits.
     securebits: AtomicSecureBits,
+
+    /// Smack task state.
+    smack: RwLock<SmackTaskState>,
 }
 
 impl Credentials_ {
@@ -101,6 +108,7 @@ impl Credentials_ {
             bounding_capset: AtomicCapSet::new(CapSet::all()),
             ambient_capset: AtomicCapSet::new(CapSet::empty()),
             securebits: AtomicSecureBits::new(SecureBits::new_empty()),
+            smack: RwLock::new(SmackTaskState::default()),
         }
     }
 
@@ -636,6 +644,16 @@ impl Credentials_ {
 
         self.securebits.try_store(securebits, Ordering::Relaxed)
     }
+
+    //  ******* Smack methods *******
+
+    pub(super) fn smack_task_state(&self) -> SmackTaskState {
+        self.smack.read().clone()
+    }
+
+    pub(super) fn set_smack_task_state(&self, task_state: SmackTaskState) {
+        *self.smack.write() = task_state;
+    }
 }
 
 impl Clone for Credentials_ {
@@ -656,6 +674,7 @@ impl Clone for Credentials_ {
             bounding_capset: self.bounding_capset.clone(),
             ambient_capset: self.ambient_capset.clone(),
             securebits: self.securebits.clone(),
+            smack: RwLock::new(self.smack.read().clone()),
         }
     }
 }

--- a/kernel/src/process/credentials/static_cap.rs
+++ b/kernel/src/process/credentials/static_cap.rs
@@ -5,7 +5,7 @@ use aster_rights_proc::require;
 use ostd::sync::{PreemptDisabled, RwLockReadGuard, RwLockWriteGuard};
 
 use super::{Credentials, Gid, SecureBits, Uid, capabilities::CapSet, credentials_::Credentials_};
-use crate::prelude::*;
+use crate::{prelude::*, security::SmackTaskState};
 
 impl<R: TRights> Credentials<R> {
     /// Creates a root `Credentials`.
@@ -402,5 +402,23 @@ impl<R: TRights> Credentials<R> {
     #[require(R > Write)]
     pub fn set_securebits(&self, securebits: SecureBits) -> Result<()> {
         self.0.set_securebits(securebits)
+    }
+
+    // *********** Smack methods **********
+
+    /// Gets the Smack task state.
+    ///
+    /// This method requires the `Read` right.
+    #[require(R > Read)]
+    pub fn smack_task_state(&self) -> SmackTaskState {
+        self.0.smack_task_state()
+    }
+
+    /// Sets the Smack task state.
+    ///
+    /// This method requires the `Write` right.
+    #[require(R > Write)]
+    pub fn set_smack_task_state(&self, task_state: SmackTaskState) {
+        self.0.set_smack_task_state(task_state);
     }
 }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -28,6 +28,7 @@ use crate::{
             signals::kernel::KernelSignal,
         },
     },
+    security,
     vm::vmar::VmarHandle,
 };
 
@@ -59,8 +60,9 @@ pub fn do_execve(
 
     let program_to_load =
         ProgramToLoad::build_from_file(elf_file.clone(), &path_resolver, argv, envp)?;
+    let loaded_elf_file = program_to_load.elf_file().clone();
 
-    let new_vmar = VmarHandle::new(ProcessVm::new(elf_file.clone()));
+    let new_vmar = VmarHandle::new(ProcessVm::new(loaded_elf_file.clone()));
     let elf_load_info = program_to_load.load_to_vmar(&new_vmar, &path_resolver)?;
 
     // Ensure no other thread is concurrently performing exit_group or execve.
@@ -86,7 +88,7 @@ pub fn do_execve(
     let res = do_execve_no_return(
         ctx,
         user_context,
-        elf_file,
+        loaded_elf_file,
         thread_name,
         new_vmar,
         &elf_load_info,
@@ -168,7 +170,9 @@ fn do_execve_no_return(
     // This prevents race conditions when checking access permissions while opening
     // `/proc/[pid]/mem` or `/proc/[pid]/maps`.
     let (vmar_guard, old_vmar) = activate_vmar(ctx, new_vmar);
-    apply_caps_from_exec(process, ctx.credentials_mut(), elf_file.inode())?;
+    let credentials = ctx.credentials_mut();
+    apply_caps_from_exec(process, &credentials, elf_file.inode())?;
+    security::bprm_committed_creds(&elf_file, &credentials)?;
     drop(vmar_guard);
     drop(old_vmar);
 
@@ -308,7 +312,7 @@ fn set_cpu_context(
 /// The capabilities will be updated accordingly.
 fn apply_caps_from_exec(
     process: &Process,
-    credentials: Credentials<ReadWriteOp>,
+    credentials: &Credentials<ReadWriteOp>,
     elf_inode: &Arc<dyn Inode>,
 ) -> Result<()> {
     let mode = elf_inode.mode()?;

--- a/kernel/src/process/posix_thread/mod.rs
+++ b/kernel/src/process/posix_thread/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         posix_thread::ptrace::TraceeStatus,
         signal::{PauseReason, PollHandle, sig_mask::SigMask},
     },
+    security::SmackTaskState,
     thread::{Thread, Tid},
     time::{Timer, TimerManager, clocks::ProfClock, timer::TimerGuard},
 };
@@ -306,6 +307,11 @@ impl PosixThread {
     /// Gets the duplicatable read-only credentials of the thread.
     pub fn credentials_dup(&self) -> Credentials<ReadDupOp> {
         self.credentials.dup().restrict()
+    }
+
+    /// Sets the Smack task state attached to this thread's credentials.
+    pub(crate) fn set_smack_task_state(&self, task_state: SmackTaskState) {
+        self.credentials.set_smack_task_state(task_state);
     }
 
     /// Returns the I/O priority value of the thread.

--- a/kernel/src/process/program_loader/mod.rs
+++ b/kernel/src/process/program_loader/mod.rs
@@ -132,6 +132,7 @@ fn check_executable_inode(inode: &dyn Inode) -> Result<()> {
     if inode.check_permission(Permission::MAY_EXEC).is_err() {
         return_errno_with_message!(Errno::EACCES, "the inode is not executable");
     }
+    security::inode_permission(inode, Permission::MAY_EXEC)?;
 
     Ok(())
 }

--- a/kernel/src/process/program_loader/mod.rs
+++ b/kernel/src/process/program_loader/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         },
     },
     prelude::*,
+    security,
     vm::vmar::Vmar,
 };
 
@@ -40,6 +41,7 @@ impl ProgramToLoad {
         envp: Vec<CString>,
     ) -> Result<Self> {
         check_executable_inode(elf_file.inode().as_ref())?;
+        security::bprm_check_security(&elf_file)?;
 
         // A limit to the recursion depth of shebang executables.
         //
@@ -70,6 +72,7 @@ impl ProgramToLoad {
                 path_resolver.lookup(&fs_path)?
             };
             check_executable_inode(interpreter.inode().as_ref())?;
+            security::bprm_check_security(&interpreter)?;
 
             // Update the argument list and the executable inode. Then, try again.
             new_argv.extend(argv);
@@ -85,6 +88,11 @@ impl ProgramToLoad {
             argv,
             envp,
         })
+    }
+
+    /// Returns the executable that will be loaded.
+    pub(super) fn elf_file(&self) -> &Path {
+        &self.elf_file
     }
 
     /// Loads the executable into the specified virtual memory space.

--- a/kernel/src/security/lsm/hooks/bprm.rs
+++ b/kernel/src/security/lsm/hooks/bprm.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_rights::ReadWriteOp;
+
+use super::super::modules;
+use crate::{fs::vfs::path::Path, prelude::*, process::Credentials};
+
+/// Runs executable image check hooks in module order.
+pub fn on_bprm_check_security(context: &BprmCheckContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_bprm_check_security(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs post-exec credential hooks in module order.
+pub fn on_bprm_committed_creds(context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_bprm_committed_creds(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for an executable image security check.
+pub struct BprmCheckContext<'a> {
+    executable: &'a Path,
+}
+
+impl<'a> BprmCheckContext<'a> {
+    /// Creates an executable image check context.
+    pub const fn new(executable: &'a Path) -> Self {
+        Self { executable }
+    }
+
+    /// Returns the executable path.
+    pub const fn executable(&self) -> &'a Path {
+        self.executable
+    }
+}
+
+/// The inputs for an executable-label transition after credentials are committed.
+pub struct BprmCommittedCredsContext<'a> {
+    executable: &'a Path,
+    credentials: &'a Credentials<ReadWriteOp>,
+}
+
+impl<'a> BprmCommittedCredsContext<'a> {
+    /// Creates a post-exec credential context.
+    pub const fn new(executable: &'a Path, credentials: &'a Credentials<ReadWriteOp>) -> Self {
+        Self {
+            executable,
+            credentials,
+        }
+    }
+
+    /// Returns the executable path.
+    pub const fn executable(&self) -> &'a Path {
+        self.executable
+    }
+
+    /// Returns the committed credentials.
+    pub const fn credentials(&self) -> &'a Credentials<ReadWriteOp> {
+        self.credentials
+    }
+}

--- a/kernel/src/security/lsm/hooks/file.rs
+++ b/kernel/src/security/lsm/hooks/file.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    fs::{file::Permission, vfs::path::Path},
+    prelude::*,
+};
+
+/// Runs file operation permission hooks in module order.
+pub fn on_file_permission(context: &FilePermissionContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_file_permission(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for checking an operation on an opened file.
+pub struct FilePermissionContext<'a> {
+    path: &'a Path,
+    permission: Permission,
+}
+
+impl<'a> FilePermissionContext<'a> {
+    /// Creates a file permission context.
+    pub const fn new(path: &'a Path, permission: Permission) -> Self {
+        Self { path, permission }
+    }
+
+    /// Returns the path backing the opened file.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the requested permission.
+    pub const fn permission(&self) -> Permission {
+        self.permission
+    }
+}

--- a/kernel/src/security/lsm/hooks/inode.rs
+++ b/kernel/src/security/lsm/hooks/inode.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    fs::{file::Permission, vfs::inode::Inode},
+    prelude::*,
+};
+
+/// Runs inode permission hooks in module order.
+pub fn on_inode_permission(context: &InodePermissionContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_inode_permission(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for checking access to an inode.
+pub struct InodePermissionContext<'a> {
+    inode: &'a dyn Inode,
+    permission: Permission,
+}
+
+impl<'a> InodePermissionContext<'a> {
+    /// Creates an inode permission context.
+    pub const fn new(inode: &'a dyn Inode, permission: Permission) -> Self {
+        Self { inode, permission }
+    }
+
+    /// Returns the target inode.
+    pub const fn inode(&self) -> &'a dyn Inode {
+        self.inode
+    }
+
+    /// Returns the requested permission.
+    pub const fn permission(&self) -> Permission {
+        self.permission
+    }
+}

--- a/kernel/src/security/lsm/hooks/mmap.rs
+++ b/kernel/src/security/lsm/hooks/mmap.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{fs::vfs::path::Path, prelude::*, vm::perms::VmPerms};
+
+/// Runs mmap and mprotect hooks for file-backed executable mappings.
+pub fn on_mmap_file(context: &MmapFileContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_mmap_file(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for checking a file-backed mapping.
+pub struct MmapFileContext<'a> {
+    path: &'a Path,
+    perms: VmPerms,
+}
+
+impl<'a> MmapFileContext<'a> {
+    /// Creates an mmap file context.
+    pub const fn new(path: &'a Path, perms: VmPerms) -> Self {
+        Self { path, perms }
+    }
+
+    /// Returns the mapped file path.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the requested mapping permissions.
+    pub const fn perms(&self) -> VmPerms {
+        self.perms
+    }
+}

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -5,6 +5,11 @@
 mod alien_access;
 mod bprm;
 mod capability;
+mod file;
+mod inode;
+mod mmap;
+mod path;
+mod socket;
 
 pub use self::{
     alien_access::{AlienAccessContext, on_alien_access},
@@ -13,6 +18,15 @@ pub use self::{
         on_bprm_committed_creds,
     },
     capability::{CapableContext, on_capable},
+    file::{FilePermissionContext, on_file_permission},
+    inode::{InodePermissionContext, on_inode_permission},
+    mmap::{MmapFileContext, on_mmap_file},
+    path::{
+        PathCreateContext, PathLinkContext, PathPostCreateContext, PathRenameContext,
+        PathSetattrContext, PathUnlinkContext, on_path_create, on_path_link, on_path_post_create,
+        on_path_rename, on_path_setattr, on_path_unlink,
+    },
+    socket::{SocketCreateContext, SocketMessageContext, on_socket_create, on_socket_message},
 };
 use crate::prelude::*;
 
@@ -38,6 +52,71 @@ pub(super) trait LsmBprmHook: Sync {
 
     /// Updates security state after executable credentials are committed.
     fn on_bprm_committed_creds(&self, _context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmInodeHook: Sync {
+    /// Checks whether an inode operation is allowed.
+    fn on_inode_permission(&self, _context: &InodePermissionContext<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmFileHook: Sync {
+    /// Checks whether an opened file operation is allowed.
+    fn on_file_permission(&self, _context: &FilePermissionContext<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmPathHook: Sync {
+    /// Checks whether a child may be created under a directory.
+    fn on_path_create(&self, _context: &PathCreateContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Updates security state after a child has been created.
+    fn on_path_post_create(&self, _context: &PathPostCreateContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a hard link may be created.
+    fn on_path_link(&self, _context: &PathLinkContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a child may be removed.
+    fn on_path_unlink(&self, _context: &PathUnlinkContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a child may be renamed.
+    fn on_path_rename(&self, _context: &PathRenameContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether file metadata may be updated.
+    fn on_path_setattr(&self, _context: &PathSetattrContext<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmMmapHook: Sync {
+    /// Checks whether a file-backed memory mapping is allowed.
+    fn on_mmap_file(&self, _context: &MmapFileContext<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmSocketHook: Sync {
+    /// Labels a newly created socket.
+    fn on_socket_create(&self, _context: &SocketCreateContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether a socket message operation is allowed.
+    fn on_socket_message(&self, _context: &SocketMessageContext<'_>) -> Result<()> {
         Ok(())
     }
 }

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -3,10 +3,15 @@
 //! LSM hook points.
 
 mod alien_access;
+mod bprm;
 mod capability;
 
 pub use self::{
     alien_access::{AlienAccessContext, on_alien_access},
+    bprm::{
+        BprmCheckContext, BprmCommittedCredsContext, on_bprm_check_security,
+        on_bprm_committed_creds,
+    },
     capability::{CapableContext, on_capable},
 };
 use crate::prelude::*;
@@ -21,6 +26,18 @@ pub(super) trait LsmAlienAccessHook: Sync {
 pub(super) trait LsmCapabilityHook: Sync {
     /// Checks whether a thread holds a capability in a user namespace.
     fn on_capable(&self, _context: &CapableContext) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) trait LsmBprmHook: Sync {
+    /// Checks whether an executable image may be used by `execve`.
+    fn on_bprm_check_security(&self, _context: &BprmCheckContext<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Updates security state after executable credentials are committed.
+    fn on_bprm_committed_creds(&self, _context: &BprmCommittedCredsContext<'_>) -> Result<()> {
         Ok(())
     }
 }

--- a/kernel/src/security/lsm/hooks/path.rs
+++ b/kernel/src/security/lsm/hooks/path.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    fs::vfs::{inode::Inode, path::Path},
+    prelude::*,
+};
+
+/// Runs path creation hooks in module order.
+pub fn on_path_create(context: &PathCreateContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_path_create(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs post-creation path hooks in module order.
+pub fn on_path_post_create(context: &PathPostCreateContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_path_post_create(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs link hooks in module order.
+pub fn on_path_link(context: &PathLinkContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_path_link(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs unlink and rmdir hooks in module order.
+pub fn on_path_unlink(context: &PathUnlinkContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_path_unlink(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs rename hooks in module order.
+pub fn on_path_rename(context: &PathRenameContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_path_rename(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs metadata update hooks in module order.
+pub fn on_path_setattr(context: &PathSetattrContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_path_setattr(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for checking creation under a directory path.
+pub struct PathCreateContext<'a> {
+    parent: &'a Path,
+}
+
+impl<'a> PathCreateContext<'a> {
+    /// Creates a path creation context.
+    pub const fn new(parent: &'a Path) -> Self {
+        Self { parent }
+    }
+
+    /// Returns the parent directory path.
+    pub const fn parent(&self) -> &'a Path {
+        self.parent
+    }
+}
+
+/// The inputs for labeling a newly created path.
+pub struct PathPostCreateContext<'a> {
+    parent: &'a Path,
+    child: &'a Path,
+}
+
+impl<'a> PathPostCreateContext<'a> {
+    /// Creates a post-creation context.
+    pub const fn new(parent: &'a Path, child: &'a Path) -> Self {
+        Self { parent, child }
+    }
+
+    /// Returns the parent directory path.
+    pub const fn parent(&self) -> &'a Path {
+        self.parent
+    }
+
+    /// Returns the newly created path.
+    pub const fn child(&self) -> &'a Path {
+        self.child
+    }
+}
+
+/// The inputs for checking a hard link creation.
+pub struct PathLinkContext<'a> {
+    old_path: &'a Path,
+    new_parent: &'a Path,
+}
+
+impl<'a> PathLinkContext<'a> {
+    /// Creates a path link context.
+    pub const fn new(old_path: &'a Path, new_parent: &'a Path) -> Self {
+        Self {
+            old_path,
+            new_parent,
+        }
+    }
+
+    /// Returns the source path.
+    pub const fn old_path(&self) -> &'a Path {
+        self.old_path
+    }
+
+    /// Returns the destination parent directory.
+    pub const fn new_parent(&self) -> &'a Path {
+        self.new_parent
+    }
+}
+
+/// The inputs for checking unlink or rmdir.
+pub struct PathUnlinkContext<'a> {
+    parent: &'a Path,
+    child: &'a dyn Inode,
+}
+
+impl<'a> PathUnlinkContext<'a> {
+    /// Creates a path unlink context.
+    pub const fn new(parent: &'a Path, child: &'a dyn Inode) -> Self {
+        Self { parent, child }
+    }
+
+    /// Returns the parent directory path.
+    pub const fn parent(&self) -> &'a Path {
+        self.parent
+    }
+
+    /// Returns the child inode being removed.
+    pub const fn child(&self) -> &'a dyn Inode {
+        self.child
+    }
+}
+
+/// The inputs for checking rename.
+pub struct PathRenameContext<'a> {
+    old_parent: &'a Path,
+    old_child: &'a dyn Inode,
+    new_parent: &'a Path,
+    new_child: Option<&'a dyn Inode>,
+}
+
+impl<'a> PathRenameContext<'a> {
+    /// Creates a path rename context.
+    pub const fn new(
+        old_parent: &'a Path,
+        old_child: &'a dyn Inode,
+        new_parent: &'a Path,
+        new_child: Option<&'a dyn Inode>,
+    ) -> Self {
+        Self {
+            old_parent,
+            old_child,
+            new_parent,
+            new_child,
+        }
+    }
+
+    /// Returns the source parent directory.
+    pub const fn old_parent(&self) -> &'a Path {
+        self.old_parent
+    }
+
+    /// Returns the inode being renamed.
+    pub const fn old_child(&self) -> &'a dyn Inode {
+        self.old_child
+    }
+
+    /// Returns the destination parent directory.
+    pub const fn new_parent(&self) -> &'a Path {
+        self.new_parent
+    }
+
+    /// Returns the overwritten child inode, if one exists.
+    pub const fn new_child(&self) -> Option<&'a dyn Inode> {
+        self.new_child
+    }
+}
+
+/// The inputs for checking metadata updates.
+pub struct PathSetattrContext<'a> {
+    path: &'a Path,
+}
+
+impl<'a> PathSetattrContext<'a> {
+    /// Creates a path metadata update context.
+    pub const fn new(path: &'a Path) -> Self {
+        Self { path }
+    }
+
+    /// Returns the path whose metadata is being updated.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+}

--- a/kernel/src/security/lsm/hooks/socket.rs
+++ b/kernel/src/security/lsm/hooks/socket.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::super::modules;
+use crate::{
+    fs::{file::Permission, vfs::path::Path},
+    prelude::*,
+};
+
+/// Runs socket creation hooks in module order.
+pub fn on_socket_create(context: &SocketCreateContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_socket_create(context)?;
+    }
+
+    Ok(())
+}
+
+/// Runs socket message hooks in module order.
+pub fn on_socket_message(context: &SocketMessageContext<'_>) -> Result<()> {
+    for module in modules::active_modules() {
+        module.on_socket_message(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for labeling a newly created socket.
+pub struct SocketCreateContext<'a> {
+    path: &'a Path,
+}
+
+impl<'a> SocketCreateContext<'a> {
+    /// Creates a socket creation context.
+    pub const fn new(path: &'a Path) -> Self {
+        Self { path }
+    }
+
+    /// Returns the socket pseudo path.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+}
+
+/// The inputs for checking socket send and receive operations.
+pub struct SocketMessageContext<'a> {
+    path: &'a Path,
+    permission: Permission,
+}
+
+impl<'a> SocketMessageContext<'a> {
+    /// Creates a socket message context.
+    pub const fn new(path: &'a Path, permission: Permission) -> Self {
+        Self { path, permission }
+    }
+
+    /// Returns the socket pseudo path.
+    pub const fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the requested permission.
+    pub const fn permission(&self) -> Permission {
+        self.permission
+    }
+}

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -7,8 +7,9 @@
 //! inspect common hook contexts before allowing or rejecting an operation.
 //!
 //! This module defines the common LSM traits and hook contexts shared by
-//! built-in modules such as `capability` and `yama`. Module selection follows
-//! the `lsm=` and legacy `security=` kernel command-line parameters.
+//! built-in modules such as `capability`, `yama`, and `smack`. Module
+//! selection follows the `lsm=` and legacy `security=` kernel command-line
+//! parameters.
 
 pub mod hooks;
 mod modules;
@@ -17,7 +18,18 @@ pub mod yama {
     pub use super::modules::yama::{YamaScope, get_scope, set_scope};
 }
 
-use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook};
+pub mod smack {
+    pub use super::modules::smack::{
+        SmackTaskState, check_xattr_removal, check_xattr_update, is_smack_xattr, set_current_label,
+        task_state,
+    };
+}
+
+use self::hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook};
+pub use self::{
+    hooks::{BprmCheckContext, BprmCommittedCredsContext},
+    smack::SmackTaskState,
+};
 use crate::prelude::*;
 
 bitflags! {
@@ -31,7 +43,7 @@ bitflags! {
 }
 
 /// The common interface for built-in LSM modules.
-trait LsmModule: LsmAlienAccessHook + LsmCapabilityHook + Sync {
+trait LsmModule: LsmAlienAccessHook + LsmBprmHook + LsmCapabilityHook + Sync {
     /// Returns the module name.
     fn name(&self) -> &'static str;
 
@@ -46,8 +58,25 @@ pub fn is_yama_enabled() -> bool {
         .any(|module| module.name() == "yama")
 }
 
+/// Returns whether the Smack LSM is enabled.
+pub fn is_smack_enabled() -> bool {
+    modules::active_modules()
+        .iter()
+        .any(|module| module.name() == "smack")
+}
+
 pub(super) fn init() {
     for module in modules::active_modules() {
         info!("[kernel] LSM module enabled: {}", module.name());
     }
+}
+
+/// Runs the LSM stack for an executable image check.
+pub fn bprm_check_security(context: &BprmCheckContext<'_>) -> Result<()> {
+    hooks::on_bprm_check_security(context)
+}
+
+/// Runs the LSM stack after executable credentials are committed.
+pub fn bprm_committed_creds(context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+    hooks::on_bprm_committed_creds(context)
 }

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -20,12 +20,16 @@ pub mod yama {
 
 pub mod smack {
     pub use super::modules::smack::{
-        SmackTaskState, check_xattr_removal, check_xattr_update, is_smack_xattr, set_current_label,
+        SmackTaskState, check_xattr_removal, check_xattr_update, is_smack_xattr, load_rules,
+        rules_as_text, set_current_label, set_exec_label, set_fscreate_label, set_sockcreate_label,
         task_state,
     };
 }
 
-use self::hooks::{LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook};
+use self::hooks::{
+    LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook, LsmMmapHook,
+    LsmPathHook, LsmSocketHook,
+};
 pub use self::{
     hooks::{BprmCheckContext, BprmCommittedCredsContext},
     smack::SmackTaskState,
@@ -43,7 +47,17 @@ bitflags! {
 }
 
 /// The common interface for built-in LSM modules.
-trait LsmModule: LsmAlienAccessHook + LsmBprmHook + LsmCapabilityHook + Sync {
+trait LsmModule:
+    LsmAlienAccessHook
+    + LsmBprmHook
+    + LsmCapabilityHook
+    + LsmInodeHook
+    + LsmFileHook
+    + LsmPathHook
+    + LsmMmapHook
+    + LsmSocketHook
+    + Sync
+{
     /// Returns the module name.
     fn name(&self) -> &'static str;
 

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -20,9 +20,12 @@ pub mod yama {
 
 pub mod smack {
     pub use super::modules::smack::{
-        SmackTaskState, check_xattr_removal, check_xattr_update, is_smack_xattr, load_rules,
-        rules_as_text, set_current_label, set_exec_label, set_fscreate_label, set_sockcreate_label,
-        task_state,
+        SmackMountLabels, SmackTaskState, access_query_result_as_text, ambient_label_as_text,
+        apply_mount_labels, change_rule, check_xattr_removal, check_xattr_update, is_smack_xattr,
+        load_rules, logging_mode_as_text, mount_labels_from_options, onlycap_labels_as_text,
+        query_access, revoke_subject, rules_as_text, set_ambient_label, set_current_label,
+        set_exec_label, set_fscreate_label, set_logging_mode, set_onlycap_labels,
+        set_sockcreate_label, task_state,
     };
 }
 
@@ -32,7 +35,7 @@ use self::hooks::{
 };
 pub use self::{
     hooks::{BprmCheckContext, BprmCommittedCredsContext},
-    smack::SmackTaskState,
+    smack::{SmackMountLabels, SmackTaskState},
 };
 use crate::prelude::*;
 

--- a/kernel/src/security/lsm/modules/capability.rs
+++ b/kernel/src/security/lsm/modules/capability.rs
@@ -2,7 +2,9 @@
 
 use super::super::{
     LsmFlags, LsmModule,
-    hooks::{AlienAccessContext, CapableContext, LsmAlienAccessHook, LsmCapabilityHook},
+    hooks::{
+        AlienAccessContext, CapableContext, LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook,
+    },
 };
 use crate::{
     prelude::*,
@@ -46,6 +48,8 @@ impl LsmCapabilityHook for CapabilityLsm {
         );
     }
 }
+
+impl LsmBprmHook for CapabilityLsm {}
 
 impl LsmAlienAccessHook for CapabilityLsm {
     fn on_alien_access(&self, context: &AlienAccessContext) -> Result<()> {

--- a/kernel/src/security/lsm/modules/capability.rs
+++ b/kernel/src/security/lsm/modules/capability.rs
@@ -4,6 +4,7 @@ use super::super::{
     LsmFlags, LsmModule,
     hooks::{
         AlienAccessContext, CapableContext, LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook,
+        LsmFileHook, LsmInodeHook, LsmMmapHook, LsmPathHook, LsmSocketHook,
     },
 };
 use crate::{
@@ -50,6 +51,16 @@ impl LsmCapabilityHook for CapabilityLsm {
 }
 
 impl LsmBprmHook for CapabilityLsm {}
+
+impl LsmInodeHook for CapabilityLsm {}
+
+impl LsmFileHook for CapabilityLsm {}
+
+impl LsmPathHook for CapabilityLsm {}
+
+impl LsmMmapHook for CapabilityLsm {}
+
+impl LsmSocketHook for CapabilityLsm {}
 
 impl LsmAlienAccessHook for CapabilityLsm {
     fn on_alien_access(&self, context: &AlienAccessContext) -> Result<()> {

--- a/kernel/src/security/lsm/modules/mod.rs
+++ b/kernel/src/security/lsm/modules/mod.rs
@@ -29,6 +29,7 @@
 //! mandatory modules plus the default optional stack are used.
 
 mod capability;
+pub mod smack;
 pub mod yama;
 
 use spin::Once;
@@ -46,7 +47,11 @@ aster_cmdline::define_kv_param!("security", LEGACY_SECURITY_PARAM);
 static MANDATORY_MODULES: [&'static dyn LsmModule; 1] = [&capability::CAPABILITY_LSM];
 
 /// All LSM modules compiled into the kernel.
-static ALL_MODULES: [&'static dyn LsmModule; 2] = [&capability::CAPABILITY_LSM, &yama::YAMA_LSM];
+static ALL_MODULES: [&'static dyn LsmModule; 3] = [
+    &capability::CAPABILITY_LSM,
+    &yama::YAMA_LSM,
+    &smack::SMACK_LSM,
+];
 
 /// The fallback optional LSM stack used when no boot-time selector is specified.
 pub(super) static DEFAULT_OPTIONAL_MODULES: [&'static dyn LsmModule; 1] = [&yama::YAMA_LSM];

--- a/kernel/src/security/lsm/modules/smack/access.rs
+++ b/kernel/src/security/lsm/modules/smack/access.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use bitflags::bitflags;
+use spin::Once;
+
+use super::label::SmackLabel;
+use crate::prelude::*;
+
+bitflags! {
+    /// Smack access modes.
+    pub struct SmackAccess: u8 {
+        /// Read access.
+        const READ = 1 << 0;
+        /// Write access.
+        const WRITE = 1 << 1;
+        /// Execute access.
+        const EXECUTE = 1 << 2;
+        /// Append access.
+        const APPEND = 1 << 3;
+        /// Transmute access.
+        const TRANSMUTE = 1 << 4;
+        /// Bring-up reporting.
+        const BRINGUP = 1 << 5;
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct RuleKey {
+    subject: SmackLabel,
+    object: SmackLabel,
+}
+
+static ACCESS_RULES: Once<RwMutex<BTreeMap<RuleKey, SmackAccess>>> = Once::new();
+
+impl SmackAccess {
+    /// Parses a Smack access string.
+    #[expect(dead_code, reason = "Smack rule loading will use this parser.")]
+    pub fn parse(access: &str) -> Result<Self> {
+        let mut parsed = Self::empty();
+        for byte in access.bytes() {
+            match byte.to_ascii_lowercase() {
+                b'r' => parsed |= Self::READ,
+                b'w' => parsed |= Self::WRITE,
+                b'x' => parsed |= Self::EXECUTE,
+                b'a' => parsed |= Self::APPEND,
+                b't' => parsed |= Self::TRANSMUTE,
+                b'b' => parsed |= Self::BRINGUP,
+                b'-' => {}
+                _ => return_errno_with_message!(Errno::EINVAL, "the Smack access mode is invalid"),
+            }
+        }
+
+        Ok(parsed)
+    }
+}
+
+/// Adds or replaces a Smack access rule.
+#[expect(
+    dead_code,
+    reason = "Smack rule loading will install policy with this helper."
+)]
+pub fn set_rule(subject: SmackLabel, object: SmackLabel, access: SmackAccess) {
+    access_rules()
+        .write()
+        .insert(RuleKey { subject, object }, access);
+}
+
+/// Checks whether a Smack subject can access an object.
+pub fn check(subject: &SmackLabel, object: &SmackLabel, requested: SmackAccess) -> Result<()> {
+    if is_allowed(subject, object, requested) {
+        return Ok(());
+    }
+
+    return_errno_with_message!(
+        Errno::EACCES,
+        "Smack access rules deny the requested access"
+    );
+}
+
+fn is_allowed(subject: &SmackLabel, object: &SmackLabel, requested: SmackAccess) -> bool {
+    if requested.is_empty() {
+        return true;
+    }
+    if subject.is_star() {
+        return false;
+    }
+    let read_execute = SmackAccess::READ | SmackAccess::EXECUTE;
+    if subject.is_hat() && read_execute.contains(requested) {
+        return true;
+    }
+    if object.is_floor() && read_execute.contains(requested) {
+        return true;
+    }
+    if object.is_star() {
+        return true;
+    }
+    if subject == object {
+        return true;
+    }
+
+    let rules = access_rules().read();
+    let key = RuleKey {
+        subject: subject.clone(),
+        object: object.clone(),
+    };
+    rules
+        .get(&key)
+        .is_some_and(|allowed| allowed.contains(requested))
+}
+
+fn access_rules() -> &'static RwMutex<BTreeMap<RuleKey, SmackAccess>> {
+    ACCESS_RULES.call_once(|| RwMutex::new(BTreeMap::new()))
+}

--- a/kernel/src/security/lsm/modules/smack/access.rs
+++ b/kernel/src/security/lsm/modules/smack/access.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::format;
+
 use bitflags::bitflags;
 use spin::Once;
 
@@ -31,6 +33,54 @@ struct RuleKey {
 }
 
 static ACCESS_RULES: Once<RwMutex<BTreeMap<RuleKey, SmackAccess>>> = Once::new();
+static ACCESS_QUERY_RESULT: Once<RwMutex<Option<bool>>> = Once::new();
+static AMBIENT_LABEL: Once<RwMutex<SmackLabel>> = Once::new();
+static ONLYCAP_LABELS: Once<RwMutex<BTreeSet<SmackLabel>>> = Once::new();
+static LOGGING_MODE: Once<RwMutex<SmackLoggingMode>> = Once::new();
+
+/// Smack access logging mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SmackLoggingMode {
+    /// Logs no access decisions.
+    None,
+    /// Logs denied access decisions.
+    Denied,
+    /// Logs accepted access decisions.
+    Accepted,
+    /// Logs denied and accepted access decisions.
+    Both,
+}
+
+impl SmackLoggingMode {
+    /// Parses a Smack logging mode.
+    pub fn parse(mode: &str) -> Result<Self> {
+        match mode.trim() {
+            "0" => Ok(Self::None),
+            "1" => Ok(Self::Denied),
+            "2" => Ok(Self::Accepted),
+            "3" => Ok(Self::Both),
+            _ => return_errno_with_message!(Errno::EINVAL, "the Smack logging mode is invalid"),
+        }
+    }
+
+    /// Returns the Linux-compatible numeric text for this logging mode.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "0",
+            Self::Denied => "1",
+            Self::Accepted => "2",
+            Self::Both => "3",
+        }
+    }
+
+    fn logs_denied(self) -> bool {
+        matches!(self, Self::Denied | Self::Both)
+    }
+
+    fn logs_accepted(self) -> bool {
+        matches!(self, Self::Accepted | Self::Both)
+    }
+}
 
 impl SmackAccess {
     /// Parses a Smack access string.
@@ -83,6 +133,19 @@ pub fn set_rule(subject: SmackLabel, object: SmackLabel, access: SmackAccess) {
         .insert(RuleKey { subject, object }, access);
 }
 
+/// Enables and disables access bits in one Smack access rule from text.
+pub fn change_rule(rule: &str) -> Result<()> {
+    let Some(rule) = parse_rule_change_line(rule)? else {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule is empty");
+    };
+
+    let mut rules = access_rules().write();
+    let access = rules.entry(rule.key).or_insert(SmackAccess::empty());
+    access.insert(rule.enabled);
+    access.remove(rule.disabled);
+    Ok(())
+}
+
 /// Loads newline-delimited Smack access rules.
 pub fn load_rules(policy: &str) -> Result<usize> {
     let mut parsed_rules = Vec::new();
@@ -101,6 +164,15 @@ pub fn load_rules(policy: &str) -> Result<usize> {
     Ok(parsed_rule_count)
 }
 
+/// Removes all access rules whose subject is `subject`.
+pub fn revoke_subject(subject: &str) -> Result<usize> {
+    let subject = SmackLabel::parse(subject.trim())?;
+    let mut rules = access_rules().write();
+    let previous_rule_count = rules.len();
+    rules.retain(|key, _| key.subject != subject);
+    Ok(previous_rule_count - rules.len())
+}
+
 /// Returns all loaded Smack access rules in deterministic order.
 pub fn rules_as_text() -> String {
     let mut text = String::new();
@@ -117,19 +189,94 @@ pub fn rules_as_text() -> String {
     text
 }
 
+/// Checks an access query and stores the result for `/proc/smack/access`.
+pub fn query_access(query: &str) -> Result<bool> {
+    let Some(rule) = parse_rule_line(query)? else {
+        return_errno_with_message!(Errno::EINVAL, "the Smack access query is empty");
+    };
+
+    let is_allowed = is_allowed(&rule.subject, &rule.object, rule.access);
+    *access_query_result().write() = Some(is_allowed);
+    Ok(is_allowed)
+}
+
+/// Returns the last access query result as Linux-compatible text.
+pub fn access_query_result_as_text() -> String {
+    match *access_query_result().read() {
+        Some(true) => "1\n".to_string(),
+        Some(false) => "0\n".to_string(),
+        None => String::new(),
+    }
+}
+
+/// Returns the current ambient label.
+pub fn ambient_label() -> SmackLabel {
+    ambient_label_lock().read().clone()
+}
+
+/// Returns the current ambient label as text.
+pub fn ambient_label_as_text() -> String {
+    let label = ambient_label_lock().read();
+    format!("{}\n", label.as_str())
+}
+
+/// Sets the current ambient label.
+pub fn set_ambient_label(label: &str) -> Result<()> {
+    *ambient_label_lock().write() = SmackLabel::parse(label.trim())?;
+    Ok(())
+}
+
+/// Returns the current `onlycap` labels as text.
+pub fn onlycap_labels_as_text() -> String {
+    let labels = onlycap_labels().read();
+    labels
+        .iter()
+        .map(|label| label.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+        + if labels.is_empty() { "" } else { "\n" }
+}
+
+/// Replaces the current `onlycap` label set.
+pub fn set_onlycap_labels(labels: &str) -> Result<()> {
+    *onlycap_labels().write() = parse_label_set(labels)?;
+    Ok(())
+}
+
+/// Checks whether `subject` is allowed by the current `onlycap` policy.
+pub fn subject_has_onlycap(subject: &SmackLabel) -> bool {
+    let labels = onlycap_labels().read();
+    labels.is_empty() || labels.contains(subject)
+}
+
+/// Returns the current logging mode as text.
+pub fn logging_mode_as_text() -> String {
+    let logging_mode = *logging_mode().read();
+    format!("{}\n", logging_mode.as_str())
+}
+
+/// Sets the current logging mode.
+pub fn set_logging_mode(mode: &str) -> Result<()> {
+    *logging_mode().write() = SmackLoggingMode::parse(mode)?;
+    Ok(())
+}
+
 /// Checks whether a Smack subject can access an object.
 pub fn check(subject: &SmackLabel, object: &SmackLabel, requested: SmackAccess) -> Result<()> {
     if is_allowed(subject, object, requested) {
+        log_access_decision(subject, object, requested, true);
         return Ok(());
     }
 
+    log_access_decision(subject, object, requested, false);
     return_errno_with_message!(
         Errno::EACCES,
         "Smack access rules deny the requested access"
     );
 }
 
-fn is_allowed(subject: &SmackLabel, object: &SmackLabel, requested: SmackAccess) -> bool {
+/// Returns whether a Smack access request is allowed.
+pub fn is_allowed(subject: &SmackLabel, object: &SmackLabel, requested: SmackAccess) -> bool {
     if requested.is_empty() {
         return true;
     }
@@ -160,10 +307,39 @@ fn is_allowed(subject: &SmackLabel, object: &SmackLabel, requested: SmackAccess)
         .is_some_and(|allowed| allowed.contains(requested))
 }
 
+fn log_access_decision(
+    subject: &SmackLabel,
+    object: &SmackLabel,
+    requested: SmackAccess,
+    allowed: bool,
+) {
+    let logging_mode = *logging_mode().read();
+    if allowed && !logging_mode.logs_accepted() {
+        return;
+    }
+    if !allowed && !logging_mode.logs_denied() {
+        return;
+    }
+
+    info!(
+        "smack access subject={} object={} request={} result={}",
+        subject.as_str(),
+        object.as_str(),
+        requested.as_rule_text(),
+        if allowed { "allow" } else { "deny" },
+    );
+}
+
 struct ParsedRule {
     subject: SmackLabel,
     object: SmackLabel,
     access: SmackAccess,
+}
+
+struct ParsedRuleChange {
+    key: RuleKey,
+    enabled: SmackAccess,
+    disabled: SmackAccess,
 }
 
 fn parse_rule_line(line: &str) -> Result<Option<ParsedRule>> {
@@ -193,6 +369,67 @@ fn parse_rule_line(line: &str) -> Result<Option<ParsedRule>> {
     }))
 }
 
+fn parse_rule_change_line(line: &str) -> Result<Option<ParsedRuleChange>> {
+    let line = line.split('#').next().unwrap_or("").trim();
+    if line.is_empty() {
+        return Ok(None);
+    }
+
+    let mut fields = line.split_whitespace();
+    let Some(subject) = fields.next() else {
+        return Ok(None);
+    };
+    let Some(object) = fields.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule object label is missing");
+    };
+    let Some(enabled) = fields.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule enabled access is missing");
+    };
+    let Some(disabled) = fields.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule disabled access is missing");
+    };
+    if fields.next().is_some() {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule has too many fields");
+    }
+
+    Ok(Some(ParsedRuleChange {
+        key: RuleKey {
+            subject: SmackLabel::parse(subject)?,
+            object: SmackLabel::parse(object)?,
+        },
+        enabled: SmackAccess::parse(enabled)?,
+        disabled: SmackAccess::parse(disabled)?,
+    }))
+}
+
+fn parse_label_set(labels: &str) -> Result<BTreeSet<SmackLabel>> {
+    let labels = labels.trim();
+    if labels.is_empty() || labels == "-" {
+        return Ok(BTreeSet::new());
+    }
+
+    labels
+        .split_whitespace()
+        .map(SmackLabel::parse)
+        .collect::<Result<_>>()
+}
+
 fn access_rules() -> &'static RwMutex<BTreeMap<RuleKey, SmackAccess>> {
     ACCESS_RULES.call_once(|| RwMutex::new(BTreeMap::new()))
+}
+
+fn access_query_result() -> &'static RwMutex<Option<bool>> {
+    ACCESS_QUERY_RESULT.call_once(|| RwMutex::new(None))
+}
+
+fn ambient_label_lock() -> &'static RwMutex<SmackLabel> {
+    AMBIENT_LABEL.call_once(|| RwMutex::new(SmackLabel::floor()))
+}
+
+fn onlycap_labels() -> &'static RwMutex<BTreeSet<SmackLabel>> {
+    ONLYCAP_LABELS.call_once(|| RwMutex::new(BTreeSet::new()))
+}
+
+fn logging_mode() -> &'static RwMutex<SmackLoggingMode> {
+    LOGGING_MODE.call_once(|| RwMutex::new(SmackLoggingMode::Denied))
 }

--- a/kernel/src/security/lsm/modules/smack/access.rs
+++ b/kernel/src/security/lsm/modules/smack/access.rs
@@ -34,7 +34,6 @@ static ACCESS_RULES: Once<RwMutex<BTreeMap<RuleKey, SmackAccess>>> = Once::new()
 
 impl SmackAccess {
     /// Parses a Smack access string.
-    #[expect(dead_code, reason = "Smack rule loading will use this parser.")]
     pub fn parse(access: &str) -> Result<Self> {
         let mut parsed = Self::empty();
         for byte in access.bytes() {
@@ -52,17 +51,70 @@ impl SmackAccess {
 
         Ok(parsed)
     }
+
+    /// Returns the canonical rule text for this access set.
+    pub fn as_rule_text(self) -> String {
+        let mut text = String::with_capacity(6);
+        for (access, name) in [
+            (Self::READ, 'r'),
+            (Self::WRITE, 'w'),
+            (Self::EXECUTE, 'x'),
+            (Self::APPEND, 'a'),
+            (Self::TRANSMUTE, 't'),
+            (Self::BRINGUP, 'b'),
+        ] {
+            if self.contains(access) {
+                text.push(name);
+            }
+        }
+
+        if text.is_empty() {
+            text.push('-');
+        }
+
+        text
+    }
 }
 
 /// Adds or replaces a Smack access rule.
-#[expect(
-    dead_code,
-    reason = "Smack rule loading will install policy with this helper."
-)]
 pub fn set_rule(subject: SmackLabel, object: SmackLabel, access: SmackAccess) {
     access_rules()
         .write()
         .insert(RuleKey { subject, object }, access);
+}
+
+/// Loads newline-delimited Smack access rules.
+pub fn load_rules(policy: &str) -> Result<usize> {
+    let mut parsed_rules = Vec::new();
+    for line in policy.lines() {
+        let Some(rule) = parse_rule_line(line)? else {
+            continue;
+        };
+        parsed_rules.push(rule);
+    }
+
+    let parsed_rule_count = parsed_rules.len();
+    for rule in parsed_rules {
+        set_rule(rule.subject, rule.object, rule.access);
+    }
+
+    Ok(parsed_rule_count)
+}
+
+/// Returns all loaded Smack access rules in deterministic order.
+pub fn rules_as_text() -> String {
+    let mut text = String::new();
+    let rules = access_rules().read();
+    for (key, access) in rules.iter() {
+        text.push_str(key.subject.as_str());
+        text.push(' ');
+        text.push_str(key.object.as_str());
+        text.push(' ');
+        text.push_str(&access.as_rule_text());
+        text.push('\n');
+    }
+
+    text
 }
 
 /// Checks whether a Smack subject can access an object.
@@ -106,6 +158,39 @@ fn is_allowed(subject: &SmackLabel, object: &SmackLabel, requested: SmackAccess)
     rules
         .get(&key)
         .is_some_and(|allowed| allowed.contains(requested))
+}
+
+struct ParsedRule {
+    subject: SmackLabel,
+    object: SmackLabel,
+    access: SmackAccess,
+}
+
+fn parse_rule_line(line: &str) -> Result<Option<ParsedRule>> {
+    let line = line.split('#').next().unwrap_or("").trim();
+    if line.is_empty() {
+        return Ok(None);
+    }
+
+    let mut fields = line.split_whitespace();
+    let Some(subject) = fields.next() else {
+        return Ok(None);
+    };
+    let Some(object) = fields.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule object label is missing");
+    };
+    let Some(access) = fields.next() else {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule access mode is missing");
+    };
+    if fields.next().is_some() {
+        return_errno_with_message!(Errno::EINVAL, "the Smack rule has too many fields");
+    }
+
+    Ok(Some(ParsedRule {
+        subject: SmackLabel::parse(subject)?,
+        object: SmackLabel::parse(object)?,
+        access: SmackAccess::parse(access)?,
+    }))
 }
 
 fn access_rules() -> &'static RwMutex<BTreeMap<RuleKey, SmackAccess>> {

--- a/kernel/src/security/lsm/modules/smack/label.rs
+++ b/kernel/src/security/lsm/modules/smack/label.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::prelude::*;
+
+/// The maximum size of a Smack label.
+pub const MAX_LABEL_LEN: usize = 255;
+
+/// A validated Smack label.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SmackLabel(String);
+
+impl SmackLabel {
+    /// Creates a Smack label from validated text.
+    pub fn parse(label: &str) -> Result<Self> {
+        validate_label(label)?;
+        Ok(Self(label.to_string()))
+    }
+
+    /// Creates a Smack label from an xattr value.
+    pub fn parse_xattr_value(value: &[u8]) -> Result<Self> {
+        let label = core::str::from_utf8(value)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "the Smack label is not UTF-8"))?;
+        Self::parse(label)
+    }
+
+    /// Creates the Smack floor label.
+    pub fn floor() -> Self {
+        Self("_".to_string())
+    }
+
+    /// Returns the label text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns whether this is the floor label.
+    pub fn is_floor(&self) -> bool {
+        self.as_str() == "_"
+    }
+
+    /// Returns whether this is the hat label.
+    pub fn is_hat(&self) -> bool {
+        self.as_str() == "^"
+    }
+
+    /// Returns whether this is the star label.
+    pub fn is_star(&self) -> bool {
+        self.as_str() == "*"
+    }
+}
+
+impl Default for SmackLabel {
+    fn default() -> Self {
+        Self::floor()
+    }
+}
+
+fn validate_label(label: &str) -> Result<()> {
+    if label.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "the Smack label is empty");
+    }
+    if label.len() > MAX_LABEL_LEN {
+        return_errno_with_message!(Errno::EINVAL, "the Smack label is too long");
+    }
+    if label.starts_with('-') {
+        return_errno_with_message!(
+            Errno::EINVAL,
+            "the Smack label starts with a reserved prefix"
+        );
+    }
+
+    for byte in label.bytes() {
+        if !byte.is_ascii_graphic() || matches!(byte, b'/' | b'\\' | b'\'' | b'"') {
+            return_errno_with_message!(Errno::EINVAL, "the Smack label contains invalid bytes");
+        }
+    }
+
+    Ok(())
+}

--- a/kernel/src/security/lsm/modules/smack/mod.rs
+++ b/kernel/src/security/lsm/modules/smack/mod.rs
@@ -49,6 +49,8 @@ impl LsmCapabilityHook for SmackLsm {}
 
 impl LsmBprmHook for SmackLsm {
     fn on_bprm_check_security(&self, context: &BprmCheckContext<'_>) -> Result<()> {
+        let _ = xattr::exec_label(context.executable().inode())?;
+
         let Some(thread) = Thread::current() else {
             return Ok(());
         };

--- a/kernel/src/security/lsm/modules/smack/mod.rs
+++ b/kernel/src/security/lsm/modules/smack/mod.rs
@@ -4,11 +4,13 @@
 
 mod access;
 mod label;
+mod mount;
 mod state;
 mod xattr;
 
 pub use self::{
-    access::SmackAccess, label::SmackLabel, state::SmackTaskState, xattr::is_smack_xattr,
+    access::SmackAccess, label::SmackLabel, mount::SmackMountLabels, state::SmackTaskState,
+    xattr::is_smack_xattr,
 };
 use super::super::{
     LsmFlags, LsmModule,
@@ -50,7 +52,31 @@ impl LsmModule for SmackLsm {
 
 impl LsmAlienAccessHook for SmackLsm {}
 
-impl LsmCapabilityHook for SmackLsm {}
+impl LsmCapabilityHook for SmackLsm {
+    fn on_capable(&self, context: &CapableContext) -> Result<()> {
+        if !context
+            .required_cap()
+            .intersects(CapSet::MAC_ADMIN | CapSet::MAC_OVERRIDE)
+        {
+            return Ok(());
+        }
+
+        let subject = context
+            .posix_thread()
+            .credentials()
+            .smack_task_state()
+            .current_label()
+            .clone();
+        if access::subject_has_onlycap(&subject) {
+            return Ok(());
+        }
+
+        return_errno_with_message!(
+            Errno::EPERM,
+            "Smack onlycap policy denies the requested capability"
+        );
+    }
+}
 
 impl LsmBprmHook for SmackLsm {
     fn on_bprm_check_security(&self, context: &BprmCheckContext<'_>) -> Result<()> {
@@ -187,9 +213,80 @@ pub fn load_rules(policy: &str) -> Result<usize> {
     access::load_rules(policy)
 }
 
+/// Enables and disables access bits in one Smack access rule.
+pub fn change_rule(rule: &str) -> Result<()> {
+    current_thread_may_admin()?;
+    access::change_rule(rule)
+}
+
+/// Removes Smack access rules for a subject.
+pub fn revoke_subject(subject: &str) -> Result<usize> {
+    current_thread_may_admin()?;
+    access::revoke_subject(subject)
+}
+
+/// Queries whether a Smack access request would be allowed.
+pub fn query_access(query: &str) -> Result<bool> {
+    current_thread_may_admin()?;
+    access::query_access(query)
+}
+
+/// Returns the last Smack access query result.
+pub fn access_query_result_as_text() -> String {
+    access::access_query_result_as_text()
+}
+
 /// Returns loaded Smack access rules.
 pub fn rules_as_text() -> String {
     access::rules_as_text()
+}
+
+/// Returns the current ambient label.
+pub fn ambient_label_as_text() -> String {
+    access::ambient_label_as_text()
+}
+
+/// Sets the current ambient label.
+pub fn set_ambient_label(label: &str) -> Result<()> {
+    current_thread_may_admin()?;
+    access::set_ambient_label(label)
+}
+
+/// Returns labels allowed to exercise Smack MAC capabilities.
+pub fn onlycap_labels_as_text() -> String {
+    access::onlycap_labels_as_text()
+}
+
+/// Replaces labels allowed to exercise Smack MAC capabilities.
+pub fn set_onlycap_labels(labels: &str) -> Result<()> {
+    current_thread_may_admin()?;
+    access::set_onlycap_labels(labels)
+}
+
+/// Returns the current access logging mode.
+pub fn logging_mode_as_text() -> String {
+    access::logging_mode_as_text()
+}
+
+/// Sets the current access logging mode.
+pub fn set_logging_mode(mode: &str) -> Result<()> {
+    current_thread_may_admin()?;
+    access::set_logging_mode(mode)
+}
+
+/// Parses Smack mount labels from mount options.
+pub fn mount_labels_from_options(args: Option<&CStr>) -> Result<SmackMountLabels> {
+    let (labels, found_smack_option) = SmackMountLabels::parse(args)?;
+    if found_smack_option {
+        current_thread_may_admin()?;
+    }
+
+    Ok(labels)
+}
+
+/// Applies root-specific Smack mount labels to a filesystem.
+pub fn apply_mount_labels(fs: &dyn crate::fs::vfs::file_system::FileSystem) -> Result<()> {
+    mount::apply_root_labels(fs)
 }
 
 /// Checks whether a Smack xattr may be updated.
@@ -383,17 +480,7 @@ fn current_thread_may_admin() -> Result<()> {
 }
 
 fn current_thread_has_mac_override() -> bool {
-    let Some(thread) = Thread::current() else {
-        return false;
-    };
-    let Some(posix_thread) = thread.as_posix_thread() else {
-        return false;
-    };
-
-    posix_thread
-        .credentials()
-        .effective_capset()
-        .contains(CapSet::MAC_OVERRIDE)
+    current_thread_has_capability(CapSet::MAC_OVERRIDE)
 }
 
 fn current_subject_label() -> Option<SmackLabel> {
@@ -414,4 +501,20 @@ fn current_socket_create_label() -> Option<SmackLabel> {
         .smack_task_state()
         .sockcreate_label()
         .cloned()
+}
+
+fn current_thread_has_capability(capability: CapSet) -> bool {
+    let Some(thread) = Thread::current() else {
+        return false;
+    };
+    let Some(posix_thread) = thread.as_posix_thread() else {
+        return false;
+    };
+
+    lsm_hooks::on_capable(CapableContext::new(
+        UserNamespace::get_init_singleton().as_ref(),
+        posix_thread,
+        capability,
+    ))
+    .is_ok()
 }

--- a/kernel/src/security/lsm/modules/smack/mod.rs
+++ b/kernel/src/security/lsm/modules/smack/mod.rs
@@ -14,10 +14,15 @@ use super::super::{
     LsmFlags, LsmModule,
     hooks::{
         BprmCheckContext, BprmCommittedCredsContext, CapableContext, LsmAlienAccessHook,
-        LsmBprmHook, LsmCapabilityHook,
+        LsmBprmHook, LsmCapabilityHook, LsmFileHook, LsmInodeHook, LsmMmapHook, LsmPathHook,
+        LsmSocketHook,
     },
 };
 use crate::{
+    fs::{
+        file::Permission,
+        vfs::{inode::Inode, path::Path},
+    },
     prelude::*,
     process::{
         UserNamespace,
@@ -49,41 +54,91 @@ impl LsmCapabilityHook for SmackLsm {}
 
 impl LsmBprmHook for SmackLsm {
     fn on_bprm_check_security(&self, context: &BprmCheckContext<'_>) -> Result<()> {
-        let _ = xattr::exec_label(context.executable().inode())?;
+        let _ = xattr::exec_label(context.executable().inode().as_ref())?;
 
-        let Some(thread) = Thread::current() else {
-            return Ok(());
-        };
-        let Some(posix_thread) = thread.as_posix_thread() else {
-            return Ok(());
-        };
-        if posix_thread
-            .credentials()
-            .effective_capset()
-            .contains(CapSet::MAC_OVERRIDE)
-        {
+        if current_thread_has_mac_override() {
             return Ok(());
         }
 
-        let subject = posix_thread
-            .credentials()
-            .smack_task_state()
-            .current_label()
-            .clone();
-        let object = xattr::access_label(context.executable().inode())?;
-        access::check(&subject, &object, SmackAccess::EXECUTE)
+        check_path_access(context.executable(), SmackAccess::EXECUTE)
     }
 
     fn on_bprm_committed_creds(&self, context: &BprmCommittedCredsContext<'_>) -> Result<()> {
-        let Some(exec_label) = xattr::exec_label(context.executable().inode())? else {
+        let task_state = context.credentials().smack_task_state();
+        let exec_label = task_state
+            .exec_label()
+            .cloned()
+            .or(xattr::exec_label(context.executable().inode().as_ref())?);
+        let Some(exec_label) = exec_label else {
             return Ok(());
         };
 
-        let task_state = context.credentials().smack_task_state();
         context
             .credentials()
             .set_smack_task_state(task_state.with_current_label(exec_label));
         Ok(())
+    }
+}
+
+impl LsmInodeHook for SmackLsm {
+    fn on_inode_permission(&self, context: &lsm_hooks::InodePermissionContext<'_>) -> Result<()> {
+        check_permission(context.inode(), context.permission())
+    }
+}
+
+impl LsmFileHook for SmackLsm {
+    fn on_file_permission(&self, context: &lsm_hooks::FilePermissionContext<'_>) -> Result<()> {
+        check_file_permission(context.path(), context.permission())
+    }
+}
+
+impl LsmPathHook for SmackLsm {
+    fn on_path_create(&self, context: &lsm_hooks::PathCreateContext<'_>) -> Result<()> {
+        check_path_access(context.parent(), SmackAccess::WRITE)
+    }
+
+    fn on_path_post_create(&self, context: &lsm_hooks::PathPostCreateContext<'_>) -> Result<()> {
+        set_created_inode_label(context.parent(), context.child())
+    }
+
+    fn on_path_link(&self, context: &lsm_hooks::PathLinkContext<'_>) -> Result<()> {
+        check_path_access(context.old_path(), SmackAccess::READ)?;
+        check_path_access(context.new_parent(), SmackAccess::WRITE)
+    }
+
+    fn on_path_unlink(&self, context: &lsm_hooks::PathUnlinkContext<'_>) -> Result<()> {
+        check_path_access(context.parent(), SmackAccess::WRITE)?;
+        check_inode_access(context.child(), SmackAccess::WRITE)
+    }
+
+    fn on_path_rename(&self, context: &lsm_hooks::PathRenameContext<'_>) -> Result<()> {
+        check_path_access(context.old_parent(), SmackAccess::WRITE)?;
+        check_inode_access(context.old_child(), SmackAccess::WRITE)?;
+        check_path_access(context.new_parent(), SmackAccess::WRITE)?;
+        if let Some(new_child) = context.new_child() {
+            check_inode_access(new_child, SmackAccess::WRITE)?;
+        }
+        Ok(())
+    }
+
+    fn on_path_setattr(&self, context: &lsm_hooks::PathSetattrContext<'_>) -> Result<()> {
+        check_path_access(context.path(), SmackAccess::WRITE)
+    }
+}
+
+impl LsmMmapHook for SmackLsm {
+    fn on_mmap_file(&self, context: &lsm_hooks::MmapFileContext<'_>) -> Result<()> {
+        check_mmap(context.path(), context.perms())
+    }
+}
+
+impl LsmSocketHook for SmackLsm {
+    fn on_socket_create(&self, context: &lsm_hooks::SocketCreateContext<'_>) -> Result<()> {
+        set_socket_label(context.path())
+    }
+
+    fn on_socket_message(&self, context: &lsm_hooks::SocketMessageContext<'_>) -> Result<()> {
+        check_socket_send_recv(context.path(), context.permission())
     }
 }
 
@@ -94,7 +149,7 @@ pub fn task_state(posix_thread: &PosixThread) -> SmackTaskState {
 
 /// Sets the current POSIX thread's Smack label.
 pub fn set_current_label(label: &str) -> Result<()> {
-    let label = SmackLabel::parse(label.trim())?;
+    let label = parse_required_label(label)?;
     let current_thread = current_thread!();
     let Some(posix_thread) = current_thread.as_posix_thread() else {
         return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
@@ -109,6 +164,32 @@ pub fn set_current_label(label: &str) -> Result<()> {
     let task_state = posix_thread.credentials().smack_task_state();
     posix_thread.set_smack_task_state(task_state.with_current_label(label));
     Ok(())
+}
+
+/// Sets the current POSIX thread's one-shot Smack exec label.
+pub fn set_exec_label(label: &str) -> Result<()> {
+    set_optional_task_label(label, SmackTaskState::with_exec_label)
+}
+
+/// Sets the current POSIX thread's filesystem creation label.
+pub fn set_fscreate_label(label: &str) -> Result<()> {
+    set_optional_task_label(label, SmackTaskState::with_fscreate_label)
+}
+
+/// Sets the current POSIX thread's socket creation label.
+pub fn set_sockcreate_label(label: &str) -> Result<()> {
+    set_optional_task_label(label, SmackTaskState::with_sockcreate_label)
+}
+
+/// Loads Smack access rules.
+pub fn load_rules(policy: &str) -> Result<usize> {
+    current_thread_may_admin()?;
+    access::load_rules(policy)
+}
+
+/// Returns loaded Smack access rules.
+pub fn rules_as_text() -> String {
+    access::rules_as_text()
 }
 
 /// Checks whether a Smack xattr may be updated.
@@ -140,4 +221,197 @@ pub fn check_xattr_removal(posix_thread: &PosixThread, name: &str) -> Result<()>
         posix_thread,
         CapSet::MAC_ADMIN,
     ))
+}
+
+pub(super) fn check_inode_access(inode: &dyn Inode, requested: SmackAccess) -> Result<()> {
+    if current_thread_has_mac_override() {
+        return Ok(());
+    }
+
+    let Some(subject) = current_subject_label() else {
+        return Ok(());
+    };
+    let object = xattr::access_label(inode)?;
+    access::check(&subject, &object, requested)
+}
+
+pub(super) fn check_path_access(path: &Path, requested: SmackAccess) -> Result<()> {
+    check_inode_access(path.inode().as_ref(), requested)
+}
+
+pub(super) fn check_permission(inode: &dyn Inode, permission: Permission) -> Result<()> {
+    check_inode_access(inode, access_from_permission(permission))
+}
+
+pub(super) fn check_file_permission(path: &Path, permission: Permission) -> Result<()> {
+    check_path_access(path, access_from_permission(permission))
+}
+
+pub(super) fn check_mmap(path: &Path, perms: crate::vm::perms::VmPerms) -> Result<()> {
+    if current_thread_has_mac_override() {
+        return Ok(());
+    }
+    if !perms.intersects(crate::vm::perms::VmPerms::READ | crate::vm::perms::VmPerms::EXEC) {
+        return Ok(());
+    }
+
+    let requested = if perms.contains(crate::vm::perms::VmPerms::EXEC) {
+        SmackAccess::EXECUTE
+    } else {
+        SmackAccess::READ
+    };
+    check_path_access(path, requested)?;
+
+    let Some(mmap_label) = xattr::mmap_label(path.inode().as_ref())? else {
+        return Ok(());
+    };
+    let Some(subject) = current_subject_label() else {
+        return Ok(());
+    };
+    access::check(&subject, &mmap_label, requested)
+}
+
+pub(super) fn set_created_inode_label(parent: &Path, child: &Path) -> Result<()> {
+    let Some(subject) = current_subject_label() else {
+        return Ok(());
+    };
+    let label = select_created_inode_label(parent, &subject)?;
+    xattr::set_access_label(child.inode().as_ref(), &label)
+}
+
+pub(super) fn set_socket_label(path: &Path) -> Result<()> {
+    let Some(subject) = current_subject_label() else {
+        return Ok(());
+    };
+    let label = current_socket_create_label().unwrap_or(subject);
+    xattr::set_access_label(path.inode().as_ref(), &label)
+}
+
+pub(super) fn check_socket_send_recv(path: &Path, permission: Permission) -> Result<()> {
+    if current_thread_has_mac_override() {
+        return Ok(());
+    }
+
+    let Some(subject) = current_subject_label() else {
+        return Ok(());
+    };
+    let object = xattr::access_label(path.inode().as_ref())?;
+    access::check(&subject, &object, access_from_permission(permission))
+}
+
+fn select_created_inode_label(parent: &Path, subject: &SmackLabel) -> Result<SmackLabel> {
+    let Some(current_thread) = Thread::current() else {
+        return Ok(subject.clone());
+    };
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return Ok(subject.clone());
+    };
+
+    let task_state = posix_thread.credentials().smack_task_state();
+    if let Some(label) = task_state.fscreate_label() {
+        return Ok(label.clone());
+    }
+
+    let parent_inode = parent.inode().as_ref();
+    if xattr::is_transmuting_directory(parent_inode)? {
+        let parent_label = xattr::access_label(parent_inode)?;
+        if access::check(subject, &parent_label, SmackAccess::TRANSMUTE).is_ok() {
+            return Ok(parent_label);
+        }
+    }
+
+    Ok(subject.clone())
+}
+
+fn access_from_permission(permission: Permission) -> SmackAccess {
+    let mut access = SmackAccess::empty();
+    if permission.may_read() {
+        access |= SmackAccess::READ;
+    }
+    if permission.may_exec() {
+        access |= SmackAccess::EXECUTE;
+    }
+    if permission.contains(Permission::MAY_APPEND) {
+        access |= SmackAccess::APPEND;
+    } else if permission.may_write() {
+        access |= SmackAccess::WRITE;
+    }
+
+    access
+}
+
+fn set_optional_task_label(
+    label: &str,
+    update_state_fn: fn(&SmackTaskState, Option<SmackLabel>) -> SmackTaskState,
+) -> Result<()> {
+    let label = parse_optional_label(label)?;
+    current_thread_may_admin()?;
+
+    let current_thread = current_thread!();
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+    };
+    let task_state = posix_thread.credentials().smack_task_state();
+    posix_thread.set_smack_task_state(update_state_fn(&task_state, label));
+    Ok(())
+}
+
+fn parse_required_label(label: &str) -> Result<SmackLabel> {
+    SmackLabel::parse(label.trim())
+}
+
+fn parse_optional_label(label: &str) -> Result<Option<SmackLabel>> {
+    let label = label.trim();
+    if label == "-" {
+        return Ok(None);
+    }
+
+    SmackLabel::parse(label).map(Some)
+}
+
+fn current_thread_may_admin() -> Result<()> {
+    let current_thread = current_thread!();
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+    };
+
+    lsm_hooks::on_capable(CapableContext::new(
+        UserNamespace::get_init_singleton().as_ref(),
+        posix_thread,
+        CapSet::MAC_ADMIN,
+    ))
+}
+
+fn current_thread_has_mac_override() -> bool {
+    let Some(thread) = Thread::current() else {
+        return false;
+    };
+    let Some(posix_thread) = thread.as_posix_thread() else {
+        return false;
+    };
+
+    posix_thread
+        .credentials()
+        .effective_capset()
+        .contains(CapSet::MAC_OVERRIDE)
+}
+
+fn current_subject_label() -> Option<SmackLabel> {
+    Some(
+        Thread::current()?
+            .as_posix_thread()?
+            .credentials()
+            .smack_task_state()
+            .current_label()
+            .clone(),
+    )
+}
+
+fn current_socket_create_label() -> Option<SmackLabel> {
+    Thread::current()?
+        .as_posix_thread()?
+        .credentials()
+        .smack_task_state()
+        .sockcreate_label()
+        .cloned()
 }

--- a/kernel/src/security/lsm/modules/smack/mod.rs
+++ b/kernel/src/security/lsm/modules/smack/mod.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Smack major LSM foundation.
+
+mod access;
+mod label;
+mod state;
+mod xattr;
+
+pub use self::{
+    access::SmackAccess, label::SmackLabel, state::SmackTaskState, xattr::is_smack_xattr,
+};
+use super::super::{
+    LsmFlags, LsmModule,
+    hooks::{
+        BprmCheckContext, BprmCommittedCredsContext, CapableContext, LsmAlienAccessHook,
+        LsmBprmHook, LsmCapabilityHook,
+    },
+};
+use crate::{
+    prelude::*,
+    process::{
+        UserNamespace,
+        credentials::capabilities::CapSet,
+        posix_thread::{AsPosixThread, PosixThread},
+    },
+    security::lsm::hooks as lsm_hooks,
+    thread::Thread,
+};
+
+pub(super) static SMACK_LSM: SmackLsm = SmackLsm;
+
+/// The Smack major LSM.
+pub(super) struct SmackLsm;
+
+impl LsmModule for SmackLsm {
+    fn name(&self) -> &'static str {
+        "smack"
+    }
+
+    fn flags(&self) -> LsmFlags {
+        LsmFlags::LEGACY_MAJOR | LsmFlags::EXCLUSIVE
+    }
+}
+
+impl LsmAlienAccessHook for SmackLsm {}
+
+impl LsmCapabilityHook for SmackLsm {}
+
+impl LsmBprmHook for SmackLsm {
+    fn on_bprm_check_security(&self, context: &BprmCheckContext<'_>) -> Result<()> {
+        let Some(thread) = Thread::current() else {
+            return Ok(());
+        };
+        let Some(posix_thread) = thread.as_posix_thread() else {
+            return Ok(());
+        };
+        if posix_thread
+            .credentials()
+            .effective_capset()
+            .contains(CapSet::MAC_OVERRIDE)
+        {
+            return Ok(());
+        }
+
+        let subject = posix_thread
+            .credentials()
+            .smack_task_state()
+            .current_label()
+            .clone();
+        let object = xattr::access_label(context.executable().inode())?;
+        access::check(&subject, &object, SmackAccess::EXECUTE)
+    }
+
+    fn on_bprm_committed_creds(&self, context: &BprmCommittedCredsContext<'_>) -> Result<()> {
+        let Some(exec_label) = xattr::exec_label(context.executable().inode())? else {
+            return Ok(());
+        };
+
+        let task_state = context.credentials().smack_task_state();
+        context
+            .credentials()
+            .set_smack_task_state(task_state.with_current_label(exec_label));
+        Ok(())
+    }
+}
+
+/// Returns the Smack task state for a POSIX thread.
+pub fn task_state(posix_thread: &PosixThread) -> SmackTaskState {
+    posix_thread.credentials().smack_task_state()
+}
+
+/// Sets the current POSIX thread's Smack label.
+pub fn set_current_label(label: &str) -> Result<()> {
+    let label = SmackLabel::parse(label.trim())?;
+    let current_thread = current_thread!();
+    let Some(posix_thread) = current_thread.as_posix_thread() else {
+        return_errno_with_message!(Errno::ESRCH, "the current thread is not a POSIX thread");
+    };
+
+    lsm_hooks::on_capable(CapableContext::new(
+        UserNamespace::get_init_singleton().as_ref(),
+        posix_thread,
+        CapSet::MAC_ADMIN,
+    ))?;
+
+    let task_state = posix_thread.credentials().smack_task_state();
+    posix_thread.set_smack_task_state(task_state.with_current_label(label));
+    Ok(())
+}
+
+/// Checks whether a Smack xattr may be updated.
+pub fn check_xattr_update(posix_thread: &PosixThread, name: &str, value: &[u8]) -> Result<()> {
+    if !is_smack_xattr(name) {
+        return Ok(());
+    }
+    let Some(xattr_name) = crate::fs::vfs::xattr::XattrName::try_from_full_name(name) else {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
+    };
+
+    lsm_hooks::on_capable(CapableContext::new(
+        UserNamespace::get_init_singleton().as_ref(),
+        posix_thread,
+        CapSet::MAC_ADMIN,
+    ))?;
+
+    xattr::validate_update(xattr_name, value)
+}
+
+/// Checks whether a Smack xattr may be removed.
+pub fn check_xattr_removal(posix_thread: &PosixThread, name: &str) -> Result<()> {
+    if !is_smack_xattr(name) {
+        return Ok(());
+    }
+
+    lsm_hooks::on_capable(CapableContext::new(
+        UserNamespace::get_init_singleton().as_ref(),
+        posix_thread,
+        CapSet::MAC_ADMIN,
+    ))
+}

--- a/kernel/src/security/lsm/modules/smack/mount.rs
+++ b/kernel/src/security/lsm/modules/smack/mount.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::label::SmackLabel;
+use crate::{fs::vfs::file_system::FileSystem, prelude::*};
+
+/// Smack label state attached to a mounted filesystem.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SmackMountLabels {
+    default_label: SmackLabel,
+    root_label: Option<SmackLabel>,
+    transmute_label: Option<SmackLabel>,
+    // Linux accepts `smackfsfloor`, but the option is not enforced.
+    floor_label: Option<SmackLabel>,
+    // Linux accepts `smackfshat`, but the option is not enforced.
+    hat_label: Option<SmackLabel>,
+}
+
+impl SmackMountLabels {
+    /// Parses Smack mount labels from Linux-compatible mount options.
+    pub fn parse(args: Option<&CStr>) -> Result<(Self, bool)> {
+        let mut labels = Self::default();
+        let Some(args) = args else {
+            return Ok((labels, false));
+        };
+
+        let mut found_smack_option = false;
+        let args = args.to_string_lossy();
+        for token in args
+            .split(',')
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+        {
+            let Some((name, value)) = token.split_once('=') else {
+                continue;
+            };
+
+            let parsed_label = match name {
+                "smackfsdef" | "smackfsdefault" => &mut labels.default_label,
+                "smackfsroot" => {
+                    found_smack_option = true;
+                    labels.root_label = Some(SmackLabel::parse(value)?);
+                    continue;
+                }
+                "smackfstransmute" => {
+                    found_smack_option = true;
+                    labels.transmute_label = Some(SmackLabel::parse(value)?);
+                    continue;
+                }
+                "smackfsfloor" => {
+                    found_smack_option = true;
+                    labels.floor_label = Some(SmackLabel::parse(value)?);
+                    continue;
+                }
+                "smackfshat" => {
+                    found_smack_option = true;
+                    labels.hat_label = Some(SmackLabel::parse(value)?);
+                    continue;
+                }
+                _ => continue,
+            };
+
+            found_smack_option = true;
+            *parsed_label = SmackLabel::parse(value)?;
+        }
+
+        Ok((labels, found_smack_option))
+    }
+
+    /// Returns the label used for filesystem objects that lack a Smack xattr.
+    pub fn default_label(&self) -> SmackLabel {
+        self.default_label.clone()
+    }
+
+    /// Returns the label to assign to the filesystem root, if specified.
+    pub fn root_label(&self) -> Option<&SmackLabel> {
+        self.transmute_label.as_ref().or(self.root_label.as_ref())
+    }
+
+    /// Returns whether the root should be marked transmuting.
+    pub fn root_is_transmuting(&self) -> bool {
+        self.transmute_label.is_some()
+    }
+}
+
+/// Applies root-specific Smack mount labels to a filesystem.
+pub fn apply_root_labels(fs: &dyn FileSystem) -> Result<()> {
+    let root_inode = fs.root_inode();
+    let labels = fs.sb().smack;
+
+    if let Some(root_label) = labels.root_label() {
+        super::xattr::set_access_label(root_inode.as_ref(), root_label)?;
+    }
+    if labels.root_is_transmuting() {
+        super::xattr::set_transmute(root_inode.as_ref())?;
+    }
+
+    Ok(())
+}

--- a/kernel/src/security/lsm/modules/smack/state.rs
+++ b/kernel/src/security/lsm/modules/smack/state.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::label::SmackLabel;
+
+/// Smack state attached to task credentials.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SmackTaskState {
+    current_label: SmackLabel,
+    exec_label: Option<SmackLabel>,
+    fscreate_label: Option<SmackLabel>,
+    previous_label: Option<SmackLabel>,
+    sockcreate_label: Option<SmackLabel>,
+}
+
+impl SmackTaskState {
+    /// Creates a task state with the default Smack floor label.
+    pub fn new_floor() -> Self {
+        Self {
+            current_label: SmackLabel::floor(),
+            exec_label: None,
+            fscreate_label: None,
+            previous_label: None,
+            sockcreate_label: None,
+        }
+    }
+
+    /// Creates a copy with a new current label.
+    pub fn with_current_label(&self, label: SmackLabel) -> Self {
+        let mut state = self.clone();
+        state.previous_label = Some(core::mem::replace(&mut state.current_label, label));
+        state.exec_label = None;
+        state
+    }
+
+    /// Returns the current Smack label.
+    pub fn current_label(&self) -> &SmackLabel {
+        &self.current_label
+    }
+}
+
+impl Default for SmackTaskState {
+    fn default() -> Self {
+        Self::new_floor()
+    }
+}

--- a/kernel/src/security/lsm/modules/smack/state.rs
+++ b/kernel/src/security/lsm/modules/smack/state.rs
@@ -32,9 +32,50 @@ impl SmackTaskState {
         state
     }
 
+    /// Creates a copy with a new exec label.
+    pub fn with_exec_label(&self, label: Option<SmackLabel>) -> Self {
+        let mut state = self.clone();
+        state.exec_label = label;
+        state
+    }
+
+    /// Creates a copy with a new filesystem creation label.
+    pub fn with_fscreate_label(&self, label: Option<SmackLabel>) -> Self {
+        let mut state = self.clone();
+        state.fscreate_label = label;
+        state
+    }
+
+    /// Creates a copy with a new socket creation label.
+    pub fn with_sockcreate_label(&self, label: Option<SmackLabel>) -> Self {
+        let mut state = self.clone();
+        state.sockcreate_label = label;
+        state
+    }
+
     /// Returns the current Smack label.
     pub fn current_label(&self) -> &SmackLabel {
         &self.current_label
+    }
+
+    /// Returns the exec label.
+    pub fn exec_label(&self) -> Option<&SmackLabel> {
+        self.exec_label.as_ref()
+    }
+
+    /// Returns the filesystem creation label.
+    pub fn fscreate_label(&self) -> Option<&SmackLabel> {
+        self.fscreate_label.as_ref()
+    }
+
+    /// Returns the previous current label.
+    pub fn previous_label(&self) -> Option<&SmackLabel> {
+        self.previous_label.as_ref()
+    }
+
+    /// Returns the socket creation label.
+    pub fn sockcreate_label(&self) -> Option<&SmackLabel> {
+        self.sockcreate_label.as_ref()
     }
 }
 

--- a/kernel/src/security/lsm/modules/smack/xattr.rs
+++ b/kernel/src/security/lsm/modules/smack/xattr.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::label::{MAX_LABEL_LEN, SmackLabel};
+use crate::{
+    fs::vfs::{inode::Inode, xattr::XattrName},
+    prelude::*,
+};
+
+const SMACK64: &str = "security.SMACK64";
+const SMACK64EXEC: &str = "security.SMACK64EXEC";
+const SMACK64MMAP: &str = "security.SMACK64MMAP";
+const SMACK64TRANSMUTE: &str = "security.SMACK64TRANSMUTE";
+const SMACK64IPIN: &str = "security.SMACK64IPIN";
+const SMACK64IPOUT: &str = "security.SMACK64IPOUT";
+
+/// A Smack-managed xattr.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SmackXattr {
+    /// The object access-control label.
+    Access,
+    /// The task label applied after `execve`.
+    Exec,
+    /// The mmap mediation label.
+    Mmap,
+    /// The directory transmutation marker.
+    Transmute,
+    /// The inbound socket packet label.
+    IpIn,
+    /// The outbound socket packet label.
+    IpOut,
+}
+
+impl SmackXattr {
+    /// Parses a Smack xattr from its full name.
+    pub fn from_full_name(full_name: &str) -> Option<Self> {
+        match full_name {
+            SMACK64 => Some(Self::Access),
+            SMACK64EXEC => Some(Self::Exec),
+            SMACK64MMAP => Some(Self::Mmap),
+            SMACK64TRANSMUTE => Some(Self::Transmute),
+            SMACK64IPIN => Some(Self::IpIn),
+            SMACK64IPOUT => Some(Self::IpOut),
+            _ => None,
+        }
+    }
+
+    /// Returns whether this xattr carries a Smack label.
+    pub const fn carries_label(self) -> bool {
+        matches!(
+            self,
+            Self::Access | Self::Exec | Self::Mmap | Self::IpIn | Self::IpOut
+        )
+    }
+}
+
+/// Returns whether an xattr belongs to Smack.
+pub fn is_smack_xattr(full_name: &str) -> bool {
+    SmackXattr::from_full_name(full_name).is_some()
+}
+
+/// Validates a Smack xattr update.
+pub fn validate_update(name: XattrName<'_>, value: &[u8]) -> Result<()> {
+    let Some(smack_xattr) = SmackXattr::from_full_name(name.full_name()) else {
+        return Ok(());
+    };
+
+    if smack_xattr.carries_label() {
+        SmackLabel::parse_xattr_value(value)?;
+        return Ok(());
+    }
+
+    if value == b"TRUE" {
+        return Ok(());
+    }
+
+    return_errno_with_message!(
+        Errno::EINVAL,
+        "`security.SMACK64TRANSMUTE` must have the value `TRUE`"
+    );
+}
+
+/// Returns the Smack access label attached to an inode.
+pub fn access_label(inode: &Arc<dyn Inode>) -> Result<SmackLabel> {
+    read_label(inode, SMACK64).map(|label| label.unwrap_or_else(SmackLabel::floor))
+}
+
+/// Returns the Smack exec label attached to an inode.
+pub fn exec_label(inode: &Arc<dyn Inode>) -> Result<Option<SmackLabel>> {
+    read_label(inode, SMACK64EXEC)
+}
+
+fn read_label(inode: &Arc<dyn Inode>, name: &'static str) -> Result<Option<SmackLabel>> {
+    let Some(xattr_name) = XattrName::try_from_full_name(name) else {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
+    };
+    let mut empty = [];
+    let mut empty_writer = VmWriter::from(empty.as_mut_slice()).to_fallible();
+    let value_len = match inode.get_xattr(xattr_name, &mut empty_writer) {
+        Ok(value_len) => value_len,
+        Err(error) if matches!(error.error(), Errno::ENODATA | Errno::EOPNOTSUPP) => {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
+    };
+
+    if value_len > MAX_LABEL_LEN {
+        return_errno_with_message!(Errno::EINVAL, "the Smack label xattr is too long");
+    }
+
+    let Some(xattr_name) = XattrName::try_from_full_name(name) else {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
+    };
+    let mut value = vec![0u8; value_len];
+    let mut value_writer = VmWriter::from(value.as_mut_slice()).to_fallible();
+    inode.get_xattr(xattr_name, &mut value_writer)?;
+
+    SmackLabel::parse_xattr_value(&value).map(Some)
+}

--- a/kernel/src/security/lsm/modules/smack/xattr.rs
+++ b/kernel/src/security/lsm/modules/smack/xattr.rs
@@ -2,7 +2,10 @@
 
 use super::label::{MAX_LABEL_LEN, SmackLabel};
 use crate::{
-    fs::vfs::{inode::Inode, xattr::XattrName},
+    fs::vfs::{
+        inode::Inode,
+        xattr::{XattrName, XattrSetFlags},
+    },
     prelude::*,
 };
 
@@ -80,16 +83,49 @@ pub fn validate_update(name: XattrName<'_>, value: &[u8]) -> Result<()> {
 }
 
 /// Returns the Smack access label attached to an inode.
-pub fn access_label(inode: &Arc<dyn Inode>) -> Result<SmackLabel> {
+pub fn access_label(inode: &dyn Inode) -> Result<SmackLabel> {
     read_label(inode, SMACK64).map(|label| label.unwrap_or_else(SmackLabel::floor))
 }
 
 /// Returns the Smack exec label attached to an inode.
-pub fn exec_label(inode: &Arc<dyn Inode>) -> Result<Option<SmackLabel>> {
+pub fn exec_label(inode: &dyn Inode) -> Result<Option<SmackLabel>> {
     read_label(inode, SMACK64EXEC)
 }
 
-fn read_label(inode: &Arc<dyn Inode>, name: &'static str) -> Result<Option<SmackLabel>> {
+/// Returns the Smack mmap label attached to an inode.
+pub fn mmap_label(inode: &dyn Inode) -> Result<Option<SmackLabel>> {
+    read_label(inode, SMACK64MMAP)
+}
+
+/// Returns whether a directory carries the Smack transmute marker.
+pub fn is_transmuting_directory(inode: &dyn Inode) -> Result<bool> {
+    let Some(xattr_name) = XattrName::try_from_full_name(SMACK64TRANSMUTE) else {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
+    };
+    let mut value = vec![0u8; b"TRUE".len()];
+    let mut value_writer = VmWriter::from(value.as_mut_slice()).to_fallible();
+    match inode.get_xattr(xattr_name, &mut value_writer) {
+        Ok(value_len) => Ok(value_len == b"TRUE".len() && value == b"TRUE"),
+        Err(error) if is_absent_or_unsupported_xattr_error(&error) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+/// Updates the Smack access label attached to an inode if the filesystem supports it.
+pub fn set_access_label(inode: &dyn Inode, label: &SmackLabel) -> Result<()> {
+    let Some(xattr_name) = XattrName::try_from_full_name(SMACK64) else {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
+    };
+    let mut value_reader = VmReader::from(label.as_str().as_bytes()).to_fallible();
+
+    match inode.set_xattr(xattr_name, &mut value_reader, XattrSetFlags::empty()) {
+        Ok(()) => Ok(()),
+        Err(error) if is_unsupported_xattr_error(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_label(inode: &dyn Inode, name: &'static str) -> Result<Option<SmackLabel>> {
     let Some(xattr_name) = XattrName::try_from_full_name(name) else {
         return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
     };
@@ -97,7 +133,7 @@ fn read_label(inode: &Arc<dyn Inode>, name: &'static str) -> Result<Option<Smack
     let mut empty_writer = VmWriter::from(empty.as_mut_slice()).to_fallible();
     let value_len = match inode.get_xattr(xattr_name, &mut empty_writer) {
         Ok(value_len) => value_len,
-        Err(error) if matches!(error.error(), Errno::ENODATA | Errno::EOPNOTSUPP) => {
+        Err(error) if is_absent_or_unsupported_xattr_error(&error) => {
             return Ok(None);
         }
         Err(error) => return Err(error),
@@ -115,4 +151,13 @@ fn read_label(inode: &Arc<dyn Inode>, name: &'static str) -> Result<Option<Smack
     inode.get_xattr(xattr_name, &mut value_writer)?;
 
     SmackLabel::parse_xattr_value(&value).map(Some)
+}
+
+fn is_absent_or_unsupported_xattr_error(error: &Error) -> bool {
+    matches!(error.error(), Errno::ENODATA) || is_unsupported_xattr_error(error)
+}
+
+fn is_unsupported_xattr_error(error: &Error) -> bool {
+    // Ramfs reports unsupported file types, such as symlinks, with `EPERM`.
+    matches!(error.error(), Errno::EOPNOTSUPP | Errno::EPERM)
 }

--- a/kernel/src/security/lsm/modules/smack/xattr.rs
+++ b/kernel/src/security/lsm/modules/smack/xattr.rs
@@ -84,7 +84,16 @@ pub fn validate_update(name: XattrName<'_>, value: &[u8]) -> Result<()> {
 
 /// Returns the Smack access label attached to an inode.
 pub fn access_label(inode: &dyn Inode) -> Result<SmackLabel> {
-    read_label(inode, SMACK64).map(|label| label.unwrap_or_else(SmackLabel::floor))
+    read_label(inode, SMACK64).map(|label| {
+        label.unwrap_or_else(|| {
+            let default_label = inode.fs().sb().smack.default_label();
+            if default_label.is_floor() {
+                super::access::ambient_label()
+            } else {
+                default_label
+            }
+        })
+    })
 }
 
 /// Returns the Smack exec label attached to an inode.
@@ -117,6 +126,20 @@ pub fn set_access_label(inode: &dyn Inode, label: &SmackLabel) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
     };
     let mut value_reader = VmReader::from(label.as_str().as_bytes()).to_fallible();
+
+    match inode.set_xattr(xattr_name, &mut value_reader, XattrSetFlags::empty()) {
+        Ok(()) => Ok(()),
+        Err(error) if is_unsupported_xattr_error(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Marks an inode as a transmuting directory if the filesystem supports it.
+pub fn set_transmute(inode: &dyn Inode) -> Result<()> {
+    let Some(xattr_name) = XattrName::try_from_full_name(SMACK64TRANSMUTE) else {
+        return_errno_with_message!(Errno::EOPNOTSUPP, "invalid xattr namespace");
+    };
+    let mut value_reader = VmReader::from(&b"TRUE"[..]).to_fallible();
 
     match inode.set_xattr(xattr_name, &mut value_reader, XattrSetFlags::empty()) {
         Ok(()) => Ok(()),

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -6,7 +6,7 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use super::super::{
     LsmFlags, LsmModule,
-    hooks::{AlienAccessContext, LsmAlienAccessHook, LsmCapabilityHook},
+    hooks::{AlienAccessContext, LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook},
 };
 use crate::{
     prelude::*,
@@ -71,6 +71,8 @@ impl LsmModule for YamaLsm {
 }
 
 impl LsmCapabilityHook for YamaLsm {}
+
+impl LsmBprmHook for YamaLsm {}
 
 /// Returns the current Yama scope for alien access.
 pub fn get_scope() -> YamaScope {

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -6,7 +6,10 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use super::super::{
     LsmFlags, LsmModule,
-    hooks::{AlienAccessContext, LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook},
+    hooks::{
+        AlienAccessContext, LsmAlienAccessHook, LsmBprmHook, LsmCapabilityHook, LsmFileHook,
+        LsmInodeHook, LsmMmapHook, LsmPathHook, LsmSocketHook,
+    },
 };
 use crate::{
     prelude::*,
@@ -73,6 +76,16 @@ impl LsmModule for YamaLsm {
 impl LsmCapabilityHook for YamaLsm {}
 
 impl LsmBprmHook for YamaLsm {}
+
+impl LsmInodeHook for YamaLsm {}
+
+impl LsmFileHook for YamaLsm {}
+
+impl LsmPathHook for YamaLsm {}
+
+impl LsmMmapHook for YamaLsm {}
+
+impl LsmSocketHook for YamaLsm {}
 
 /// Returns the current Yama scope for alien access.
 pub fn get_scope() -> YamaScope {

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -14,9 +14,13 @@ cfg_if! {
 
 pub use self::lsm::SmackTaskState;
 use crate::{
-    fs::vfs::path::Path,
+    fs::{
+        file::Permission,
+        vfs::{inode::Inode, path::Path},
+    },
     prelude::*,
     process::{Credentials, posix_thread::PosixThread},
+    vm::perms::VmPerms,
 };
 
 pub(super) fn init() {
@@ -46,6 +50,51 @@ pub fn set_current_smack_label(label: &str) -> Result<()> {
     }
 
     lsm::smack::set_current_label(label)
+}
+
+/// Sets the current POSIX thread's one-shot Smack exec label.
+pub fn set_current_smack_exec_label(label: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::set_exec_label(label)
+}
+
+/// Sets the current POSIX thread's Smack filesystem creation label.
+pub fn set_current_smack_fscreate_label(label: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::set_fscreate_label(label)
+}
+
+/// Sets the current POSIX thread's Smack socket creation label.
+pub fn set_current_smack_sockcreate_label(label: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::set_sockcreate_label(label)
+}
+
+/// Loads Smack access rules.
+pub fn load_smack_rules(policy: &str) -> Result<usize> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::load_rules(policy)
+}
+
+/// Returns loaded Smack access rules.
+pub fn smack_rules_as_text() -> Result<String> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    Ok(lsm::smack::rules_as_text())
 }
 
 /// Checks whether a Smack xattr update is permitted and valid.
@@ -78,4 +127,66 @@ pub fn bprm_check_security(path: &Path) -> Result<()> {
 /// Updates security state after credentials are committed for a new executable.
 pub fn bprm_committed_creds(path: &Path, credentials: &Credentials<ReadWriteOp>) -> Result<()> {
     lsm::bprm_committed_creds(&lsm::BprmCommittedCredsContext::new(path, credentials))
+}
+
+/// Checks whether an inode permission request is allowed.
+pub fn inode_permission(inode: &dyn Inode, permission: Permission) -> Result<()> {
+    lsm::hooks::on_inode_permission(&lsm::hooks::InodePermissionContext::new(inode, permission))
+}
+
+/// Checks whether an opened file operation is allowed.
+pub fn file_permission(path: &Path, permission: Permission) -> Result<()> {
+    lsm::hooks::on_file_permission(&lsm::hooks::FilePermissionContext::new(path, permission))
+}
+
+/// Checks whether a child may be created under a directory.
+pub fn path_create(parent: &Path) -> Result<()> {
+    lsm::hooks::on_path_create(&lsm::hooks::PathCreateContext::new(parent))
+}
+
+/// Updates security state after a child has been created.
+pub fn path_post_create(parent: &Path, child: &Path) -> Result<()> {
+    lsm::hooks::on_path_post_create(&lsm::hooks::PathPostCreateContext::new(parent, child))
+}
+
+/// Checks whether a hard link may be created.
+pub fn path_link(old_path: &Path, new_parent: &Path) -> Result<()> {
+    lsm::hooks::on_path_link(&lsm::hooks::PathLinkContext::new(old_path, new_parent))
+}
+
+/// Checks whether a child may be removed.
+pub fn path_unlink(parent: &Path, child: &dyn Inode) -> Result<()> {
+    lsm::hooks::on_path_unlink(&lsm::hooks::PathUnlinkContext::new(parent, child))
+}
+
+/// Checks whether a child may be renamed.
+pub fn path_rename(
+    old_parent: &Path,
+    old_child: &dyn Inode,
+    new_parent: &Path,
+    new_child: Option<&dyn Inode>,
+) -> Result<()> {
+    lsm::hooks::on_path_rename(&lsm::hooks::PathRenameContext::new(
+        old_parent, old_child, new_parent, new_child,
+    ))
+}
+
+/// Checks whether file metadata may be updated.
+pub fn path_setattr(path: &Path) -> Result<()> {
+    lsm::hooks::on_path_setattr(&lsm::hooks::PathSetattrContext::new(path))
+}
+
+/// Checks whether a file-backed memory mapping is allowed.
+pub fn mmap_file(path: &Path, perms: VmPerms) -> Result<()> {
+    lsm::hooks::on_mmap_file(&lsm::hooks::MmapFileContext::new(path, perms))
+}
+
+/// Labels a newly created socket.
+pub fn socket_create(path: &Path) -> Result<()> {
+    lsm::hooks::on_socket_create(&lsm::hooks::SocketCreateContext::new(path))
+}
+
+/// Checks whether a socket message operation is allowed.
+pub fn socket_message(path: &Path, permission: Permission) -> Result<()> {
+    lsm::hooks::on_socket_message(&lsm::hooks::SocketMessageContext::new(path, permission))
 }

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -12,11 +12,11 @@ cfg_if! {
     }
 }
 
-pub use self::lsm::SmackTaskState;
+pub use self::lsm::{SmackMountLabels, SmackTaskState};
 use crate::{
     fs::{
         file::Permission,
-        vfs::{inode::Inode, path::Path},
+        vfs::{file_system::FileSystem, inode::Inode, path::Path},
     },
     prelude::*,
     process::{Credentials, posix_thread::PosixThread},
@@ -88,6 +88,42 @@ pub fn load_smack_rules(policy: &str) -> Result<usize> {
     lsm::smack::load_rules(policy)
 }
 
+/// Enables and disables access bits in one Smack access rule.
+pub fn change_smack_rule(rule: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::change_rule(rule)
+}
+
+/// Removes Smack access rules for a subject.
+pub fn revoke_smack_subject(subject: &str) -> Result<usize> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::revoke_subject(subject)
+}
+
+/// Queries whether a Smack access request would be allowed.
+pub fn query_smack_access(query: &str) -> Result<bool> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::query_access(query)
+}
+
+/// Returns the last Smack access query result.
+pub fn smack_access_query_result_as_text() -> Result<String> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    Ok(lsm::smack::access_query_result_as_text())
+}
+
 /// Returns loaded Smack access rules.
 pub fn smack_rules_as_text() -> Result<String> {
     if !is_smack_enabled() {
@@ -95,6 +131,78 @@ pub fn smack_rules_as_text() -> Result<String> {
     }
 
     Ok(lsm::smack::rules_as_text())
+}
+
+/// Returns the current Smack ambient label.
+pub fn smack_ambient_label_as_text() -> Result<String> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    Ok(lsm::smack::ambient_label_as_text())
+}
+
+/// Sets the current Smack ambient label.
+pub fn set_smack_ambient_label(label: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::set_ambient_label(label)
+}
+
+/// Returns the Smack `onlycap` label set.
+pub fn smack_onlycap_labels_as_text() -> Result<String> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    Ok(lsm::smack::onlycap_labels_as_text())
+}
+
+/// Sets the Smack `onlycap` label set.
+pub fn set_smack_onlycap_labels(labels: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::set_onlycap_labels(labels)
+}
+
+/// Returns the current Smack logging mode.
+pub fn smack_logging_mode_as_text() -> Result<String> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    Ok(lsm::smack::logging_mode_as_text())
+}
+
+/// Sets the current Smack logging mode.
+pub fn set_smack_logging_mode(mode: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::set_logging_mode(mode)
+}
+
+/// Parses Smack mount labels from mount options.
+pub fn smack_mount_labels_from_options(args: Option<&CStr>) -> Result<SmackMountLabels> {
+    if !is_smack_enabled() {
+        return Ok(SmackMountLabels::default());
+    }
+
+    lsm::smack::mount_labels_from_options(args)
+}
+
+/// Applies root-specific Smack mount labels to a filesystem.
+pub fn apply_smack_mount_labels(fs: &dyn FileSystem) -> Result<()> {
+    if !is_smack_enabled() {
+        return Ok(());
+    }
+
+    lsm::smack::apply_mount_labels(fs)
 }
 
 /// Checks whether a Smack xattr update is permitted and valid.

--- a/kernel/src/security/mod.rs
+++ b/kernel/src/security/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod lsm;
 
+use aster_rights::ReadWriteOp;
 use cfg_if::cfg_if;
 
 cfg_if! {
@@ -11,6 +12,13 @@ cfg_if! {
     }
 }
 
+pub use self::lsm::SmackTaskState;
+use crate::{
+    fs::vfs::path::Path,
+    prelude::*,
+    process::{Credentials, posix_thread::PosixThread},
+};
+
 pub(super) fn init() {
     lsm::init();
 
@@ -19,4 +27,55 @@ pub(super) fn init() {
         tsm::init();
         tsm_mr::init();
     });
+}
+
+/// Returns whether the Smack LSM is enabled.
+pub fn is_smack_enabled() -> bool {
+    lsm::is_smack_enabled()
+}
+
+/// Returns the Smack task state for a POSIX thread if the module is active.
+pub fn smack_task_state(posix_thread: &PosixThread) -> Option<SmackTaskState> {
+    is_smack_enabled().then(|| lsm::smack::task_state(posix_thread))
+}
+
+/// Sets the current POSIX thread's Smack label.
+pub fn set_current_smack_label(label: &str) -> Result<()> {
+    if !is_smack_enabled() {
+        return_errno_with_message!(Errno::ENOENT, "the Smack LSM is not enabled");
+    }
+
+    lsm::smack::set_current_label(label)
+}
+
+/// Checks whether a Smack xattr update is permitted and valid.
+pub fn check_smack_xattr_update(
+    posix_thread: &PosixThread,
+    name: &str,
+    value: &[u8],
+) -> Result<()> {
+    if !is_smack_enabled() || !lsm::smack::is_smack_xattr(name) {
+        return Ok(());
+    }
+
+    lsm::smack::check_xattr_update(posix_thread, name, value)
+}
+
+/// Checks whether a Smack xattr removal is permitted.
+pub fn check_smack_xattr_removal(posix_thread: &PosixThread, name: &str) -> Result<()> {
+    if !is_smack_enabled() || !lsm::smack::is_smack_xattr(name) {
+        return Ok(());
+    }
+
+    lsm::smack::check_xattr_removal(posix_thread, name)
+}
+
+/// Runs the LSM stack for an executable image check.
+pub fn bprm_check_security(path: &Path) -> Result<()> {
+    lsm::bprm_check_security(&lsm::BprmCheckContext::new(path))
+}
+
+/// Updates security state after credentials are committed for a new executable.
+pub fn bprm_committed_creds(path: &Path, credentials: &Credentials<ReadWriteOp>) -> Result<()> {
+    lsm::bprm_committed_creds(&lsm::BprmCommittedCredsContext::new(path, credentials))
 }

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -3,10 +3,11 @@
 use super::SyscallReturn;
 use crate::{
     fs::file::{
-        CreationFlags, StatusFlags,
+        CreationFlags, Permission, StatusFlags,
         file_table::{FdFlags, RawFileDesc, get_file_fast},
     },
     prelude::*,
+    security,
     util::net::write_socket_addr_to_user,
 };
 
@@ -50,6 +51,7 @@ fn do_accept(
     let file = get_file_fast!(&mut file_table, sockfd.try_into()?);
     let socket = file.as_socket_or_err()?;
 
+    security::socket_message(socket.pseudo_path(), Permission::MAY_READ)?;
     let (connected_socket, socket_addr) = {
         socket.accept().map_err(|err| match err.error() {
             // FIXME: `accept` should not be restarted if a timeout has been set on the socket using `setsockopt`.

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -8,6 +8,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
     prelude::*,
+    security,
 };
 
 pub fn sys_faccessat(
@@ -100,12 +101,15 @@ fn do_faccessat(
     // F_OK is represented by `AccessMode::empty()`, which does not perform permission checks.
     if mode.contains(AccessMode::R_OK) {
         inode.check_permission(Permission::MAY_READ)?;
+        security::inode_permission(inode.as_ref(), Permission::MAY_READ)?;
     }
     if mode.contains(AccessMode::W_OK) {
         inode.check_permission(Permission::MAY_WRITE)?;
+        security::inode_permission(inode.as_ref(), Permission::MAY_WRITE)?;
     }
     if mode.contains(AccessMode::X_OK) {
         inode.check_permission(Permission::MAY_EXEC)?;
+        security::inode_permission(inode.as_ref(), Permission::MAY_EXEC)?;
     }
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/bind.rs
+++ b/kernel/src/syscall/bind.rs
@@ -2,8 +2,12 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        Permission,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
+    security,
     util::net::read_socket_addr_from_user,
 };
 
@@ -20,6 +24,7 @@ pub fn sys_bind(
     let file = get_file_fast!(&mut file_table, sockfd.try_into()?);
     let socket = file.as_socket_or_err()?;
 
+    security::socket_message(socket.pseudo_path(), Permission::MAY_WRITE)?;
     socket.bind(socket_addr)?;
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/connect.rs
+++ b/kernel/src/syscall/connect.rs
@@ -2,8 +2,12 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        Permission,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
+    security,
     util::net::read_socket_addr_from_user,
 };
 
@@ -20,6 +24,7 @@ pub fn sys_connect(
     let file = get_file_fast!(&mut file_table, sockfd.try_into()?);
     let socket = file.as_socket_or_err()?;
 
+    security::socket_message(socket.pseudo_path(), Permission::MAY_WRITE)?;
     socket
         .connect(socket_addr)
         .map_err(|err| match err.error() {

--- a/kernel/src/syscall/inotify.rs
+++ b/kernel/src/syscall/inotify.rs
@@ -13,6 +13,7 @@ use crate::{
         },
     },
     prelude::*,
+    security,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -93,6 +94,7 @@ pub fn sys_inotify_add_watch(
     // Verify caller has read permissions on the inode.
     let inode = dentry.inode();
     inode.check_permission(Permission::MAY_READ)?;
+    security::inode_permission(inode.as_ref(), Permission::MAY_READ)?;
 
     if options.contains(InotifyControls::ONLYDIR) && inode.type_() != InodeType::Dir {
         return_errno_with_message!(Errno::ENOTDIR, "path is not a directory");

--- a/kernel/src/syscall/listen.rs
+++ b/kernel/src/syscall/listen.rs
@@ -2,8 +2,12 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        Permission,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
+    security,
 };
 
 pub fn sys_listen(sockfd: RawFileDesc, backlog: i32, ctx: &Context) -> Result<SyscallReturn> {
@@ -13,6 +17,7 @@ pub fn sys_listen(sockfd: RawFileDesc, backlog: i32, ctx: &Context) -> Result<Sy
     let file = get_file_fast!(&mut file_table, sockfd.try_into()?);
     let socket = file.as_socket_or_err()?;
 
+    security::socket_message(socket.pseudo_path(), Permission::MAY_WRITE)?;
     socket.listen(backlog as usize)?;
 
     Ok(SyscallReturn::Return(0))

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -6,6 +6,7 @@ use super::SyscallReturn;
 use crate::{
     fs::file::file_table::{RawFileDesc, get_file_fast},
     prelude::*,
+    security,
     vm::{
         page_cache::VmoOptions,
         perms::VmPerms,
@@ -129,6 +130,7 @@ fn do_sys_mmap(
                 vm_may_perms.remove(VmPerms::MAY_WRITE);
             }
 
+            security::mmap_file(file.path(), vm_perms)?;
             options = options
                 .may_perms(vm_may_perms)
                 .mappable(file.as_ref().as_ref())?

--- a/kernel/src/syscall/recvmsg.rs
+++ b/kernel/src/syscall/recvmsg.rs
@@ -4,9 +4,13 @@ use ostd::mm::VmIo;
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        Permission,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     net::socket::util::SendRecvFlags,
     prelude::*,
+    security,
     util::net::CUserMsgHdr,
 };
 
@@ -28,6 +32,7 @@ pub fn sys_recvmsg(
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, sockfd.try_into()?);
     let socket = file.as_socket_or_err()?;
+    security::socket_message(socket.pseudo_path(), Permission::MAY_READ)?;
 
     let (total_bytes, message_header) = {
         let mut io_vec_writer = c_user_msghdr.copy_writer_array_from_user(&user_space)?;

--- a/kernel/src/syscall/removexattr.rs
+++ b/kernel/src/syscall/removexattr.rs
@@ -11,6 +11,7 @@ use crate::{
     fs,
     fs::file::file_table::{RawFileDesc, get_file_fast},
     prelude::*,
+    security,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -56,6 +57,7 @@ fn removexattr(
     let name_str = name_cstr.to_string_lossy();
     let xattr_name = parse_xattr_name(name_str.as_ref())?;
     check_xattr_namespace(xattr_name.namespace(), ctx)?;
+    security::check_smack_xattr_removal(ctx.posix_thread, xattr_name.full_name())?;
 
     match lookup_path_for_xattr(&file_ctx, ctx) {
         Ok(path) => {

--- a/kernel/src/syscall/sendmsg.rs
+++ b/kernel/src/syscall/sendmsg.rs
@@ -4,12 +4,13 @@ use ostd::mm::VmIo;
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::RawFileDesc,
+    fs::file::{Permission, file_table::RawFileDesc},
     net::socket::{
         Socket,
         util::{MessageHeader, SendRecvFlags},
     },
     prelude::*,
+    security,
     util::net::CUserMsgHdr,
 };
 
@@ -36,6 +37,7 @@ pub fn sys_sendmsg(
         file_table_locked.get_file(sockfd.try_into()?)?.clone()
     };
     let socket = file.as_socket_or_err()?;
+    security::socket_message(socket.pseudo_path(), Permission::MAY_WRITE)?;
 
     let total_bytes = send_one_message(socket, &c_user_msghdr, &user_space, flags)?;
 

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet},
-    security::lsm::hooks as lsm_hooks,
+    security::{self, lsm::hooks as lsm_hooks},
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -116,9 +116,13 @@ fn setxattr(
     if value_len > XATTR_VALUE_MAX_LEN {
         return_errno_with_message!(Errno::E2BIG, "xattr value too long");
     }
-    let mut value_reader = user_space.reader(value_ptr, value_len)?;
+    let mut value = vec![0u8; value_len];
+    let mut user_value_reader = user_space.reader(value_ptr, value_len)?;
+    user_value_reader.read_fallible(&mut VmWriter::from(value.as_mut_slice()))?;
+    security::check_smack_xattr_update(ctx.posix_thread, xattr_name.full_name(), &value)?;
 
     let path = lookup_path_for_xattr(&file_ctx, ctx)?;
+    let mut value_reader = VmReader::from(value.as_slice()).to_fallible();
     path.set_xattr(xattr_name, &mut value_reader, flags)?;
     fs::vfs::notify::on_attr_change(&path);
     Ok(())

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -116,12 +116,13 @@ fn setxattr(
     if value_len > XATTR_VALUE_MAX_LEN {
         return_errno_with_message!(Errno::E2BIG, "xattr value too long");
     }
+
+    let path = lookup_path_for_xattr(&file_ctx, ctx)?;
     let mut value = vec![0u8; value_len];
     let mut user_value_reader = user_space.reader(value_ptr, value_len)?;
     user_value_reader.read_fallible(&mut VmWriter::from(value.as_mut_slice()))?;
     security::check_smack_xattr_update(ctx.posix_thread, xattr_name.full_name(), &value)?;
 
-    let path = lookup_path_for_xattr(&file_ctx, ctx)?;
     let mut value_reader = VmReader::from(value.as_slice()).to_fallible();
     path.set_xattr(xattr_name, &mut value_reader, flags)?;
     fs::vfs::notify::on_attr_change(&path);

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -27,13 +27,13 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
     let is_nonblocking = sock_flags.contains(SockFlags::SOCK_NONBLOCK);
     let file_like = match (domain, sock_type) {
         (CSocketAddrFamily::AF_UNIX, SockType::SOCK_STREAM) => {
-            UnixStreamSocket::new(is_nonblocking, sock_type) as Arc<dyn FileLike>
+            UnixStreamSocket::new(is_nonblocking, sock_type)? as Arc<dyn FileLike>
         }
         (CSocketAddrFamily::AF_UNIX, SockType::SOCK_SEQPACKET) => {
-            UnixStreamSocket::new(is_nonblocking, sock_type) as Arc<dyn FileLike>
+            UnixStreamSocket::new(is_nonblocking, sock_type)? as Arc<dyn FileLike>
         }
         (CSocketAddrFamily::AF_UNIX, SockType::SOCK_RAW | SockType::SOCK_DGRAM) => {
-            UnixDatagramSocket::new(is_nonblocking) as Arc<dyn FileLike>
+            UnixDatagramSocket::new(is_nonblocking)? as Arc<dyn FileLike>
         }
         (CSocketAddrFamily::AF_INET | CSocketAddrFamily::AF_INET6, SockType::SOCK_STREAM) => {
             let protocol = Protocol::try_from(protocol)?;
@@ -45,7 +45,7 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
                         CSocketAddrFamily::AF_INET6 => IpAddressFamily::IPv6,
                         _ => unreachable!(),
                     };
-                    StreamSocket::new(is_nonblocking, family) as Arc<dyn FileLike>
+                    StreamSocket::new(is_nonblocking, family)? as Arc<dyn FileLike>
                 }
                 _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported protocol"),
             }
@@ -55,7 +55,7 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
             debug!("protocol = {:?}", protocol);
             match protocol {
                 Protocol::IPPROTO_IP | Protocol::IPPROTO_UDP => {
-                    DatagramSocket::new(is_nonblocking) as Arc<dyn FileLike>
+                    DatagramSocket::new(is_nonblocking)? as Arc<dyn FileLike>
                 }
                 _ => return_errno_with_message!(Errno::EAFNOSUPPORT, "unsupported protocol"),
             }
@@ -65,10 +65,10 @@ pub fn sys_socket(domain: i32, type_: i32, protocol: i32, ctx: &Context) -> Resu
             debug!("netlink family = {:?}", netlink_family);
             match netlink_family {
                 Ok(StandardNetlinkProtocol::ROUTE) => {
-                    NetlinkRouteSocket::new(is_nonblocking, sock_type) as Arc<dyn FileLike>
+                    NetlinkRouteSocket::new(is_nonblocking, sock_type)? as Arc<dyn FileLike>
                 }
                 Ok(StandardNetlinkProtocol::KOBJECT_UEVENT) => {
-                    NetlinkUeventSocket::new(is_nonblocking, sock_type) as Arc<dyn FileLike>
+                    NetlinkUeventSocket::new(is_nonblocking, sock_type)? as Arc<dyn FileLike>
                 }
                 Ok(_) => {
                     return_errno_with_message!(

--- a/kernel/src/syscall/socketpair.rs
+++ b/kernel/src/syscall/socketpair.rs
@@ -31,7 +31,7 @@ pub fn sys_socketpair(
 
     macro_rules! file_pair {
         ($expr:expr) => {{
-            let (socket_a, socket_b) = $expr;
+            let (socket_a, socket_b) = $expr?;
             (socket_a as Arc<dyn FileLike>, socket_b as Arc<dyn FileLike>)
         }};
     }

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -155,6 +155,11 @@ impl VmMapping {
         self.path.as_ref().map(|path| path.inode())
     }
 
+    /// Returns the path of the file that backs the mapping.
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_ref()
+    }
+
     /// Returns a reference to the VMO if this mapping is VMO-backed.
     pub(super) fn vmo(&self) -> Option<&MappedVmo> {
         match &self.mapped_mem {

--- a/kernel/src/vm/vmar/vmar_impls/protect.rs
+++ b/kernel/src/vm/vmar/vmar_impls/protect.rs
@@ -3,7 +3,7 @@
 use core::ops::Range;
 
 use super::{Interval, Vmar, util::get_intersected_range};
-use crate::{prelude::*, vm::perms::VmPerms};
+use crate::{prelude::*, security, vm::perms::VmPerms};
 
 impl Vmar {
     /// Change the permissions of the memory mappings in the specified range.
@@ -24,11 +24,15 @@ impl Vmar {
         let mut protect_mappings = Vec::new();
 
         for vm_mapping in inner.vm_mappings.find(&range) {
-            protect_mappings.push((vm_mapping.range(), vm_mapping.perms()))
+            protect_mappings.push((
+                vm_mapping.range(),
+                vm_mapping.perms(),
+                vm_mapping.path().cloned(),
+            ))
         }
 
         let mut last_mapping_end = range.start;
-        for (vm_mapping_range, vm_mapping_perms) in protect_mappings {
+        for (vm_mapping_range, vm_mapping_perms, vm_mapping_path) in protect_mappings {
             if last_mapping_end < vm_mapping_range.start {
                 return_errno_with_message!(
                     Errno::ENOMEM,
@@ -42,6 +46,9 @@ impl Vmar {
             }
             let new_perms = perms | (vm_mapping_perms & VmPerms::ALL_MAY_PERMS);
             new_perms.check()?;
+            if let Some(path) = vm_mapping_path {
+                security::mmap_file(&path, perms)?;
+            }
 
             let Some(vm_mapping) = inner.remove(&vm_mapping_range.start) else {
                 // This can happen only if the mapping is merged to the previous one (just

--- a/test/initramfs/src/regression/security/lsm/smack.c
+++ b/test/initramfs/src/regression/security/lsm/smack.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -21,16 +23,18 @@
 #define SMACK_ATTR_CURRENT_MAX_LEN (SMACK_LABEL_MAX_LEN + 1)
 #define SMACK_XATTR_ACCESS "security.SMACK64"
 #define SMACK_XATTR_EXEC "security.SMACK64EXEC"
+#define SMACK_XATTR_MMAP "security.SMACK64MMAP"
 #define SMACK_XATTR_TRANSMUTE "security.SMACK64TRANSMUTE"
+#define SMACK_LOAD_PATH "/proc/smack/load"
 
-static void build_attr_current_path(char *buf, size_t size)
+static void build_attr_path(char *buf, size_t size, const char *name)
 {
-	CHECK_WITH(snprintf(buf, size, "/proc/%ld/task/%ld/attr/current",
-			    (long)getpid(), (long)syscall(SYS_gettid)),
+	CHECK_WITH(snprintf(buf, size, "/proc/%ld/task/%ld/attr/%s",
+			    (long)getpid(), (long)syscall(SYS_gettid), name),
 		   _ret > 0 && (size_t)_ret < size);
 }
 
-static int read_current_label(char *buf, size_t size)
+static int read_attr_label(const char *name, char *buf, size_t size)
 {
 	char path[128];
 	int saved_errno;
@@ -38,7 +42,7 @@ static int read_current_label(char *buf, size_t size)
 	ssize_t len;
 	char *newline;
 
-	build_attr_current_path(path, sizeof(path));
+	build_attr_path(path, sizeof(path), name);
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
 		return -1;
@@ -61,7 +65,7 @@ static int read_current_label(char *buf, size_t size)
 	return 0;
 }
 
-static int write_current_label(const char *label)
+static int write_attr_label(const char *name, const char *label)
 {
 	char path[128];
 	size_t len = strlen(label);
@@ -69,7 +73,7 @@ static int write_current_label(const char *label)
 	ssize_t written;
 	int saved_errno;
 
-	build_attr_current_path(path, sizeof(path));
+	build_attr_path(path, sizeof(path), name);
 	fd = open(path, O_WRONLY);
 	if (fd < 0) {
 		return -1;
@@ -85,6 +89,16 @@ static int write_current_label(const char *label)
 	}
 
 	return 0;
+}
+
+static int read_current_label(char *buf, size_t size)
+{
+	return read_attr_label("current", buf, size);
+}
+
+static int write_current_label(const char *label)
+{
+	return write_attr_label("current", label);
 }
 
 static bool smack_is_disabled(void)
@@ -115,6 +129,40 @@ static int write_all(int fd, const void *buf, size_t len)
 		len -= written;
 	}
 
+	return 0;
+}
+
+static int write_text_file(const char *path, const char *text)
+{
+	int fd = open(path, O_WRONLY);
+	int saved_errno;
+	int ret;
+
+	if (fd < 0) {
+		return -1;
+	}
+
+	ret = write_all(fd, text, strlen(text));
+	saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	return ret;
+}
+
+static int load_smack_rule(const char *rule)
+{
+	return write_text_file(SMACK_LOAD_PATH, rule);
+}
+
+static int read_xattr_label(const char *path, const char *name, char *buf,
+			    size_t size)
+{
+	ssize_t len = getxattr(path, name, buf, size - 1);
+
+	if (len < 0) {
+		return -1;
+	}
+	buf[len] = '\0';
 	return 0;
 }
 
@@ -162,7 +210,8 @@ static int copy_self_to(const char *path)
 	return chmod(path, 0755);
 }
 
-static void run_exec_helper_if_requested(void) __attribute__((constructor(101)));
+static void run_exec_helper_if_requested(void)
+	__attribute__((constructor(101)));
 
 static void run_exec_helper_if_requested(void)
 {
@@ -210,6 +259,37 @@ FN_TEST(attr_current_roundtrip)
 }
 END_TEST()
 
+FN_TEST(attr_full_roundtrip)
+{
+	char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	CHECK(write_current_label("smack_attr_a\n"));
+	CHECK(write_current_label("smack_attr_b\n"));
+	CHECK(read_attr_label("prev", label, sizeof(label)));
+	CHECK_WITH(strcmp(label, "smack_attr_a"), _ret == 0);
+
+	CHECK(write_attr_label("exec", "smack_attr_exec\n"));
+	CHECK(read_attr_label("exec", label, sizeof(label)));
+	CHECK_WITH(strcmp(label, "smack_attr_exec"), _ret == 0);
+	CHECK(write_attr_label("exec", "-\n"));
+	CHECK(read_attr_label("exec", label, sizeof(label)));
+	CHECK_WITH(strcmp(label, ""), _ret == 0);
+
+	CHECK(write_attr_label("fscreate", "smack_attr_fs\n"));
+	CHECK(read_attr_label("fscreate", label, sizeof(label)));
+	CHECK_WITH(strcmp(label, "smack_attr_fs"), _ret == 0);
+	CHECK(write_attr_label("fscreate", "-\n"));
+
+	CHECK(write_attr_label("sockcreate", "smack_attr_sock\n"));
+	CHECK(read_attr_label("sockcreate", label, sizeof(label)));
+	CHECK_WITH(strcmp(label, "smack_attr_sock"), _ret == 0);
+	CHECK(write_attr_label("sockcreate", "-\n"));
+	CHECK(write_current_label("_\n"));
+}
+END_TEST()
+
 FN_TEST(xattr_validation_and_capability)
 {
 	pid_t pid;
@@ -223,13 +303,13 @@ FN_TEST(xattr_validation_and_capability)
 		int file = CHECK(mkstemp(file_template));
 
 		CHECK(close(file));
-		CHECK_WITH(setxattr(file_template, SMACK_XATTR_ACCESS, "bad/name",
-				    strlen("bad/name"), 0),
+		CHECK_WITH(setxattr(file_template, SMACK_XATTR_ACCESS,
+				    "bad/name", strlen("bad/name"), 0),
 			   _ret == -1 && errno == EINVAL);
 		CHECK(setxattr(file_template, SMACK_XATTR_ACCESS, "smack_file",
 			       strlen("smack_file"), 0));
-		CHECK_WITH(setxattr(file_template, SMACK_XATTR_TRANSMUTE, "FALSE",
-				    strlen("FALSE"), 0),
+		CHECK_WITH(setxattr(file_template, SMACK_XATTR_TRANSMUTE,
+				    "FALSE", strlen("FALSE"), 0),
 			   _ret == -1 && errno == EINVAL);
 		CHECK(setxattr(file_template, SMACK_XATTR_TRANSMUTE, "TRUE",
 			       strlen("TRUE"), 0));
@@ -252,6 +332,210 @@ FN_TEST(xattr_validation_and_capability)
 	TEST_RES(waitpid(pid, &status, 0),
 		 _ret == pid && WIFEXITED(status) &&
 			 WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+END_TEST()
+
+FN_TEST(policy_load_and_file_access)
+{
+	char file_template[] = "/tmp/smack_accessXXXXXX";
+	int fd = TEST_SUCC(mkstemp(file_template));
+	pid_t pid;
+	int status;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	TEST_SUCC(write_all(fd, "content", strlen("content")));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(setxattr(file_template, SMACK_XATTR_ACCESS, "smack_object",
+			   strlen("smack_object"), 0));
+	TEST_SUCC(write_current_label("smack_subject\n"));
+	TEST_SUCC(load_smack_rule("smack_subject smack_object r\n"));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_MAC_OVERRIDE);
+
+		int readable = CHECK(open(file_template, O_RDONLY));
+		CHECK(close(readable));
+
+		errno = 0;
+		CHECK_WITH(open(file_template, O_WRONLY),
+			   _ret == -1 && errno == EACCES);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(unlink(file_template));
+	TEST_SUCC(write_current_label("_\n"));
+}
+END_TEST()
+
+FN_TEST(fscreate_and_transmute_labels)
+{
+	char file_template[] = "/tmp/smack_fscreateXXXXXX";
+	char dir_template[] = "/tmp/smack_transmuteXXXXXX";
+	char child_path[128];
+	char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+	int fd;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	TEST_SUCC(write_attr_label("fscreate", "smack_fscreate\n"));
+	fd = TEST_SUCC(mkstemp(file_template));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(read_xattr_label(file_template, SMACK_XATTR_ACCESS, label,
+				   sizeof(label)));
+	TEST_RES(strcmp(label, "smack_fscreate"), _ret == 0);
+	TEST_SUCC(write_attr_label("fscreate", "-\n"));
+	TEST_SUCC(unlink(file_template));
+
+	CHECK_WITH(mkdtemp(dir_template), _ret == dir_template);
+	TEST_SUCC(setxattr(dir_template, SMACK_XATTR_ACCESS, "smack_parent",
+			   strlen("smack_parent"), 0));
+	TEST_SUCC(setxattr(dir_template, SMACK_XATTR_TRANSMUTE, "TRUE",
+			   strlen("TRUE"), 0));
+	TEST_SUCC(write_current_label("smack_transmuter\n"));
+	TEST_SUCC(load_smack_rule("smack_transmuter smack_parent t\n"));
+	CHECK_WITH(snprintf(child_path, sizeof(child_path), "%s/child",
+			    dir_template),
+		   _ret > 0 && (size_t)_ret < sizeof(child_path));
+	fd = TEST_SUCC(open(child_path, O_CREAT | O_RDWR, 0600));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(read_xattr_label(child_path, SMACK_XATTR_ACCESS, label,
+				   sizeof(label)));
+	TEST_RES(strcmp(label, "smack_parent"), _ret == 0);
+
+	TEST_SUCC(unlink(child_path));
+	TEST_SUCC(rmdir(dir_template));
+	TEST_SUCC(write_current_label("_\n"));
+}
+END_TEST()
+
+FN_TEST(mmap_label_access)
+{
+	char file_template[] = "/tmp/smack_mmapXXXXXX";
+	int fd = TEST_SUCC(mkstemp(file_template));
+	pid_t pid;
+	int status;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	TEST_SUCC(write_all(fd, "page", strlen("page")));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(setxattr(file_template, SMACK_XATTR_ACCESS, "smack_mmap_file",
+			   strlen("smack_mmap_file"), 0));
+	TEST_SUCC(setxattr(file_template, SMACK_XATTR_MMAP, "smack_mmap_guard",
+			   strlen("smack_mmap_guard"), 0));
+	{
+		char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+
+		TEST_SUCC(read_xattr_label(file_template, SMACK_XATTR_MMAP,
+					   label, sizeof(label)));
+		TEST_RES(strcmp(label, "smack_mmap_guard"), _ret == 0);
+	}
+	TEST_SUCC(write_current_label("smack_mmap_subject\n"));
+	TEST_SUCC(load_smack_rule("smack_mmap_subject smack_mmap_file r\n"));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_MAC_OVERRIDE);
+		fd = CHECK(open(file_template, O_RDONLY));
+		CHECK_WITH(mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, fd, 0),
+			   _ret == MAP_FAILED && errno == EACCES);
+		CHECK(close(fd));
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+
+	TEST_SUCC(load_smack_rule("smack_mmap_subject smack_mmap_guard r\n"));
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		void *addr;
+
+		drop_capability(CAP_MAC_OVERRIDE);
+		fd = CHECK(open(file_template, O_RDONLY));
+		addr = CHECK_WITH(mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, fd,
+				       0),
+				  _ret != MAP_FAILED);
+		CHECK(munmap(addr, 4096));
+		CHECK(close(fd));
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(unlink(file_template));
+	TEST_SUCC(write_current_label("_\n"));
+}
+END_TEST()
+
+FN_TEST(unlink_requires_object_write)
+{
+	char file_template[] = "/tmp/smack_unlinkXXXXXX";
+	int fd = TEST_SUCC(mkstemp(file_template));
+	pid_t pid;
+	int status;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(setxattr(file_template, SMACK_XATTR_ACCESS,
+			   "smack_unlink_obj", strlen("smack_unlink_obj"), 0));
+	TEST_SUCC(write_current_label("smack_unlink_subject\n"));
+	TEST_SUCC(load_smack_rule("smack_unlink_subject _ w\n"));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_MAC_OVERRIDE);
+
+		errno = 0;
+		CHECK_WITH(unlink(file_template),
+			   _ret == -1 && errno == EACCES);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(unlink(file_template));
+	TEST_SUCC(write_current_label("_\n"));
+}
+END_TEST()
+
+FN_TEST(sockcreate_label_access)
+{
+	int sv[2];
+	pid_t pid;
+	int status;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	TEST_SUCC(write_current_label("smack_sock_subject\n"));
+	TEST_SUCC(write_attr_label("sockcreate", "smack_sock_object\n"));
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM, 0, sv));
+	TEST_SUCC(write_attr_label("sockcreate", "-\n"));
+	TEST_SUCC(load_smack_rule("smack_sock_subject _ w\n"));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_MAC_OVERRIDE);
+		errno = 0;
+		CHECK_WITH(write(sv[0], "x", 1), _ret == -1 && errno == EACCES);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(close(sv[0]));
+	TEST_SUCC(close(sv[1]));
+	TEST_SUCC(write_current_label("_\n"));
 }
 END_TEST()
 
@@ -279,7 +563,8 @@ FN_TEST(exec_label_transition)
 		char fd_string[16];
 
 		CHECK(close(pipefd[0]));
-		CHECK_WITH(snprintf(fd_string, sizeof(fd_string), "%d", pipefd[1]),
+		CHECK_WITH(snprintf(fd_string, sizeof(fd_string), "%d",
+				    pipefd[1]),
 			   _ret > 0 && (size_t)_ret < sizeof(fd_string));
 		CHECK(setenv("SMACK_HELPER_FD", fd_string, 1));
 		execl(helper_path, helper_path, NULL);

--- a/test/initramfs/src/regression/security/lsm/smack.c
+++ b/test/initramfs/src/regression/security/lsm/smack.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mount.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -26,6 +27,13 @@
 #define SMACK_XATTR_MMAP "security.SMACK64MMAP"
 #define SMACK_XATTR_TRANSMUTE "security.SMACK64TRANSMUTE"
 #define SMACK_LOAD_PATH "/proc/smack/load"
+#define SMACK_LOAD2_PATH "/proc/smack/load2"
+#define SMACK_ACCESS2_PATH "/proc/smack/access2"
+#define SMACK_CHANGE_RULE_PATH "/proc/smack/change-rule"
+#define SMACK_REVOKE_SUBJECT_PATH "/proc/smack/revoke-subject"
+#define SMACK_AMBIENT_PATH "/proc/smack/ambient"
+#define SMACK_ONLYCAP_PATH "/proc/smack/onlycap"
+#define SMACK_LOGGING_PATH "/proc/smack/logging"
 
 static void build_attr_path(char *buf, size_t size, const char *name)
 {
@@ -147,6 +155,28 @@ static int write_text_file(const char *path, const char *text)
 	close(fd);
 	errno = saved_errno;
 	return ret;
+}
+
+static int read_text_file(const char *path, char *buf, size_t size)
+{
+	int fd = open(path, O_RDONLY);
+	int saved_errno;
+	ssize_t len;
+
+	if (fd < 0) {
+		return -1;
+	}
+
+	len = read(fd, buf, size - 1);
+	saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	if (len < 0) {
+		return -1;
+	}
+
+	buf[len] = '\0';
+	return 0;
 }
 
 static int load_smack_rule(const char *rule)
@@ -290,6 +320,98 @@ FN_TEST(attr_full_roundtrip)
 }
 END_TEST()
 
+FN_TEST(policy_abi_management)
+{
+	char buf[256] = {};
+	char ready;
+	int pipefd[2];
+	pid_t pid;
+	int status;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	TEST_SUCC(write_current_label("smack_policy_admin\n"));
+	TEST_SUCC(write_text_file(
+		SMACK_LOAD2_PATH,
+		"smack_policy_subject smack_policy_object rwxat\n"));
+	TEST_SUCC(write_text_file(
+		SMACK_ACCESS2_PATH,
+		"smack_policy_subject smack_policy_object rw\n"));
+	TEST_SUCC(read_text_file(SMACK_ACCESS2_PATH, buf, sizeof(buf)));
+	TEST_RES(strcmp(buf, "1\n"), _ret == 0);
+	TEST_SUCC(
+		write_text_file(SMACK_ACCESS2_PATH,
+				"smack_policy_subject smack_policy_other r\n"));
+	TEST_SUCC(read_text_file(SMACK_ACCESS2_PATH, buf, sizeof(buf)));
+	TEST_RES(strcmp(buf, "0\n"), _ret == 0);
+
+	TEST_SUCC(write_text_file(
+		SMACK_CHANGE_RULE_PATH,
+		"smack_policy_subject smack_policy_object - rwxat\n"));
+	TEST_SUCC(write_text_file(
+		SMACK_ACCESS2_PATH,
+		"smack_policy_subject smack_policy_object r\n"));
+	TEST_SUCC(read_text_file(SMACK_ACCESS2_PATH, buf, sizeof(buf)));
+	TEST_RES(strcmp(buf, "0\n"), _ret == 0);
+
+	TEST_SUCC(write_text_file(
+		SMACK_LOAD2_PATH,
+		"smack_revoke_subject smack_revoke_object r\n"));
+	TEST_SUCC(write_text_file(
+		SMACK_ACCESS2_PATH,
+		"smack_revoke_subject smack_revoke_object r\n"));
+	TEST_SUCC(read_text_file(SMACK_ACCESS2_PATH, buf, sizeof(buf)));
+	TEST_RES(strcmp(buf, "1\n"), _ret == 0);
+	TEST_SUCC(write_text_file(SMACK_REVOKE_SUBJECT_PATH,
+				  "smack_revoke_subject\n"));
+	TEST_SUCC(write_text_file(
+		SMACK_ACCESS2_PATH,
+		"smack_revoke_subject smack_revoke_object r\n"));
+	TEST_SUCC(read_text_file(SMACK_ACCESS2_PATH, buf, sizeof(buf)));
+	TEST_RES(strcmp(buf, "0\n"), _ret == 0);
+
+	TEST_SUCC(write_text_file(SMACK_AMBIENT_PATH, "smack_ambient\n"));
+	TEST_SUCC(read_text_file(SMACK_AMBIENT_PATH, buf, sizeof(buf)));
+	TEST_RES(strcmp(buf, "smack_ambient\n"), _ret == 0);
+	TEST_SUCC(write_text_file(SMACK_AMBIENT_PATH, "_\n"));
+
+	TEST_SUCC(write_text_file(SMACK_LOGGING_PATH, "3\n"));
+	TEST_SUCC(read_text_file(SMACK_LOGGING_PATH, buf, sizeof(buf)));
+	TEST_RES(strcmp(buf, "3\n"), _ret == 0);
+	TEST_SUCC(write_text_file(SMACK_LOGGING_PATH, "1\n"));
+
+	TEST_SUCC(write_current_label("smack_onlycap_admin\n"));
+	TEST_SUCC(write_text_file(SMACK_LOAD2_PATH,
+				  "smack_onlycap_user _ rwxat\n"));
+	TEST_SUCC(write_text_file(SMACK_ONLYCAP_PATH, "smack_onlycap_admin\n"));
+	TEST_SUCC(pipe(pipefd));
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK(close(pipefd[1]));
+		CHECK_WITH(read(pipefd[0], &ready, sizeof(ready)),
+			   _ret == sizeof(ready));
+		CHECK(close(pipefd[0]));
+		CHECK(write_current_label("smack_onlycap_user\n"));
+		errno = 0;
+		CHECK_WITH(
+			write_text_file(
+				SMACK_LOAD2_PATH,
+				"smack_onlycap_user smack_onlycap_object r\n"),
+			_ret == -1 && errno == EPERM);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_SUCC(close(pipefd[0]));
+	TEST_SUCC(write_all(pipefd[1], "x", 1));
+	TEST_SUCC(close(pipefd[1]));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(write_text_file(SMACK_ONLYCAP_PATH, "-\n"));
+	TEST_SUCC(write_current_label("_\n"));
+}
+END_TEST()
+
 FN_TEST(xattr_validation_and_capability)
 {
 	pid_t pid;
@@ -368,6 +490,92 @@ FN_TEST(policy_load_and_file_access)
 		 _ret == pid && WIFEXITED(status) &&
 			 WEXITSTATUS(status) == EXIT_SUCCESS);
 	TEST_SUCC(unlink(file_template));
+	TEST_SUCC(write_current_label("_\n"));
+}
+END_TEST()
+
+FN_TEST(mount_label_options)
+{
+	char default_mount_template[] = "/tmp/smack_mnt_defXXXXXX";
+	char root_mount_template[] = "/tmp/smack_mnt_rootXXXXXX";
+	char child_path[128];
+	char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+	char transmute[sizeof("TRUE")] = {};
+	pid_t pid;
+	int status;
+	int fd;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	CHECK_WITH(mkdtemp(default_mount_template),
+		   _ret == default_mount_template);
+	TEST_SUCC(write_current_label("smack_mount_subject\n"));
+	TEST_SUCC(mount("none", default_mount_template, "ramfs", 0,
+			"smackfsdef=smack_mount_default"));
+	CHECK_WITH(snprintf(child_path, sizeof(child_path), "%s/child",
+			    default_mount_template),
+		   _ret > 0 && (size_t)_ret < sizeof(child_path));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_MAC_OVERRIDE);
+		errno = 0;
+		CHECK_WITH(open(child_path, O_CREAT | O_RDWR, 0600),
+			   _ret == -1 && errno == EACCES);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(
+		load_smack_rule("smack_mount_subject smack_mount_default w\n"));
+	fd = TEST_SUCC(open(child_path, O_CREAT | O_RDWR, 0600));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(removexattr(child_path, SMACK_XATTR_ACCESS));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_MAC_OVERRIDE);
+		errno = 0;
+		CHECK_WITH(open(child_path, O_RDONLY),
+			   _ret == -1 && errno == EACCES);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(load_smack_rule(
+		"smack_mount_subject smack_mount_default rwxat\n"));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		drop_capability(CAP_MAC_OVERRIDE);
+		fd = CHECK(open(child_path, O_RDONLY));
+		CHECK(close(fd));
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_SUCC(unlink(child_path));
+	TEST_SUCC(umount(default_mount_template));
+	TEST_SUCC(rmdir(default_mount_template));
+
+	CHECK_WITH(mkdtemp(root_mount_template), _ret == root_mount_template);
+	TEST_SUCC(mount(
+		"none", root_mount_template, "ramfs", 0,
+		"smackfsroot=smack_mount_root,smackfstransmute=smack_mount_transmute"));
+	TEST_SUCC(read_xattr_label(root_mount_template, SMACK_XATTR_ACCESS,
+				   label, sizeof(label)));
+	TEST_RES(strcmp(label, "smack_mount_transmute"), _ret == 0);
+	TEST_SUCC(read_xattr_label(root_mount_template, SMACK_XATTR_TRANSMUTE,
+				   transmute, sizeof(transmute)));
+	TEST_RES(strcmp(transmute, "TRUE"), _ret == 0);
+	TEST_SUCC(umount(root_mount_template));
+	TEST_SUCC(rmdir(root_mount_template));
 	TEST_SUCC(write_current_label("_\n"));
 }
 END_TEST()

--- a/test/initramfs/src/regression/security/lsm/smack.c
+++ b/test/initramfs/src/regression/security/lsm/smack.c
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+#include "../../common/capability.h"
+
+#define SMACK_LABEL_MAX_LEN 255
+#define SMACK_ATTR_CURRENT_MAX_LEN (SMACK_LABEL_MAX_LEN + 1)
+#define SMACK_XATTR_ACCESS "security.SMACK64"
+#define SMACK_XATTR_EXEC "security.SMACK64EXEC"
+#define SMACK_XATTR_TRANSMUTE "security.SMACK64TRANSMUTE"
+
+static void build_attr_current_path(char *buf, size_t size)
+{
+	CHECK_WITH(snprintf(buf, size, "/proc/%ld/task/%ld/attr/current",
+			    (long)getpid(), (long)syscall(SYS_gettid)),
+		   _ret > 0 && (size_t)_ret < size);
+}
+
+static int read_current_label(char *buf, size_t size)
+{
+	char path[128];
+	int saved_errno;
+	int fd;
+	ssize_t len;
+	char *newline;
+
+	build_attr_current_path(path, sizeof(path));
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	len = read(fd, buf, size - 1);
+	saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	if (len < 0) {
+		return -1;
+	}
+
+	buf[len] = '\0';
+	newline = strchr(buf, '\n');
+	if (newline != NULL) {
+		*newline = '\0';
+	}
+
+	return 0;
+}
+
+static int write_current_label(const char *label)
+{
+	char path[128];
+	size_t len = strlen(label);
+	int fd;
+	ssize_t written;
+	int saved_errno;
+
+	build_attr_current_path(path, sizeof(path));
+	fd = open(path, O_WRONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	written = write(fd, label, len);
+	saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	if (written != (ssize_t)len) {
+		errno = written < 0 ? saved_errno : EIO;
+		return -1;
+	}
+
+	return 0;
+}
+
+static bool smack_is_disabled(void)
+{
+	char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+
+	if (read_current_label(label, sizeof(label)) == 0) {
+		return false;
+	}
+
+	return errno == ENOENT;
+}
+
+static int write_all(int fd, const void *buf, size_t len)
+{
+	const char *cursor = buf;
+
+	while (len > 0) {
+		ssize_t written = write(fd, cursor, len);
+		if (written < 0) {
+			return -1;
+		}
+		if (written == 0) {
+			errno = EIO;
+			return -1;
+		}
+		cursor += written;
+		len -= written;
+	}
+
+	return 0;
+}
+
+static int copy_self_to(const char *path)
+{
+	char buf[4096];
+	int src = open("/proc/self/exe", O_RDONLY);
+	int dst;
+
+	if (src < 0) {
+		return -1;
+	}
+
+	dst = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0755);
+	if (dst < 0) {
+		close(src);
+		return -1;
+	}
+
+	for (;;) {
+		ssize_t len = read(src, buf, sizeof(buf));
+		if (len < 0) {
+			close(src);
+			close(dst);
+			return -1;
+		}
+		if (len == 0) {
+			break;
+		}
+		if (write_all(dst, buf, len) < 0) {
+			close(src);
+			close(dst);
+			return -1;
+		}
+	}
+
+	if (close(src) < 0) {
+		close(dst);
+		return -1;
+	}
+	if (close(dst) < 0) {
+		return -1;
+	}
+
+	return chmod(path, 0755);
+}
+
+static void run_exec_helper_if_requested(void) __attribute__((constructor(101)));
+
+static void run_exec_helper_if_requested(void)
+{
+	const char *fd_string = getenv("SMACK_HELPER_FD");
+	char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+	int fd;
+
+	if (fd_string == NULL) {
+		return;
+	}
+
+	fd = atoi(fd_string);
+	if (read_current_label(label, sizeof(label)) < 0) {
+		_exit(EXIT_FAILURE);
+	}
+	if (write_all(fd, label, strlen(label)) < 0) {
+		_exit(EXIT_FAILURE);
+	}
+
+	_exit(EXIT_SUCCESS);
+}
+
+FN_TEST(attr_current_roundtrip)
+{
+	pid_t pid;
+	int status;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+
+		CHECK(read_current_label(label, sizeof(label)));
+		CHECK_WITH(strcmp(label, "_"), _ret == 0);
+		CHECK(write_current_label("smack_foundation\n"));
+		CHECK(read_current_label(label, sizeof(label)));
+		CHECK_WITH(strcmp(label, "smack_foundation"), _ret == 0);
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+END_TEST()
+
+FN_TEST(xattr_validation_and_capability)
+{
+	pid_t pid;
+	int status;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		char file_template[] = "/tmp/smack_xattrXXXXXX";
+		int file = CHECK(mkstemp(file_template));
+
+		CHECK(close(file));
+		CHECK_WITH(setxattr(file_template, SMACK_XATTR_ACCESS, "bad/name",
+				    strlen("bad/name"), 0),
+			   _ret == -1 && errno == EINVAL);
+		CHECK(setxattr(file_template, SMACK_XATTR_ACCESS, "smack_file",
+			       strlen("smack_file"), 0));
+		CHECK_WITH(setxattr(file_template, SMACK_XATTR_TRANSMUTE, "FALSE",
+				    strlen("FALSE"), 0),
+			   _ret == -1 && errno == EINVAL);
+		CHECK(setxattr(file_template, SMACK_XATTR_TRANSMUTE, "TRUE",
+			       strlen("TRUE"), 0));
+		CHECK(removexattr(file_template, SMACK_XATTR_TRANSMUTE));
+
+		drop_capability(CAP_MAC_ADMIN);
+
+		errno = 0;
+		CHECK_WITH(setxattr(file_template, SMACK_XATTR_ACCESS, "other",
+				    strlen("other"), 0),
+			   _ret == -1 && errno == EPERM);
+		errno = 0;
+		CHECK_WITH(removexattr(file_template, SMACK_XATTR_ACCESS),
+			   _ret == -1 && errno == EPERM);
+
+		CHECK(unlink(file_template));
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+}
+END_TEST()
+
+FN_TEST(exec_label_transition)
+{
+	char helper_path[64];
+	int pipefd[2];
+	pid_t pid;
+	int status;
+	char label[SMACK_ATTR_CURRENT_MAX_LEN] = {};
+	ssize_t len;
+
+	SKIP_TEST_IF(smack_is_disabled());
+
+	CHECK_WITH(snprintf(helper_path, sizeof(helper_path),
+			    "/tmp/smack_exec_%ld", (long)getpid()),
+		   _ret > 0 && (size_t)_ret < sizeof(helper_path));
+	TEST_SUCC(copy_self_to(helper_path));
+	TEST_SUCC(setxattr(helper_path, SMACK_XATTR_EXEC, "smack_exec",
+			   strlen("smack_exec"), 0));
+	TEST_SUCC(pipe(pipefd));
+
+	pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		char fd_string[16];
+
+		CHECK(close(pipefd[0]));
+		CHECK_WITH(snprintf(fd_string, sizeof(fd_string), "%d", pipefd[1]),
+			   _ret > 0 && (size_t)_ret < sizeof(fd_string));
+		CHECK(setenv("SMACK_HELPER_FD", fd_string, 1));
+		execl(helper_path, helper_path, NULL);
+		_exit(EXIT_FAILURE);
+	}
+
+	TEST_SUCC(close(pipefd[1]));
+	len = TEST_RES(read(pipefd[0], label, sizeof(label) - 1), _ret > 0);
+	label[len] = '\0';
+	TEST_SUCC(close(pipefd[0]));
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+	TEST_RES(strcmp(label, "smack_exec"), _ret == 0);
+
+	TEST_SUCC(removexattr(helper_path, SMACK_XATTR_EXEC));
+	TEST_SUCC(unlink(helper_path));
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -14,6 +14,7 @@ set -e
 ./capability/trusted_xattr
 
 ./lsm/module_selection
+./lsm/smack
 ./lsm/yama
 
 ./namespace/cgroup_ns


### PR DESCRIPTION
## Summary

- Extend the Smack policy-management ABI with `load2`, `access`/`access2`, `change-rule`, `revoke-subject`, `ambient`, `onlycap`, and `logging`.
- Add Smack mount-label state to VFS superblocks and parse Linux-compatible mount options, including `smackfsdef`/`smackfsdefault`, `smackfsroot`, `smackfstransmute`, `smackfsfloor`, and `smackfshat`.
- Wire Smack mount labels into ramfs, tmpfs, and ext2, including filesystem root labeling and `SMACK64TRANSMUTE` setup.
- Extend Smack regression coverage for policy ABI management, access queries, `change-rule`, `revoke-subject`, `onlycap`, and mount label behavior.

## Motivation

This PR continues the Smack major LSM foundation work by filling in the policy-management and filesystem-label surfaces needed by common Smack workflows.

Before this change, Smack enforcement could use labels and access rules, but the module still lacked several Linux-compatible management files and mount-time label defaults. With this change, userspace can load and query policy, adjust selected global Smack state, restrict MAC capabilities through `onlycap`, and mount supported filesystems with Smack default, root, and transmute labels.

## Compatibility and Scope

- `change-rule` follows the Linux four-field form: `subject object allow deny`.
- Both `smackfsdef` and `smackfsdefault` are accepted for the filesystem default label.
- `smackfsfloor` and `smackfshat` are accepted and stored for ABI compatibility, but are not enforced.
- The ABI is currently exposed through Asterinas' existing `/proc/smack` surface.
- A standalone Linux-style `smackfs` mount point, network/CIPSO/netlabel support, and additional Smack files such as `load-self` remain future work.