### PR TITLE
Update LTP to 20260529

### DIFF
--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -119,7 +119,7 @@ which are summarized in the table below.
 | 96      | gettimeofday           | ✅             | 💯 |
 | 97      | getrlimit              | ✅             | 💯 |
 | 98      | getrusage              | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#getrusage) |
-| 99      | sysinfo                | ✅             | 💯 |
+| 99      | sysinfo                | ✅             | [⚠️](syscall-flag-coverage/system-information-and-misc/#sysinfo) |
 | 100     | times                  | ❌             | N/A |
 | 101     | ptrace                 | ✅             | [⚠️](syscall-flag-coverage/process-and-thread-management/#ptrace) |
 | 102     | getuid                 | ✅             | 💯 |

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/README.md
@@ -68,6 +68,25 @@ Unsupported `op` flags:
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/reboot.2.html).
 
+### `sysinfo`
+
+Supported functionality in SCML:
+
+```c
+{{#include sysinfo.scml}}
+```
+
+Supported returned fields:
+* `uptime`, rounded up to seconds when it has a fractional part
+* `loads`, containing the 1-, 5-, and 15-minute load averages as fixed-point values scaled by `1 << SI_LOAD_SHIFT`
+* `totalram`, `freeram`, `procs`, and `mem_unit`
+
+The `sharedram`, `bufferram`, `totalhigh`, and `freehigh` fields are reported as zero.
+The `totalswap` and `freeswap` fields are reported as zero because swap is not supported.
+
+For more information,
+see [the man page](https://man7.org/linux/man-pages/man2/sysinfo.2.html).
+
 ## POSIX clocks
 
 ### `clock_gettime`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/fully_covered.scml
@@ -1,9 +1,6 @@
 // Set pointer to thread ID
 set_tid_address(tidptr);
 
-// Return system information
-sysinfo(info);
-
 // Get directory entries
 getdents(fd, dirp, count);
 getdents64(fd, dirp, count);

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/sysinfo.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/system-information-and-misc/sysinfo.scml
@@ -1,0 +1,2 @@
+// Return system information.
+sysinfo(info);

--- a/kernel/libs/aster-util/src/fixed_point.rs
+++ b/kernel/libs/aster-util/src/fixed_point.rs
@@ -11,159 +11,164 @@ use core::{
     ops::{Add, Div, Mul, Sub},
 };
 
-/// A generic fixed-point number with `FRAC_BITS` fractional bits.
-///
-/// This type represents a non-negative real number using a `u32` for storage,
-/// with the lower `FRAC_BITS` representing the fractional part.
-///
-/// **Standard arithmetic operations can overflow and wrap around.** This follows
-/// Rust's default integer overflow behavior.
-///
-/// For safer arithmetic that prevents overflow, use the `saturating_*` methods:
-/// - [`saturating_add`](Self::saturating_add)
-/// - [`saturating_sub`](Self::saturating_sub)
-/// - [`saturating_mul`](Self::saturating_mul)
-/// - [`saturating_div`](Self::saturating_div)
-///
-/// # Examples
-///
-/// ```rust
-/// use fixed_point::FixedU32;
-///
-/// type FixedU32_8 = FixedU32<8>;
-/// let max_val = FixedU32_8::from_raw(u32::MAX);
-/// let one = FixedU32_8::saturating_from_num(1);
-///
-/// // Standard operations can overflow.
-/// let wrapped = max_val + one;
-///
-/// // Saturating operations prevent overflow.
-/// let saturated = max_val.saturating_add(one);
-/// assert_eq!(saturated, max_val); // Stays at maximum.
-/// ```
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FixedU32<const FRAC_BITS: u32>(u32);
+macro_rules! define_fixed_unsigned {
+    ($name:ident, $raw:ty, $wide:ty) => {
+        /// A generic fixed-point number with `FRAC_BITS` fractional bits.
+        ///
+        /// This type represents a non-negative real number using an unsigned
+        /// integer for storage, with the lower `FRAC_BITS` representing the
+        /// fractional part.
+        ///
+        /// **Standard arithmetic operations can overflow and wrap around.**
+        /// This follows Rust's default integer overflow behavior.
+        ///
+        /// For safer arithmetic that prevents overflow, use the
+        /// `saturating_*` methods.
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        pub struct $name<const FRAC_BITS: u32>($raw);
 
-impl<const FRAC_BITS: u32> FixedU32<FRAC_BITS> {
-    const FRAC_SCALE: u32 = {
-        // Do not remove or rewrite the const expression below.
-        // It implicitly prevents users from giving invalid values of `FRAC_BITS` greater
-        // than 31 because doing so would cause integer overflow during const evaluation.
-        1 << FRAC_BITS
+        impl<const FRAC_BITS: u32> $name<FRAC_BITS> {
+            const FRAC_SCALE: $raw = {
+                // Do not remove or rewrite the const expression below.
+                // It implicitly prevents users from giving invalid values of
+                // `FRAC_BITS` greater than or equal to the raw integer width
+                // because doing so would cause integer overflow during const
+                // evaluation.
+                1 << FRAC_BITS
+            };
+
+            pub const ZERO: Self = Self(0);
+            pub const ONE: Self = Self(Self::FRAC_SCALE);
+            const MAX_INT: $raw = <$raw>::MAX >> FRAC_BITS;
+
+            /// Creates a fixed-point number from an integer.
+            ///
+            /// If the value is too large to be represented, it will saturate
+            /// at the maximum representable value.
+            pub const fn saturating_from_num(val: $raw) -> Self {
+                if val > Self::MAX_INT {
+                    Self(<$raw>::MAX)
+                } else {
+                    Self(val << FRAC_BITS)
+                }
+            }
+
+            /// Creates a fixed-point number from raw bits.
+            pub const fn from_raw(raw: $raw) -> Self {
+                Self(raw)
+            }
+
+            /// Returns the raw underlying fixed-point value.
+            pub const fn raw(self) -> $raw {
+                self.0
+            }
+
+            /// Adds two fixed-point numbers, saturating on overflow.
+            pub const fn saturating_add(self, other: Self) -> Self {
+                Self(self.0.saturating_add(other.0))
+            }
+
+            /// Subtracts two fixed-point numbers, saturating on underflow.
+            pub const fn saturating_sub(self, other: Self) -> Self {
+                Self(self.0.saturating_sub(other.0))
+            }
+
+            /// Multiplies two fixed-point numbers, saturating on overflow.
+            pub const fn saturating_mul(self, other: Self) -> Self {
+                let result = (self.0 as $wide * other.0 as $wide) >> FRAC_BITS;
+                Self(if result > <$raw>::MAX as $wide {
+                    <$raw>::MAX
+                } else {
+                    result as $raw
+                })
+            }
+
+            /// Divides two fixed-point numbers, saturating on overflow.
+            ///
+            /// Returns `None` if division by zero is attempted.
+            pub const fn saturating_div(self, other: Self) -> Option<Self> {
+                if other.0 == 0 {
+                    return None;
+                }
+
+                let result = ((self.0 as $wide) << FRAC_BITS) / other.0 as $wide;
+                Some(Self(if result > <$raw>::MAX as $wide {
+                    <$raw>::MAX
+                } else {
+                    result as $raw
+                }))
+            }
+        }
+
+        impl<const FRAC_BITS: u32> Add for $name<FRAC_BITS> {
+            type Output = Self;
+
+            fn add(self, rhs: Self) -> Self::Output {
+                Self(self.0 + rhs.0)
+            }
+        }
+
+        impl<const FRAC_BITS: u32> Sub for $name<FRAC_BITS> {
+            type Output = Self;
+
+            fn sub(self, rhs: Self) -> Self::Output {
+                Self(self.0 - rhs.0)
+            }
+        }
+
+        impl<const FRAC_BITS: u32> Mul for $name<FRAC_BITS> {
+            type Output = Self;
+
+            fn mul(self, rhs: Self) -> Self::Output {
+                let result = (self.0 as $wide * rhs.0 as $wide) >> FRAC_BITS;
+                debug_assert!(
+                    result <= <$raw>::MAX as $wide,
+                    "attempt to multiply with overflow"
+                );
+                Self(result as $raw)
+            }
+        }
+
+        impl<const FRAC_BITS: u32> Div for $name<FRAC_BITS> {
+            type Output = Self;
+
+            fn div(self, rhs: Self) -> Self::Output {
+                let result = ((self.0 as $wide) << FRAC_BITS) / rhs.0 as $wide;
+                debug_assert!(
+                    result <= <$raw>::MAX as $wide,
+                    "attempt to divide with overflow"
+                );
+                Self(result as $raw)
+            }
+        }
+
+        impl<const FRAC_BITS: u32> fmt::Display for $name<FRAC_BITS> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "{}.{:>03}",
+                    self.0 >> FRAC_BITS,
+                    ((self.0 % Self::FRAC_SCALE) as $wide) * 1000 / Self::FRAC_SCALE as $wide
+                )?;
+                Ok(())
+            }
+        }
     };
+}
 
-    pub const ZERO: Self = Self(0);
-    pub const ONE: Self = Self(Self::FRAC_SCALE);
-    const MAX_INT: u32 = u32::MAX >> FRAC_BITS;
+define_fixed_unsigned!(FixedU32, u32, u64);
+define_fixed_unsigned!(FixedU64, u64, u128);
 
-    /// Creates a fixed-point number from an integer.
-    ///
-    /// If the value is too large to be represented, it will saturate
-    /// at the maximum representable value.
-    pub const fn saturating_from_num(val: u32) -> Self {
-        if val > Self::MAX_INT {
-            Self(u32::MAX)
-        } else {
-            Self(val << FRAC_BITS)
-        }
-    }
-
-    /// Creates a fixed-point number from raw bits.
-    pub const fn from_raw(raw: u32) -> Self {
-        Self(raw)
-    }
-
-    /// Gets the raw underlying value.
-    #[cfg(ktest)]
-    const fn raw(self) -> u32 {
-        self.0
-    }
-
-    /// Adds two fixed-point numbers, saturating on overflow.
-    pub const fn saturating_add(self, other: Self) -> Self {
-        Self(self.0.saturating_add(other.0))
-    }
-
-    /// Subtracts two fixed-point numbers, saturating on underflow.
-    pub const fn saturating_sub(self, other: Self) -> Self {
-        Self(self.0.saturating_sub(other.0))
-    }
-
-    /// Multiplies two fixed-point numbers, saturating on overflow.
-    pub const fn saturating_mul(self, other: Self) -> Self {
-        let result = (self.0 as u64 * other.0 as u64) >> FRAC_BITS;
-        Self(if result > u32::MAX as u64 {
-            u32::MAX
-        } else {
-            result as u32
-        })
-    }
-
-    /// Divides two fixed-point numbers, saturating on overflow.
-    ///
-    /// Returns `None` if division by zero is attempted.
-    pub const fn saturating_div(self, other: Self) -> Option<Self> {
-        if other.0 == 0 {
-            return None;
+impl<const FROM_FRAC_BITS: u32, const TO_FRAC_BITS: u32> From<FixedU32<FROM_FRAC_BITS>>
+    for FixedU64<TO_FRAC_BITS>
+{
+    fn from(value: FixedU32<FROM_FRAC_BITS>) -> Self {
+        const {
+            assert!(TO_FRAC_BITS >= FROM_FRAC_BITS);
+            assert!(u64::BITS - TO_FRAC_BITS >= u32::BITS - FROM_FRAC_BITS);
         }
 
-        let result = ((self.0 as u64) << FRAC_BITS) / other.0 as u64;
-        Some(Self(if result > u32::MAX as u64 {
-            u32::MAX
-        } else {
-            result as u32
-        }))
-    }
-}
-
-impl<const FRAC_BITS: u32> Add for FixedU32<FRAC_BITS> {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0 + rhs.0)
-    }
-}
-
-impl<const FRAC_BITS: u32> Sub for FixedU32<FRAC_BITS> {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self(self.0 - rhs.0)
-    }
-}
-
-impl<const FRAC_BITS: u32> Mul for FixedU32<FRAC_BITS> {
-    type Output = Self;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        let result = (self.0 as u64 * rhs.0 as u64) >> FRAC_BITS;
-        debug_assert!(
-            result <= u32::MAX as u64,
-            "attempt to multiply with overflow"
-        );
-        Self(result as u32)
-    }
-}
-
-impl<const FRAC_BITS: u32> Div for FixedU32<FRAC_BITS> {
-    type Output = Self;
-
-    fn div(self, rhs: Self) -> Self::Output {
-        let result = ((self.0 as u64) << FRAC_BITS) / rhs.0 as u64;
-        debug_assert!(result <= u32::MAX as u64, "attempt to divide with overflow");
-        Self(result as u32)
-    }
-}
-
-impl<const FRAC_BITS: u32> fmt::Display for FixedU32<FRAC_BITS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}.{:>03}",
-            self.0 >> FRAC_BITS,
-            ((self.0 % Self::FRAC_SCALE) as u64) * 1000 / Self::FRAC_SCALE as u64
-        )?;
-        Ok(())
+        Self::from_raw((value.raw() as u64) << (TO_FRAC_BITS - FROM_FRAC_BITS))
     }
 }
 
