### PR TITLE
Remove redundant empty-path checks

### DIFF
--- a/kernel/src/syscall/chdir.rs
+++ b/kernel/src/syscall/chdir.rs
@@ -21,9 +21,6 @@ pub fn sys_chdir(path_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     let mut path_resolver = fs_ref.resolver().write();
     let path = {
         let path_name = path_name.to_string_lossy();
-        if path_name.is_empty() {
-            return_errno_with_message!(Errno::ENOENT, "path is empty");
-        }
         let fs_path = FsPath::try_from(path_name.as_ref())?;
         path_resolver.lookup(&fs_path)?
     };

--- a/kernel/src/syscall/chown.rs
+++ b/kernel/src/syscall/chown.rs
@@ -63,10 +63,6 @@ pub fn sys_fchownat(
         dirfd, path_name, uid, gid, flags
     );
 
-    if flags.contains(ChownFlags::AT_EMPTY_PATH) && path_name.is_empty() {
-        return sys_fchown(dirfd, uid, gid, ctx);
-    }
-
     let uid = to_optional_id(uid, Uid::new)?;
     let gid = to_optional_id(gid, Gid::new)?;
     if uid.is_none() && gid.is_none() {

--- a/kernel/src/syscall/chroot.rs
+++ b/kernel/src/syscall/chroot.rs
@@ -17,9 +17,6 @@ pub fn sys_chroot(path_ptr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
     let mut path_resolver = fs_ref.resolver().write();
     let path = {
         let path_name = path_name.to_string_lossy();
-        if path_name.is_empty() {
-            return_errno_with_message!(Errno::ENOENT, "path is empty");
-        }
         let fs_path = FsPath::try_from(path_name.as_ref())?;
         path_resolver.lookup(&fs_path)?
     };

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -58,10 +58,6 @@ pub fn sys_fstatat(
         dirfd, filename, stat_buf_ptr, flags
     );
 
-    if flags.contains(StatFlags::AT_EMPTY_PATH) && filename.is_empty() {
-        return sys_fstat(dirfd, stat_buf_ptr, ctx);
-    }
-
     let path = {
         let filename = filename.to_string_lossy();
         let fs_path =


### PR DESCRIPTION
This PR removes three redundant empty path checks.

I identified this issue while reviewing #3572 (see the related discussion https://github.com/asterinas/asterinas/pull/3572#discussion_r3558635411). Since `FsPath::try_from` and `FsPath::from_fd_at` already handle empty paths and `AT_EMPTY_PATH` internally, there is no need to perform these checks at the call sites beforehand.

Note that the `fchown` case is intentionally excluded from this PR, as it is expected to be addressed by #3572.