### PR TITLE
Introduce `FileCommon` for all `FileLike`s

### DIFF
--- a/kernel/libs/atomic-integer-wrapper/src/lib.rs
+++ b/kernel/libs/atomic-integer-wrapper/src/lib.rs
@@ -197,6 +197,25 @@ pub fn define_atomic_version_of_integer_like_type(input: TokenStream) -> TokenSt
                 .map_err(|val| val.#from_integer)
         }
     };
+    let fn_update = quote! {
+        pub fn update<F>(
+            &self,
+            set_order: core::sync::atomic::Ordering,
+            fetch_order: core::sync::atomic::Ordering,
+            mut f: F
+        ) -> #integer_like_type
+        where
+            F: FnMut(#integer_like_type) -> #integer_like_type,
+        {
+            self.0
+                .update(
+                    set_order,
+                    fetch_order,
+                    |old| f(old.#from_integer).into()
+                )
+                .#from_integer
+        }
+    };
 
     let expanded = quote! {
         #item
@@ -213,6 +232,8 @@ pub fn define_atomic_version_of_integer_like_type(input: TokenStream) -> TokenSt
             #fn_compare_exchange
 
             #fn_fetch_update
+
+            #fn_update
         }
     };
 

--- a/kernel/src/device/evdev/file.rs
+++ b/kernel/src/device/evdev/file.rs
@@ -16,7 +16,7 @@ use super::EvdevDevice;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
         vfs::inode::FileOps,
     },
     prelude::*,
@@ -496,6 +496,10 @@ impl PerOpenFileOps for EvdevFile {
         });
 
         Ok(0)
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_async()
     }
 }
 

--- a/kernel/src/device/pty/file.rs
+++ b/kernel/src/device/pty/file.rs
@@ -6,7 +6,7 @@ use crate::{
     device::PtySlave,
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
         vfs::inode::FileOps,
     },
     prelude::*,
@@ -90,5 +90,9 @@ impl PerOpenFileOps for PtySlaveFile {
 
     fn is_offset_aware(&self) -> bool {
         false
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_async()
     }
 }

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -10,7 +10,10 @@ use crate::{
     events::IoEvents,
     fs::{
         devpts::Ptmx,
-        file::{AccessMode, OpenArgs, PerOpenFileOps, StatusFlags, file_table::FdFlags, mkmod},
+        file::{
+            AccessMode, OpenArgs, PerOpenFileOps, SettableStatusFlags, StatusFlags,
+            file_table::FdFlags, mkmod,
+        },
         vfs::{inode::FileOps, path::FsPath},
     },
     prelude::*,
@@ -241,6 +244,10 @@ impl PerOpenFileOps for PtyMaster {
         });
 
         Ok(0)
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_async()
     }
 }
 

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -11,7 +11,7 @@ use crate::{
     device::{Device, DeviceType, DevtmpfsInodeMeta, add_node},
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
         vfs::{inode::FileOps, path::PathResolver},
     },
     prelude::*,
@@ -232,6 +232,10 @@ impl PerOpenFileOps for OpenBlockFile {
                 "the ioctl command is not supported by block devices"
             ),
         })
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_direct()
     }
 }
 

--- a/kernel/src/device/tty/file.rs
+++ b/kernel/src/device/tty/file.rs
@@ -6,7 +6,7 @@ use super::{Tty, TtyDriver};
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
         vfs::inode::FileOps,
     },
     prelude::*,
@@ -57,5 +57,9 @@ impl<D: TtyDriver> PerOpenFileOps for TtyFile<D> {
 
     fn is_offset_aware(&self) -> bool {
         false
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_async()
     }
 }

--- a/kernel/src/device/tty/vt/file.rs
+++ b/kernel/src/device/tty/vt/file.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
         vfs::inode::FileOps,
     },
     prelude::*,
@@ -114,5 +114,9 @@ impl PerOpenFileOps for VtFile {
 
     fn is_offset_aware(&self) -> bool {
         false
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_async()
     }
 }

--- a/kernel/src/events/epoll/file.rs
+++ b/kernel/src/events/epoll/file.rs
@@ -12,11 +12,10 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, CreationFlags, FileLike,
+            AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags,
             file_table::{FdFlags, FileDesc, get_file_fast},
         },
         pseudofs::AnonInodeFs,
