### PR TITLE
Support BLKPBSZGET ioctl on block devices

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/ioctl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/ioctl.scml
@@ -27,7 +27,7 @@ ioctl(
 );
 
 // Control block devices
-ioctl(fd, op = BLKGETSIZE64 | BLKSSZGET, ..);
+ioctl(fd, op = BLKGETSIZE64 | BLKPBSZGET | BLKSSZGET, ..);
 
 // Control Trust Domain Extensions (TDX) guest devices
 ioctl(fd, op = TDX_CMD_GET_REPORT0, ..);

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -87,6 +87,9 @@ mod ioctl_defs {
     /// ioctl must return that larger value. Otherwise user programs will align
     /// correctly for the device but still hit `EINVAL` at the filesystem.
     pub(super) type BlkGetSectorSize = ioc!(BLKSSZGET, 0x12, 104, NoData);
+
+    /// Returns the physical block size of the block device.
+    pub(super) type BlkGetPhysicalBlockSize = ioc!(BLKPBSZGET, 0x12, 123, NoData);
 }
 
 /// Represents a block device inode in the filesystem.
@@ -213,6 +216,14 @@ impl PerOpenFileOps for OpenBlockFile {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {
+            _cmd @ BlkGetPhysicalBlockSize => {
+                // TODO: Query the per-device physical block size once block device metadata
+                // exposes it. For now, report the same effective granularity as `BLKSSZGET`
+                // to keep the advertised block geometry consistent.
+                let physical_block_size = SECTOR_SIZE.max(BLOCK_SIZE) as i32;
+                current_userspace!().write_val(raw_ioctl.arg(), &physical_block_size)?;
+                Ok(0)
+            }
             _cmd @ BlkGetSectorSize => {
                 // TODO: Query the per-device logical block size once block device metadata
                 // exposes it. For now, report the effective minimum I/O granularity enforced

--- a/test/initramfs/src/regression/io/file_io/block_device.c
+++ b/test/initramfs/src/regression/io/file_io/block_device.c
@@ -54,6 +54,24 @@ static int close_block_device(int fd)
 }
 #endif
 
+// Verifies that the block device reports a physical block size compatible
+// with its logical sector size.
+FN_TEST(get_physical_block_size)
+{
+	int fd;
+	int logical_sector_size;
+	int physical_block_size;
+
+	fd = TEST_SUCC(open_block_device());
+
+	TEST_SUCC(ioctl(fd, BLKSSZGET, &logical_sector_size));
+	TEST_SUCC(ioctl(fd, BLKPBSZGET, &physical_block_size));
+	TEST_RES(physical_block_size, _ret >= logical_sector_size);
+
+	TEST_SUCC(close_block_device(fd));
+}
+END_TEST()
+
 // Verifies that seeking to the end of a block device reports the same
 // byte-granular size that the block-device ioctl reports.
 FN_TEST(seek_end_matches_block_device_size)


### PR DESCRIPTION
## Summary

Add support for the Linux `BLKPBSZGET` ioctl on block device files.

`BLKPBSZGET` lets userspace query the physical block size of a block device. Asterinas currently returns `ENOTTY` for this ioctl, which breaks some block-device compatibility probes. This patch reports the same effective granularity as `BLKSSZGET` until block-device metadata exposes a per-device physical block size.

Fixes #3213.

## Changes

- Add the `BLKPBSZGET` ioctl definition for block devices.
- Return the effective block I/O granularity for `BLKPBSZGET`.
- Add a regression test that checks `BLKPBSZGET` against `BLKSSZGET`.
- Update the ioctl SCML coverage entry.

## Validation

- `cargo fmt --check --all`
- `git diff --check`
- `cargo check -p aster-kernel --target x86_64-unknown-none`
- `cargo clippy -p aster-kernel --target x86_64-unknown-none -- -D warnings`
