### PR TITLE
Reject O_PATH fds in direct fchown

### DIFF
--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs::{
-        file::file_table::{RawFileDesc, get_file_fast},
+        file::{
+            StatusFlags,
+            file_table::{RawFileDesc, get_file_fast},
+        },
         utils::PATH_MAX,
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath},
     },
@@ -16,12 +19,16 @@ pub fn sys_fchown(raw_fd: RawFileDesc, uid: i32, gid: i32, ctx: &Context) -> Res
 
     let uid = to_optional_id(uid, Uid::new)?;
     let gid = to_optional_id(gid, Gid::new)?;
+
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
+    if file.status_flags().contains(StatusFlags::O_PATH) {
+        return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
+    }
     if uid.is_none() && gid.is_none() {
         return Ok(SyscallReturn::Return(0));
     }
 
-    let mut file_table = ctx.thread_local.borrow_file_table_mut();
-    let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
     let path = file.path();
     if let Some(uid) = uid {
         path.set_owner(uid)?;
@@ -65,6 +72,7 @@ pub fn sys_fchownat(
 
     let uid = to_optional_id(uid, Uid::new)?;
     let gid = to_optional_id(gid, Gid::new)?;
+
     if uid.is_none() && gid.is_none() {
         return Ok(SyscallReturn::Return(0));
     }

--- a/test/initramfs/src/conformance/gvisor/blocklists/chown_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/chown_test
@@ -1,5 +1,3 @@
-ChownTest.FchownDirWithOpath
-ChownTest.FchownFileWithOpath
 ChownTest.FchownPipeFileFails
 ChownTest.ChownRemovesSecurityCapability
 ChownTest.SetGroupIdBitDeniedWithoutCapFsetIdOrRelevantGroup

--- a/test/initramfs/src/regression/fs/ext2/permissions.c
+++ b/test/initramfs/src/regression/fs/ext2/permissions.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#define _GNU_SOURCE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -9,6 +11,7 @@
 
 #define BASE_DIR "/ext2/perm_test"
 #define TEST_FILE BASE_DIR "/testfile"
+#define TEST_DIR BASE_DIR "/testdir"
 
 FN_SETUP(create_base_dir)
 {
@@ -30,6 +33,27 @@ FN_TEST(chown_changes_owner)
 	// Restore ownership to root before cleanup
 	TEST_SUCC(chown(TEST_FILE, 0, 0));
 	TEST_SUCC(unlink(TEST_FILE));
+}
+END_TEST()
+
+FN_TEST(fchown_rejects_opath_fd)
+{
+	int file_fd = TEST_SUCC(open(TEST_FILE, O_CREAT | O_RDWR, 0644));
+	TEST_SUCC(close(file_fd));
+	file_fd = TEST_SUCC(open(TEST_FILE, O_PATH));
+	TEST_ERRNO(fchown(file_fd, geteuid(), getegid()), EBADF);
+	TEST_ERRNO(fchown(file_fd, -1, -1), EBADF);
+	TEST_SUCC(fchownat(file_fd, "", geteuid(), getegid(), AT_EMPTY_PATH));
+	TEST_SUCC(fchownat(file_fd, "", -1, -1, AT_EMPTY_PATH));
+	TEST_SUCC(close(file_fd));
+	TEST_SUCC(unlink(TEST_FILE));
+
+	TEST_SUCC(mkdir(TEST_DIR, 0755));
+	int dir_fd = TEST_SUCC(open(TEST_DIR, O_PATH | O_DIRECTORY));
+	TEST_ERRNO(fchown(dir_fd, geteuid(), getegid()), EBADF);
+	TEST_SUCC(fchownat(dir_fd, "", geteuid(), getegid(), AT_EMPTY_PATH));
+	TEST_SUCC(close(dir_fd));
+	TEST_SUCC(rmdir(TEST_DIR));
 }
 END_TEST()
 


### PR DESCRIPTION
## Summary

Make direct `fchown()` reject `O_PATH` file descriptors with `EBADF`.

## Changes

- Reject `O_PATH` file descriptors in the direct `fchown()` path.
- Keep `fchownat(..., "", AT_EMPTY_PATH)` separate so it can still operate on `O_PATH` descriptors.
- Preserve fd validation before no-op ownership changes, so `fchown(O_PATH, -1, -1)` returns `EBADF`.
- Add regression coverage for file and directory `O_PATH` descriptors.
- Unblock the fixed gVisor `Fchown*WithOpath` cases.