-        vfs::path::Path,
     },
     prelude::*,
     process::{
@@ -46,8 +45,8 @@ pub struct EpollFile {
     // Keep this in a separate `Arc` to avoid dropping `EpollFile` in the observer callback, which
     // may cause deadlocks.
     ready: Arc<ReadySet>,
-    /// The pseudo path associated with this epoll file.
-    pseudo_path: Path,
+    /// The common state for this epoll file.
+    common: FileCommon,
 }
 
 impl EpollFile {
@@ -58,7 +57,7 @@ impl EpollFile {
         Arc::new(Self {
             interest: Mutex::new(BTreeSet::new()),
             ready: Arc::new(ReadySet::new()),
-            pseudo_path,
+            common: FileCommon::new(pseudo_path, StatusFlags::empty()),
         })
     }
 
@@ -270,8 +269,8 @@ impl FileLike for EpollFile {
         AccessMode::O_RDWR
     }
 
-    fn path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {

--- a/kernel/src/fs/file/file_attr/status_flags.rs
+++ b/kernel/src/fs/file/file_attr/status_flags.rs
@@ -27,6 +27,47 @@ bitflags! {
     }
 }
 
+impl StatusFlags {
+    /// Status flags that can be changed by `F_SETFL`.
+    pub const SETFL_MASK: Self = Self::O_APPEND
+        .union(Self::O_ASYNC)
+        .union(Self::O_DIRECT)
+        .union(Self::O_NOATIME)
+        .union(Self::O_NONBLOCK);
+}
+
+/// Status flags that a file supports changing after it is opened.
+///
+/// Every value contains `O_APPEND`, `O_NOATIME`, and `O_NONBLOCK`. Files may additionally support
+/// changing `O_ASYNC` and `O_DIRECT`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SettableStatusFlags(StatusFlags);
+
+impl SettableStatusFlags {
+    /// Creates the minimal set of status flags supported by all files.
+    pub const fn minimal() -> Self {
+        Self(
+            StatusFlags::O_APPEND
+                .union(StatusFlags::O_NOATIME)
+                .union(StatusFlags::O_NONBLOCK),
+        )
+    }
+
+    /// Adds support for changing `O_ASYNC`.
+    pub const fn with_o_async(self) -> Self {
+        Self(self.0.union(StatusFlags::O_ASYNC))
+    }
+
+    /// Adds support for changing `O_DIRECT`.
+    pub const fn with_o_direct(self) -> Self {
+        Self(self.0.union(StatusFlags::O_DIRECT))
+    }
+
+    pub(in crate::fs::file) fn contains(self, flags: StatusFlags) -> bool {
+        self.0.contains(flags)
+    }
+}
+
 impl From<u32> for StatusFlags {
     fn from(value: u32) -> Self {
         Self::from_bits_truncate(value)

--- a/kernel/src/fs/file/file_common.rs
+++ b/kernel/src/fs/file/file_common.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! State shared by all references to a file description.
+
+use core::sync::atomic::Ordering;
+
+use super::{AtomicStatusFlags, FileLike, StatusFlags, file_handle::StatusFlagsUpdate};
+use crate::{
+    events::{IoEvents, Observer},
+    fs::vfs::path::Path,
+    prelude::*,
+    process::{
+        Pid, Process,
+        signal::{PollAdaptor, constants::SIGIO},
+    },
+};
+
+/// Common fields for a file description.
+///
+/// This type is intended to collect state that belongs to the file description rather than to a
+/// specific file descriptor.
+pub struct FileCommon {
+    path: Path,
+    status_flags: AtomicStatusFlags,
+    owner: FileOwner,
+}
+
+impl FileCommon {
+    /// Creates common state for a file description.
+    pub fn new(path: Path, status_flags: StatusFlags) -> Self {
+        Self {
+            path,
+            status_flags: AtomicStatusFlags::new(status_flags),
+            owner: FileOwner::new(),
+        }
+    }
+
+    /// Returns the path associated with the file description.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the current file status flags.
+    pub fn status_flags(&self) -> StatusFlags {
+        self.status_flags.load(Ordering::Relaxed)
+    }
+
+    /// Returns whether the file description is in non-blocking mode.
+    pub fn is_nonblocking(&self) -> bool {
+        self.status_flags().contains(StatusFlags::O_NONBLOCK)
+    }
+
+    /// Atomically updates the file status flags.
+    pub(super) fn update_status_flags(&self, file: &dyn FileLike, update: StatusFlagsUpdate) {
+        if !update.affects(StatusFlags::O_ASYNC) {
+            self.apply_status_flags(update);
+            return;
+        }
+
+        let mut owner_guard = self.owner.inner.lock();
+        if let Some(owner) = owner_guard.as_mut() {
+            if update.flags().contains(StatusFlags::O_ASYNC) {
+                owner.register_observer(file);
+            } else {
+                owner.unregister_observer();
+            }
+        }
+        self.apply_status_flags(update);
+    }
+
+    fn apply_status_flags(&self, update: StatusFlagsUpdate) {
+        self.status_flags
+            .update(Ordering::Relaxed, Ordering::Relaxed, |status_flags| {
+                update.apply(status_flags)
+            });
+    }
+
+    /// Returns the asynchronous I/O signal owner.
+    pub fn owner(&self) -> &FileOwner {
+        &self.owner
+    }
+}
+
+/// The process that receives asynchronous I/O signals for a file description.
+pub struct FileOwner {
+    inner: Mutex<Option<Owner>>,
+}
+
+impl FileOwner {
+    /// Creates an owner state with no process assigned.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Returns the process ID of the current owner.
+    pub fn pid(&self) -> Option<Pid> {
+        self.inner.lock().as_ref().map(|owner| owner.pid)
+    }
+
+    pub(super) fn set(&self, file: &dyn FileLike, owner: Option<&Arc<Process>>) {
+        let mut owner_guard = self.inner.lock();
+        *owner_guard = None;
+
+        let Some(process) = owner else {
+            return;
+        };
+
+        let mut owner = Owner::new(process);
+        if file.status_flags().contains(StatusFlags::O_ASYNC) {
+            owner.register_observer(file);
+        }
+        *owner_guard = Some(owner);
+    }
+}
+
+impl Default for FileOwner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct Owner {
+    pid: Pid,
+    process: Weak<Process>,
+    poller: Option<PollAdaptor<OwnerObserver>>,
+}
+
+impl Owner {
+    fn new(process: &Arc<Process>) -> Self {
+        Self {
+            pid: process.pid(),
+            process: Arc::downgrade(process),
+            poller: None,
+        }
+    }
+
+    fn register_observer(&mut self, file: &dyn FileLike) {
+        if self.poller.is_some() {
+            return;
+        }
+
+        let mut poller = PollAdaptor::with_observer(OwnerObserver::new(self.process.clone()));
+        file.poll(IoEvents::IN | IoEvents::OUT, Some(poller.as_handle_mut()));
+        self.poller = Some(poller);
+    }
+
+    fn unregister_observer(&mut self) {
+        self.poller = None;
+    }
+}
+
+struct OwnerObserver {
+    owner: Weak<Process>,
+}
+
+impl OwnerObserver {
+    fn new(owner: Weak<Process>) -> Self {
+        Self { owner }
+    }
+}
+
+impl Observer<IoEvents> for OwnerObserver {
+    fn on_events(&self, _events: &IoEvents) {
+        crate::process::enqueue_signal_async(self.owner.clone(), SIGIO);
+    }
+}

--- a/kernel/src/fs/file/file_handle.rs
+++ b/kernel/src/fs/file/file_handle.rs
@@ -8,12 +8,15 @@ use core::fmt::Display;
 
 use ostd::io::IoMem;
 
-use super::{AccessMode, InodeHandle, StatusFlags, file_table::FdFlags, inode_handle::SeekFrom};
+use super::{
+    AccessMode, FileCommon, InodeHandle, SettableStatusFlags, StatusFlags, file_table::FdFlags,
+    inode_handle::SeekFrom,
+};
 use crate::{
     fs::vfs::{inode::FallocMode, path::Path},
     net::socket::Socket,
     prelude::*,
-    process::signal::Pollable,
+    process::{Process, signal::Pollable},
     util::ioctl::RawIoctl,
     vm::page_cache::Vmo,
 };
@@ -108,11 +111,14 @@ pub trait FileLike: Pollable + Send + Sync + Any {
     }
 
     fn status_flags(&self) -> StatusFlags {
-        StatusFlags::empty()
+        self.common().status_flags()
     }
 
-    fn set_status_flags(&self, _new_flags: StatusFlags) -> Result<()> {
-        return_errno_with_message!(Errno::EINVAL, "set_status_flags is not supported");
+    /// Returns the status flags that can be set for this file.
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        // `O_ASYNC` and `O_DIRECT` can only be set on file descriptions that explicitly
+        // support them.
+        SettableStatusFlags::minimal()
     }
 
     /// Returns the access mode of this file.
@@ -152,7 +158,8 @@ pub trait FileLike: Pollable + Send + Sync + Any {
         None
     }
 
-    fn path(&self) -> &Path;
+    /// Returns the common state shared by file-like objects.
+    fn common(&self) -> &FileCommon;
 
     /// Dumps information to appear in the `fdinfo` file under procfs.
     ///
@@ -169,6 +176,70 @@ pub trait FileLike: Pollable + Send + Sync + Any {
 }
 
 impl dyn FileLike {
+    /// Returns the path associated with the file description.
+    pub fn path(&self) -> &Path {
+        self.common().path()
+    }
+
+    /// Updates file status flags atomically.
+    ///
+    /// `O_ASYNC` is ignored if it is not supported. An attempt to enable
+    /// unsupported `O_DIRECT` returns `EINVAL`.
+    pub fn update_status_flags(&self, mut update: StatusFlagsUpdate) -> Result<()> {
+        let settable_flags = self.settable_status_flags();
+        if update.flags().contains(StatusFlags::O_DIRECT)
+            && !settable_flags.contains(StatusFlags::O_DIRECT)
+        {
+            return_errno_with_message!(Errno::EINVAL, "the `O_DIRECT` flag is not supported");
+        }
+        if !settable_flags.contains(StatusFlags::O_ASYNC) {
+            update.ignore(StatusFlags::O_ASYNC);
+        }
+
+        self.common().update_status_flags(self, update);
+        Ok(())
+    }
+
+    /// Updates the `O_NONBLOCK` status flag.
+    pub fn update_status_nonblock(&self, is_nonblocking: bool) {
+        let update = if is_nonblocking {
+            StatusFlagsUpdate::set(StatusFlags::O_NONBLOCK)
+        } else {
+            StatusFlagsUpdate::unset(StatusFlags::O_NONBLOCK)
+        };
+
+        self.common().update_status_flags(self, update);
+    }
+
+    /// Updates the `O_ASYNC` status flag.
+    ///
+    /// An attempt to enable `O_ASYNC` on a file that does not support it returns
+    /// `ENOTTY`.
+    pub fn update_status_async(&self, is_async: bool) -> Result<()> {
+        let settable_flags = self.settable_status_flags();
+        if is_async && !settable_flags.contains(StatusFlags::O_ASYNC) {
+            return_errno_with_message!(Errno::ENOTTY, "signal-driven I/O is not supported");
+        }
+
+        let update = if is_async {
+            StatusFlagsUpdate::set(StatusFlags::O_ASYNC)
+        } else {
+            StatusFlagsUpdate::unset(StatusFlags::O_ASYNC)
+        };
+
+        self.common().update_status_flags(self, update);
+        Ok(())
+    }
+
+    /// Sets a process as the owner of the file description.
+    ///
+    /// Passing `None` clears the current owner.
+    ///
+    /// The owner receives `SIGIO` for I/O events on the file description when `O_ASYNC` is set.
+    pub fn set_owner(&self, owner: Option<&Arc<Process>>) {
+        self.common().owner().set(self, owner);
+    }
+
     pub fn downcast_ref<T: FileLike>(&self) -> Option<&T> {
         (self as &dyn Any).downcast_ref::<T>()
     }
@@ -203,6 +274,64 @@ impl dyn FileLike {
         self.downcast_ref().ok_or_else(|| {
             Error::with_message(Errno::EINVAL, "the file is not related to an inode")
         })
+    }
+}
+
+/// An atomic update to a subset of file status flags.
+#[derive(Clone, Copy, Debug)]
+pub struct StatusFlagsUpdate {
+    mask: StatusFlags,
+    flags: StatusFlags,
+}
+
+impl StatusFlagsUpdate {
+    /// Creates an update that replaces all updatable flags with `flags`.
+    ///
+    /// Replacing flags outside [`StatusFlags::SETFL_MASK`] is a no-op.
+    pub fn replace(mut flags: StatusFlags) -> Self {
+        flags &= StatusFlags::SETFL_MASK;
+        Self::new(StatusFlags::SETFL_MASK, flags)
+    }
+
+    /// Creates an update that sets `flags`.
+    ///
+    /// Setting flags outside [`StatusFlags::SETFL_MASK`] is a no-op.
+    pub fn set(mut flags: StatusFlags) -> Self {
+        flags &= StatusFlags::SETFL_MASK;
+        Self::new(flags, flags)
+    }
+
+    /// Creates an update that unsets `flags`.
+    ///
+    /// Unsetting flags outside [`StatusFlags::SETFL_MASK`] is a no-op.
+    pub fn unset(mut flags: StatusFlags) -> Self {
+        flags &= StatusFlags::SETFL_MASK;
+        Self::new(flags, StatusFlags::empty())
+    }
+
+    /// Makes this update leave `flags` unchanged.
+    fn ignore(&mut self, flags: StatusFlags) {
+        self.mask.remove(flags);
+        self.flags &= self.mask;
+    }
+
+    fn new(mask: StatusFlags, flags: StatusFlags) -> Self {
+        Self { mask, flags }
+    }
+
+    /// Returns the flags that this update will set.
+    pub(super) fn flags(self) -> StatusFlags {
+        self.flags
+    }
+
+    /// Returns whether this update affects any of the specified flags.
+    pub(super) fn affects(self, flags: StatusFlags) -> bool {
+        self.mask.intersects(flags)
+    }
+
+    /// Applies this update to the current file status flags.
+    pub(super) fn apply(self, current: StatusFlags) -> StatusFlags {
+        (current - self.mask) | self.flags
     }
 }
 

--- a/kernel/src/fs/file/file_table.rs
+++ b/kernel/src/fs/file/file_table.rs
@@ -7,16 +7,8 @@ use core::{
 
 use aster_util::{ranged_integer::RangedU32, slot_vec::SlotVec};
 
-use super::{StatusFlags, file_handle::FileLike};
-use crate::{
-    events::{IoEvents, Observer},
-    prelude::*,
-    process::{
-        Pid, Process,
-        posix_thread::FileTableRefMut,
-        signal::{PollAdaptor, constants::SIGIO},
-    },
-};
+use super::file_handle::FileLike;
+use crate::{prelude::*, process::posix_thread::FileTableRefMut};
 
 /// Represents a validated, non-negative file descriptor.
 ///
@@ -321,7 +313,6 @@ pub(crate) use get_file_fast;
 pub struct FileTableEntry {
     file: Arc<dyn FileLike>,
     flags: AtomicU8,
-    owner: Option<Owner>,
 }
 
 impl FileTableEntry {
@@ -329,39 +320,11 @@ impl FileTableEntry {
         Self {
             file,
             flags: AtomicU8::new(flags.bits()),
-            owner: None,
         }
     }
 
     pub fn file(&self) -> &Arc<dyn FileLike> {
         &self.file
-    }
-
-    pub fn owner(&self) -> Option<Pid> {
-        self.owner.as_ref().map(|(pid, _)| *pid)
-    }
-
-    /// Set a process (group) as owner of the file descriptor.
-    ///
-    /// Such that this process (group) will receive `SIGIO` and `SIGURG` signals
-    /// for I/O events on the file descriptor, if `O_ASYNC` status flag is set
-    /// on this file.
-    pub fn set_owner(&mut self, owner: Option<&Arc<Process>>) -> Result<()> {
-        let Some(process) = owner else {
-            self.owner = None;
-            return Ok(());
-        };
-
-        let mut poller = PollAdaptor::with_observer(OwnerObserver::new(
-            self.file.clone(),
-            Arc::downgrade(process),
-        ));
-        self.file
-            .poll(IoEvents::IN | IoEvents::OUT, Some(poller.as_handle_mut()));
-
-        self.owner = Some((process.pid(), poller));
-
-        Ok(())
     }
 
     pub fn flags(&self) -> FdFlags {
@@ -378,7 +341,6 @@ impl Clone for FileTableEntry {
         Self {
             file: self.file.clone(),
             flags: AtomicU8::new(self.flags.load(Ordering::Relaxed)),
-            owner: None,
         }
     }
 }
@@ -387,26 +349,5 @@ bitflags! {
     pub struct FdFlags: u8 {
         /// Close on exec
         const CLOEXEC = 1;
-    }
-}
-
-type Owner = (Pid, PollAdaptor<OwnerObserver>);
-
-struct OwnerObserver {
-    file: Arc<dyn FileLike>,
-    owner: Weak<Process>,
-}
-
-impl OwnerObserver {
-    pub fn new(file: Arc<dyn FileLike>, owner: Weak<Process>) -> Self {
-        Self { file, owner }
-    }
-}
-
-impl Observer<IoEvents> for OwnerObserver {
-    fn on_events(&self, _events: &IoEvents) {
-        if self.file.status_flags().contains(StatusFlags::O_ASYNC) {
-            crate::process::enqueue_signal_async(self.owner.clone(), SIGIO);
-        }
     }
 }

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -2,7 +2,7 @@
 
 use core::fmt::Display;
 
-use super::{AccessMode, CreationFlags, FileLike, InodeMode};
+use super::{AccessMode, CreationFlags, FileCommon, FileLike, InodeMode, StatusFlags};
 use crate::{
     events::IoEvents,
     fs::{
@@ -26,7 +26,7 @@ use crate::{
 pub struct FsConfigFile {
     fs_type: &'static dyn FsType,
     state: Mutex<FsConfigState>,
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 enum FsConfigState {
@@ -52,6 +52,7 @@ struct CreatedFs {
 impl FsConfigFile {
     /// Creates a filesystem configuration file for a filesystem type.
     pub fn new(fs_type: &'static dyn FsType) -> Self {
+        let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string());
         Self {
             fs_type,
             state: Mutex::new(FsConfigState::Configuring(FsCreationConfig {
@@ -60,7 +61,7 @@ impl FsConfigFile {
                 mode: None,
                 extra_options: String::new(),
             })),
-            pseudo_path: AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string()),
+            common: FileCommon::new(pseudo_path, StatusFlags::empty()),
         }
     }
 
@@ -225,19 +226,20 @@ impl FileLike for FsConfigFile {
         AccessMode::O_RDWR
     }
 
-    fn path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
         struct FdInfo {
             access_mode: AccessMode,
+            status_flags: StatusFlags,
             fd_flags: FdFlags,
         }
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.access_mode as u32;
+                let mut flags = self.status_flags.bits() | self.access_mode as u32;
                 if self.fd_flags.contains(FdFlags::CLOEXEC) {
                     flags |= CreationFlags::O_CLOEXEC.bits();
                 }
@@ -251,6 +253,7 @@ impl FileLike for FsConfigFile {
 
         Box::new(FdInfo {
             access_mode: self.access_mode(),
+            status_flags: self.status_flags(),
             fd_flags,
         })
     }
@@ -259,14 +262,17 @@ impl FileLike for FsConfigFile {
 /// Represents a detached mount returned by `fsmount`.
 pub struct DetachedMountFile {
     mount: Arc<Mount>,
-    root_path: Path,
+    common: FileCommon,
 }
 
 impl DetachedMountFile {
     /// Creates a detached mount file.
     pub fn new(mount: Arc<Mount>) -> Self {
         let root_path = Path::new_fs_root(mount.clone());
-        Self { mount, root_path }
+        Self {
+            mount,
+            common: FileCommon::new(root_path, StatusFlags::empty()),
+        }
     }
 
     /// Returns the detached mount.
@@ -287,19 +293,20 @@ impl FileLike for DetachedMountFile {
         AccessMode::O_RDONLY
     }
 
-    fn path(&self) -> &Path {
-        &self.root_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
         struct FdInfo {
             access_mode: AccessMode,
+            status_flags: StatusFlags,
             fd_flags: FdFlags,
         }
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.access_mode as u32;
+                let mut flags = self.status_flags.bits() | self.access_mode as u32;
                 if self.fd_flags.contains(FdFlags::CLOEXEC) {
                     flags |= CreationFlags::O_CLOEXEC.bits();
                 }
@@ -313,6 +320,7 @@ impl FileLike for DetachedMountFile {
 
         Box::new(FdInfo {
             access_mode: self.access_mode(),
+            status_flags: self.status_flags(),
             fd_flags,
         })
     }

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -2,18 +2,17 @@
 
 //! Opened Inode-backed File Handle
 
-use core::{fmt::Display, sync::atomic::Ordering};
+use core::fmt::Display;
 
 use aster_rights::Rights;
 
 use super::{
-    AccessMode, AtomicStatusFlags, CreationFlags, FileLike, InodeType, Mappable, StatusFlags,
-    file_table::FdFlags, flock::FlockItem,
+    AccessMode, CreationFlags, FileCommon, FileLike, InodeType, Mappable, SettableStatusFlags,
+    StatusFlags, file_table::FdFlags, flock::FlockItem,
 };
 use crate::{
     events::IoEvents,
     fs::{
-        pipe::PipeHandle,
         utils::DirentVisitor,
         vfs::{
             inode::{FallocMode, FileOps},
@@ -28,13 +27,12 @@ use crate::{
 };
 
 pub struct InodeHandle {
-    path: Path,
+    common: FileCommon,
     /// `open_file` is similar to the `file_private` field in Linux's `file` structure. If
     /// `open_file` is `Some(_)`, typical file operations including `read`, `write`, `poll`,
     /// and `ioctl` will be provided by the per-open file object instead of `path`.
     open_file: Option<Box<dyn PerOpenFileOps>>,
     offset: Mutex<usize>,
-    status_flags: AtomicStatusFlags,
     rights: Rights,
 }
 
@@ -68,16 +66,15 @@ impl InodeHandle {
         };
 
         Ok(Self {
-            path,
+            common: FileCommon::new(path, status_flags),
             open_file,
             offset: Mutex::new(0),
-            status_flags: AtomicStatusFlags::new(status_flags),
             rights,
         })
     }
 
     pub fn path(&self) -> &Path {
-        &self.path
+        self.common.path()
     }
 
     pub fn offset(&self) -> usize {
@@ -95,7 +92,7 @@ impl InodeHandle {
             return (open_file.as_ref(), is_offset_aware);
         }
 
-        let inode = self.path.inode();
+        let inode = self.path().inode();
         let is_offset_aware = inode.type_().is_seekable();
         (inode.as_ref(), is_offset_aware)
     }
@@ -108,7 +105,7 @@ impl InodeHandle {
             return Ok(open_file.as_ref());
         }
 
-        let inode = self.path.inode();
+        let inode = self.path().inode();
         if !inode.type_().is_seekable() {
             return_errno_with_message!(
                 Errno::ESPIPE,
@@ -126,7 +123,7 @@ impl InodeHandle {
         let file_ops: &dyn FileOps = if let Some(ref open_file) = self.open_file {
             open_file.as_ref()
         } else {
-            self.path.inode().as_ref()
+            self.path().inode().as_ref()
         };
         let mut offset = self.offset.lock();
         let read_cnt = file_ops.readdir_at(*offset, visitor)?;
@@ -140,7 +137,7 @@ impl InodeHandle {
         }
 
         let Some(range_lock_list) = self
-            .path
+            .path()
             .inode()
             .fs_lock_context()
             .map(|c| c.range_lock_list())
@@ -179,7 +176,7 @@ impl InodeHandle {
         }
 
         let range_lock_list = self
-            .path
+            .path()
             .inode()
             .fs_lock_context_or_init()
             .range_lock_list();
@@ -196,7 +193,7 @@ impl InodeHandle {
 
     fn unlock_range_lock(&self, lock: &RangeLockItem) {
         if let Some(range_lock_list) = self
-            .path
+            .path()
             .inode()
             .fs_lock_context()
             .map(|c| c.range_lock_list())
@@ -210,7 +207,7 @@ impl InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
 
-        let flock_list = self.path.inode().fs_lock_context_or_init().flock_list();
+        let flock_list = self.path().inode().fs_lock_context_or_init().flock_list();
         flock_list.set_lock(lock, is_nonblocking)
     }
 
@@ -219,7 +216,12 @@ impl InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
 
-        if let Some(flock_list) = self.path.inode().fs_lock_context().map(|c| c.flock_list()) {
+        if let Some(flock_list) = self
+            .path()
+            .inode()
+            .fs_lock_context()
+            .map(|c| c.flock_list())
+        {
             flock_list.unlock(self);
         }
 
@@ -293,7 +295,7 @@ impl FileLike for InodeHandle {
         if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {
             // FIXME: `O_APPEND` should ensure that new content is appended even if another process
             // is writing to the file concurrently.
-            *offset = self.path.size();
+            *offset = self.path().size();
         }
 
         let len = file_ops.write_at(*offset, reader, status_flags)?;
@@ -326,7 +328,7 @@ impl FileLike for InodeHandle {
             // If the file has the `O_APPEND` flag, the offset is ignored.
             // FIXME: `O_APPEND` should ensure that new content is appended even if another process
             // is writing to the file concurrently.
-            offset = self.path.size();
+            offset = self.path().size();
         }
 
         file_ops.write_at(offset, reader, status_flags)
@@ -349,7 +351,7 @@ impl FileLike for InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
 
-        let inode = self.path.inode();
+        let inode = self.path().inode();
         if let Some(ref page_cache) = inode.page_cache() {
             // If the inode has a page cache, it is a file-backed mapping and
             // we return the VMO as the mappable object.
@@ -375,29 +377,20 @@ impl FileLike for InodeHandle {
             // FIXME: It's allowed to `ftruncate` an append-only file on Linux.
             return_errno_with_message!(Errno::EPERM, "can not resize append-only file");
         }
-        self.path.inode().resize(new_size)
+        self.path().inode().resize(new_size)
     }
 
-    fn status_flags(&self) -> StatusFlags {
-        self.status_flags.load(Ordering::Relaxed)
-    }
-
-    fn set_status_flags(&self, new_status_flags: StatusFlags) -> Result<()> {
-        // TODO: Pipes currently require a special status flag check because
-        // "packet" mode is not yet supported. Remove this check once "packet"
-        // mode is implemented.
-        if self
-            .open_file
-            .as_ref()
-            .and_then(|open_file| (open_file.as_ref() as &dyn Any).downcast_ref::<PipeHandle>())
-            .is_some()
-        {
-            crate::fs::pipe::check_status_flags(new_status_flags)?;
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        if let Some(ref open_file) = self.open_file {
+            return open_file.settable_status_flags();
         }
 
-        self.status_flags.store(new_status_flags, Ordering::Relaxed);
-
-        Ok(())
+        if self.path().inode().type_().is_regular_file() {
+            // FIXME: This operation should depend on whether the underlying filesystem supports `O_DIRECT`.
+            SettableStatusFlags::minimal().with_o_direct()
+        } else {
+            SettableStatusFlags::minimal()
+        }
     }
 
     fn access_mode(&self) -> AccessMode {
@@ -418,7 +411,7 @@ impl FileLike for InodeHandle {
             }
         }
 
-        let inode = self.path.inode();
+        let inode = self.path().inode();
         if !inode.type_().is_seekable() {
             return_errno_with_message!(Errno::ESPIPE, "seek is not supported");
         }
@@ -430,7 +423,7 @@ impl FileLike for InodeHandle {
             return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
         }
 
-        let inode = self.path.inode().as_ref();
+        let inode = self.path().inode().as_ref();
         let inode_type = inode.type_();
 
         // TODO: `fallocate` on pipe files also fails with `ESPIPE`.
@@ -467,8 +460,8 @@ impl FileLike for InodeHandle {
         inode.fallocate(mode, offset, len)
     }
 
-    fn path(&self) -> &Path {
-        &self.path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
@@ -486,8 +479,8 @@ impl FileLike for InodeHandle {
 
                 writeln!(f, "pos:\t{}", self.inner.offset())?;
                 writeln!(f, "flags:\t0{:o}", flags)?;
-                writeln!(f, "mnt_id:\t{}", self.inner.path.mount_node().id())?;
-                writeln!(f, "ino:\t{}", self.inner.path.inode().ino())
+                writeln!(f, "mnt_id:\t{}", self.inner.path().mount_node().id())?;
+                writeln!(f, "ino:\t{}", self.inner.path().inode().ino())
             }
         }
 
@@ -508,7 +501,7 @@ impl Drop for InodeHandle {
 impl Debug for InodeHandle {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("InodeHandle")
-            .field("path", &self.path)
+            .field("path", &self.path())
             .field("offset", &self.offset())
             .field("status_flags", &self.status_flags())
             .field("rights", &self.rights)
@@ -568,6 +561,13 @@ pub trait PerOpenFileOps: Pollable + FileOps + Any + Send + Sync + 'static {
 
     fn ioctl(&self, _raw_ioctl: RawIoctl) -> Result<i32> {
         return_errno_with_message!(Errno::ENOTTY, "ioctl is not supported");
+    }
+
+    /// Returns the status flags that can be set for this opened file.
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        // `O_ASYNC` and `O_DIRECT` can only be set on file descriptions that explicitly
+        // support them.
+        SettableStatusFlags::minimal()
     }
 }
 

--- a/kernel/src/fs/file/mod.rs
+++ b/kernel/src/fs/file/mod.rs
@@ -3,6 +3,7 @@
 //! File-level abstractions and management.
 
 mod file_attr;
+mod file_common;
 mod file_handle;
 pub mod file_table;
 pub mod flock;
@@ -14,9 +15,10 @@ pub use file_attr::{
     access_mode::AccessMode,
     creation_flags::CreationFlags,
     open_args::OpenArgs,
-    status_flags::{AtomicStatusFlags, StatusFlags},
+    status_flags::{AtomicStatusFlags, SettableStatusFlags, StatusFlags},
 };
-pub use file_handle::{FileLike, Mappable};
+pub use file_common::FileCommon;
+pub use file_handle::{FileLike, Mappable, StatusFlagsUpdate};
 pub use fs_config_file::{DetachedMountFile, FsConfigFile};
 pub(crate) use inode_attr::mode::{
     chmod, mkmod, perms_to_mask, who_and_perms_to_mask, who_to_mask,

--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -10,7 +10,7 @@ use ostd::sync::WaitQueue;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, PerOpenFileOps, StatusFlags},
+        file::{AccessMode, PerOpenFileOps, SettableStatusFlags, StatusFlags},
         utils::{Endpoint, EndpointState},
         vfs::inode::FileOps,
     },
@@ -157,6 +157,11 @@ impl PerOpenFileOps for PipeHandle {
             }
             _ => return_errno_with_message!(Errno::ENOTTY, "the ioctl command is unknown"),
         })
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        // TODO: Support "packet" mode for pipes then `O_DIRECT` can be supported.
+        SettableStatusFlags::minimal().with_o_async()
     }
 }
 

--- a/kernel/src/fs/pipe/mod.rs
+++ b/kernel/src/fs/pipe/mod.rs
@@ -6,7 +6,7 @@
 
 pub(super) use anon_pipe::AnonPipeInode;
 pub use anon_pipe::new_file_pair;
-pub(super) use common::{Pipe, PipeHandle, check_status_flags};
+pub(super) use common::Pipe;
 
 mod anon_pipe;
 mod common;

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -12,7 +12,10 @@ use hashbrown::HashMap;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{
+            AccessMode, CreationFlags, FileCommon, FileLike, SettableStatusFlags, StatusFlags,
+            file_table::FdFlags,
+        },
         pseudofs::AnonInodeFs,
         vfs::{
             inode::{FallocMode, Inode},
@@ -43,18 +46,16 @@ pub struct InotifyFile {
     watch_map: SpinLock<HashMap<u32, SubscriberEntry>>,
     // A mutex to synchronize `read()` operations.
     read_mutex: Mutex<()>,
-    // Whether the file is opened in non-blocking mode.
-    is_nonblocking: AtomicBool,
     // A bounded queue of inotify events.
     event_queue: SpinLock<VecDeque<InotifyEvent>>,
     // The maximum capacity of the event queue.
     queue_capacity: usize,
     // A pollable object for this inotify file.
     pollee: Pollee,
+    // The common state for this inotify file.
+    common: FileCommon,
     // A weak reference to this inotify file.
     this: Weak<InotifyFile>,
-    /// The pseudo path associated with this inotify file.
-    pseudo_path: Path,
 }
 
 impl Drop for InotifyFile {
@@ -91,6 +92,11 @@ impl InotifyFile {
     /// Creates a new inotify file.
     pub fn new(is_nonblocking: bool) -> Result<Arc<Self>> {
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:inotify".to_string());
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
 
         Ok(Arc::new_cyclic(|weak_self| Self {
             // Allocate watch descriptors from 1.
@@ -98,12 +104,11 @@ impl InotifyFile {
             next_wd: AtomicU32::new(1),
             watch_map: SpinLock::new(HashMap::new()),
             read_mutex: Mutex::new(()),
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             event_queue: SpinLock::new(VecDeque::new()),
             queue_capacity: DEFAULT_MAX_QUEUED_EVENTS,
             pollee: Pollee::new(),
+            common: FileCommon::new(pseudo_path, status_flags),
             this: weak_self.clone(),
-            pseudo_path,
         }))
     }
 
@@ -324,7 +329,7 @@ impl Pollable for InotifyFile {
 
 impl FileLike for InotifyFile {
     fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        if self.is_nonblocking.load(Ordering::Relaxed) {
+        if self.common.is_nonblocking() {
             self.try_read(writer)
         } else {
             self.wait_events(IoEvents::IN, None, || self.try_read(writer))
@@ -345,24 +350,12 @@ impl FileLike for InotifyFile {
         })
     }
 
-    fn status_flags(&self) -> StatusFlags {
-        if self.is_nonblocking.load(Ordering::Relaxed) {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        }
-    }
-
-    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
-        self.is_nonblocking.store(
-            new_flags.contains(StatusFlags::O_NONBLOCK),
-            Ordering::Relaxed,
-        );
-        Ok(())
-    }
-
     fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
         return_errno_with_message!(Errno::EBADF, "inotify file is not opened writable");
+    }
+
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_async()
     }
 
     fn access_mode(&self) -> AccessMode {
@@ -370,8 +363,8 @@ impl FileLike for InotifyFile {
         AccessMode::O_RDONLY
     }
 
-    fn path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use aster_bigtcp::wire::IpEndpoint;
 use bound::BoundDatagram;
 use unbound::{BindOptions, UnboundDatagram};
@@ -9,7 +7,10 @@ use unbound::{BindOptions, UnboundDatagram};
 use super::addr::UNSPECIFIED_LOCAL_ENDPOINT;
 use crate::{
     events::IoEvents,
-    fs::{pseudofs::SockFs, vfs::path::Path},
+    fs::{
+        file::{FileCommon, StatusFlags},
+        pseudofs::SockFs,
+    },
     net::{
         iface::is_broadcast_endpoint,
         socket::{
@@ -41,9 +42,8 @@ pub struct DatagramSocket {
     options: RwLock<OptionSet>,
     timeouts: SocketTimeouts,
 
-    is_nonblocking: AtomicBool,
     pollee: Pollee,
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 #[derive(Clone, Debug)]
@@ -64,13 +64,17 @@ impl OptionSet {
 impl DatagramSocket {
     pub fn new(is_nonblocking: bool) -> Arc<Self> {
         let unbound_datagram = UnboundDatagram::new();
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Arc::new(Self {
             inner: RwMutex::new(Inner::Unbound(unbound_datagram)),
             options: RwLock::new(OptionSet::new()),
             timeouts: SocketTimeouts::new(),
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         })
     }
 
@@ -132,11 +136,7 @@ impl Pollable for DatagramSocket {
 
 impl SocketPrivate for DatagramSocket {
     fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
-    }
-
-    fn set_nonblocking(&self, is_nonblocking: bool) {
-        self.is_nonblocking.store(is_nonblocking, Ordering::Relaxed);
+        self.common.is_nonblocking()
     }
 }
 
@@ -304,8 +304,8 @@ impl Socket for DatagramSocket {
         Ok(())
     }
 
-    fn pseudo_path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 }
 

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use aster_bigtcp::{
     socket::{NeedIfacePoll, RawTcpOption, RawTcpSetOption},
     time::Duration,
@@ -26,7 +24,10 @@ use super::{
 };
 use crate::{
     events::IoEvents,
-    fs::{file::FileLike, pseudofs::SockFs, vfs::path::Path},
+    fs::{
+        file::{FileCommon, FileLike, StatusFlags},
+        pseudofs::SockFs,
+    },
     net::{
         iface::Iface,
         socket::{
@@ -65,9 +66,8 @@ pub struct StreamSocket {
     options: RwLock<OptionSet>,
     timeouts: SocketTimeouts,
 
-    is_nonblocking: AtomicBool,
     pollee: Pollee,
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 enum State {
@@ -109,13 +109,17 @@ impl OptionSet {
 impl StreamSocket {
     pub fn new(is_nonblocking: bool, family: IpAddressFamily) -> Arc<Self> {
         let init_stream = InitStream::new(family);
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Init(init_stream))),
             options: RwLock::new(OptionSet::new()),
             timeouts: SocketTimeouts::new(),
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         })
     }
 
@@ -448,11 +452,7 @@ impl Pollable for StreamSocket {
 
 impl SocketPrivate for StreamSocket {
     fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
-    }
-
-    fn set_nonblocking(&self, nonblocking: bool) {
-        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
+        self.common.is_nonblocking()
     }
 }
 
@@ -765,8 +765,8 @@ impl Socket for StreamSocket {
         Ok(())
     }
 
-    fn pseudo_path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 }
 

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -127,6 +127,7 @@ impl StreamSocket {
         connected_stream: ConnectedStream,
         listener_options: &OptionSet,
         listener_timeouts: &SocketTimeouts,
+        is_nonblocking: bool,
     ) -> Arc<Self> {
         let options = connected_stream.raw_with(|raw_tcp_socket| {
             let mut options = OptionSet::new();
@@ -162,13 +163,18 @@ impl StreamSocket {
         let pollee = Pollee::new();
         connected_stream.init_observer(StreamObserver::new(pollee.clone()));
 
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
+
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
             options: RwLock::new(options),
             timeouts: listener_timeouts.clone(),
-            is_nonblocking: AtomicBool::new(false),
             pollee,
-            pseudo_path: SockFs::new_path(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         })
     }
 
@@ -325,7 +331,7 @@ impl StreamSocket {
         }
     }
 
-    fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+    fn try_accept(&self, is_nonblocking: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         let state = self.read_updated_state();
 
         let State::Listen(listen_stream) = state.as_ref() else {
@@ -335,8 +341,12 @@ impl StreamSocket {
         let accepted = listen_stream.try_accept().map(|connected_stream| {
             let remote_endpoint = connected_stream.remote_endpoint();
             let listener_options = self.options.read();
-            let accepted_socket =
-                Self::new_accepted(connected_stream, &listener_options, &self.timeouts);
+            let accepted_socket = Self::new_accepted(
+                connected_stream,
+                &listener_options,
+                &self.timeouts,
+                is_nonblocking,
+            );
             (accepted_socket as _, remote_endpoint.into())
         });
         let iface_to_poll = listen_stream.iface().clone();
@@ -525,9 +535,9 @@ impl Socket for StreamSocket {
         })
     }
 
-    fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+    fn accept(&self, is_nonblocking: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
-            self.try_accept()
+            self.try_accept(is_nonblocking)
         })
     }
 

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -7,9 +7,11 @@ use util::{MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr};
 
 use crate::{
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{
+            AccessMode, CreationFlags, FileCommon, FileLike, SettableStatusFlags,
+            file_table::FdFlags,
+        },
         pseudofs::SockFs,
-        vfs::path::Path,
     },
     prelude::*,
     util::{MultiRead, MultiWrite},
@@ -34,9 +36,6 @@ mod private {
     pub trait SocketPrivate: Pollable {
         /// Returns whether the socket is in non-blocking mode.
         fn is_nonblocking(&self) -> bool;
-
-        /// Sets whether the socket is in non-blocking mode.
-        fn set_nonblocking(&self, nonblocking: bool);
 
         /// Blocks until some events occur to complete I/O operations.
         ///
@@ -138,8 +137,8 @@ pub trait Socket: private::SocketPrivate + Send + Sync {
         flags: SendRecvFlags,
     ) -> Result<(usize, MessageHeader)>;
 
-    /// Returns a reference to the pseudo path associated with this socket.
-    fn pseudo_path(&self) -> &Path;
+    /// Returns the common state for this socket.
+    fn common(&self) -> &FileCommon;
 }
 
 impl<T: Socket + 'static> FileLike for T {
@@ -163,23 +162,8 @@ impl<T: Socket + 'static> FileLike for T {
         )
     }
 
-    fn status_flags(&self) -> StatusFlags {
-        // TODO: Support other flags (e.g., `O_ASYNC`)
-        if self.is_nonblocking() {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        }
-    }
-
-    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
-        // TODO: Support other flags (e.g., `O_ASYNC`)
-        if new_flags.contains(StatusFlags::O_NONBLOCK) {
-            self.set_nonblocking(true);
-        } else {
-            self.set_nonblocking(false);
-        }
-        Ok(())
+    fn settable_status_flags(&self) -> SettableStatusFlags {
+        SettableStatusFlags::minimal().with_o_async()
     }
 
     fn access_mode(&self) -> AccessMode {
@@ -191,8 +175,8 @@ impl<T: Socket + 'static> FileLike for T {
         Some(self)
     }
 
-    fn path(&self) -> &Path {
-        self.pseudo_path()
+    fn common(&self) -> &FileCommon {
+        Socket::common(self)
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
@@ -217,7 +201,7 @@ impl<T: Socket + 'static> FileLike for T {
 
         Box::new(FdInfo {
             flags,
-            ino: self.pseudo_path().inode().ino(),
+            ino: self.common().path().inode().ino(),
         })
     }
 }

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -87,7 +87,7 @@ pub trait Socket: private::SocketPrivate + Send + Sync {
     }
 
     /// Accepts a connection on the socket.
-    fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+    fn accept(&self, _is_nonblocking: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "accept() is not supported");
     }
 

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 pub(super) use bound::BoundNetlink;
 use unbound::UnboundNetlink;
 
 use super::{GroupIdSet, NetlinkSocketAddr};
 use crate::{
     events::IoEvents,
-    fs::{pseudofs::SockFs, vfs::path::Path},
+    fs::{
+        file::{FileCommon, StatusFlags},
+        pseudofs::SockFs,
+    },
     net::socket::{
         Socket,
         netlink::{AddMembership, DropMembership, table::SupportedNetlinkProtocol},
@@ -39,9 +40,8 @@ pub struct NetlinkSocket<P: SupportedNetlinkProtocol> {
     socket_type: SockType,
     timeouts: SocketTimeouts,
 
-    is_nonblocking: AtomicBool,
     pollee: Pollee,
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 #[derive(Clone, Debug)]
@@ -65,14 +65,18 @@ where
         debug_assert!(socket_type == SockType::SOCK_RAW || socket_type == SockType::SOCK_DGRAM);
 
         let unbound = UnboundNetlink::new();
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Arc::new(Self {
             inner: RwMutex::new(Inner::Unbound(unbound)),
             options: RwLock::new(OptionSet::new()),
             socket_type,
             timeouts: SocketTimeouts::new(),
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         })
     }
 
@@ -237,8 +241,8 @@ where
         do_netlink_setsockopt(option, &mut inner)
     }
 
-    fn pseudo_path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 }
 
@@ -247,11 +251,7 @@ where
     BoundNetlink<P::Message>: Bound<Endpoint = NetlinkSocketAddr>,
 {
     fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
-    }
-
-    fn set_nonblocking(&self, nonblocking: bool) {
-        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
+        self.common.is_nonblocking()
     }
 }
 

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -10,7 +10,10 @@ use aster_rights::ReadDupOp;
 use super::message::{MessageQueue, MessageReceiver};
 use crate::{
     events::IoEvents,
-    fs::{pseudofs::SockFs, vfs::path::Path},
+    fs::{
+        file::{FileCommon, StatusFlags},
+        pseudofs::SockFs,
+    },
     net::socket::{
         Socket,
         options::{Error as SocketError, PeerCred, SocketOption, macros::sock_option_mut},
@@ -38,9 +41,8 @@ pub struct UnixDatagramSocket {
     // when a socket pair is created using the `socketpair` system call.
     peer_cred: Option<SocketCred>,
 
-    is_nonblocking: AtomicBool,
     is_write_shutdown: AtomicBool,
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 #[derive(Clone, Debug)]
@@ -79,15 +81,19 @@ impl UnixDatagramSocket {
     }
 
     fn new_raw(is_nonblocking: bool) -> Self {
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Self {
             local_receiver: MessageReceiver::new(),
             remote_queue: RwLock::new(None),
             options: RwLock::new(OptionSet::new()),
             timeouts: SocketTimeouts::new(),
             peer_cred: None,
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             is_write_shutdown: AtomicBool::new(false),
-            pseudo_path: SockFs::new_path(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         }
     }
 
@@ -162,11 +168,7 @@ impl Pollable for UnixDatagramSocket {
 
 impl SocketPrivate for UnixDatagramSocket {
     fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
-    }
-
-    fn set_nonblocking(&self, nonblocking: bool) {
-        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
+        self.common.is_nonblocking()
     }
 }
 
@@ -322,8 +324,8 @@ impl Socket for UnixDatagramSocket {
         Ok((received_bytes, message_header))
     }
 
-    fn pseudo_path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 }
 

--- a/kernel/src/net/socket/unix/stream/listener.rs
+++ b/kernel/src/net/socket/unix/stream/listener.rs
@@ -62,6 +62,7 @@ impl Listener {
     pub(super) fn try_accept(
         &self,
         socket_type: SockType,
+        is_nonblocking: bool,
     ) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         debug_assert!(
             socket_type == SockType::SOCK_STREAM || socket_type == SockType::SOCK_SEQPACKET
@@ -72,7 +73,8 @@ impl Listener {
         let peer_addr = connected.peer_addr().into();
         let options = OptionSet::new_accepted(connected.is_pass_cred());
 
-        let socket = UnixStreamSocket::new_connected(connected, options, false, socket_type);
+        let socket =
+            UnixStreamSocket::new_connected(connected, options, is_nonblocking, socket_type);
         Ok((socket, peer_addr))
     }
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use aster_rights::ReadDupOp;
 use takeable::Takeable;
 
@@ -12,7 +10,11 @@ use super::{
 };
 use crate::{
     events::IoEvents,
-    fs::{file::FileLike, pseudofs::SockFs, utils::EndpointState, vfs::path::Path},
+    fs::{
+        file::{FileCommon, FileLike, StatusFlags},
+        pseudofs::SockFs,
+        utils::EndpointState,
+    },
     net::socket::{
         Socket,
         options::{
@@ -41,11 +43,9 @@ pub struct UnixStreamSocket {
     options: RwLock<OptionSet>,
     timeouts: SocketTimeouts,
 
-    pollee: Pollee,
-    is_nonblocking: AtomicBool,
-
     socket_type: SockType,
-    pseudo_path: Path,
+    pollee: Pollee,
+    common: FileCommon,
 }
 
 enum State {
@@ -175,14 +175,18 @@ impl UnixStreamSocket {
     }
 
     fn new_init(init: Init, is_nonblocking: bool, socket_type: SockType) -> Arc<Self> {
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Arc::new(Self {
             state: RwMutex::new(Takeable::new(State::Init(init))),
             options: RwLock::new(OptionSet::new()),
             timeouts: SocketTimeouts::new(),
-            pollee: Pollee::new(),
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             socket_type,
-            pseudo_path: SockFs::new_path(),
+            pollee: Pollee::new(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         })
     }
 
@@ -214,14 +218,18 @@ impl UnixStreamSocket {
         socket_type: SockType,
     ) -> Arc<Self> {
         let cloned_pollee = connected.cloned_pollee();
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Arc::new(Self {
             state: RwMutex::new(Takeable::new(State::Connected(connected))),
             options: RwLock::new(options),
             timeouts: SocketTimeouts::new(),
-            pollee: cloned_pollee,
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             socket_type,
-            pseudo_path: SockFs::new_path(),
+            pollee: cloned_pollee,
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         })
     }
 
@@ -319,11 +327,7 @@ impl Pollable for UnixStreamSocket {
 
 impl SocketPrivate for UnixStreamSocket {
     fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
-    }
-
-    fn set_nonblocking(&self, nonblocking: bool) {
-        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
+        self.common.is_nonblocking()
     }
 }
 
@@ -541,8 +545,8 @@ impl Socket for UnixStreamSocket {
         Ok((received_bytes, message_header))
     }
 
-    fn pseudo_path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 }
 

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -300,9 +300,9 @@ impl UnixStreamSocket {
         })
     }
 
-    fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+    fn try_accept(&self, is_nonblocking: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         match self.state.read().as_ref() {
-            State::Listen(listen) => listen.try_accept(self.socket_type) as _,
+            State::Listen(listen) => listen.try_accept(self.socket_type, is_nonblocking) as _,
             State::Init(_) | State::Connected(_) => {
                 return_errno_with_message!(Errno::EINVAL, "the socket is not listening")
             }
@@ -397,9 +397,9 @@ impl Socket for UnixStreamSocket {
         })
     }
 
-    fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+    fn accept(&self, is_nonblocking: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         self.block_on(IoEvents::IN, self.timeouts.recv_timeout(), || {
-            self.try_accept()
+            self.try_accept(is_nonblocking)
         })
     }
 

--- a/kernel/src/net/socket/vsock/stream/mod.rs
+++ b/kernel/src/net/socket/vsock/stream/mod.rs
@@ -5,8 +5,6 @@ mod connecting;
 mod init;
 mod listen;
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use connected::ConnectedStream;
 use connecting::{ConnResult, ConnectingStream};
 use init::InitStream;
@@ -15,7 +13,10 @@ use takeable::Takeable;
 
 use crate::{
     events::IoEvents,
-    fs::{file::FileLike, pseudofs::SockFs, vfs::path::Path},
+    fs::{
+        file::{FileCommon, FileLike, StatusFlags},
+        pseudofs::SockFs,
+    },
     net::socket::{
         Socket,
         options::{Error as SocketError, SocketOption, macros::sock_option_mut},
@@ -30,11 +31,10 @@ use crate::{
 
 pub struct VsockStreamSocket {
     state: Mutex<Takeable<State>>,
-    is_nonblocking: AtomicBool,
     // Note that for vsock, all pollee notifications and invalidations live in the transport module
     // (e.g., `super::transport`) rather than in this module.
     pollee: Pollee,
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 enum State {
@@ -46,11 +46,15 @@ enum State {
 
 impl VsockStreamSocket {
     pub fn new(is_nonblocking: bool) -> Result<Arc<Self>> {
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Ok(Arc::new(Self {
             state: Mutex::new(Takeable::new(State::Init(InitStream::new()))),
-            is_nonblocking: AtomicBool::new(is_nonblocking),
             pollee: Pollee::new(),
-            pseudo_path: SockFs::new_path(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         }))
     }
 
@@ -237,11 +241,7 @@ impl Pollable for VsockStreamSocket {
 
 impl SocketPrivate for VsockStreamSocket {
     fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
-    }
-
-    fn set_nonblocking(&self, nonblocking: bool) {
-        self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
+        self.common.is_nonblocking()
     }
 }
 
@@ -422,7 +422,7 @@ impl Socket for VsockStreamSocket {
         Ok((received_bytes, message_header))
     }
 
-    fn pseudo_path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 }

--- a/kernel/src/net/socket/vsock/stream/mod.rs
+++ b/kernel/src/net/socket/vsock/stream/mod.rs
@@ -140,7 +140,7 @@ impl VsockStreamSocket {
         }
     }
 
-    fn try_accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+    fn try_accept(&self, is_nonblocking: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
         let state = self.lock_updated_state();
         let State::Listen(listen_stream) = state.as_ref() else {
             return_errno_with_message!(Errno::EINVAL, "the socket is not listening");
@@ -150,12 +150,16 @@ impl VsockStreamSocket {
 
         let peer_addr = connected.remote_addr().into();
         let pollee = connected.pollee().clone();
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
 
         let accepted = Arc::new(Self {
             state: Mutex::new(Takeable::new(State::Connected(connected))),
-            is_nonblocking: AtomicBool::new(false),
             pollee,
-            pseudo_path: SockFs::new_path(),
+            common: FileCommon::new(SockFs::new_path(), status_flags),
         });
 
         Ok((accepted, peer_addr))
@@ -300,8 +304,8 @@ impl Socket for VsockStreamSocket {
         // The pollee should have already been invalidated in the transport module.
     }
 
-    fn accept(&self) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
-        self.block_on(IoEvents::IN, None, || self.try_accept())
+    fn accept(&self, is_nonblocking: bool) -> Result<(Arc<dyn FileLike>, SocketAddr)> {
+        self.block_on(IoEvents::IN, None, || self.try_accept(is_nonblocking))
     }
 
     fn shutdown(&self, cmd: SockShutdownCmd) -> Result<()> {

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{
-    fmt::Display,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use core::fmt::Display;
 
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::PidfdFs,
-        vfs::path::Path,
     },
     prelude::*,
     process::{
@@ -21,9 +17,7 @@ use crate::{
 
 pub struct PidFile {
     process: Weak<Process>,
-    is_nonblocking: AtomicBool,
-    /// The pseudo path associated with this pid file.
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 impl Debug for PidFile {
@@ -31,10 +25,7 @@ impl Debug for PidFile {
         let pid = self.process.upgrade().map_or(u32::MAX, |p| p.pid());
         f.debug_struct("PidFile")
             .field("process", &pid)
-            .field(
-                "is_nonblocking",
-                &self.is_nonblocking.load(Ordering::Relaxed),
-            )
+            .field("is_nonblocking", &self.common.is_nonblocking())
             .finish_non_exhaustive()
     }
 }
@@ -42,11 +33,15 @@ impl Debug for PidFile {
 impl PidFile {
     pub fn new(process: Arc<Process>, is_nonblocking: bool) -> Self {
         let pseudo_path = PidfdFs::new_path(|_| "anon_inode:[pidfd]".to_string());
+        let status_flags = if is_nonblocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
 
         Self {
             process: Arc::downgrade(&process),
-            is_nonblocking: AtomicBool::new(is_nonblocking),
-            pseudo_path,
+            common: FileCommon::new(pseudo_path, status_flags),
         }
     }
 
@@ -67,7 +62,7 @@ impl PidFile {
     }
 
     pub(super) fn is_nonblocking(&self) -> bool {
-        self.is_nonblocking.load(Ordering::Relaxed)
+        self.common.is_nonblocking()
     }
 
     pub fn process_opt(&self) -> Option<Arc<Process>> {
@@ -90,31 +85,13 @@ impl FileLike for PidFile {
         );
     }
 
-    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
-        if new_flags.contains(StatusFlags::O_NONBLOCK) {
-            self.is_nonblocking.store(true, Ordering::Relaxed);
-        } else {
-            self.is_nonblocking.store(false, Ordering::Relaxed);
-        }
-
-        Ok(())
-    }
-
-    fn status_flags(&self) -> StatusFlags {
-        if self.is_nonblocking() {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        }
-    }
-
     fn access_mode(&self) -> AccessMode {
         // Reference: <https://elixir.bootlin.com/linux/v7.0/source/kernel/fork.c#L1898>.
         AccessMode::O_RDWR
     }
 
-    fn path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -50,17 +50,17 @@ fn do_accept(
     let file = get_file_fast!(&mut file_table, sockfd.try_into()?);
     let socket = file.as_socket_or_err()?;
 
-    let (connected_socket, socket_addr) = {
-        socket.accept().map_err(|err| match err.error() {
-            // FIXME: `accept` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-            _ => err,
-        })?
-    };
+    let is_nonblocking = flags.contains(Flags::SOCK_NONBLOCK);
 
-    if flags.contains(Flags::SOCK_NONBLOCK) {
-        connected_socket.set_status_flags(StatusFlags::O_NONBLOCK)?;
-    }
+    let (connected_socket, socket_addr) = {
+        socket
+            .accept(is_nonblocking)
+            .map_err(|err| match err.error() {
+                // FIXME: `accept` should not be restarted if a timeout has been set on the socket using `setsockopt`.
+                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
+                _ => err,
+            })?
+    };
 
     let fd_flags = if flags.contains(Flags::SOCK_CLOEXEC) {
         FdFlags::CLOEXEC

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -69,7 +69,7 @@ bitflags! {
 struct EventFile {
     counter: Mutex<u64>,
     pollee: Pollee,
-    flags: Mutex<Flags>,
+    is_semaphore: bool,
     common: FileCommon,
     write_wait_queue: WaitQueue,
 }
@@ -82,6 +82,7 @@ impl EventFile {
         let pollee = Pollee::new();
         let write_wait_queue = WaitQueue::new();
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[eventfd]".to_string());
+        let is_semaphore = flags.contains(Flags::EFD_SEMAPHORE);
         let status_flags = if flags.contains(Flags::EFD_NONBLOCK) {
             StatusFlags::O_NONBLOCK
         } else {
@@ -90,14 +91,14 @@ impl EventFile {
         Self {
             counter,
             pollee,
-            flags: Mutex::new(flags),
+            is_semaphore,
             common: FileCommon::new(pseudo_path, status_flags),
             write_wait_queue,
         }
     }
 
     fn is_nonblocking(&self) -> bool {
-        self.flags.lock().contains(Flags::EFD_NONBLOCK)
+        self.common.is_nonblocking()
     }
 
     fn check_io_events(&self) -> IoEvents {
@@ -129,7 +130,7 @@ impl EventFile {
         }
 
         // Copy the value from the counter and set the new counter value
-        if self.flags.lock().contains(Flags::EFD_SEMAPHORE) {
+        if self.is_semaphore {
             writer.write_fallible(&mut 1u64.as_bytes().into())?;
             *counter -= 1;
         } else {

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -22,9 +22,8 @@ use super::SyscallReturn;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::AnonInodeFs,
-        vfs::path::Path,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
@@ -71,9 +70,8 @@ struct EventFile {
     counter: Mutex<u64>,
     pollee: Pollee,
     flags: Mutex<Flags>,
+    common: FileCommon,
     write_wait_queue: WaitQueue,
-    /// The pseudo path associated with this eventfd file.
-    pseudo_path: Path,
 }
 
 impl EventFile {
@@ -84,12 +82,17 @@ impl EventFile {
         let pollee = Pollee::new();
         let write_wait_queue = WaitQueue::new();
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[eventfd]".to_string());
+        let status_flags = if flags.contains(Flags::EFD_NONBLOCK) {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
         Self {
             counter,
             pollee,
             flags: Mutex::new(flags),
+            common: FileCommon::new(pseudo_path, status_flags),
             write_wait_queue,
-            pseudo_path,
         }
     }
 
@@ -209,35 +212,13 @@ impl FileLike for EventFile {
         Ok(write_len)
     }
 
-    fn status_flags(&self) -> StatusFlags {
-        if self.is_nonblocking() {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        }
-    }
-
-    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
-        let mut flags = self.flags.lock();
-
-        if new_flags.contains(StatusFlags::O_NONBLOCK) {
-            *flags |= Flags::EFD_NONBLOCK;
-        } else {
-            *flags &= !Flags::EFD_NONBLOCK;
-        }
-
-        // TODO: Deal with other flags
-
-        Ok(())
-    }
-
     fn access_mode(&self) -> AccessMode {
         // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L401>.
         AccessMode::O_RDWR
     }
 
-    fn path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -6,7 +6,7 @@ use super::SyscallReturn;
 use crate::{
     fs::{
         file::{
-            FileLike, StatusFlags,
+            FileLike, StatusFlags, StatusFlagsUpdate,
             file_table::{FdFlags, FileDesc, RawFileDesc, WithFileTable, get_file_fast},
         },
         ramfs::memfd::{FileSeals, MemfdInodeHandle},
@@ -83,15 +83,8 @@ fn handle_getfl(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
 fn handle_setfl(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
-    let valid_flags_mask = StatusFlags::O_APPEND
-        | StatusFlags::O_ASYNC
-        | StatusFlags::O_DIRECT
-        | StatusFlags::O_NOATIME
-        | StatusFlags::O_NONBLOCK;
-    let mut status_flags = file.status_flags();
-    status_flags.remove(valid_flags_mask);
-    status_flags.insert(StatusFlags::from_bits_truncate(arg as _) & valid_flags_mask);
-    file.set_status_flags(status_flags)?;
+    let new_flags = StatusFlags::from_bits_truncate(arg as _);
+    file.update_status_flags(StatusFlagsUpdate::replace(new_flags))?;
     Ok(SyscallReturn::Return(0))
 }
 
@@ -131,10 +124,9 @@ fn handle_setlk(
 
 fn handle_getown(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
-    file_table.read_with(|inner| {
-        let pid = inner.get_entry(fd)?.owner().unwrap_or(0);
-        Ok(SyscallReturn::Return(pid as _))
-    })
+    let file = get_file_fast!(&mut file_table, fd);
+    let pid = file.common().owner().pid().unwrap_or(0);
+    Ok(SyscallReturn::Return(pid as _))
 }
 
 fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
@@ -159,10 +151,9 @@ fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn>
         )
     };
 
-    let file_table = ctx.thread_local.borrow_file_table();
-    let mut file_table_locked = file_table.unwrap().write();
-    let file_entry = file_table_locked.get_entry_mut(fd)?;
-    file_entry.set_owner(owner_process.as_ref())?;
+    let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let file = get_file_fast!(&mut file_table, fd);
+    file.set_owner(owner_process.as_ref());
     Ok(SyscallReturn::Return(0))
 }
 

--- a/kernel/src/syscall/ioctl.rs
+++ b/kernel/src/syscall/ioctl.rs
@@ -3,7 +3,7 @@
 use super::SyscallReturn;
 use crate::{
     fs::file::{
-        FileLike, StatusFlags,
+        FileLike,
         file_table::{FdFlags, RawFileDesc, WithFileTable, get_file_fast},
     },
     prelude::*,
@@ -99,10 +99,8 @@ fn handle_file_ioctl(file: &dyn FileLike, raw_ioctl: RawIoctl) -> Option<Result<
             let handler = || {
                 let is_nonblocking = cmd.read()? != 0;
 
-                let mut flags = file.status_flags();
-                flags.set(StatusFlags::O_NONBLOCK, is_nonblocking);
-                // FIXME: This is racy.
-                file.set_status_flags(flags)
+                file.update_status_nonblock(is_nonblocking);
+                Ok(())
             };
             Some(handler())
         }
@@ -113,10 +111,7 @@ fn handle_file_ioctl(file: &dyn FileLike, raw_ioctl: RawIoctl) -> Option<Result<
                 // Setting the `O_ASYNC` flag will cause the kernel to send the owner process a
                 // `SIGIO` signal when input/output is possible. The user should first call
                 // `fcntl(fd, F_SETOWN, pid)` to specify the process to be notified.
-                let mut flags = file.status_flags();
-                flags.set(StatusFlags::O_ASYNC, is_async);
-                // FIXME: This is racy.
-                file.set_status_flags(flags)
+                file.update_status_async(is_async)
             };
             Some(handler())
         }

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -6,10 +6,7 @@
 //! enabling better integration with event loops.
 //! See <https://man7.org/linux/man-pages/man2/signalfd.2.html>.
 
-use core::{
-    fmt::Display,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use core::{fmt::Display, sync::atomic::Ordering};
 
 use bitflags::bitflags;
 use ostd::mm::VmIo;
@@ -19,11 +16,10 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, CreationFlags, FileLike, StatusFlags,
+            AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags,
             file_table::{FdFlags, RawFileDesc, get_file_fast},
         },
         pseudofs::AnonInodeFs,
-        vfs::path::Path,
     },
     prelude::*,
     process::{
@@ -138,21 +134,23 @@ bitflags! {
 struct SignalFile {
     /// Atomic signal mask for filtering signals
     signals_mask: AtomicSigMask,
-    /// Non-blocking mode flag
-    non_blocking: AtomicBool,
-    /// The pseudo path associated with this signalfd file.
-    pseudo_path: Path,
+    /// The common state for this signalfd file.
+    common: FileCommon,
 }
 
 impl SignalFile {
     /// Create a new signalfd instance
     fn new(mask: AtomicSigMask, non_blocking: bool) -> Self {
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[signalfd]".to_string());
+        let status_flags = if non_blocking {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
 
         Self {
             signals_mask: mask,
-            non_blocking: AtomicBool::new(non_blocking),
-            pseudo_path,
+            common: FileCommon::new(pseudo_path, status_flags),
         }
     }
 
@@ -165,12 +163,12 @@ impl SignalFile {
         Ok(())
     }
 
-    fn set_non_blocking(&self, non_blocking: bool) {
-        self.non_blocking.store(non_blocking, Ordering::Relaxed);
+    fn is_non_blocking(&self) -> bool {
+        self.common.is_nonblocking()
     }
 
-    fn is_non_blocking(&self) -> bool {
-        self.non_blocking.load(Ordering::Relaxed)
+    fn set_non_blocking(&self, non_blocking: bool) {
+        (self as &dyn FileLike).update_status_nonblock(non_blocking);
     }
 
     /// Check current readable I/O events
@@ -248,26 +246,13 @@ impl FileLike for SignalFile {
         }
     }
 
-    fn status_flags(&self) -> StatusFlags {
-        if self.is_non_blocking() {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        }
-    }
-
-    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
-        self.set_non_blocking(new_flags.contains(StatusFlags::O_NONBLOCK));
-        Ok(())
-    }
-
     fn access_mode(&self) -> AccessMode {
         // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/signalfd.c#L276>.
         AccessMode::O_RDWR
     }
 
-    fn path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {

--- a/kernel/src/time/timerfd.rs
+++ b/kernel/src/time/timerfd.rs
@@ -12,9 +12,8 @@ use super::clockid_t;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileLike, StatusFlags, file_table::FdFlags},
+        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
         pseudofs::AnonInodeFs,
-        vfs::path::Path,
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
@@ -31,10 +30,8 @@ pub struct TimerfdFile {
     timer: Arc<Timer>,
     ticks: Arc<AtomicU64>,
     pollee: Pollee,
-    flags: AtomicTFDFlags,
     settime_flags: AtomicTFDSetTimeFlags,
-    /// The pseudo path associated with this timerfd file.
-    pseudo_path: Path,
+    common: FileCommon,
 }
 
 bitflags! {
@@ -60,12 +57,6 @@ impl From<TFDFlags> for u32 {
         value.bits()
     }
 }
-
-define_atomic_version_of_integer_like_type!(TFDFlags, try_from = true, {
-    /// An atomic version of `TFDFlags`.
-    #[derive(Debug, Default)]
-    struct AtomicTFDFlags(AtomicU32);
-});
 
 bitflags! {
     /// The flags used for timerfd settime operations.
@@ -116,15 +107,19 @@ impl TimerfdFile {
         }?;
 
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[timerfd]".to_string());
+        let status_flags = if flags.contains(TFDFlags::TFD_NONBLOCK) {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
 
         Ok(TimerfdFile {
             clockid,
             timer,
             ticks,
             pollee,
-            flags: AtomicTFDFlags::new(flags),
             settime_flags: AtomicTFDSetTimeFlags::default(),
-            pseudo_path,
+            common: FileCommon::new(pseudo_path, status_flags),
         })
     }
 
@@ -176,9 +171,7 @@ impl TimerfdFile {
     }
 
     fn is_nonblocking(&self) -> bool {
-        self.flags
-            .load(Ordering::Relaxed)
-            .contains(TFDFlags::TFD_NONBLOCK)
+        self.common.is_nonblocking()
     }
 
     fn try_read(&self, writer: &mut VmWriter) -> Result<()> {
@@ -228,35 +221,13 @@ impl FileLike for TimerfdFile {
         Ok(read_len)
     }
 
-    fn status_flags(&self) -> StatusFlags {
-        if self.is_nonblocking() {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        }
-    }
-
-    fn set_status_flags(&self, new_flags: StatusFlags) -> Result<()> {
-        self.flags
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |flags| {
-                if new_flags.contains(StatusFlags::O_NONBLOCK) {
-                    Some(flags | TFDFlags::TFD_NONBLOCK)
-                } else {
-                    Some(flags & !TFDFlags::TFD_NONBLOCK)
-                }
-            })
-            .unwrap();
-
-        Ok(())
-    }
-
     fn access_mode(&self) -> AccessMode {
         // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/timerfd.c#L436>.
         AccessMode::O_RDWR
     }
 
-    fn path(&self) -> &Path {
-        &self.pseudo_path
+    fn common(&self) -> &FileCommon {
+        &self.common
     }
 
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {

--- a/test/initramfs/src/regression/io/file_io/fcntl_owner.c
+++ b/test/initramfs/src/regression/io/file_io/fcntl_owner.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define TEST_FILE "/tmp/fcntl_owner_regression"
+
+FN_SETUP(create)
+{
+	int fd = CHECK(open(TEST_FILE, O_CREAT | O_RDWR | O_TRUNC, 0666));
+	CHECK(close(fd));
+}
+END_SETUP()
+
+FN_TEST(dup_shares_owner)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+	int duplicated_fd = TEST_SUCC(dup(fd));
+	int separate_fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+	pid_t pid = TEST_SUCC(getpid());
+
+	TEST_SUCC(fcntl(fd, F_SETOWN, pid));
+	TEST_RES(syscall(SYS_fcntl, duplicated_fd, F_GETOWN, 0), _ret == pid);
+	TEST_RES(syscall(SYS_fcntl, separate_fd, F_GETOWN, 0), _ret == 0);
+
+	TEST_SUCC(fcntl(duplicated_fd, F_SETOWN, 0));
+	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == 0);
+
+	TEST_SUCC(close(separate_fd));
+	TEST_SUCC(close(duplicated_fd));
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(unlink(TEST_FILE));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/io/file_io/fcntl_status_flags.c
+++ b/test/initramfs/src/regression/io/file_io/fcntl_status_flags.c
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <sys/signalfd.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/timerfd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+enum fd_index {
+	/* Objects opened through filesystem paths. */
+	REGULAR_FILE_FD,
+	DIRECTORY_FD,
+	NULL_DEVICE_FD,
+	PROCFS_FILE_FD,
+
+	/* Anonymous and special file descriptors. */
+	EPOLL_FD,
+	EVENT_FD,
+	INOTIFY_FD,
+	PID_FD,
+	SIGNAL_FD,
+	TIMER_FD,
+
+	/* Inter-process communication file descriptors. */
+	SOCKET_FD,
+	PIPE_READ_FD,
+	PIPE_WRITE_FD,
+	FD_COUNT,
+};
+
+static int fds[FD_COUNT];
+
+enum async_support {
+	DOES_NOT_SUPPORT_ASYNC,
+	SUPPORTS_ASYNC,
+};
+
+static const enum async_support async_support_by_fd[FD_COUNT] = {
+	[REGULAR_FILE_FD] = DOES_NOT_SUPPORT_ASYNC,
+	[DIRECTORY_FD] = DOES_NOT_SUPPORT_ASYNC,
+	[NULL_DEVICE_FD] = DOES_NOT_SUPPORT_ASYNC,
+	[PROCFS_FILE_FD] = DOES_NOT_SUPPORT_ASYNC,
+
+	[EPOLL_FD] = DOES_NOT_SUPPORT_ASYNC,
+	[EVENT_FD] = DOES_NOT_SUPPORT_ASYNC,
+	[INOTIFY_FD] = SUPPORTS_ASYNC,
+	[PID_FD] = DOES_NOT_SUPPORT_ASYNC,
+	[SIGNAL_FD] = DOES_NOT_SUPPORT_ASYNC,
+	[TIMER_FD] = DOES_NOT_SUPPORT_ASYNC,
+
+	[SOCKET_FD] = SUPPORTS_ASYNC,
+	[PIPE_READ_FD] = SUPPORTS_ASYNC,
+	[PIPE_WRITE_FD] = SUPPORTS_ASYNC,
+};
+
+FN_SETUP(create)
+{
+	fds[REGULAR_FILE_FD] = CHECK(open("fcntl_status_flags_file",
+					  O_CREAT | O_RDWR | O_TRUNC, 0600));
+	fds[DIRECTORY_FD] = CHECK(open(".", O_RDONLY | O_DIRECTORY));
+	fds[NULL_DEVICE_FD] = CHECK(open("/dev/null", O_RDWR));
+	fds[PROCFS_FILE_FD] = CHECK(open("/proc/self/maps", O_RDONLY));
+
+	fds[EPOLL_FD] = CHECK(epoll_create1(0));
+	fds[EVENT_FD] = CHECK(eventfd(0, 0));
+	fds[INOTIFY_FD] = CHECK(inotify_init1(0));
+	fds[PID_FD] = CHECK(syscall(SYS_pidfd_open, getpid(), 0));
+
+	sigset_t mask;
+	CHECK(sigemptyset(&mask));
+	CHECK(sigaddset(&mask, SIGUSR1));
+	fds[SIGNAL_FD] = CHECK(signalfd(-1, &mask, 0));
+	fds[TIMER_FD] = CHECK(timerfd_create(CLOCK_MONOTONIC, 0));
+
+	fds[SOCKET_FD] = CHECK(socket(AF_UNIX, SOCK_STREAM, 0));
+	CHECK(pipe(&fds[PIPE_READ_FD]));
+}
+END_SETUP()
+
+static int set_flag_and_get_flags(int fd, int flag)
+{
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (flags < 0)
+		return -1;
+	if (fcntl(fd, F_SETFL, flags | flag) < 0)
+		return -1;
+
+	return fcntl(fd, F_GETFL, 0);
+}
+
+static int set_async_with_ioctl_and_get_flags(int fd, int is_async)
+{
+	if (ioctl(fd, FIOASYNC, &is_async) < 0)
+		return -1;
+
+	return fcntl(fd, F_GETFL, 0);
+}
+
+FN_TEST(set_nonblocking_on_file_types)
+{
+	for (size_t i = 0; i < FD_COUNT; i++)
+		TEST_RES(set_flag_and_get_flags(fds[i], O_NONBLOCK),
+			 (_ret & O_NONBLOCK) != 0);
+}
+END_TEST()
+
+FN_TEST(set_append_on_file_types)
+{
+	for (size_t i = 0; i < FD_COUNT; i++)
+		TEST_RES(set_flag_and_get_flags(fds[i], O_APPEND),
+			 (_ret & O_APPEND) != 0);
+}
+END_TEST()
+
+FN_TEST(set_noatime_on_file_types)
+{
+	/* Regression tests run as root, which may set `O_NOATIME` on any inode. */
+	for (size_t i = 0; i < FD_COUNT; i++)
+		TEST_RES(set_flag_and_get_flags(fds[i], O_NOATIME),
+			 (_ret & O_NOATIME) != 0);
+}
+END_TEST()
+
+FN_TEST(set_async_with_ioctl_on_file_types)
+{
+	for (size_t i = 0; i < FD_COUNT; i++) {
+		if (async_support_by_fd[i] == SUPPORTS_ASYNC) {
+			TEST_RES(set_async_with_ioctl_and_get_flags(fds[i], 1),
+				 (_ret & O_ASYNC) != 0);
+		} else {
+			TEST_ERRNO(set_async_with_ioctl_and_get_flags(fds[i],
+								      1),
+				   ENOTTY);
+		}
+		TEST_RES(set_async_with_ioctl_and_get_flags(fds[i], 0),
+			 (_ret & O_ASYNC) == 0);
+	}
+}
+END_TEST()
+
+FN_TEST(set_async_on_file_types)
+{
+	/*
+	 * Linux keeps `O_ASYNC` only when the file type provides a fasync callback.
+	 * `F_SETFL` still succeeds for unsupported file types but leaves the bit clear.
+	 */
+	for (size_t i = 0; i < FD_COUNT; i++)
+		TEST_RES(set_flag_and_get_flags(fds[i], O_ASYNC),
+			 ((_ret & O_ASYNC) != 0) ==
+				 (async_support_by_fd[i] == SUPPORTS_ASYNC));
+}
+END_TEST()
+
+FN_TEST(set_direct_on_file_types)
+{
+	TEST_RES(set_flag_and_get_flags(fds[REGULAR_FILE_FD], O_DIRECT),
+		 (_ret & O_DIRECT) != 0);
+
+	for (size_t i = DIRECTORY_FD; i < PIPE_READ_FD; i++) {
+		TEST_ERRNO(set_flag_and_get_flags(fds[i], O_DIRECT), EINVAL);
+	}
+
+	/*
+	 * FIXME: Linux enables pipe packet mode when `O_DIRECT` is set with `F_SETFL`,
+	 * while Asterinas returns `EINVAL` because packet mode is not supported yet.
+	 */
+#ifdef __asterinas__
+	for (size_t i = PIPE_READ_FD; i < FD_COUNT; i++)
+		TEST_ERRNO(set_flag_and_get_flags(fds[i], O_DIRECT), EINVAL);
+#else
+	for (size_t i = PIPE_READ_FD; i < FD_COUNT; i++)
+		TEST_RES(set_flag_and_get_flags(fds[i], O_DIRECT),
+			 (_ret & O_DIRECT) != 0);
+#endif
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	for (size_t i = 0; i < FD_COUNT; i++)
+		CHECK(close(fds[i]));
+	CHECK(unlink("fcntl_status_flags_file"));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/io/run_test.sh
+++ b/test/initramfs/src/regression/io/run_test.sh
@@ -14,5 +14,7 @@ set -e
 ./file_io/access_err
 ./file_io/block_device
 ./file_io/fcntl_lock
+./file_io/fcntl_owner
+./file_io/fcntl_status_flags
 ./file_io/file_err
 ./file_io/iovec_err


### PR DESCRIPTION
Implement the proposal in this [comment](https://github.com/asterinas/asterinas/issues/2864#issuecomment-3734310440).

Unlike Linux, which has a unified `file` struct, we need to implement separate abstractions for each `FileLike` type. While this offers greater flexibility, handling shared state can lead to code redundancy or improper handling, resulting in issues like the one mentioned in #2864. Therefore, this PR introduces `FileCommon` to manage such shared state.

This PR also unifies the interface for handling `status_flags` and further aligns some of the rejection behavior for `O_DIRECT` with Linux.