@@ -268,6 +273,14 @@ mod tests {
         let high_precision = FixedU32_16::from_raw(98304); // 1.5 in 16.16 format
         let display_str = format!("{}", high_precision);
         assert_eq!(display_str, "1.500");
+    }
+
+    #[ktest]
+    fn fixed_u32_to_fixed_u64_conversion() {
+        let value = FixedU32_8::from_raw(0x1234);
+        let converted = FixedU64::<16>::from(value);
+
+        assert_eq!(converted.raw(), 0x1234u64 << 8);
     }
 
     #[expect(clippy::eq_op)]

--- a/kernel/src/fs/fs_impls/procfs/meminfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/meminfo.rs
@@ -49,6 +49,8 @@ impl ProcFileOps for MemInfoFileOps {
         writeln!(printer, "MemTotal:\t{} kB", total)?;
         writeln!(printer, "MemFree:\t{} kB", available)?;
         writeln!(printer, "MemAvailable:\t{} kB", available)?;
+        writeln!(printer, "SwapTotal:\t0 kB")?;
+        writeln!(printer, "SwapFree:\t0 kB")?;
 
         Ok(printer.bytes_written())
     }

--- a/kernel/src/fs/fs_impls/procfs/uptime.rs
+++ b/kernel/src/fs/fs_impls/procfs/uptime.rs
@@ -5,6 +5,8 @@
 //!
 //! Reference: <https://man7.org/linux/man-pages/man5/proc_uptime.5.html>
 
