### PR TITLE
Support RENAME_NOREPLACE and RENAME_EXCHANGE for ext2

### DIFF
--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -217,14 +217,10 @@ impl Inode for Ext2Inode {
         new_name: &str,
         mode: RenameMode,
     ) -> Result<()> {
-        if mode == RenameMode::Exchange {
-            return_errno_with_message!(Errno::EINVAL, "RENAME_EXCHANGE is not supported on ext2");
-        }
-
         let target = target
             .downcast_ref::<Ext2Inode>()
             .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
-        self.rename(old_name, target, new_name)
+        self.rename(old_name, target, new_name, mode)
     }
 
     fn read_link(&self) -> Result<SymbolicLink> {

--- a/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -11,7 +11,10 @@ mod dir_entry;
 
 use self::dir_entry::{DOT_BYTE, DOT_DOT_BYTE, DirBlockView, DirEntryFileType, DirEntryHeader};
 use super::{super::Ext2, FileFlags, FilePerm, Inode, InodeInner, MAX_LINK_COUNT};
-use crate::fs::ext2::{prelude::*, utils};
+use crate::fs::{
+    ext2::{prelude::*, utils},
+    vfs::inode::RenameMode,
+};
 
 /// Information about a candidate directory entry slot.
 #[derive(Clone, Copy, Debug)]
@@ -235,6 +238,7 @@ impl Inode {
         old_name: &str,
         target: &Inode,
         new_name: &str,
+        mode: RenameMode,
     ) -> Result<()> {
         let fs = self.fs()?;
         let is_same_dir = self.ino == target.ino;
@@ -252,28 +256,45 @@ impl Inode {
         let old_inode = fs.read_inode(old_ino)?;
         let replaced_inode = {
             let target_inner = target.inner.read();
-            target_inner
-                .find_entry_info(new_name)
-                .ok()
-                .map(|entry_info| fs.read_inode(entry_info.ino))
-                .transpose()?
+            match target_inner.find_entry_info(new_name) {
+                Ok(entry_info) => Some(fs.read_inode(entry_info.ino)?),
+                Err(err) if err.error() == Errno::ENOENT => None,
+                Err(err) => return Err(err),
+            }
         };
+
+        // The VFS layer guarantees that the destination exists for
+        // `RenameMode::Exchange`.
+        debug_assert!(
+            mode != RenameMode::Exchange || replaced_inode.is_some(),
+            "destination must exist for RENAME_EXCHANGE"
+        );
 
         // The `DirDentry.children` lock in the VFS layer keeps the parent
         // directory entry stable during this operation, so we only need to
         // lock all related inodes in order, without rechecking the lookup
         // result.
         // Step 2: lock all participating inodes in global ino order.
+        let destination_inode = match mode {
+            RenameMode::Exchange => replaced_inode.as_deref().unwrap(),
+            _ => replaced_inode.as_deref().unwrap_or(old_inode.as_ref()),
+        };
         let lock_targets = [
             self as &Inode,
             target,
             old_inode.as_ref(),
-            replaced_inode.as_deref().unwrap_or(old_inode.as_ref()),
+            destination_inode,
         ];
         let mut guards = MultiInodeInnerGuards::lock(&lock_targets);
 
         // Step 3: validate invariants under lock.
-        self.validate_rename_invariants(&guards, &old_inode, replaced_inode.as_deref())?;
+        self.validate_rename_invariants(
+            &guards,
+            target,
+            &old_inode,
+            replaced_inode.as_deref(),
+            mode,
+        )?;
 
         // Step 4: apply directory mutations and metadata updates.
         self.apply_dir_mutations(
@@ -283,6 +304,7 @@ impl Inode {
             &old_inode,
             replaced_inode.as_deref(),
             new_name,
+            mode,
         )?;
 
         Ok(())
@@ -291,8 +313,10 @@ impl Inode {
     fn validate_rename_invariants(
         &self,
         guards: &MultiInodeInnerGuards,
+        target: &Inode,
         old_inode: &Inode,
         replaced_inode: Option<&Inode>,
+        mode: RenameMode,
     ) -> Result<()> {
         // Step 3.1: sanity-check that the moved directory's `..` still
         // points to the source parent. A mismatch indicates on-disk
@@ -309,16 +333,35 @@ impl Inode {
         if let Some(replaced) = replaced_inode {
             let replaced_is_dir = replaced.type_ == InodeType::Dir;
             let old_is_dir = old_inode.type_ == InodeType::Dir;
-            if old_is_dir && !replaced_is_dir {
-                return_errno!(Errno::ENOTDIR);
+            // Exchange allows mismatched types (file↔dir) — same as
+            // Linux `vfs_rename` and the ramfs reference implementation.
+            if mode != RenameMode::Exchange {
+                if old_is_dir && !replaced_is_dir {
+                    return_errno!(Errno::ENOTDIR);
+                }
+                if !old_is_dir && replaced_is_dir {
+                    return_errno!(Errno::EISDIR);
+                }
             }
-            if !old_is_dir && replaced_is_dir {
-                return_errno!(Errno::EISDIR);
-            }
-            if replaced_is_dir {
+            // For Exchange, non-empty directories can be swapped (the two
+            // entries simply exchange places).
+            if mode != RenameMode::Exchange && replaced_is_dir {
                 let replaced_inner = guards.inner(replaced.ino());
                 if !replaced_inner.empty_dir(replaced.ino()) {
                     return_errno!(Errno::ENOTEMPTY);
+                }
+            }
+            // For Exchange, verify that the destination directory's `..`
+            // points to the expected parent (the target directory, where
+            // the destination entry lives).
+            if mode == RenameMode::Exchange && replaced_is_dir {
+                let replaced_inner = guards.inner(replaced.ino());
+                let parent_ino = replaced_inner.find_entry_info("..")?.ino;
+                if parent_ino != target.ino {
+                    return_errno_with_message!(
+                        Errno::EIO,
+                        "dotdot entry inconsistent with destination dir"
+                    );
                 }
             }
         }
@@ -326,6 +369,7 @@ impl Inode {
         Ok(())
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn apply_dir_mutations(
         &self,
         guards: &mut MultiInodeInnerGuards,
@@ -334,13 +378,91 @@ impl Inode {
         old_inode: &Inode,
         replaced_inode: Option<&Inode>,
         new_name: &str,
+        mode: RenameMode,
     ) -> Result<()> {
         let old_is_dir = old_inode.type_ == InodeType::Dir;
-        let has_replaced = replaced_inode.is_some();
         let old_ino = old_inode.ino();
         let is_same_dir = self.ino == target.ino;
         let moved_file_type = DirEntryFileType::from(old_inode.type_);
         let fs = self.fs()?;
+
+        if mode == RenameMode::Exchange {
+            // VFS guarantees the destination exists.
+            let replaced = replaced_inode.unwrap();
+            let replaced_ino = replaced.ino();
+            let replaced_is_dir = replaced.type_ == InodeType::Dir;
+            let replaced_file_type = DirEntryFileType::from(replaced.type_);
+            let now = utils::now();
+
+            if is_same_dir {
+                // Same directory: swap the two entry targets in place.
+                let dir_inner = guards.inner_mut(self.ino);
+                dir_inner.overwrite_entry(old_name, replaced_ino, replaced_file_type)?;
+                dir_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
+                dir_inner.set_mtime_ctime(now);
+            } else {
+                // Cross-directory: both entries already exist (the VFS layer
+                // guarantees the destination exists for `Exchange`), so swap
+                // each entry's target inode in place. This avoids any
+                // delete+add window and the link-count churn it would need.
+                {
+                    let target_inner = guards.inner_mut(target.ino);
+                    target_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
+                    target_inner.set_mtime_ctime(now);
+                }
+                {
+                    let source_inner = guards.inner_mut(self.ino);
+                    source_inner.overwrite_entry(old_name, replaced_ino, replaced_file_type)?;
+                    source_inner.set_mtime_ctime(now);
+                }
+            }
+
+            // Each inode leaves one directory and enters another, so the net
+            // change to each inode's own link count is zero. The moved
+            // directories' `..` still needs repointing, and the *parent*
+            // directories' link counts must reflect the moved `..` entries.
+            // Update ctime on both moved inodes.
+            let old_inner = guards.inner_mut(old_ino);
+            old_inner.set_ctime(now);
+            let replaced_inner = guards.inner_mut(replaced_ino);
+            replaced_inner.set_ctime(now);
+
+            // Update `..` and parent link counts for directories that crossed
+            // directory boundaries. A directory's `..` contributes 1 to its
+            // parent's link count, so moving a dir to a new parent decrements
+            // the old parent and increments the new one.
+            if !is_same_dir {
+                if old_is_dir {
+                    let old_inner = guards.inner_mut(old_ino);
+                    let dotdot = old_inner.find_entry_info("..")?;
+                    old_inner.set_entry_target(&dotdot, target.ino, DirEntryFileType::Dir)?;
+                    old_inner.remove_flags(FileFlags::INDEX_DIR);
+                    old_inner.set_mtime_ctime(now);
+                }
+                if replaced_is_dir {
+                    let replaced_inner = guards.inner_mut(replaced_ino);
+                    let dotdot = replaced_inner.find_entry_info("..")?;
+                    replaced_inner.set_entry_target(&dotdot, self.ino, DirEntryFileType::Dir)?;
+                    replaced_inner.remove_flags(FileFlags::INDEX_DIR);
+                    replaced_inner.set_mtime_ctime(now);
+                }
+                // Adjust parent link counts: `old` moved from `self` to
+                // `target`, and `replaced` moved from `target` to `self`.
+                if old_is_dir {
+                    guards.inner_mut(self.ino).dec_link_count(1);
+                    guards.inner_mut(target.ino).inc_link_count(1);
+                }
+                if replaced_is_dir {
+                    guards.inner_mut(target.ino).dec_link_count(1);
+                    guards.inner_mut(self.ino).inc_link_count(1);
+                }
+            }
+
+            return Ok(());
+        }
+
+        // --- Replace / NoReplace (unchanged logic below) ---
+        let has_replaced = replaced_inode.is_some();
 
         // Step 4.1: apply directory entry mutations.
         if is_same_dir {

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/ext2.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/ext2.txt
@@ -1,2 +1,0 @@
-renameat201
-renameat202

--- a/test/initramfs/src/regression/fs/ext2/renameat2.c
+++ b/test/initramfs/src/regression/fs/ext2/renameat2.c
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/fs.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define BASE_DIR "/ext2/renameat2_test"
+#define OUT_FILE BASE_DIR "/out.txt"
+
+// do_renameat2 wrapper via raw syscall, portable across libc versions.
+static int do_renameat2(int olddirfd, const char *oldpath, int newdirfd,
+			const char *newpath, unsigned int flags)
+{
+	return (int)syscall(__NR_renameat2, olddirfd, oldpath, newdirfd,
+			    newpath, flags);
+}
+
+static void ensure_dir(const char *path)
+{
+	CHECK_WITH(mkdir(path, 0755), _ret >= 0 || errno == EEXIST);
+}
+
+static void remove_if_exists(const char *path)
+{
+	CHECK_WITH(rmdir(path), _ret == 0 || errno == ENOENT);
+}
+
+static void unlink_if_exists(const char *path)
+{
+	CHECK_WITH(unlink(path), _ret == 0 || errno == ENOENT);
+}
+
+static void write_file(const char *path, const char *content)
+{
+	int fd = CHECK_WITH(open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644),
+			    _ret >= 0);
+	ssize_t len = (ssize_t)strlen(content);
+	ssize_t n = CHECK_WITH(write(fd, content, (size_t)len), _ret >= 0);
+	if (n != len) {
+		fprintf(stderr, "write_file short write\n");
+		exit(EXIT_FAILURE);
+	}
+	CHECK_WITH(close(fd), _ret >= 0);
+}
+
+static void read_file_expect(const char *path, const char *expected)
+{
+	char buf[256];
+	int fd = CHECK_WITH(open(path, O_RDONLY), _ret >= 0);
+	ssize_t n = CHECK_WITH(read(fd, buf, sizeof(buf) - 1), _ret >= 0);
+	CHECK_WITH(close(fd), _ret >= 0);
+	buf[n] = '\0';
+	if (strcmp(buf, expected) != 0) {
+		fprintf(stderr, "read_file_expect: got '%s', expected '%s'\n",
+			buf, expected);
+		exit(EXIT_FAILURE);
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup                                                               */
+/* ------------------------------------------------------------------ */
+
+FN_SETUP(cleanup)
+{
+	unlink_if_exists(OUT_FILE);
+	remove_if_exists(BASE_DIR);
+}
+END_SETUP()
+
+/* ------------------------------------------------------------------ */
+/* 1. Same-directory file↔file exchange                                */
+/* ------------------------------------------------------------------ */
+FN_TEST(exchange_same_dir_files)
+{
+	ensure_dir(BASE_DIR);
+	const char *f1 = BASE_DIR "/f1";
+	const char *f2 = BASE_DIR "/f2";
+
+	write_file(f1, "aaa");
+	write_file(f2, "bbb");
+
+	TEST_SUCC(do_renameat2(AT_FDCWD, f1, AT_FDCWD, f2, RENAME_EXCHANGE));
+
+	read_file_expect(f1, "bbb");
+	read_file_expect(f2, "aaa");
+
+	unlink_if_exists(f1);
+	unlink_if_exists(f2);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()
+
+/* ------------------------------------------------------------------ */
+/* 2. Cross-directory file↔file exchange — content + parent nlink      */
+/* ------------------------------------------------------------------ */
+FN_TEST(exchange_cross_dir_files)
+{
+	ensure_dir(BASE_DIR);
+	const char *da = BASE_DIR "/da";
+	const char *db = BASE_DIR "/db";
+	const char *fa = BASE_DIR "/da/fa";
+	const char *fb = BASE_DIR "/db/fb";
+	ensure_dir(da);
+	ensure_dir(db);
+
+	write_file(fa, "hello");
+	write_file(fb, "world");
+
+	struct stat st_a_before, st_b_before;
+	TEST_SUCC(stat(da, &st_a_before));
+	TEST_SUCC(stat(db, &st_b_before));
+
+	TEST_SUCC(do_renameat2(AT_FDCWD, fa, AT_FDCWD, fb, RENAME_EXCHANGE));
+
+	read_file_expect(fa, "world");
+	read_file_expect(fb, "hello");
+
+	// Parent directory link counts must not change (both are non-dirs).
+	struct stat st_a_after, st_b_after;
+	TEST_SUCC(stat(da, &st_a_after));
+	TEST_SUCC(stat(db, &st_b_after));
+	TEST_RES(stat(da, &st_a_after),
+		 st_a_after.st_nlink == st_a_before.st_nlink);
+	TEST_RES(stat(db, &st_b_after),
+		 st_b_after.st_nlink == st_b_before.st_nlink);
+
+	unlink_if_exists(fa);
+	unlink_if_exists(fb);
+	remove_if_exists(da);
+	remove_if_exists(db);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()
+
+/* ------------------------------------------------------------------ */
+/* 3. Cross-directory dir↔dir exchange — .. + parent nlink unchanged    */
+/* ------------------------------------------------------------------ */
+FN_TEST(exchange_cross_dir_dirs)
+{
+	ensure_dir(BASE_DIR);
+	const char *da = BASE_DIR "/da";
+	const char *db = BASE_DIR "/db";
+	const char *da_child = BASE_DIR "/da/src";
+	const char *db_child = BASE_DIR "/db/dst";
+	ensure_dir(da);
+	ensure_dir(db);
+	ensure_dir(da_child);
+	ensure_dir(db_child);
+
+	struct stat st_a_before, st_b_before;
+	TEST_SUCC(stat(da, &st_a_before));
+	TEST_SUCC(stat(db, &st_b_before));
+
+	TEST_SUCC(do_renameat2(AT_FDCWD, da_child, AT_FDCWD, db_child,
+			       RENAME_EXCHANGE));
+
+	// Exchange swaps the inodes that the entries point to, not the entry
+	// names. Both paths still exist, just under opposite parents.
+	TEST_SUCC(access(BASE_DIR "/da/src", F_OK));
+	TEST_SUCC(access(BASE_DIR "/db/dst", F_OK));
+
+	// Net parent link counts unchanged: each loses one child dir's ..
+	// and gains the other's.
+	struct stat st_a_after, st_b_after;
+	TEST_SUCC(stat(da, &st_a_after));
+	TEST_SUCC(stat(db, &st_b_after));
+	TEST_RES(stat(da, &st_a_after),
+		 st_a_after.st_nlink == st_a_before.st_nlink);
+	TEST_RES(stat(db, &st_b_after),
+		 st_b_after.st_nlink == st_b_before.st_nlink);
+
+	remove_if_exists(BASE_DIR "/da/src");
+	remove_if_exists(BASE_DIR "/db/dst");
+	remove_if_exists(da);
+	remove_if_exists(db);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()
+
+/* ------------------------------------------------------------------ */
+/* 4. Cross-directory dir→file exchange (single-dir, aligns Linux)      */
+/* ------------------------------------------------------------------ */
+FN_TEST(exchange_cross_dir_dir_with_file)
+{
+	ensure_dir(BASE_DIR);
+	const char *da = BASE_DIR "/da";
+	const char *db = BASE_DIR "/db";
+	const char *da_child = BASE_DIR "/da/src"; // directory
+	const char *db_file = BASE_DIR "/db/dst"; // regular file
+	ensure_dir(da);
+	ensure_dir(db);
+	ensure_dir(da_child);
+	write_file(db_file, "content");
+
+	struct stat st_a_before, st_b_before;
+	TEST_SUCC(stat(da, &st_a_before));
+	TEST_SUCC(stat(db, &st_b_before));
+
+	// dir ↔ file must succeed — same as Linux and ramfs.
+	TEST_SUCC(do_renameat2(AT_FDCWD, da_child, AT_FDCWD, db_file,
+			       RENAME_EXCHANGE));
+
+	// After exchange: da/src is now a regular file, db/dst is a dir.
+	TEST_SUCC(access(BASE_DIR "/da/src", F_OK));
+	TEST_SUCC(access(BASE_DIR "/db/dst", F_OK));
+
+	// Parent nlink: da loses one child dir (src left), db gains one
+	// child dir (dst arrived).
+	struct stat st_a_after, st_b_after;
+	TEST_SUCC(stat(da, &st_a_after));
+	TEST_SUCC(stat(db, &st_b_after));
+	TEST_RES(stat(da, &st_a_after),
+		 st_a_after.st_nlink == st_a_before.st_nlink - 1);
+	TEST_RES(stat(db, &st_b_after),
+		 st_b_after.st_nlink == st_b_before.st_nlink + 1);
+
+	unlink_if_exists(BASE_DIR "/da/src");
+	remove_if_exists(BASE_DIR "/db/dst");
+	remove_if_exists(da);
+	remove_if_exists(db);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()
+
+/* ------------------------------------------------------------------ */
+/* 5. Cross-directory file→dir exchange (single-dir, symmetric of #4)   */
+/* ------------------------------------------------------------------ */
+FN_TEST(exchange_cross_dir_file_with_dir)
+{
+	ensure_dir(BASE_DIR);
+	const char *da = BASE_DIR "/da";
+	const char *db = BASE_DIR "/db";
+	const char *da_file = BASE_DIR "/da/src"; // regular file
+	const char *db_child = BASE_DIR "/db/dst"; // directory
+	ensure_dir(da);
+	ensure_dir(db);
+	write_file(da_file, "data");
+	ensure_dir(db_child);
+
+	struct stat st_a_before, st_b_before;
+	TEST_SUCC(stat(da, &st_a_before));
+	TEST_SUCC(stat(db, &st_b_before));
+
+	// file ↔ dir — symmetric of case 4.
+	TEST_SUCC(do_renameat2(AT_FDCWD, da_file, AT_FDCWD, db_child,
+			       RENAME_EXCHANGE));
+
+	// Parent nlink: da gains one dir (dst arrived), db loses one dir
+	// (dst left).
+	struct stat st_a_after, st_b_after;
+	TEST_SUCC(stat(da, &st_a_after));
+	TEST_SUCC(stat(db, &st_b_after));
+	TEST_RES(stat(da, &st_a_after),
+		 st_a_after.st_nlink == st_a_before.st_nlink + 1);
+	TEST_RES(stat(db, &st_b_after),
+		 st_b_after.st_nlink == st_b_before.st_nlink - 1);
+
+	unlink_if_exists(BASE_DIR "/db/dst");
+	remove_if_exists(BASE_DIR "/da/src");
+	remove_if_exists(da);
+	remove_if_exists(db);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()
+
+/* ------------------------------------------------------------------ */
+/* 6. NOREPLACE — destination exists → EEXIST                          */
+/* ------------------------------------------------------------------ */
+FN_TEST(noreplace_target_exists)
+{
+	ensure_dir(BASE_DIR);
+	const char *f1 = BASE_DIR "/f1";
+	const char *f2 = BASE_DIR "/f2";
+	write_file(f1, "x");
+	write_file(f2, "y");
+
+	TEST_ERRNO(do_renameat2(AT_FDCWD, f1, AT_FDCWD, f2, RENAME_NOREPLACE),
+		   EEXIST);
+
+	// Neither file should have been modified.
+	read_file_expect(f1, "x");
+	read_file_expect(f2, "y");
+
+	unlink_if_exists(f1);
+	unlink_if_exists(f2);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()
+
+/* ------------------------------------------------------------------ */
+/* 7. EXCHANGE — destination does not exist → ENOENT                    */
+/* ------------------------------------------------------------------ */
+FN_TEST(exchange_target_missing)
+{
+	ensure_dir(BASE_DIR);
+	const char *f1 = BASE_DIR "/f1";
+	const char *missing = BASE_DIR "/no_such";
+	write_file(f1, "x");
+
+	TEST_ERRNO(do_renameat2(AT_FDCWD, f1, AT_FDCWD, missing,
+				RENAME_EXCHANGE),
+		   ENOENT);
+
+	read_file_expect(f1, "x");
+	unlink_if_exists(f1);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()
+
+/* ------------------------------------------------------------------ */
+/* 8. NOREPLACE | EXCHANGE → EINVAL                                    */
+/* ------------------------------------------------------------------ */
+FN_TEST(noreplace_and_exchange_einval)
+{
+	ensure_dir(BASE_DIR);
+	const char *f1 = BASE_DIR "/f1";
+	const char *f2 = BASE_DIR "/f2";
+	write_file(f1, "a");
+	write_file(f2, "b");
+
+	TEST_ERRNO(do_renameat2(AT_FDCWD, f1, AT_FDCWD, f2,
+				RENAME_NOREPLACE | RENAME_EXCHANGE),
+		   EINVAL);
+
+	unlink_if_exists(f1);
+	unlink_if_exists(f2);
+	remove_if_exists(BASE_DIR);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -96,6 +96,7 @@ test_ext2 "/ext2" "test_file.txt"
 ./ext2/permissions
 ./ext2/readdir
 ./ext2/rename
+./ext2/renameat2
 ./ext2/rmdir
 ./ext2/short_rw
 ./ext2/sparse


### PR DESCRIPTION
为 ext2 文件系统实现 RENAME_NOREPLACE 和 RENAME_EXCHANGE 支持。

VFS dentry 层已在 commit fd5d02d1b 中完成前端检查（EEXIST / ENOENT /
重命名环路），ext2 只需处理底层目录项操作。

- 用 overwrite_entry 原地交换入口目标，避免 delete+add 窗口
- Exchange 跳过 ENOTEMPTY 检查（非空目录可以交换）
- Exchange 的类型检查对齐 Linux vfs_rename 和 ramfs 参考实现（允许
  file↔dir 交换）
- 跨目录移动目录时更新父目录 link count 并重定向 ..
- 两个交换的 inode 的 ctime/mtime 更新对称一致
- 区分 ENOENT 与 EIO：损坏的目录块不再被 .ok() 吞掉导致 panic

解封 ext2 上的 LTP renameat201 和 renameat202，新增 8 个回归测试
覆盖同目录/跨目录 file<->file、dir<->dir、file<->dir Exchange、
NoReplace EEXIST、Exchange ENOENT 和 flag 组合 EINVAL 场景。