### PR TITLE
Refactor the syscall restart machnism

### DIFF
--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -491,6 +491,10 @@ impl Socket for StreamSocket {
             self.check_connect()
         })
         .map_err(|err| match err.error() {
+            Errno::ERESTARTSYS if send_timeout.is_some() => Error::with_message(
+                Errno::EINTR,
+                "the socket operation is interrupted by a signal",
+            ),
             Errno::ETIME => Error::with_message(Errno::EINPROGRESS, "the socket timeout expired"),
             _ => err,
         })

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -59,6 +59,10 @@ mod private {
             } else {
                 self.wait_events(events, timeout.as_ref(), try_op)
                     .map_err(|err| match err.error() {
+                        Errno::ERESTARTSYS if timeout.is_some() => Error::with_message(
+                            Errno::EINTR,
+                            "the socket operation is interrupted by a signal",
+                        ),
                         Errno::ETIME => {
                             Error::with_message(Errno::EAGAIN, "the socket timeout expired")
                         }

--- a/kernel/src/net/socket/unix/datagram/message.rs
+++ b/kernel/src/net/socket/unix/datagram/message.rs
@@ -118,6 +118,10 @@ impl MessageQueue {
                 timeout.as_ref(),
             )
             .map_err(|err| match err.error() {
+                Errno::ERESTARTSYS if timeout.is_some() => Error::with_message(
+                    Errno::EINTR,
+                    "the socket operation is interrupted by a signal",
+                ),
                 Errno::ETIME => Error::with_message(Errno::EAGAIN, "the socket timeout expired"),
                 _ => err,
             })?

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -345,6 +345,10 @@ impl Backlog {
                 timeout.as_ref(),
             )
             .map_err(|err| match err.error() {
+                Errno::ERESTARTSYS if timeout.is_some() => Error::with_message(
+                    Errno::EINTR,
+                    "the socket operation is interrupted by a signal",
+                ),
                 Errno::ETIME => Error::with_message(Errno::EAGAIN, "the socket timeout expired"),
                 _ => err,
             })?

--- a/kernel/src/process/posix_thread/futex.rs
+++ b/kernel/src/process/posix_thread/futex.rs
@@ -116,7 +116,13 @@ pub fn futex_wait_bitset(
     // Release the lock.
     drop(futex_bucket);
 
-    let result = waiter.pause_timeout(&timeout.into());
+    let has_timeout = timeout.is_some();
+    let result = waiter
+        .pause_timeout(&timeout.into())
+        .map_err(|err| match err.error() {
+            Errno::ERESTARTSYS if has_timeout => Error::new(Errno::EINTR),
+            _ => err,
+        });
 
     // If the futex wait operation was interrupted by a signal or timed out, the
     // `FutexItem` must be dequeued and dropped. Otherwise, malicious user programs

--- a/kernel/src/process/signal/pause.rs
+++ b/kernel/src/process/signal/pause.rs
@@ -26,16 +26,16 @@ use crate::{
 /// On top of `WaitTimeout`, this `Pause` trait provides the `pause`-family methods,
 /// which are similar to the `wait`-family methods except that the methods also return
 /// when the waiting thread is interrupted by a POSIX signal.
-/// When this happens, the `pause`-family methods return `Err(EINTR)`.
+/// When this happens, the `pause`-family methods return `Err(ERESTARTSYS)`.
 pub trait Pause: WaitTimeout {
     /// Pauses until the condition is met or a signal interrupts.
     ///
     /// # Errors
     ///
-    /// This method will return an error with [`EINTR`] if a signal is received before the
+    /// This method will return an error with [`ERESTARTSYS`] if a signal is received before the
     /// condition is met.
     ///
-    /// [`EINTR`]: crate::error::Errno::EINTR
+    /// [`ERESTARTSYS`]: crate::error::Errno::ERESTARTSYS
     #[track_caller]
     fn pause_until<F, R>(&self, cond: F) -> Result<R>
     where
@@ -53,10 +53,10 @@ pub trait Pause: WaitTimeout {
     ///
     /// # Errors
     ///
-    /// This method will return an error with [`EINTR`] if a signal is received before the
+    /// This method will return an error with [`ERESTARTSYS`] if a signal is received before the
     /// condition is met.
     ///
-    /// [`EINTR`]: crate::error::Errno::EINTR
+    /// [`ERESTARTSYS`]: crate::error::Errno::ERESTARTSYS
     #[track_caller]
     fn pause_until_by<F, R>(&self, cond: F, reason: PauseReason) -> Result<R>
     where
@@ -70,11 +70,11 @@ pub trait Pause: WaitTimeout {
     /// # Errors
     ///
     /// Before the condition is met, this method will return an error with
-    ///  - [`EINTR`] if a signal is received;
+    ///  - [`ERESTARTSYS`] if a signal is received;
     ///  - [`ETIME`] if the timeout is reached.
     ///
     /// [`ETIME`]: crate::error::Errno::ETIME
-    /// [`EINTR`]: crate::error::Errno::EINTR
+    /// [`ERESTARTSYS`]: crate::error::Errno::ERESTARTSYS
     #[track_caller]
     fn pause_until_or_timeout<'a, F, T, R>(&self, mut cond: F, timeout: T) -> Result<R>
     where
@@ -95,11 +95,11 @@ pub trait Pause: WaitTimeout {
     /// # Errors
     ///
     /// Before the condition is met, this method will return an error with
-    ///  - [`EINTR`] if a signal is received;
+    ///  - [`ERESTARTSYS`] if a signal is received;
     ///  - [`ETIME`] if the timeout is reached.
     ///
     /// [`ETIME`]: crate::error::Errno::ETIME
-    /// [`EINTR`]: crate::error::Errno::EINTR
+    /// [`ERESTARTSYS`]: crate::error::Errno::ERESTARTSYS
     #[doc(hidden)]
     #[track_caller]
     fn pause_until_or_timeout_impl<F, R>(
@@ -116,11 +116,11 @@ pub trait Pause: WaitTimeout {
     /// # Errors
     ///
     /// This method will return an error with
-    ///  - [`EINTR`] if a signal is received;
+    ///  - [`ERESTARTSYS`] if a signal is received;
     ///  - [`ETIME`] if the timeout is reached.
     ///
     /// [`ETIME`]: crate::error::Errno::ETIME
-    /// [`EINTR`]: crate::error::Errno::EINTR
+    /// [`ERESTARTSYS`]: crate::error::Errno::ERESTARTSYS
     #[track_caller]
     fn pause_timeout(&self, timeout: &TimeoutExt<'_>) -> Result<()>;
 }
@@ -154,7 +154,7 @@ impl Pause for Waiter {
 
             if has_pending {
                 return Err(Error::with_message(
-                    Errno::EINTR,
+                    Errno::ERESTARTSYS,
                     "the current thread is interrupted by a signal",
                 ));
             }
@@ -187,7 +187,7 @@ impl Pause for Waiter {
             if posix_thread.has_pending() {
                 posix_thread.clear_signalled_waker();
                 return_errno_with_message!(
-                    Errno::EINTR,
+                    Errno::ERESTARTSYS,
                     "the current thread is interrupted by a signal"
                 );
             }
@@ -213,7 +213,7 @@ impl Pause for Waiter {
             .is_some_and(|posix_thread| posix_thread.has_pending())
         {
             return_errno_with_message!(
-                Errno::EINTR,
+                Errno::ERESTARTSYS,
                 "the current thread is interrupted by a signal"
             );
         }

--- a/kernel/src/process/signal/poll.rs
+++ b/kernel/src/process/signal/poll.rs
@@ -306,9 +306,9 @@ impl Poller {
 
     /// Waits until some interesting events happen since the last wait.
     ///
-    /// This method will fail with [`EINTR`] if interrupted by signals or [`ETIME`] on timeout.
+    /// This method will fail with [`ERESTARTSYS`] if interrupted by signals or [`ETIME`] on timeout.
     ///
-    /// [`EINTR`]: crate::error::Errno::EINTR
+    /// [`ERESTARTSYS`]: crate::error::Errno::ERESTARTSYS
     /// [`ETIME`]: crate::error::Errno::ETIME
     pub fn wait(&self) -> Result<()> {
         self.waiter.pause_timeout(&self.timeout)
@@ -346,6 +346,7 @@ pub trait Pollable {
     ///
     /// This method will fail with `ETIME` if the timeout is specified and the event does not occur
     /// before the timeout expires.
+    /// This method will fail with `ERESTARTSYS` if interrupted by a signal.
     ///
     /// The user must ensure that a call to `try_op()` does not fail with `EAGAIN` when the
     /// interesting events occur. However, it is allowed to have spurious `EAGAIN` failures due to

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -52,15 +52,7 @@ fn do_accept(
 
     let is_nonblocking = flags.contains(Flags::SOCK_NONBLOCK);
 
-    let (connected_socket, socket_addr) = {
-        socket
-            .accept(is_nonblocking)
-            .map_err(|err| match err.error() {
-                // FIXME: `accept` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-                _ => err,
-            })?
-    };
+    let (connected_socket, socket_addr) = socket.accept(is_nonblocking)?;
 
     let fd_flags = if flags.contains(Flags::SOCK_CLOEXEC) {
         FdFlags::CLOEXEC

--- a/kernel/src/syscall/connect.rs
+++ b/kernel/src/syscall/connect.rs
@@ -20,13 +20,7 @@ pub fn sys_connect(
     let file = get_file_fast!(&mut file_table, sockfd.try_into()?);
     let socket = file.as_socket_or_err()?;
 
-    socket
-        .connect(socket_addr)
-        .map_err(|err| match err.error() {
-            // FIXME: `connect` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        })?;
+    socket.connect(socket_addr)?;
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -137,6 +137,9 @@ fn do_epoll_pwait2(
         Err(e) if e.error() == Errno::ETIME => {
             return Ok(0);
         }
+        Err(e) if e.error() == Errno::ERESTARTSYS => {
+            return_errno_with_message!(Errno::EINTR, "epoll wait was interrupted");
+        }
         Err(e) => {
             return Err(e);
         }

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -29,10 +29,7 @@ pub fn sys_fcntl(raw_fd: RawFileDesc, cmd: i32, arg: u64, ctx: &Context) -> Resu
         FcntlCmd::F_SETFL => handle_setfl(fd, arg, ctx),
         FcntlCmd::F_GETLK => handle_getlk(fd, arg, ctx),
         FcntlCmd::F_SETLK => handle_setlk(fd, arg, true, ctx),
-        FcntlCmd::F_SETLKW => handle_setlk(fd, arg, false, ctx).map_err(|err| match err.error() {
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        }),
+        FcntlCmd::F_SETLKW => handle_setlk(fd, arg, false, ctx),
         FcntlCmd::F_GETOWN => handle_getown(fd, ctx),
         FcntlCmd::F_SETOWN => handle_setown(fd, arg, ctx),
         FcntlCmd::F_ADD_SEALS => handle_addseal(fd, arg, ctx),

--- a/kernel/src/syscall/flock.rs
+++ b/kernel/src/syscall/flock.rs
@@ -24,12 +24,7 @@ pub fn sys_flock(raw_fd: RawFileDesc, ops: i32, ctx: &Context) -> Result<Syscall
             let type_ = FlockType::from(ops);
             FlockItem::new(&file, type_)
         };
-        inode_file
-            .set_flock(flock, is_nonblocking)
-            .map_err(|err| match err.error() {
-                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-                _ => err,
-            })?;
+        inode_file.set_flock(flock, is_nonblocking)?;
     }
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/src/syscall/futex.rs
+++ b/kernel/src/syscall/futex.rs
@@ -139,7 +139,6 @@ pub fn sys_futex(
     }
     .map_err(|err| match err.error() {
         Errno::ETIME => Error::new(Errno::ETIMEDOUT),
-        Errno::EINTR => Error::new(Errno::ERESTARTSYS),
         _ => err,
     })?;
 

--- a/kernel/src/syscall/nanosleep.rs
+++ b/kernel/src/syscall/nanosleep.rs
@@ -115,7 +115,7 @@ fn do_clock_nanosleep(
 
     match res {
         Err(e) if e.error() == Errno::ETIME => Ok(SyscallReturn::Return(0)),
-        Err(e) if e.error() == Errno::EINTR => {
+        Err(e) if e.error() == Errno::ERESTARTSYS => {
             let end_time = read_clock(clockid, ctx)?;
 
             if end_time >= start_time + duration {

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -44,11 +44,7 @@ pub fn sys_openat(
             &fs_path,
             flags,
             InodeMode::from_bits_truncate(mask_mode),
-        )
-        .map_err(|err| match err.error() {
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        })?
+        )?
     };
 
     let fd = {

--- a/kernel/src/syscall/pause.rs
+++ b/kernel/src/syscall/pause.rs
@@ -10,7 +10,12 @@ pub fn sys_pause(_ctx: &Context) -> Result<SyscallReturn> {
     // handler or terminate current process
     let waiter = Waiter::new_pair().0;
 
-    waiter.pause_until(|| None)?;
+    waiter
+        .pause_until(|| None::<()>)
+        .map_err(|err| match err.error() {
+            Errno::ERESTARTSYS => Error::with_message(Errno::EINTR, "pause was interrupted"),
+            _ => err,
+        })?;
 
     unreachable!("[Internal Error] pause should always return EINTR");
 }

--- a/kernel/src/syscall/poll.rs
+++ b/kernel/src/syscall/poll.rs
@@ -111,6 +111,7 @@ pub(super) fn do_poll(
             // We should return zero if the timeout expires
             // before any file descriptors are ready.
             Err(err) if err.error() == Errno::ETIME => return Ok(0),
+            Err(err) if err.error() == Errno::ERESTARTSYS => return Err(Error::new(Errno::EINTR)),
             Err(err) => return Err(err),
         };
 

--- a/kernel/src/syscall/read.rs
+++ b/kernel/src/syscall/read.rs
@@ -32,11 +32,7 @@ pub fn sys_read(
         } else {
             file.read_bytes(&mut [])
         }
-    }
-    .map_err(|err| match err.error() {
-        Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-        _ => err,
-    })?;
+    }?;
 
     if read_len > 0 {
         fs::vfs::notify::on_access(&file);

--- a/kernel/src/syscall/recvfrom.rs
+++ b/kernel/src/syscall/recvfrom.rs
@@ -29,15 +29,7 @@ pub fn sys_recvfrom(
     let user_space = ctx.user_space();
     let mut writers = user_space.writer(buf, len)?;
 
-    let (output, message_header) = {
-        socket
-            .recvmsg(&mut writers, flags)
-            .map_err(|err| match err.error() {
-                // FIXME: `recvfrom` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-                _ => err,
-            })?
-    };
+    let (output, message_header) = socket.recvmsg(&mut writers, flags)?;
 
     if let Some(socket_addr) = message_header.addr()
         && src_addr != 0

--- a/kernel/src/syscall/recvmsg.rs
+++ b/kernel/src/syscall/recvmsg.rs
@@ -31,13 +31,7 @@ pub fn sys_recvmsg(
 
     let (output, message_header) = {
         let mut io_vec_writer = c_user_msghdr.copy_writer_array_from_user(&user_space)?;
-        socket
-            .recvmsg(&mut io_vec_writer, flags)
-            .map_err(|err| match err.error() {
-                // FIXME: `recvmsg` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-                _ => err,
-            })?
+        socket.recvmsg(&mut io_vec_writer, flags)?
     };
 
     // Writing control messages may access the file table, so it should be called after dropping

--- a/kernel/src/syscall/rt_sigsuspend.rs
+++ b/kernel/src/syscall/rt_sigsuspend.rs
@@ -27,7 +27,14 @@ pub fn sys_rt_sigsuspend(
 
     // Wait until receiving any signal
     let waiter = Waiter::new_pair().0;
-    waiter.pause_until(|| None::<()>)?;
+    waiter
+        .pause_until(|| None::<()>)
+        .map_err(|err| match err.error() {
+            Errno::ERESTARTSYS => {
+                Error::with_message(Errno::EINTR, "rt_sigsuspend was interrupted")
+            }
+            _ => err,
+        })?;
 
     // This syscall should always return `Err(EINTR)`. This path should never be reached.
     unreachable!("rt_sigsuspend always return EINTR");

--- a/kernel/src/syscall/rt_sigtimedwait.rs
+++ b/kernel/src/syscall/rt_sigtimedwait.rs
@@ -85,6 +85,8 @@ pub fn sys_rt_sigtimedwait(
                 .map_err(|e| {
                     if e.error() == Errno::ETIME {
                         Error::new(Errno::EAGAIN)
+                    } else if e.error() == Errno::ERESTARTSYS {
+                        Error::new(Errno::EINTR)
                     } else {
                         e
                     }

--- a/kernel/src/syscall/sendmsg.rs
+++ b/kernel/src/syscall/sendmsg.rs
@@ -55,11 +55,5 @@ pub(super) fn send_one_message(
     };
     let mut io_vec_reader = c_user_msghdr.copy_reader_array_from_user(user_space)?;
 
-    socket
-        .sendmsg(&mut io_vec_reader, message_header, flags)
-        .map_err(|err| match err.error() {
-            // FIXME: `sendmsg` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        })
+    socket.sendmsg(&mut io_vec_reader, message_header, flags)
 }

--- a/kernel/src/syscall/sendto.rs
+++ b/kernel/src/syscall/sendto.rs
@@ -36,13 +36,7 @@ pub fn sys_sendto(
 
     let user_space = ctx.user_space();
     let mut reader = user_space.reader(buf, len)?;
-    let send_size = socket
-        .sendmsg(&mut reader, message_header, flags)
-        .map_err(|err| match err.error() {
-            // FIXME: `sendto` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        })?;
+    let send_size = socket.sendmsg(&mut reader, message_header, flags)?;
 
     Ok(SyscallReturn::Return(send_size as _))
 }

--- a/kernel/src/syscall/wait4.rs
+++ b/kernel/src/syscall/wait4.rs
@@ -33,11 +33,7 @@ pub fn sys_wait4(
         );
     }
 
-    let wait_status =
-        do_wait(process_filter, wait_options, ctx).map_err(|err| match err.error() {
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        })?;
+    let wait_status = do_wait(process_filter, wait_options, ctx)?;
     let Some(wait_status) = wait_status else {
         return Ok(SyscallReturn::Return(0 as _));
     };

--- a/kernel/src/syscall/waitid.rs
+++ b/kernel/src/syscall/waitid.rs
@@ -40,11 +40,7 @@ pub fn sys_waitid(
         );
     }
 
-    let wait_status =
-        do_wait(process_filter, wait_options, ctx).map_err(|err| match err.error() {
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        })?;
+    let wait_status = do_wait(process_filter, wait_options, ctx)?;
 
     let Some(wait_status) = wait_status else {
         return Ok(SyscallReturn::Return(0));

--- a/kernel/src/syscall/write.rs
+++ b/kernel/src/syscall/write.rs
@@ -32,11 +32,7 @@ pub fn sys_write(
         } else {
             file.write_bytes(&[])
         }
-    }
-    .map_err(|err| match err.error() {
-        Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-        _ => err,
-    })?;
+    }?;
 
     if write_len > 0 {
         fs::vfs::notify::on_modify(&file);

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -60,6 +60,7 @@ fi
 ./signal/parent_death_signal
 ./signal/pidfd_send_signal
 ./signal/signal_fd
+./signal/syscall_restart
 ./signal/signal_test2
 
 if [ "$(uname -m)" = "x86_64" ]; then

--- a/test/initramfs/src/regression/process/signal/syscall_restart.c
+++ b/test/initramfs/src/regression/process/signal/syscall_restart.c
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <poll.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+static volatile sig_atomic_t signal_count;
+
+static void signal_handler(int signum)
+{
+	signal_count++;
+}
+
+FN_SETUP(install_restart_handler)
+{
+	struct sigaction action = {};
+	action.sa_handler = signal_handler;
+	action.sa_flags = SA_RESTART;
+	CHECK(sigaction(SIGUSR1, &action, NULL));
+}
+END_SETUP()
+
+FN_TEST(read_restarts_with_sa_restart)
+{
+	signal_count = 0;
+
+	int pipefds[2];
+	TEST_SUCC(pipe(pipefds));
+
+	pid_t parent = getpid();
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		CHECK(close(pipefds[0]));
+		sleep(1);
+		CHECK(kill(parent, SIGUSR1));
+		sleep(1);
+		CHECK(write(pipefds[1], "a", 1));
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pipefds[1]));
+
+	char byte = 0;
+	TEST_RES(read(pipefds[0], &byte, sizeof(byte)),
+		 _ret == 1 && byte == 'a' && signal_count > 0);
+
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_SUCC(close(pipefds[0]));
+}
+END_TEST()
+
+FN_TEST(poll_does_not_restart_with_sa_restart)
+{
+	signal_count = 0;
+
+	int pipefds[2];
+	TEST_SUCC(pipe(pipefds));
+
+	pid_t parent = getpid();
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		CHECK(close(pipefds[0]));
+		sleep(1);
+		CHECK(kill(parent, SIGUSR1));
+		sleep(1);
+		CHECK(write(pipefds[1], "a", 1));
+		_exit(0);
+	}
+
+	TEST_SUCC(close(pipefds[1]));
+
+	struct pollfd pfd = {
+		.fd = pipefds[0],
+		.events = POLLIN,
+	};
+	TEST_ERRNO(poll(&pfd, 1, -1), EINTR);
+
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_SUCC(close(pipefds[0]));
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/signal/syscall_restart.c
+++ b/test/initramfs/src/regression/process/signal/syscall_restart.c
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #define _GNU_SOURCE
+#include <linux/futex.h>
 #include <poll.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "../../common/test.h"
@@ -90,6 +95,77 @@ FN_TEST(poll_does_not_restart_with_sa_restart)
 						     WIFEXITED(status) &&
 						     WEXITSTATUS(status) == 0);
 	TEST_SUCC(close(pipefds[0]));
+}
+END_TEST()
+
+FN_TEST(futex_wait_without_timeout_restarts)
+{
+	signal_count = 0;
+
+	uint32_t *futex_word =
+		TEST_RES(mmap(NULL, sizeof(*futex_word), PROT_READ | PROT_WRITE,
+			      MAP_SHARED | MAP_ANONYMOUS, -1, 0),
+			 _ret != MAP_FAILED);
+	*futex_word = 0;
+
+	pid_t parent = getpid();
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		sleep(1);
+		CHECK(kill(parent, SIGUSR1));
+		sleep(1);
+		__atomic_store_n(futex_word, 1, __ATOMIC_SEQ_CST);
+		CHECK(syscall(SYS_futex, futex_word, FUTEX_WAKE, 1, NULL, NULL,
+			      0));
+		_exit(0);
+	}
+
+	TEST_RES(syscall(SYS_futex, futex_word, FUTEX_WAIT, 0, NULL, NULL, 0),
+		 _ret == 0 && signal_count > 0);
+
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_SUCC(munmap(futex_word, sizeof(*futex_word)));
+}
+END_TEST()
+
+FN_TEST(futex_wait_with_timeout_does_not_restart)
+{
+	for (int wait_bitset = 0; wait_bitset <= 1; wait_bitset++) {
+		signal_count = 0;
+		uint32_t futex_word = 0;
+		struct timespec timeout;
+		if (wait_bitset) {
+			TEST_SUCC(clock_gettime(CLOCK_MONOTONIC, &timeout));
+			timeout.tv_sec += 3;
+		} else {
+			timeout.tv_sec = 3;
+			timeout.tv_nsec = 0;
+		}
+
+		pid_t parent = getpid();
+		pid_t child = TEST_SUCC(fork());
+		if (child == 0) {
+			sleep(1);
+			CHECK(kill(parent, SIGUSR1));
+			_exit(0);
+		}
+
+		int futex_op = wait_bitset ? FUTEX_WAIT_BITSET_PRIVATE :
+					     FUTEX_WAIT_PRIVATE;
+		uint32_t bitset = wait_bitset ? FUTEX_BITSET_MATCH_ANY : 0;
+		TEST_ERRNO(syscall(SYS_futex, &futex_word, futex_op, 0,
+				   &timeout, NULL, bitset),
+			   EINTR);
+		TEST_RES(signal_count > 0, _ret);
+
+		int status = 0;
+		TEST_RES(waitpid(child, &status, 0),
+			 _ret == child && WIFEXITED(status) &&
+				 WEXITSTATUS(status) == 0);
+	}
 }
 END_TEST()
 

--- a/test/initramfs/src/regression/process/signal/syscall_restart.c
+++ b/test/initramfs/src/regression/process/signal/syscall_restart.c
@@ -4,6 +4,8 @@
 #include <poll.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -88,5 +90,73 @@ FN_TEST(poll_does_not_restart_with_sa_restart)
 						     WIFEXITED(status) &&
 						     WEXITSTATUS(status) == 0);
 	TEST_SUCC(close(pipefds[0]));
+}
+END_TEST()
+
+FN_TEST(socket_read_without_timeout_restarts)
+{
+	signal_count = 0;
+
+	int sockets[2];
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets));
+
+	pid_t parent = getpid();
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		CHECK(close(sockets[0]));
+		sleep(1);
+		CHECK(kill(parent, SIGUSR1));
+		sleep(1);
+		CHECK(write(sockets[1], "a", 1));
+		_exit(0);
+	}
+
+	TEST_SUCC(close(sockets[1]));
+
+	char byte = 0;
+	TEST_RES(read(sockets[0], &byte, sizeof(byte)),
+		 _ret == 1 && byte == 'a' && signal_count > 0);
+
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_SUCC(close(sockets[0]));
+}
+END_TEST()
+
+FN_TEST(socket_read_with_timeout_does_not_restart)
+{
+	signal_count = 0;
+
+	int sockets[2];
+	TEST_SUCC(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets));
+
+	struct timeval timeout = { .tv_sec = 5 };
+	TEST_SUCC(setsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &timeout,
+			     sizeof(timeout)));
+
+	pid_t parent = getpid();
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		CHECK(close(sockets[0]));
+		sleep(1);
+		CHECK(kill(parent, SIGUSR1));
+		sleep(1);
+		CHECK(write(sockets[1], "a", 1));
+		_exit(0);
+	}
+
+	TEST_SUCC(close(sockets[1]));
+
+	char byte = 0;
+	TEST_ERRNO(read(sockets[0], &byte, sizeof(byte)), EINTR);
+	TEST_RES(signal_count > 0, _ret);
+
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_SUCC(close(sockets[0]));
 }
 END_TEST()


### PR DESCRIPTION
Our current syscall restart mechanism is implemented in a rather unusual way. We map `EINTR` to `ERESTARTSTS` at the syscall level. However, this approach both misses some cases where a restart should occur, and causes some cases where a restart should not occur to be restarted incorrectly.

Since socket timeout is now supported, this PR also fixes the issue where socket-related syscalls should not be restarted when a socket timeout is set, as shown in the following Linux kernel code:

```C
/* Alas, with timeout socket operations are not restartable.
 * Compare this to poll().
 */
static inline int sock_intr_errno(long timeo)
{
	return timeo == MAX_SCHEDULE_TIMEOUT ? -ERESTARTSYS : -EINTR;
}
```

More background can be viewed in the discussion at https://github.com/asterinas/asterinas/pull/3494#issuecomment-4899734406:

> I took a quick look at the Linux implementation. In our current approach, the waiting APIs (e.g., `pause_until`) return `EINTR`, and the conversion from `EINTR` to `ERESTARTSYS` happens at the system call layer. However, Linux does the opposite — the waiting primitives return `ERESTARTSYS` directly, and the conversion to `EINTR` only happens when necessary(The common case seems to be handled by the signal handler, but sockets handle it separately, as do certain other cases.). For example, `wait_event_interruptible` returns `ERESTARTSYS`:
> 
> ```c
> /**
>  * wait_event_interruptible - sleep until a condition gets true
>  * @wq_head: the waitqueue to wait on
>  * @condition: a C expression for the event to wait for
>  *
>  * The process is put to sleep (TASK_INTERRUPTIBLE) until the
>  * @condition evaluates to true or a signal is received.
>  * The @condition is checked each time the waitqueue @wq_head is woken up.
>  *
>  * wake_up() has to be called after changing any variable that could
>  * change the result of the wait condition.
>  *
>  * The function will return -ERESTARTSYS if it was interrupted by a
>  * signal and 0 if @condition evaluated to true.
>  */
> #define wait_event_interruptible(wq_head, condition)	
> ```
> 
> Mapping this to our implementation, the `pause_until` family of functions should return `ERESTARTSYS` when interrupted by a signal. For sockets specifically, we could handle the conversion from `ERESTARTSYS` to `EINTR` in a common place — for example, in `block_on` — by checking whether a non-zero timeout has been set. This way, we wouldn't need to convert `EINTR` to `ERESTARTSYS` at each individual system call site, which also seems incorrect.