+use core::time::Duration;
+
 use aster_util::printer::VmPrinter;
 
 use crate::{
@@ -14,7 +16,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    time::cpu_time_stats::CpuTimeStatsManager,
+    time::{NSEC_PER_SEC, cpu_time_stats::CpuTimeStatsManager},
 };
 
 /// Represents the inode at `/proc/uptime`.
@@ -29,18 +31,26 @@ impl UptimeFileOps {
     }
 
     fn print_uptime(printer: &mut VmPrinter) -> Result<()> {
-        let uptime = aster_time::read_monotonic_time().as_secs_f32();
+        let (uptime_secs, uptime_centis) =
+            duration_to_seconds_and_centiseconds(aster_time::read_monotonic_time());
 
         let cpustat = CpuTimeStatsManager::singleton();
-        let idle_time = cpustat
-            .collect_stats_on_all_cpus()
-            .idle
-            .as_duration()
-            .as_secs_f32();
+        let (idle_secs, idle_centis) = duration_to_seconds_and_centiseconds(
+            cpustat.collect_stats_on_all_cpus().idle.as_duration(),
+        );
 
-        writeln!(printer, "{:.2} {:.2}", uptime, idle_time)?;
+        writeln!(
+            printer,
+            "{uptime_secs}.{uptime_centis:02} {idle_secs}.{idle_centis:02}"
+        )?;
         Ok(())
     }
