### PR TITLE
Allow partial reads for integer socket options

### DIFF
--- a/kernel/src/util/net/options/utils.rs
+++ b/kernel/src/util/net/options/utils.rs
@@ -54,13 +54,9 @@ macro_rules! impl_read_write_for_32bit_type {
 
         impl WriteToUser for $pod_ty {
             fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-                let write_len = size_of::<$pod_ty>();
-
-                if (max_len as usize) < write_len {
-                    return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-                }
-
-                crate::context::current_userspace!().write_val(addr, self)?;
+                let write_len = size_of::<$pod_ty>().min(max_len as usize);
+                crate::context::current_userspace!()
+                    .write_bytes(addr, &self.as_bytes()[..write_len])?;
                 Ok(write_len)
             }
         }
@@ -125,19 +121,11 @@ impl WriteToUser for IpTtl {
 
 impl WriteToUser for Option<Error> {
     fn write_to_user(&self, addr: Vaddr, max_len: u32) -> Result<usize> {
-        let write_len = size_of::<i32>();
-
-        if (max_len as usize) < write_len {
-            return_errno_with_message!(Errno::EINVAL, "max_len is too short");
-        }
-
         let val = match self {
             None => 0i32,
             Some(error) => error.error() as i32,
         };
-
-        current_userspace!().write_val(addr, &val)?;
-        Ok(write_len)
+        val.write_to_user(addr, max_len)
     }
 }
 

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -98,7 +98,8 @@ FN_TEST(short_optlen)
 
 	memset(value, 0xa5, sizeof(value));
 	len = 2;
-	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, value, &len),
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, value,
+			    &len),
 		 _ret == 0 && len == 2);
 	TEST_RES(memcmp(value, &expected, len), _ret == 0);
 	TEST_RES(value[2], _ret == 0xa5);
@@ -106,7 +107,8 @@ FN_TEST(short_optlen)
 
 	memset(value, 0xa5, sizeof(value));
 	len = 0;
-	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, value, &len),
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, value,
+			    &len),
 		 _ret == 0 && len == 0);
 	TEST_RES(value[0], _ret == 0xa5);
 }

--- a/test/initramfs/src/regression/network/sockoption.c
+++ b/test/initramfs/src/regression/network/sockoption.c
@@ -87,6 +87,31 @@ FN_TEST(null_optval)
 }
 END_TEST()
 
+FN_TEST(short_optlen)
+{
+	int expected = 1;
+	unsigned char value[sizeof(expected)];
+	socklen_t len;
+
+	TEST_SUCC(setsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, &expected,
+			     sizeof(expected)));
+
+	memset(value, 0xa5, sizeof(value));
+	len = 2;
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, value, &len),
+		 _ret == 0 && len == 2);
+	TEST_RES(memcmp(value, &expected, len), _ret == 0);
+	TEST_RES(value[2], _ret == 0xa5);
+	TEST_RES(value[3], _ret == 0xa5);
+
+	memset(value, 0xa5, sizeof(value));
+	len = 0;
+	TEST_RES(getsockopt(sk_connected, SOL_SOCKET, SO_KEEPALIVE, value, &len),
+		 _ret == 0 && len == 0);
+	TEST_RES(value[0], _ret == 0xa5);
+}
+END_TEST()
+
 int refresh_connection()
 {
 	close(sk_connected);


### PR DESCRIPTION
## Summary

Match Linux `getsockopt` behavior for 32-bit integer options when the supplied `optlen` is shorter than the option value. The kernel now copies only `min(optlen, sizeof(value))` bytes instead of returning `EINVAL`.

The regression test covers both a two-byte buffer and a zero-length buffer, and verifies that bytes beyond the requested length remain unchanged.

Fixes #3374.

## Testing

Targeted QEMU regression test using `asterinas/asterinas:0.18.0-20260702`:

```bash
make initramfs ENABLE_REGRESSION_TEST=true
cargo osdk run \
  --boot-method=qemu-direct \
  --grub-boot-protocol=multiboot2 \
  --qemu-args="-accel kvm" \
  --kcmd-args=loglevel=error \
  --kcmd-args=console=hvc0 \
  --init-args=-c \
  --init-args=/test/network/sockoption
```

Result: `test_short_optlen summary: 7 tests passed, 0 tests failed`.

Additional checks:

- `cargo fmt --check --all`
- `git diff --check`
- `cargo check -p aster-kernel --target x86_64-unknown-none`
- `cargo clippy -p aster-kernel --target x86_64-unknown-none -- -D warnings`
