### PR TITLE
Rustfmt code under `kernel/comps/time/src/rtc`

### DIFF
--- a/kernel/comps/time/src/rtc/cmos.rs
+++ b/kernel/comps/time/src/rtc/cmos.rs
@@ -15,10 +15,18 @@
 
 use core::num::NonZeroU8;
 
-use ostd::{arch::{device::io_port::{ReadWriteAccess, WriteOnlyAccess}, kernel::ACPI_INFO}, io::IoPort, sync::SpinLock, warn};
+use ostd::{
+    arch::{
+        device::io_port::{ReadWriteAccess, WriteOnlyAccess},
+        kernel::ACPI_INFO,
+    },
+    io::IoPort,
+    sync::SpinLock,
+    warn,
+};
 
-use crate::SystemTime;
 use super::Driver;
+use crate::SystemTime;
 
 pub struct RtcCmos {
     access: SpinLock<CmosAccess>,
@@ -41,7 +49,10 @@ impl Driver for RtcCmos {
 
         let acpi_info = ACPI_INFO.get().unwrap();
 
-        if acpi_info.boot_flags.is_some_and(|flags| flags.use_time_and_alarm_namespace_for_rtc()) {
+        if acpi_info
+            .boot_flags
+            .is_some_and(|flags| flags.use_time_and_alarm_namespace_for_rtc())
+        {
             // "If set, indicates that the CMOS RTC is either not implemented, or does not exist at
             // the legacy addresses". See:
             // <https://uefi.org/specs/ACPI/6.5/05_ACPI_Software_Programming_Model.html#ia-pc-boot-architecture-flags>.
@@ -140,7 +151,8 @@ impl CmosAccess {
     }
 
     pub(self) fn read_century(&mut self) -> Option<u8> {
-        self.century_register.map(|r| self.read_register_impl(r.get()))
+        self.century_register
+            .map(|r| self.read_register_impl(r.get()))
     }
 
     pub(self) fn read_status_a(&mut self) -> StatusA {
@@ -181,7 +193,9 @@ impl CmosData {
         let mut now = Self::from_rtc_raw(&mut access);
         // Retry if the new value differs from the old one. An RTC update may occur in the
         // meantime, which would result in an invalid value.
-        while let new = Self::from_rtc_raw(&mut access) && now != new {
+        while let new = Self::from_rtc_raw(&mut access)
+            && now != new
+        {
             now = new;
         }
 
@@ -231,11 +245,14 @@ impl CmosData {
 
         self.second = bcd_to_binary(self.second);
         self.minute = bcd_to_binary(self.minute);
-        self.hour = bcd_to_binary(self.hour & !Self::HOUR_IS_AFTERNOON) | (self.hour & Self::HOUR_IS_AFTERNOON);
+        self.hour = bcd_to_binary(self.hour & !Self::HOUR_IS_AFTERNOON)
+            | (self.hour & Self::HOUR_IS_AFTERNOON);
         self.day = bcd_to_binary(self.day);
         self.month = bcd_to_binary(self.month);
         self.year = bcd_to_binary(self.year as u8) as u16;
-        self.century = self.century.and_then(|c| NonZeroU8::new(bcd_to_binary(c.get())));
+        self.century = self
+            .century
+            .and_then(|c| NonZeroU8::new(bcd_to_binary(c.get())));
     }
 
     const HOUR_IS_AFTERNOON: u8 = 0x80;
@@ -251,7 +268,11 @@ impl CmosData {
     fn modify_year(&mut self) {
         const DEFAULT_21_CENTURY: u8 = 20;
 
-        self.year += (self.century.map(NonZeroU8::get).unwrap_or(DEFAULT_21_CENTURY) as u16) * 100;
+        self.year += (self
+            .century
+            .map(NonZeroU8::get)
+            .unwrap_or(DEFAULT_21_CENTURY) as u16)
+            * 100;
     }
 }
 

--- a/kernel/comps/time/src/rtc/goldfish.rs
+++ b/kernel/comps/time/src/rtc/goldfish.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Datelike, Timelike};
 use ostd::{arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce, warn};
 
-use crate::{rtc::Driver, SystemTime};
+use crate::{SystemTime, rtc::Driver};
 
 pub struct RtcGoldfish {
     io_mem: IoMem,

--- a/kernel/comps/time/src/rtc/loongson.rs
+++ b/kernel/comps/time/src/rtc/loongson.rs
@@ -2,7 +2,7 @@
 
 use ostd::{arch::boot::DEVICE_TREE, io::IoMem, mm::VmIoOnce};
 
-use crate::{rtc::Driver, SystemTime};
+use crate::{SystemTime, rtc::Driver};
 
 pub struct RtcLoongson {
     io_mem: IoMem,

--- a/kernel/comps/time/src/rtc/mod.rs
+++ b/kernel/comps/time/src/rtc/mod.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 
 use crate::SystemTime;
 
-/// Generic interface for RTC drivers
+/// Generic interface for RTC drivers.
 pub trait Driver {
     /// Creates a RTC driver.
     /// Returns [`Some<Self>`] on success, [`None`] otherwise (e.g. platform unsupported).
@@ -18,13 +18,8 @@ pub trait Driver {
 
 macro_rules! declare_rtc_drivers {
     ( $( #[cfg $cfg:tt ] $module:ident :: $name:ident),* $(,)? ) => {
-        $(
-            #[cfg $cfg]
-            mod $module;
-        )*
-
         pub fn init_rtc_driver() -> Arc<dyn Driver + Send + Sync> {
-            // iterate all possible drivers and pick one that can be initialized
+            // Iterate all possible drivers and pick one that can be initialized.
             $(
                 #[cfg $cfg]
                 if let Some(driver) = $module::$name::try_new() {
@@ -38,6 +33,13 @@ macro_rules! declare_rtc_drivers {
         }
     }
 }
+
+#[cfg(target_arch = "x86_64")]
+mod cmos;
+#[cfg(target_arch = "riscv64")]
+mod goldfish;
+#[cfg(target_arch = "loongarch64")]
+mod loongson;
 
 declare_rtc_drivers! {
     #[cfg(target_arch = "x86_64")] cmos::RtcCmos,

--- a/kernel/src/net/uts_ns.rs
+++ b/kernel/src/net/uts_ns.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::{const_assert, sync::RwMutexReadGuard};
+use ostd::sync::RwMutexReadGuard;
 use spin::Once;
 
 use crate::{
@@ -159,7 +159,7 @@ impl UtsName {
         const PREEMPT_FLAGS: &str = "";
         const VERSION: &str =
             const_format::formatcp!("#{BUILD_VERSION} {SMP_FLAGS}{PREEMPT_FLAGS}{BUILD_TIMESTAMP}");
-        const_assert!(VERSION.len() <= 64);
+        assert!(VERSION.len() <= UtsField::MAX_BYTES);
         VERSION
     };
 

--- a/kernel/src/vm/vmar/mod.rs
+++ b/kernel/src/vm/vmar/mod.rs
@@ -14,7 +14,7 @@ use ostd::mm::Vaddr;
 pub use self::{
     handle::VmarHandle,
     vmar_impls::{
-        RemapOldMappingAction, RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo,
+        RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo, remap::RemapOldMappingAction,
     },
 };
 

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -6,8 +6,9 @@ pub(super) mod map;
 pub(super) mod page_fault;
 mod protect;
 mod query;
-mod remap;
+pub(super) mod remap;
 mod unmap;
+
 use core::{
     array,
     ops::Range,
@@ -17,7 +18,6 @@ use core::{
 use align_ext::AlignExt;
 use aster_util::per_cpu_counter::PerCpuCounter;
 use ostd::{cpu::CpuId, mm::VmSpace};
-pub use remap::RemapOldMappingAction;
 
 use super::{
     VMAR_CAP_ADDR, VMAR_LOWEST_ADDR,


### PR DESCRIPTION
rustfmt does not work with:
https://github.com/asterinas/asterinas/blob/435916bf0714a61e0fd1ebab5f6486532dedd8e4/kernel/comps/time/src/rtc/mod.rs#L21-L24

To make rustfmt happy, I propose to remove it and use:
```rust
#[cfg(target_arch = "x86_64")]
mod cmos;
#[cfg(target_arch = "riscv64")]
mod goldfish;
#[cfg(target_arch = "loongarch64")]
mod loongson;
```