+}
+
+/// Splits a duration into seconds and the centiseconds printed by `/proc/uptime`.
+fn duration_to_seconds_and_centiseconds(duration: Duration) -> (u64, u32) {
+    let centiseconds = duration.subsec_nanos() / (NSEC_PER_SEC as u32 / 100);
+    (duration.as_secs(), centiseconds)
 }
 
 impl ProcFileOps for UptimeFileOps {
@@ -50,5 +60,34 @@ impl ProcFileOps for UptimeFileOps {
         Self::print_uptime(&mut printer)?;
 
         Ok(printer.bytes_written())
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use core::time::Duration;
+
+    use ostd::prelude::ktest;
+
+    use super::duration_to_seconds_and_centiseconds;
+
+    #[ktest]
+    fn uptime_centiseconds_are_truncated() {
+        assert_eq!(
+            duration_to_seconds_and_centiseconds(Duration::new(42, 0)),
+            (42, 0)
+        );
+        assert_eq!(
+            duration_to_seconds_and_centiseconds(Duration::new(42, 9_999_999)),
+            (42, 0)
+        );
+        assert_eq!(
+            duration_to_seconds_and_centiseconds(Duration::new(42, 10_000_000)),
+            (42, 1)
+        );
+        assert_eq!(
+            duration_to_seconds_and_centiseconds(Duration::new(42, 999_999_999)),
+            (42, 99)
+        );
     }
 }

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -894,24 +894,22 @@ impl Inode for RamInode {
             return_errno_with_message!(Errno::EEXIST, "entry exists");
         }
 
+        let (uid, gid) = current_fs_ids();
         let new_inode = match type_ {
             MknodType::CharDevice(dev_id) | MknodType::BlockDevice(dev_id) => {
                 let dev_type = type_.device_type().unwrap();
                 RamInode::new_device(
                     &self.fs.upgrade().unwrap(),
                     mode,
-                    Uid::new_root(),
-                    Gid::new_root(),
+                    uid,
+                    gid,
                     dev_type,
                     dev_id,
                 )
             }
-            MknodType::NamedPipe => RamInode::new_named_pipe(
-                &self.fs.upgrade().unwrap(),
-                mode,
-                Uid::new_root(),
-                Gid::new_root(),
-            ),
+            MknodType::NamedPipe => {
+                RamInode::new_named_pipe(&self.fs.upgrade().unwrap(), mode, uid, gid)
+            }
         };
 
         let mut self_dir = self_dir.upgrade();
@@ -944,13 +942,7 @@ impl Inode for RamInode {
         }
 
         let fs = self.fs.upgrade().unwrap();
-        let (uid, gid) = Thread::current()
-            .and_then(|thread| {
-                let posix_thread = thread.as_posix_thread()?;
-                let credentials = posix_thread.credentials();
-                Some((credentials.fsuid(), credentials.fsgid()))
-            })
-            .unwrap_or((Uid::new_root(), Gid::new_root()));
+        let (uid, gid) = current_fs_ids();
         let new_inode = match type_ {
             InodeType::File => RamInode::new_file(&fs, mode, uid, gid),
             InodeType::SymLink => RamInode::new_symlink(&fs, mode, uid, gid),
@@ -987,13 +979,8 @@ impl Inode for RamInode {
         }
 
         let fs = self.fs.upgrade().unwrap();
-        Ok(RamInode::new_tmpfile(
-            &fs,
-            mode,
-            Uid::new_root(),
-            Gid::new_root(),
-            hard_linkability,
-        ))
+        let (uid, gid) = current_fs_ids();
+        Ok(RamInode::new_tmpfile(&fs, mode, uid, gid, hard_linkability))
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
@@ -1461,6 +1448,16 @@ fn write_lock_two_direntries_by_ino<'a>(
 
 fn now() -> Duration {
     RealTimeCoarseClock::get().read_time()
+}
+
+fn current_fs_ids() -> (Uid, Gid) {
+    Thread::current()
+        .and_then(|thread| {
+            let posix_thread = thread.as_posix_thread()?;
+            let credentials = posix_thread.credentials();
+            Some((credentials.fsuid(), credentials.fsgid()))
+        })
+        .unwrap_or((Uid::new_root(), Gid::new_root()))
 }
 
 pub(super) struct RamFsType;

--- a/kernel/src/syscall/sysinfo.rs
+++ b/kernel/src/syscall/sysinfo.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use aster_time::read_monotonic_time;
+use aster_util::fixed_point::FixedU64;
 use ostd::mm::VmIo;
 
 use super::SyscallReturn;
-use crate::{prelude::*, process::pid_table};
+use crate::{prelude::*, process::pid_table, sched::loadavg};
 
 #[padding_struct]
 #[repr(C)]
@@ -25,8 +26,16 @@ struct SysInfo {
 }
 
 pub fn sys_sysinfo(sysinfo_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
+    type SysinfoLoadAvg = FixedU64<16>;
+
+    let loadavg = loadavg::get_loadavg();
     let info = SysInfo {
         uptime: read_monotonic_time().as_secs() as i64,
+        loads: [
+            SysinfoLoadAvg::from(loadavg[0]).raw(),
+            SysinfoLoadAvg::from(loadavg[1]).raw(),
+            SysinfoLoadAvg::from(loadavg[2]).raw(),
+        ],
         totalram: crate::vm::mem_total() as u64,
         freeram: osdk_frame_allocator::load_total_free_size() as u64,
         procs: pid_table::pid_table_mut().process_count() as u16,

--- a/kernel/src/syscall/sysinfo.rs
+++ b/kernel/src/syscall/sysinfo.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::time::Duration;
+
 use aster_time::read_monotonic_time;
 use aster_util::fixed_point::FixedU64;
 use ostd::mm::VmIo;
@@ -30,7 +32,7 @@ pub fn sys_sysinfo(sysinfo_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> 
 
     let loadavg = loadavg::get_loadavg();
     let info = SysInfo {
-        uptime: read_monotonic_time().as_secs() as i64,
+        uptime: read_monotonic_time().as_secs_round_up() as i64,
         loads: [
             SysinfoLoadAvg::from(loadavg[0]).raw(),
             SysinfoLoadAvg::from(loadavg[1]).raw(),
@@ -46,4 +48,36 @@ pub fn sys_sysinfo(sysinfo_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> 
     };
     ctx.user_space().write_val(sysinfo_addr, &info)?;
     Ok(SyscallReturn::Return(0))
+}
+
+trait RoundUpSeconds {
+    /// Returns the duration in seconds, rounding up a nonzero sub-second part.
+    ///
+    /// This matches the rounding used by Linux `sysinfo`.
+    /// Reference: <https://elixir.bootlin.com/linux/v6.18/source/kernel/sys.c#L2904-L2906>
+    fn as_secs_round_up(&self) -> u64;
+}
+
+impl RoundUpSeconds for Duration {
+    fn as_secs_round_up(&self) -> u64 {
+        self.as_secs()
+            .saturating_add(u64::from(self.subsec_nanos() != 0))
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use core::time::Duration;
+
+    use ostd::prelude::ktest;
+
+    use super::RoundUpSeconds;
+
+    #[ktest]
+    fn as_secs_round_up() {
+        assert_eq!(Duration::new(0, 0).as_secs_round_up(), 0);
+        assert_eq!(Duration::new(42, 0).as_secs_round_up(), 42);
+        assert_eq!(Duration::new(42, 1).as_secs_round_up(), 43);
+        assert_eq!(Duration::new(42, 999_999_999).as_secs_round_up(), 43);
+    }
 }

--- a/test/initramfs/etc/group
+++ b/test/initramfs/etc/group
@@ -7,4 +7,9 @@
 # See the group(5) man page for additional information about this file.
 ##
 root:x:0:
+# Both daemon and users groups are required by the LTP conformance tests chmod07
+# and fchmod02. The tests look up the "users" group first and fallback to "daemon"
+# (via SAFE_GETGRNAM_FALLBACK("users", "daemon")).
+daemon:x:1:
+users:x:100:
 nogroup:x:65534:

--- a/test/initramfs/nix/conformance/ltp.nix
+++ b/test/initramfs/nix/conformance/ltp.nix
@@ -1,12 +1,22 @@
-{ stdenv, fetchFromGitHub, hostPlatform, libcap, pkgsBuildBuild, }:
+{ stdenv, fetchFromGitHub, hostPlatform, libcap, pkgsBuildBuild, python3Minimal,
+}:
 stdenv.mkDerivation rec {
   pname = "ltp";
-  version = "20250930";
+  version = "20260529";
   src = fetchFromGitHub {
     owner = "linux-test-project";
     repo = "ltp";
     rev = "${version}";
-    hash = "sha256-vmsC4QRM4U1MoRjLbRsodX4jAolWeifaP9zetwIbWl4";
+    hash = "sha256-h4cIK0sDbyGiGwvba3jkJ+W28oNzvQAfGu1RbGAFljA=";
+  };
+  # Kirk is the official LTP tests executor.
+  kirkSrc = fetchFromGitHub {
+    owner = "linux-test-project";
+    repo = "kirk";
+    # Pinned to version v4.1.0, which is the exact version of the kirk
+    # submodule specified by the LTP 20260529 release.
+    rev = "v4.1.0";
+    hash = "sha256-W/6sxdqNACs0yI+g8BLYFdqPzJXA1VHYbUN/YL7kuJE=";
   };
 
   # Clear `CFLAGS` and `DEBUG_CFLAGS` to prevent `-g` from being automatically added.
@@ -37,7 +47,6 @@ stdenv.mkDerivation rec {
     make -C testcases/kernel
     make -C testcases/lib
     make -C runtest
-    make -C pan
 
     runHook postBuild
   '';
@@ -47,9 +56,11 @@ stdenv.mkDerivation rec {
     make -C testcases/kernel install
     make -C testcases/lib install
     make -C runtest install
-    make -C pan install
 
-    install -m 00755 $src/runltp $out/runltp
+    cp -r ${kirkSrc}/libkirk $out/libkirk
+    install -m 00755 ${kirkSrc}/kirk $out/kirk
+    substituteInPlace $out/kirk \
+      --replace-fail '#!/usr/bin/env python3' '#!${python3Minimal}/bin/python3'
     install -m 00444 $src/VERSION $out/Version
     install -m 00755 $src/ver_linux $out/ver_linux
     install -m 00755 $src/IDcheck.sh $out/IDcheck.sh

--- a/test/initramfs/src/conformance/ltp/Makefile
+++ b/test/initramfs/src/conformance/ltp/Makefile
@@ -40,8 +40,11 @@ $(TARGET_DIR): $(RUN_BASH) $(ALL_TESTS) $(EXT2_BLOCKLIST) $(EXFAT_BLOCKLIST)
 	@# Remove intermediate files
 	@rm -f $@/all.txt $@/filtered.txt
 	@# Copy bash scripts
-	@cp -r $(LTP_PREBUILT_DIR)/bin $@
-	@cp -f $(LTP_PREBUILT_DIR)/runltp $@
+	@if [ -d $(LTP_PREBUILT_DIR)/bin ]; then \
+		cp -r $(LTP_PREBUILT_DIR)/bin $@; \
+	fi
+	@cp -r $(LTP_PREBUILT_DIR)/libkirk $@
+	@cp -f $(LTP_PREBUILT_DIR)/kirk $@
 	@cp -f $(LTP_PREBUILT_DIR)/Version $@
 	@cp -f $(LTP_PREBUILT_DIR)/ver_linux $@
 	@cp -f $(LTP_PREBUILT_DIR)/IDcheck.sh $@

--- a/test/initramfs/src/conformance/ltp/run_ltp_test.sh
+++ b/test/initramfs/src/conformance/ltp/run_ltp_test.sh
@@ -4,21 +4,41 @@
 
 LTP_DIR=$(dirname "$0")
 TEST_TMP_DIR=${CONFORMANCE_TEST_WORKDIR:-/tmp}
+KIRK_TMP_DIR=${KIRK_TMP_DIR:-/tmp}
 LOG_FILE=$TEST_TMP_DIR/result.log
+JSON_REPORT=$TEST_TMP_DIR/result.json
 RESULT=0
 
 # Some test cases require a block device. Select the dedicated LTP device by default.
 export LTP_DEV=${LTP_DEV:-/dev/vdc}
 export LTP_TIMEOUT_MUL=5
+export LTPROOT=$LTP_DIR
+export TMPDIR=$TEST_TMP_DIR
+export LTP_COLORIZE_OUTPUT=0
+export KCONFIG_SKIP_CHECK=1
 
-rm -f $LOG_FILE
-CREATE_ENTRIES=1 $LTP_DIR/runltp -f syscalls -Q -p -d $TEST_TMP_DIR -l $LOG_FILE
+chmod 1777 "$TEST_TMP_DIR" 2>/dev/null || true
+rm -f "$LOG_FILE" "$JSON_REPORT"
+KIRK_ARGS="--run-suite syscalls"
+if [ "$KIRK_VERBOSE" = "1" ]; then
+    KIRK_ARGS="--verbose $KIRK_ARGS"
+fi
+
+CREATE_ENTRIES=1 "$LTP_DIR/kirk" --no-colors --tmp-dir "$KIRK_TMP_DIR" \
+    --json-report "$JSON_REPORT" $KIRK_ARGS > "$LOG_FILE" 2>&1
 if [ $? -ne 0 ]; then
     RESULT=1
 fi
 
-cat $LOG_FILE
-if ! grep -q "Total Failures: 0" $LOG_FILE; then
+cat "$LOG_FILE"
+if [ -f "$JSON_REPORT" ]; then
+    STATS_BLOCK=$(sed -n '/"stats": {/,/}/p' "$JSON_REPORT")
+    if ! echo "$STATS_BLOCK" | grep -q '"failed": 0' ||
+       ! echo "$STATS_BLOCK" | grep -q '"broken": 0' ||
+       ! echo "$STATS_BLOCK" | grep -q '"warnings": 0'; then
+        RESULT=1
+    fi
+else
     RESULT=1
 fi
 

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -68,6 +68,7 @@ capset04
 # cachestat04
 
 # chdir01
+chdir02
 chdir04
 
 chmod01
@@ -123,10 +124,13 @@ clone06
 clone07
 # clone08
 # clone09
+clone10
+# clone11
 
 # clone301
 # clone302
 # clone303
+clone304
 
 close01
 close02
@@ -250,6 +254,7 @@ fallocate03
 # file_attr02
 # file_attr03
 # file_attr04
+# file_attr05
 
 #posix_fadvise test cases
 # posix_fadvise01
@@ -618,6 +623,7 @@ getxattr01
 # ioctl_ficlonerange01
 # ioctl_ficlonerange02
 # ioctl_fiemap01
+# ioctl_getlbmd01
 
 # ioctl_pidfd01
 # ioctl_pidfd02
@@ -666,6 +672,7 @@ getxattr01
 # fanotify22
 # fanotify23
 # fanotify24
+# fanotify25
 
 # ioperm01
 # ioperm02
@@ -693,6 +700,7 @@ ioprio_set02
 # io_submit01
 # io_submit02
 # io_submit03
+# io_submit04
 
 # keyctl01
 # keyctl02
@@ -920,6 +928,7 @@ mremap03
 # mremap04
 mremap05
 # mremap06
+mremap07
 
 # mseal01
 # mseal02
@@ -973,6 +982,7 @@ nanosleep02
 
 # name_to_handle_at01
 # name_to_handle_at02
+# name_to_handle_at03
 
 # nftw01
 # nftw6401
@@ -1087,6 +1097,8 @@ pipeio_8
 
 poll01
 # poll02
+poll03
+poll04
 
 ppoll01
 
@@ -1766,6 +1778,11 @@ unshare04
 # umount2_02
 
 # userfaultfd01
+# userfaultfd02
+# userfaultfd03
+# userfaultfd04
+# userfaultfd05
+# userfaultfd06
 
 # ustat01
 # ustat02
@@ -1885,6 +1902,7 @@ statx03
 
 # io_uring01
 # io_uring02
+# io_uring03
 
 # Tests below may cause kernel memory leak
 # perf_event_open03

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -827,7 +827,7 @@ mknod02
 # mknod05
 mknod06
 # mknod07
-# mknod08
+mknod08
 mknod09
 
 #mknodat test cases

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -37,6 +37,7 @@ mknod01
 mknod02
 mknod06
 mknod08
+mmap09
 open07
 open15
 pipeio_1

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -36,6 +36,7 @@ mkdir04
 mknod01
 mknod02
 mknod06
+mknod08
 open07
 open15
 pipeio_1


### PR DESCRIPTION
This is part of the groundwork for #3488.

This PR updates the bundled LTP conformance setup and includes the compatibility fixes needed by the newer test coverage.

- Update the bundled LTP test suite to `20260529`.
- Switch the LTP conformance runner from `runltp` to `kirk`, and consume the `kirk` JSON report when determining test success.
- Report load averages through `sysinfo`.
- Report zero swap totals in `/proc/meminfo`.
- Assign new `ramfs` inode owners from filesystem credentials (`fsuid`/`fsgid`).

## Blocked Test Cases

We disabled/blocked `mknod08` and `mmap09` on `exfat` conformance tests:
- **`mknod08`**: This test verifies group ownership inheritance of newly created FIFOs. Since `exfat` does not support creating named pipes (FIFOs) via `mknod` (returning `ENOTSUP`), it has been added to the exfat blocklist.
- **`mmap09`**: In the new LTP `20260529`, the test file `mmaptest` is opened in the current working directory (instead of `/tmp` in the old version). Under `CONFORMANCE_TEST_WORKDIR=/exfat`, this file resides on the `exfat` filesystem. Since `exfat` in Asterinas does not support shared writable memory mapping (`MAP_SHARED` + `PROT_WRITE`), it fails during setup and has been blocked on `exfat`.

## Runner and Environment Notes

- Set `LTPROOT` so `kirk` and LTP helpers resolve the installed test tree from the runner location instead of relying on the default `/opt/ltp` path.
- Set `TMPDIR` to `CONFORMANCE_TEST_WORKDIR` so LTP test temporary files are created on the target filesystem, such as `/ext2` or `/exfat`, instead of always using `/tmp`.
- Set `LTP_COLORIZE_OUTPUT=0` to keep LTP testcase output stable and free of ANSI color sequences in CI logs.
- Set `KCONFIG_SKIP_CHECK=1` because the Asterinas test image does not provide a normal Linux kernel config file for LTP kconfig probes.
- Use a separate `KIRK_TMP_DIR` for `kirk`'s own session directory. `kirk` creates a `latest` symlink under `--tmp-dir`; using `/exfat` there fails before tests start because exFAT does not support symlinks. LTP testcases still use `TMPDIR` and therefore still exercise the requested filesystem.
- Run `chmod 1777` on `TEST_TMP_DIR` so LTP cases that drop privileges, for example to `nobody`, can create their per-test temporary directories under `/ext2` or `/exfat`.
- Add common `daemon` and `users` entries to `test/initramfs/etc/group` so the initramfs user/group database is closer to the Linux environments expected by newer LTP tests.
