### PR TITLE
Add RISC-V AIA interrupt support

### DIFF
--- a/kernel/comps/uart/src/arch/riscv/ns16550a.rs
+++ b/kernel/comps/uart/src/arch/riscv/ns16550a.rs
@@ -66,10 +66,7 @@ pub(super) fn init(fdt_node: FdtNode) {
 
     let Ok(mut irq_line) = IrqLine::alloc().and_then(|irq_line| {
         IRQ_CHIP.get().unwrap().map_fdt_pin_to(
-            InterruptSourceInFdt {
-                interrupt_parent: intr_parent as u32,
-                interrupt: intr as u32,
-            },
+            InterruptSourceInFdt::new(intr_parent as u32, intr),
             irq_line,
         )
     }) else {

--- a/kernel/comps/virtio/src/transport/mmio/bus/arch/riscv.rs
+++ b/kernel/comps/virtio/src/transport/mmio/bus/arch/riscv.rs
@@ -23,13 +23,12 @@ pub(super) fn probe_for_device() {
         let mmio_start = mmio_region.starting_address as usize;
         let mmio_end = mmio_start + mmio_region.size.unwrap();
 
-        let interrupt_source_in_fdt = InterruptSourceInFdt {
-            interrupt: node.interrupts().unwrap().next().unwrap() as u32,
-            interrupt_parent: node
-                .property("interrupt-parent")
+        let interrupt_source_in_fdt = InterruptSourceInFdt::new(
+            node.property("interrupt-parent")
                 .and_then(|prop| prop.as_usize())
                 .unwrap() as u32,
-        };
+            node.interrupts().unwrap().next().unwrap(),
+        );
 
         let _ = super::try_register_mmio_device(mmio_start..mmio_end, |irq_line| {
             IRQ_CHIP

--- a/ostd/src/arch/riscv/irq/chip/aplic.rs
+++ b/ostd/src/arch/riscv/irq/chip/aplic.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Advanced Platform-Level Interrupt Controller (APLIC).
+
+use alloc::{boxed::Box, vec::Vec};
+
+use fdt::Fdt;
+
+use super::InterruptTrigger;
+use crate::{
+    Error, Result,
+    io::{IoMem, IoMemAllocatorBuilder, Sensitive},
+    irq::IrqLine,
+};
+
+/// A supervisor-level APLIC domain operating in MSI delivery mode.
+pub(super) struct Aplic {
+    phandle: u32,
+    io_mem: IoMem<Sensitive>,
+    num_sources: u32,
+    interrupt_number_mappings: Box<[Option<u8>]>,
+}
+
+impl Aplic {
+    // Register offsets and bit definitions follow the RISC-V AIA
+    // specification's APLIC register layout.
+    const DOMAINCFG: usize = 0x0000;
+    const SOURCECFG_BASE: usize = 0x0004;
+    const SETIENUM: usize = 0x1edc;
+    const CLRIENUM: usize = 0x1fdc;
+    const TARGET_BASE: usize = 0x3004;
+
+    const DOMAINCFG_IE: u32 = 1 << 8;
+    const DOMAINCFG_DM: u32 = 1 << 2;
+
+    /// Discovers supervisor APLIC domains connected to the selected IMSIC.
+    pub(super) fn from_fdt(
+        fdt: &Fdt<'_>,
+        io_mem_builder: &IoMemAllocatorBuilder,
+        imsic_phandle: u32,
+    ) -> Vec<Self> {
+        fdt.all_nodes()
+            .filter(|node| {
+                node.compatible().is_some_and(|compatibles| {
+                    compatibles
+                        .all()
+                        .any(|compatible| compatible == "riscv,aplic")
+                }) && node
+                    .property("msi-parent")
+                    .and_then(|property| property.as_usize())
+                    .is_some_and(|phandle| phandle as u32 == imsic_phandle)
+            })
+            .map(|node| {
+                let phandle = node
+                    .property("phandle")
+                    .and_then(|property| property.as_usize())
+                    .expect("Missing APLIC phandle") as u32;
+                let num_sources = node
+                    .property("riscv,num-sources")
+                    .and_then(|property| property.as_usize())
+                    .expect("Missing APLIC source count") as u32;
+                let region = node
+                    .reg()
+                    .expect("Missing APLIC reg property")
+                    .next()
+                    .expect("Empty APLIC reg property");
+                let start = region.starting_address as usize;
+                let size = region.size.expect("Incomplete APLIC reg property");
+                let end = start.checked_add(size).expect("APLIC MMIO range overflows");
+
+                Self {
+                    phandle,
+                    io_mem: io_mem_builder.reserve(start..end, crate::mm::CachePolicy::Uncacheable),
+                    num_sources,
+                    interrupt_number_mappings: (0..=num_sources)
+                        .map(|_| None)
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                }
+            })
+            .collect()
+    }
+
+    pub(super) fn phandle(&self) -> u32 {
+        self.phandle
+    }
+
+    pub(super) fn init(&mut self) {
+        self.write(Self::DOMAINCFG, 0);
+        for source in 1..=self.num_sources {
+            self.write(Self::CLRIENUM, source);
+            self.write(Self::SOURCECFG_BASE + source as usize * 4 - 4, 0);
+        }
+        self.write(Self::DOMAINCFG, Self::DOMAINCFG_IE | Self::DOMAINCFG_DM);
+    }
+
+    pub(super) fn map_interrupt_source_to(
+        &mut self,
+        interrupt_source: u32,
+        trigger: InterruptTrigger,
+        irq_line: &IrqLine,
+        msi_interrupt_id: u16,
+    ) -> Result<()> {
+        if interrupt_source == 0 || interrupt_source > self.num_sources {
+            return Err(Error::InvalidArgs);
+        }
+        if self.interrupt_number_mappings[interrupt_source as usize].is_some() {
+            return Err(Error::AccessDenied);
+        }
+
+        let source_mode = match trigger {
+            InterruptTrigger::EdgeRising => 4,
+            InterruptTrigger::EdgeFalling => 5,
+            InterruptTrigger::LevelHigh => 6,
+            InterruptTrigger::LevelLow => 7,
+        };
+        let source_config = Self::SOURCECFG_BASE + interrupt_source as usize * 4 - 4;
+        let target = Self::TARGET_BASE + interrupt_source as usize * 4 - 4;
+
+        self.write(Self::CLRIENUM, interrupt_source);
+        self.write(source_config, source_mode);
+        // This initial single-target setup leaves hart and guest indexes at zero
+        // and writes only the IMSIC interrupt identity as the target EIID.
+        self.write(target, u32::from(msi_interrupt_id));
+        self.write(Self::SETIENUM, interrupt_source);
+        self.interrupt_number_mappings[interrupt_source as usize] = Some(irq_line.num());
+        Ok(())
+    }
+
+    pub(super) fn unmap_interrupt_source(&mut self, interrupt_source: u32) {
+        if interrupt_source == 0 || interrupt_source > self.num_sources {
+            return;
+        }
+        self.write(Self::CLRIENUM, interrupt_source);
+        self.write(Self::SOURCECFG_BASE + interrupt_source as usize * 4 - 4, 0);
+        self.interrupt_number_mappings[interrupt_source as usize] = None;
+    }
+
+    fn write(&mut self, offset: usize, value: u32) {
+        // SAFETY: `offset` is a naturally aligned APLIC register within the
+        // device-tree-provided MMIO region exclusively reserved by this driver.
+        unsafe { self.io_mem.write_once(offset, &value) };
+    }
+}

--- a/ostd/src/arch/riscv/irq/chip/imsic.rs
+++ b/ostd/src/arch/riscv/irq/chip/imsic.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Incoming Message-Signaled Interrupt Controller (IMSIC).
+
+use alloc::{boxed::Box, vec::Vec};
+use core::arch::asm;
+
+use fdt::Fdt;
+
+use crate::io::{IoMem, IoMemAllocatorBuilder, Sensitive};
+
+/// A supervisor-level IMSIC interrupt-file group.
+pub(super) struct Imsic {
+    phandle: u32,
+    message_address: usize,
+    num_ids: u32,
+    _regions: Box<[IoMem<Sensitive>]>,
+}
+
+impl Imsic {
+    // Register offsets follow the RISC-V AIA specification's IMSIC
+    // register layout.
+    const EIDELIVERY: usize = 0x70;
+    const EITHRESHOLD: usize = 0x72;
+    const EIP0: usize = 0x80;
+    const EIE0: usize = 0xc0;
+
+    /// Discovers the supervisor-level IMSIC from the device tree.
+    pub(super) fn from_fdt(fdt: &Fdt<'_>, io_mem_builder: &IoMemAllocatorBuilder) -> Option<Self> {
+        let node = fdt.all_nodes().find(|node| {
+            let compatible = node.compatible().is_some_and(|compatibles| {
+                compatibles
+                    .all()
+                    .any(|compatible| compatible == "riscv,imsics")
+            });
+            let supervisor_interrupt =
+                node.property("interrupts-extended")
+                    .is_some_and(|property| {
+                        property
+                            .value
+                            .chunks_exact(8)
+                            .any(|entry| u32::from_be_bytes(entry[4..8].try_into().unwrap()) == 9)
+                    });
+            compatible && supervisor_interrupt
+        })?;
+
+        let phandle = node.property("phandle")?.as_usize()? as u32;
+        let num_ids = node.property("riscv,num-ids")?.as_usize()? as u32;
+        let mut message_address = None;
+        let regions = node
+            .reg()?
+            .map(|region| {
+                let start = region.starting_address as usize;
+                let size = region.size.expect("Incomplete IMSIC 'reg' property");
+                let end = start.checked_add(size).expect("IMSIC MMIO range overflows");
+                message_address.get_or_insert(start);
+                io_mem_builder.reserve(start..end, crate::mm::CachePolicy::Uncacheable)
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+
+        Some(Self {
+            phandle,
+            message_address: message_address?,
+            num_ids,
+            _regions: regions,
+        })
+    }
+
+    pub(super) fn phandle(&self) -> u32 {
+        self.phandle
+    }
+
+    pub(super) fn message_address(&self) -> usize {
+        self.message_address
+    }
+
+    /// Initializes the current hart's supervisor interrupt file.
+    pub(super) fn init_current_hart(&self) {
+        Self::write_indirect(Self::EIDELIVERY, 0);
+        Self::write_indirect(Self::EITHRESHOLD, 0);
+
+        let register_count = (self.num_ids as usize).div_ceil(64);
+        for register_index in 0..register_count {
+            let selector_offset = register_index * 2;
+            Self::write_indirect(Self::EIE0 + selector_offset, 0);
+            Self::write_indirect(Self::EIP0 + selector_offset, 0);
+        }
+
+        Self::write_indirect(Self::EIDELIVERY, 1);
+    }
+
+    /// Enables an interrupt identity in the current hart's interrupt file.
+    pub(super) fn enable(&self, interrupt_id: u16) -> bool {
+        if !self.is_valid_interrupt_id(interrupt_id) {
+            return false;
+        }
+
+        let interrupt_id = interrupt_id as usize;
+        let register_index = interrupt_id / 64;
+        let bit_index = interrupt_id % 64;
+        let selector = Self::EIE0 + register_index * 2;
+        let enabled = Self::read_indirect(selector) | 1usize << bit_index;
+        Self::write_indirect(selector, enabled);
+        true
+    }
+
+    /// Disables an interrupt identity in the current hart's interrupt file.
+    pub(super) fn disable(&self, interrupt_id: u16) {
+        if !self.is_valid_interrupt_id(interrupt_id) {
+            return;
+        }
+
+        let interrupt_id = interrupt_id as usize;
+        let register_index = interrupt_id / 64;
+        let bit_index = interrupt_id % 64;
+        let selector = Self::EIE0 + register_index * 2;
+        let enabled = Self::read_indirect(selector) & !(1usize << bit_index);
+        Self::write_indirect(selector, enabled);
+    }
+
+    /// Claims the highest-priority pending interrupt identity.
+    pub(super) fn claim(&self) -> Option<u16> {
+        let value: usize;
+        // SAFETY: This driver is instantiated only when the device tree exposes
+        // a supervisor-level IMSIC, making `stopei` a valid CSR.
+        unsafe {
+            asm!("csrrw {value}, 0x15c, zero", value = out(reg) value, options(nostack));
+        }
+        let interrupt_id = ((value >> 16) & 0x7ff) as u16;
+        self.is_valid_interrupt_id(interrupt_id)
+            .then_some(interrupt_id)
+    }
+
+    fn is_valid_interrupt_id(&self, interrupt_id: u16) -> bool {
+        interrupt_id != 0 && u32::from(interrupt_id) < self.num_ids
+    }
+
+    fn read_indirect(selector: usize) -> usize {
+        let value: usize;
+        // SAFETY: The selected register belongs to the supervisor IMSIC
+        // interrupt file discovered from the device tree.
+        unsafe {
+            asm!("csrw 0x150, {selector}", selector = in(reg) selector, options(nostack));
+            asm!("csrr {value}, 0x151", value = out(reg) value, options(nostack));
+        }
+        value
+    }
+
+    fn write_indirect(selector: usize, value: usize) {
+        // SAFETY: The selected register belongs to the supervisor IMSIC
+        // interrupt file discovered from the device tree.
+        unsafe {
+            asm!("csrw 0x150, {selector}", selector = in(reg) selector, options(nostack));
+            asm!("csrw 0x151, {value}", value = in(reg) value, options(nostack));
+        }
+    }
+}

--- a/ostd/src/arch/riscv/irq/chip/mod.rs
+++ b/ostd/src/arch/riscv/irq/chip/mod.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Interrupts.
+//! Interrupt controllers.
 
+mod aplic;
+mod imsic;
 mod plic;
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use core::{
     fmt,
     ops::{Deref, DerefMut},
@@ -13,10 +15,13 @@ use core::{
 use spin::Once;
 
 use crate::{
-    Result,
+    Error, Result,
     arch::{
         boot::DEVICE_TREE,
-        irq::{HwIrqLine, InterruptSource, chip::plic::Plic},
+        irq::{
+            HwIrqLine, InterruptSource,
+            chip::{aplic::Aplic, imsic::Imsic, plic::Plic},
+        },
     },
     io::IoMemAllocatorBuilder,
     irq::IrqLine,
@@ -26,7 +31,7 @@ use crate::{
 /// The [`IrqChip`] singleton.
 pub static IRQ_CHIP: Once<IrqChip> = Once::new();
 
-/// Initializes the Platform-Level Interrupt Controller (PLIC) on the BSP.
+/// Initializes the platform interrupt controllers on the BSP.
 ///
 /// # Safety
 ///
@@ -37,18 +42,27 @@ pub static IRQ_CHIP: Once<IrqChip> = Once::new();
 pub(in crate::arch) unsafe fn init_on_bsp(io_mem_builder: &IoMemAllocatorBuilder) {
     let device_tree = DEVICE_TREE.get().unwrap();
     let mut plics = Plic::from_fdt(device_tree, io_mem_builder);
-    plics.iter_mut().for_each(|plic| plic.init());
+    plics.iter_mut().for_each(Plic::init);
+
+    let imsic = Imsic::from_fdt(device_tree, io_mem_builder);
+    let mut aplics = imsic.as_ref().map_or_else(Vec::new, |imsic| {
+        Aplic::from_fdt(device_tree, io_mem_builder, imsic.phandle())
+    });
+    aplics.iter_mut().for_each(Aplic::init);
+
     IRQ_CHIP.call_once(|| IrqChip {
         plics: SpinLock::new(plics.into_boxed_slice()),
+        aplics: SpinLock::new(aplics.into_boxed_slice()),
+        imsic: imsic.map(SpinLock::new),
     });
-    // SAFETY: Accessing the `sie` CSR to enable the external interrupt is safe
-    // here because this function is only called during PLIC initialization,
-    // and we ensure that only the external interrupt bit is set without
-    // affecting other interrupt sources.
+    IRQ_CHIP.get().unwrap().init_current_hart();
+
+    // SAFETY: The interrupt controllers for this hart are initialized before
+    // enabling supervisor external interrupts.
     unsafe { riscv::register::sie::set_sext() };
 }
 
-/// Initializes application-processor-specific PLIC state.
+/// Initializes application-processor-specific interrupt controller state.
 ///
 /// # Safety
 ///
@@ -57,59 +71,90 @@ pub(in crate::arch) unsafe fn init_on_bsp(io_mem_builder: &IoMemAllocatorBuilder
 /// 2. It is called before any other public functions of this module is called
 ///    on this AP.
 pub(in crate::arch) unsafe fn init_on_ap() {
-    // SAFETY: Accessing the `sie` CSR to enable the external interrupt is safe
-    // here due to the same reasons mentioned in `init`.
+    IRQ_CHIP.get().unwrap().init_current_hart();
+    // SAFETY: The interrupt controllers for this hart are initialized before
+    // enabling supervisor external interrupts.
     unsafe { riscv::register::sie::set_sext() };
 }
 
-/// An IRQ chip.
-///
-/// This abstracts the hardware IRQ chips (or IRQ controllers), allowing the bus
-/// or device drivers to enable [`IrqLine`]s (via, e.g., [`map_fdt_pin_to`])
-/// regardless of the specifics of the IRQ chip.
-///
-/// In the RISC-V architecture, the underlying hardware is typically Platform-Level
-/// Interrupt Controller (PLIC).
-///
-/// [`map_fdt_pin_to`]: Self::map_fdt_pin_to
+/// The platform external interrupt controllers.
 pub struct IrqChip {
     plics: SpinLock<Box<[Plic]>, LocalIrqDisabled>,
+    aplics: SpinLock<Box<[Aplic]>, LocalIrqDisabled>,
+    imsic: Option<SpinLock<Imsic, LocalIrqDisabled>>,
 }
 
 impl IrqChip {
-    /// Maps an IRQ pin specified by `interrupt_source_in_fdt` to an IRQ line.
+    /// Maps an interrupt source described by the device tree to an IRQ line.
     pub fn map_fdt_pin_to(
         &self,
         interrupt_source_in_fdt: InterruptSourceInFdt,
         irq_line: IrqLine,
     ) -> Result<MappedIrqLine> {
         let mut plics = self.plics.lock();
-        let (index, plic) = plics
+        if let Some((index, plic)) = plics
             .iter_mut()
             .enumerate()
             .find(|(_, plic)| plic.phandle() == interrupt_source_in_fdt.interrupt_parent)
-            .unwrap();
+        {
+            plic.map_interrupt_source_to(interrupt_source_in_fdt.interrupt, &irq_line)?;
+            plic.set_priority(interrupt_source_in_fdt.interrupt, 1);
+            plic.managed_harts().for_each(|hart| {
+                plic.set_interrupt_enabled(hart, interrupt_source_in_fdt.interrupt, true)
+            });
+            return Ok(MappedIrqLine {
+                irq_line,
+                interrupt_source_on_chip: InterruptSourceOnChip {
+                    controller: InterruptController::Plic,
+                    index,
+                    interrupt: interrupt_source_in_fdt.interrupt,
+                },
+            });
+        }
+        drop(plics);
 
-        plic.map_interrupt_source_to(interrupt_source_in_fdt.interrupt, &irq_line)?;
-        plic.set_priority(interrupt_source_in_fdt.interrupt, 1);
-        plic.managed_harts().for_each(|hart| {
-            plic.set_interrupt_enabled(hart, interrupt_source_in_fdt.interrupt, true)
-        });
+        let mut aplics = self.aplics.lock();
+        let Some((index, aplic)) = aplics
+            .iter_mut()
+            .enumerate()
+            .find(|(_, aplic)| aplic.phandle() == interrupt_source_in_fdt.interrupt_parent)
+        else {
+            return Err(Error::InvalidArgs);
+        };
+        let msi_interrupt_id = Self::msi_interrupt_id(irq_line.num());
+        self.enable_msi(irq_line.num())?;
+        if let Err(err) = aplic.map_interrupt_source_to(
+            interrupt_source_in_fdt.interrupt,
+            interrupt_source_in_fdt.trigger,
+            &irq_line,
+            msi_interrupt_id,
+        ) {
+            self.disable_msi(irq_line.num());
+            return Err(err);
+        }
 
         Ok(MappedIrqLine {
             irq_line,
             interrupt_source_on_chip: InterruptSourceOnChip {
+                controller: InterruptController::Aplic,
                 index,
                 interrupt: interrupt_source_in_fdt.interrupt,
             },
         })
     }
 
-    /// Claims an external interrupt that is pending on a specific hart.
-    ///
-    /// It returns the software IRQ number if there's a pending interrupt on the
-    /// hart, otherwise it will return `None`.
+    /// Claims an external interrupt pending on the current hart.
     pub(in crate::arch) fn claim_interrupt(&self, hart: u32) -> Option<HwIrqLine> {
+        if let Some(imsic) = &self.imsic
+            && let Some(msi_interrupt_id) = imsic.lock().claim()
+            && let Some(irq_num) = Self::irq_num_from_msi_interrupt_id(msi_interrupt_id)
+        {
+            return Some(HwIrqLine {
+                irq_num,
+                source: InterruptSource::Message,
+            });
+        }
+
         self.plics
             .lock()
             .iter()
@@ -120,6 +165,7 @@ impl IrqChip {
                     .map(|irq_num| HwIrqLine {
                         irq_num,
                         source: InterruptSource::External(InterruptSourceOnChip {
+                            controller: InterruptController::Plic,
                             index,
                             interrupt,
                         }),
@@ -127,34 +173,86 @@ impl IrqChip {
             })
     }
 
-    /// Acknowledges the completion of an interrupt.
+    /// Returns the MSI write address for the currently supported supervisor
+    /// IMSIC target.
+    ///
+    /// The initial implementation uses the first supervisor IMSIC MMIO region
+    /// discovered from the device tree. Multi-hart target selection should pass
+    /// an explicit hart in the future.
+    pub fn msi_address(&self) -> Option<usize> {
+        self.imsic
+            .as_ref()
+            .map(|imsic| imsic.lock().message_address())
+    }
+
+    /// Enables the software IRQ's MSI identity in the current hart's IMSIC
+    /// interrupt file.
+    pub fn enable_msi(&self, irq_num: u8) -> Result<()> {
+        let Some(imsic) = &self.imsic else {
+            return Err(Error::NotEnoughResources);
+        };
+        if imsic.lock().enable(Self::msi_interrupt_id(irq_num)) {
+            Ok(())
+        } else {
+            Err(Error::InvalidArgs)
+        }
+    }
+
+    fn disable_msi(&self, irq_num: u8) {
+        if let Some(imsic) = &self.imsic {
+            imsic.lock().disable(Self::msi_interrupt_id(irq_num));
+        }
+    }
+
+    fn msi_interrupt_id(irq_num: u8) -> u16 {
+        u16::from(irq_num) + 1
+    }
+
+    fn irq_num_from_msi_interrupt_id(interrupt_id: u16) -> Option<u8> {
+        interrupt_id
+            .checked_sub(1)
+            .and_then(|irq_num| u8::try_from(irq_num).ok())
+    }
+
+    fn init_current_hart(&self) {
+        if let Some(imsic) = &self.imsic {
+            imsic.lock().init_current_hart();
+        }
+    }
+
     pub(super) fn complete_interrupt(
         &self,
         hart: u32,
         interrupt_source_on_chip: InterruptSourceOnChip,
     ) {
+        if interrupt_source_on_chip.controller != InterruptController::Plic {
+            return;
+        }
         let plics = self.plics.lock();
         plics[interrupt_source_on_chip.index]
             .complete_interrupt(hart, interrupt_source_on_chip.interrupt);
     }
 
-    /// Unmaps an IRQ line from the IRQ chip.
     fn unmap_irq_line(&self, mapped_irq_line: &MappedIrqLine) {
-        let mut plics = self.plics.lock();
-
-        let InterruptSourceOnChip { index, interrupt } = &mapped_irq_line.interrupt_source_on_chip;
-        let plic = &mut plics[*index];
-
-        plic.managed_harts()
-            .for_each(|hart| plic.set_interrupt_enabled(hart, *interrupt, false));
-        plic.set_priority(*interrupt, 0);
-        plic.unmap_interrupt_source(*interrupt);
+        let source = mapped_irq_line.interrupt_source_on_chip;
+        match source.controller {
+            InterruptController::Plic => {
+                let mut plics = self.plics.lock();
+                let plic = &mut plics[source.index];
+                plic.managed_harts()
+                    .for_each(|hart| plic.set_interrupt_enabled(hart, source.interrupt, false));
+                plic.set_priority(source.interrupt, 0);
+                plic.unmap_interrupt_source(source.interrupt);
+            }
+            InterruptController::Aplic => {
+                self.aplics.lock()[source.index].unmap_interrupt_source(source.interrupt);
+                self.disable_msi(mapped_irq_line.irq_line.num());
+            }
+        }
     }
 }
 
-/// An [`IrqLine`] mapped to an IRQ pin managed by the [`IRQ_CHIP`].
-///
-/// When the object is dropped, the IRQ line will be unmapped by the IRQ chip.
+/// An [`IrqLine`] mapped to an interrupt-controller source.
 pub struct MappedIrqLine {
     irq_line: IrqLine,
     interrupt_source_on_chip: InterruptSourceOnChip,
@@ -196,13 +294,57 @@ pub struct InterruptSourceInFdt {
     pub interrupt_parent: u32,
     /// Interrupt source number on the interrupt controller.
     pub interrupt: u32,
+    /// Electrical trigger mode encoded by the device tree.
+    pub trigger: InterruptTrigger,
 }
 
-/// Interrupt source identifier on the `IRQ_CHIP`.
+impl InterruptSourceInFdt {
+    /// Decodes an interrupt specifier returned by `FdtNode::interrupts`.
+    pub fn new(interrupt_parent: u32, specifier: usize) -> Self {
+        let specifier = specifier as u64;
+        let (interrupt, flags) = if specifier > u32::MAX as u64 {
+            ((specifier >> 32) as u32, specifier as u32)
+        } else {
+            (specifier as u32, 0)
+        };
+        Self {
+            interrupt_parent,
+            interrupt,
+            trigger: InterruptTrigger::from_fdt_flags(flags),
+        }
+    }
+}
+
+/// Interrupt source trigger mode.
+#[derive(Clone, Copy, Debug)]
+pub enum InterruptTrigger {
+    EdgeRising,
+    EdgeFalling,
+    LevelHigh,
+    LevelLow,
+}
+
+impl InterruptTrigger {
+    fn from_fdt_flags(flags: u32) -> Self {
+        match flags & 0xf {
+            1 => Self::EdgeRising,
+            2 => Self::EdgeFalling,
+            8 => Self::LevelLow,
+            _ => Self::LevelHigh,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InterruptController {
+    Plic,
+    Aplic,
+}
+
+/// Interrupt source identifier on the platform interrupt controller.
 #[derive(Clone, Copy, Debug)]
 pub(super) struct InterruptSourceOnChip {
-    /// Index of the interrupt controller it connects to on `IRQ_CHIP`.
+    controller: InterruptController,
     index: usize,
-    /// Interrupt source number on the interrupt controller.
     interrupt: u32,
 }

--- a/ostd/src/arch/riscv/irq/mod.rs
+++ b/ostd/src/arch/riscv/irq/mod.rs
@@ -35,6 +35,7 @@ pub(super) enum InterruptSource {
     Timer,
     #[expect(private_interfaces)]
     External(InterruptSourceOnChip),
+    Message,
     Software,
 }
 
@@ -49,7 +50,7 @@ impl HwIrqLine {
 
     pub(crate) fn ack(&self) {
         match &self.source {
-            InterruptSource::Timer => {}
+            InterruptSource::Timer | InterruptSource::Message => {}
             InterruptSource::External(interrupt_source_on_chip) => {
                 IRQ_CHIP.get().unwrap().complete_interrupt(
                     // No races because we are in IRQs.


### PR DESCRIPTION
# Summary

This PR adds basic RISC-V AIA interrupt-controller support for Asterinas.

It introduces supervisor-level IMSIC and APLIC support, wires them into the existing RISC-V IRQ chip abstraction, and updates RISC-V UART/Virtio MMIO interrupt mapping to decode device-tree interrupt specifiers through the shared IRQ mapping path.

This PR is also a preparation step for the larger RISC-V IOMMU support work, where QEMU's RISC-V `virt` machine uses AIA/APLIC/IMSIC interrupt delivery when the IOMMU scheme is enabled. See #3474 .

# Background

Before this PR, the RISC-V IRQ chip implementation was centered on PLIC-based external interrupts. That works for the existing non-AIA RISC-V platform setup, but it is not enough for platforms that expose RISC-V AIA interrupt controllers.

On QEMU RISC-V `virt`, AIA configurations may expose:

- IMSIC interrupt files for message-signaled interrupts;
- APLIC domains that can deliver wired interrupt sources as MSI messages;
- device-tree interrupt specifiers that include both interrupt source IDs and trigger flags.

The later RISC-V IOMMU stack depends on this foundation because the QEMU IOMMU configuration uses AIA/APLIC/IMSIC interrupt delivery. Without this support, Asterinas cannot correctly initialize and route interrupts for devices under that platform configuration.

# Main Behavior

This PR extends the RISC-V interrupt-controller path as follows:

- discovers supervisor-level IMSIC nodes from the device tree;
- discovers APLIC domains connected to the selected IMSIC;
- initializes IMSIC interrupt files on the BSP and APs;
- initializes APLIC domains in MSI delivery mode;
- maps device-tree interrupt sources either through PLIC or through APLIC, depending on the interrupt parent;
- maps software IRQ numbers to IMSIC interrupt identities with an offset, so software IRQ 0 maps to IMSIC identity 1 instead of the reserved identity 0;
- validates IMSIC interrupt identities before enabling, disabling, or accepting claimed message interrupts;
- claims message interrupts from IMSIC before falling back to PLIC external interrupts;
- treats IMSIC message interrupts as already acknowledged in the generic IRQ ack path;
- exposes the IMSIC MSI message address and interrupt-ID enable path for later MSI/MSI-X users;
- updates RISC-V UART and Virtio MMIO interrupt mapping to use a common `InterruptSourceInFdt::new()` decoder.

# Implementation Notes

The implementation keeps PLIC support intact and adds AIA support alongside it.

- `ostd/src/arch/riscv/irq/chip/imsic.rs` implements supervisor IMSIC discovery, per-hart initialization, interrupt-ID enable/disable, MSI message address reporting, and interrupt claiming.
- `ostd/src/arch/riscv/irq/chip/aplic.rs` implements supervisor APLIC discovery, initialization in MSI delivery mode, source configuration, target programming, source enable/disable, and unmapping.
- `ostd/src/arch/riscv/irq/chip/mod.rs` extends `IrqChip` to manage PLIC, APLIC, and IMSIC together.
- `ostd/src/arch/riscv/irq/mod.rs` adds a message-interrupt source type so IMSIC-delivered interrupts do not go through PLIC completion.
- `kernel/comps/uart/src/arch/riscv/ns16550a.rs` and `kernel/comps/virtio/src/transport/mmio/bus/arch/riscv.rs` now construct interrupt sources through the shared RISC-V FDT interrupt-specifier decoder.

The MSI path does not use the software IRQ number directly as the IMSIC interrupt identity. IMSIC identity 0 is reserved/non-deliverable, while Asterinas software IRQ allocation may return IRQ 0. Therefore, this PR maps `irq_num` to `irq_num + 1` when programming IMSIC/APLIC state, and maps the claimed IMSIC identity back to `irq_num` in the message interrupt claim path.

The APLIC mapping path enables the IMSIC interrupt identity and then maps the APLIC interrupt source to that identity. If APLIC mapping fails after enabling the MSI identity, the MSI identity is disabled again before returning the error.

The APLIC target programming currently uses a single-target setup: hart and guest indexes are left at zero, and only the IMSIC interrupt identity is written as the target EIID. Multi-hart or multi-IMSIC target selection is left for future work.

APLIC/IMSIC MMIO ranges discovered from the device tree are checked with `checked_add()` before reservation.

# References

- RISC-V Advanced Interrupt Architecture specification:
  - https://github.com/riscv/riscv-aia
- QEMU RISC-V AIA documentation:
  - https://www.qemu.org/docs/master/specs/riscv-aia.html

# Validation

The following checks passed:

```bash
cargo check -p ostd --target riscv64imac-unknown-none-elf
cargo check -p aster-virtio --target riscv64imac-unknown-none-elf
cargo check -p aster-uart --target riscv64imac-unknown-none-elf
cargo fmt --check --package ostd --package aster-virtio --package aster-uart
```

# Gaps and Future Work
This PR intentionally focuses on the RISC-V AIA interrupt-controller foundation.

The MSI address path currently uses the first supervisor IMSIC MMIO region discovered from the device tree, and APLIC target programming uses the initial single-target setup. More complete multi-hart, multi-IMSIC-group, or explicit target-selection support should be added later when needed by PCI MSI/MSI-X or SMP-oriented use cases.

The implementation is currently validated by build checks. Runtime validation with the full QEMU RISC-V AIA/IOMMU configuration should be covered by the later stacked PRs that enable the complete scheme.