### PR TITLE
Fix a potential overflow in `Cursor::new`

### DIFF
--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -106,7 +106,7 @@ impl<'rcu, C: PageTableConfig> Cursor<'rcu, C> {
         guard: &'rcu dyn InAtomicMode,
         va: &Range<Vaddr>,
     ) -> Result<Self, PageTableError> {
-        if !is_valid_range::<C>(va) || va.is_empty() {
+        if va.is_empty() || !is_valid_range::<C>(va) {
             return Err(PageTableError::InvalidVaddrRange(va.start, va.end));
         }
         if !va.start.is_multiple_of(C::BASE_PAGE_SIZE) || !va.end.is_multiple_of(C::BASE_PAGE_SIZE)


### PR DESCRIPTION
`Cursor::new` may trigger an `r.end - 1` integer overflow in `is_valid_range` if the user passes in an exotic range like `2..0` through the OSTD API [VmSpace::cursor_mut](https://asterinas.github.io/api-docs/0.18.0/ostd/mm/vm_space/struct.VmSpace.html#method.cursor_mut). 

Although it would be highly unusual for a wise user to do so, this modification makes the code slightly more robust at no additional cost.

https://github.com/asterinas/asterinas/blob/37411049265056135a5e18c8c75a0c3d16b18579/ostd/src/mm/page_table/cursor/mod.rs#L104-L111

https://github.com/asterinas/asterinas/blob/37411049265056135a5e18c8c75a0c3d16b18579/ostd/src/mm/page_table/mod.rs#L285-L287