### PR TITLE
Support socket nodes in mknod

### DIFF
--- a/kernel/src/syscall/mknod.rs
+++ b/kernel/src/syscall/mknod.rs
@@ -57,7 +57,7 @@ pub fn sys_mknodat(
             let _ = dir_path.mknod(&name, inode_mode, MknodType::NamedPipe)?;
         }
         InodeType::Socket => {
-            return_errno_with_message!(Errno::EINVAL, "unsupported file types")
+            let _ = dir_path.new_fs_child(&name, InodeType::Socket, inode_mode)?;
         }
         _ => return_errno_with_message!(Errno::EPERM, "unimplemented file types"),
     }

--- a/test/initramfs/src/regression/fs/ext2/mknod.c
+++ b/test/initramfs/src/regression/fs/ext2/mknod.c
@@ -17,6 +17,7 @@
 #define NO_CAP_BLOCK_DEVICE_PATH "/ext2/no_cap_block_device"
 #define NO_CAP_EXISTING_PATH "/ext2/no_cap_existing"
 #define NO_CAP_FIFO_PATH "/ext2/no_cap_fifo"
+#define SOCKET_PATH "/ext2/mknod.socket"
 
 FN_TEST(make_device_node)
 {
@@ -98,5 +99,16 @@ FN_TEST(make_fifo_node)
 	TEST_SUCC(close(reader_fd));
 	TEST_SUCC(close(writer_fd));
 	TEST_SUCC(unlink(FIFO_PATH));
+}
+END_TEST()
+
+FN_TEST(make_socket_node)
+{
+	struct stat statbuf;
+
+	TEST_SUCC(mknod(SOCKET_PATH, S_IFSOCK | 0600, 0));
+	TEST_RES(lstat(SOCKET_PATH, &statbuf),
+		 _ret == 0 && S_ISSOCK(statbuf.st_mode));
+	TEST_SUCC(unlink(SOCKET_PATH));
 }
 END_TEST()


### PR DESCRIPTION
## Summary

Allow `mknod` and `mknodat` to create `S_IFSOCK` filesystem nodes, matching Linux behavior. Socket nodes are created through the regular filesystem child-creation path, while the device argument remains unused as expected.

An ext2 regression test verifies that the call succeeds, `lstat` reports a socket node, and the node can be removed normally.

Fixes #3357.

## Testing

Targeted QEMU regression test using `asterinas/asterinas:0.18.0-20260702`:

```bash
make initramfs ENABLE_REGRESSION_TEST=true
cargo osdk run \
  --boot-method=qemu-direct \
  --grub-boot-protocol=multiboot2 \
  --qemu-args="-accel kvm" \
  --kcmd-args=loglevel=error \
  --kcmd-args=console=hvc0 \
  --init-args=-c \
  --init-args=/test/fs/ext2/mknod
```

Result: `test_make_socket_node summary: 3 tests passed, 0 tests failed`.

Additional checks:

- `cargo fmt --check --all`
- `git diff --check`
- `cargo check -p aster-kernel --target x86_64-unknown-none`
- `cargo clippy -p aster-kernel --target x86_64-unknown-none -- -D warnings`
