### PR TITLE
Require `CAP_MKNOD` for device nodes

### DIFF
--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -611,6 +611,7 @@ impl DirDentry<'_> {
         type_: MknodType,
     ) -> Result<Arc<Dentry>> {
         let children = self.validate_child_absent(name)?;
+        Self::check_mknod_capability(&type_)?;
         let inode = self.inode.mknod(name, mode, type_)?;
         let new_child = Dentry::new(
             inode,
@@ -619,6 +620,23 @@ impl DirDentry<'_> {
         let mut children = children.upgrade();
 
         Ok(self.insert_positive_child(&mut children, name, new_child))
+    }
+
+    fn check_mknod_capability(type_: &MknodType) -> Result<()> {
+        if !matches!(type_, MknodType::CharDevice(_) | MknodType::BlockDevice(_)) {
+            return Ok(());
+        }
+
+        let current_thread = current_thread!();
+        let Some(posix_thread) = current_thread.as_posix_thread() else {
+            return Ok(());
+        };
+
+        lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+            UserNamespace::get_init_singleton().as_ref(),
+            posix_thread,
+            CapSet::MKNOD,
+        ))
     }
 
     /// Links a new `Dentry` by `link()` the old inode.

--- a/test/initramfs/src/conformance/gvisor/blocklists/mknod_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/mknod_test
@@ -1,6 +1,4 @@
 # Broken support or no support at all.
-MknodTest.BlockDeviceRequiresCapMknod
-MknodTest.CharacterDeviceRequiresCapMknod
 MknodTest.Socket
 MknodTest.Fifo
 MknodTest.FifoOtrunc

--- a/test/initramfs/src/regression/fs/ext2/mknod.c
+++ b/test/initramfs/src/regression/fs/ext2/mknod.c
@@ -6,11 +6,17 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/sysmacros.h>
+#include <sys/wait.h>
 #include "../../common/test.h"
+#include "../../common/capability.h"
 
 #define NULL_DEVICE_PATH "/ext2/my_null_device"
 #define ZERO_DEVICE_PATH "/ext2/my_zero_device"
 #define FIFO_PATH "/ext2/myfifo.fifo"
+#define NO_CAP_CHAR_DEVICE_PATH "/ext2/no_cap_char_device"
+#define NO_CAP_BLOCK_DEVICE_PATH "/ext2/no_cap_block_device"
+#define NO_CAP_EXISTING_PATH "/ext2/no_cap_existing"
+#define NO_CAP_FIFO_PATH "/ext2/no_cap_fifo"
 
 FN_TEST(make_device_node)
 {
@@ -32,6 +38,42 @@ FN_TEST(make_device_node)
 		 _ret == sizeof(buffer) && buffer[0] == 0);
 	TEST_SUCC(close(zero_fd));
 	TEST_SUCC(unlink(ZERO_DEVICE_PATH));
+}
+END_TEST()
+
+FN_TEST(make_device_node_requires_cap_mknod)
+{
+	pid_t pid = TEST_SUCC(fork());
+	if (pid == 0) {
+		CHECK_WITH(unlink(NO_CAP_EXISTING_PATH),
+			   _ret == 0 || errno == ENOENT);
+		int existing_fd = CHECK(open(NO_CAP_EXISTING_PATH,
+					     O_CREAT | O_EXCL | O_RDWR, 0666));
+		CHECK(close(existing_fd));
+
+		drop_capability(CAP_MKNOD);
+
+		CHECK_WITH(mknod(NO_CAP_EXISTING_PATH, S_IFCHR | 0666,
+				 makedev(1, 3)),
+			   _ret == -1 && errno == EEXIST);
+		CHECK_WITH(mknod(NO_CAP_CHAR_DEVICE_PATH, S_IFCHR | 0666,
+				 makedev(1, 3)),
+			   _ret == -1 && errno == EPERM);
+		CHECK_WITH(mknod(NO_CAP_BLOCK_DEVICE_PATH, S_IFBLK | 0666,
+				 makedev(8, 0)),
+			   _ret == -1 && errno == EPERM);
+		CHECK_WITH(unlink(NO_CAP_FIFO_PATH),
+			   _ret == 0 || errno == ENOENT);
+		CHECK(mkfifo(NO_CAP_FIFO_PATH, 0666));
+		CHECK(unlink(NO_CAP_FIFO_PATH));
+		CHECK(unlink(NO_CAP_EXISTING_PATH));
+
+		_exit(0);
+	}
+
+	int status;
+	TEST_RES(waitpid(pid, &status, 0),
+		 _ret == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
 }
 END_TEST()
 


### PR DESCRIPTION
## Summary

Require `CAP_MKNOD` before creating character or block device nodes through `mknod()` / `mknodat()`.

## Changes

- Add the missing `CAP_MKNOD` check in the VFS mknod path for character and block device nodes.
- Keep FIFO creation exempt from `CAP_MKNOD`.
- Preserve VFS error precedence by checking `CAP_MKNOD` after the target entry absence check and before the filesystem `mknod` operation.
- Add regression coverage for:
  - char device creation without `CAP_MKNOD` returning `EPERM`
  - block device creation without `CAP_MKNOD` returning `EPERM`
  - existing target path still returning `EEXIST` before the capability check
  - FIFO creation still succeeding without `CAP_MKNOD`
- Unblock the fixed gVisor capability-denial mknod cases.

## Notes

This PR only fixes the capability gate for device-node creation. It does not expand filesystem support for device nodes, including exfat.
