### PR TITLE
Update linux kernel binary for benchmark

### DIFF
--- a/test/initramfs/src/benchmark/common/prepare_host.sh
+++ b/test/initramfs/src/benchmark/common/prepare_host.sh
@@ -23,7 +23,7 @@ prepare_libs() {
 
     # Array of files to download and their URLs
     declare -A files=(
-        ["${LINUX_KERNEL}"]="https://raw.githubusercontent.com/asterinas/linux_binary_cache/24db4ff/vmlinuz-${LINUX_KERNEL_VERSION}"
+        ["${LINUX_KERNEL}"]="https://raw.githubusercontent.com/asterinas/linux_binary_cache/8e6e8ad382aac7e605d7a058811d09bce478cd7d/${LINUX_KERNEL_VERSION}/vmlinuz"
     )
 
     # Download files if they don't exist

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 #= Download dependency =====================================================
 
 WORKDIR /opt/linux_binary_cache
-RUN wget https://raw.githubusercontent.com/asterinas/linux_binary_cache/24db4ff/vmlinuz-6.16.0 \
+RUN wget https://raw.githubusercontent.com/asterinas/linux_binary_cache/8e6e8ad382aac7e605d7a058811d09bce478cd7d/6.16.0/vmlinuz \
         -O vmlinuz
 
 #= Download VDSO files =====================================================


### PR DESCRIPTION
## Summary
  - Update the Docker image to download the Linux kernel binary
## Note
- This PR should be merged after https://github.com/asterinas/linux_binary_cache/pull/4
- It may be better that the path is pinned to a specifical commit.
