### PR TITLE
Prevent NixOS image space exhaustion on repeated builds

### DIFF
--- a/.github/workflows/test_iso_image.yml
+++ b/.github/workflows/test_iso_image.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run ISO image and install Asterinas NixOS
         run: |
           make run_iso || true
-          tail --lines 10 qemu.log | grep -q "^Installation finished" || (echo "Test ISO failed" && exit 1)
+          tail --lines 10 qemu.log | grep -q "^Congratulations!" || (echo "Test ISO failed" && exit 1)
           echo "Test ISO succeeds!"
       - name : Run Asterinas NixOS
         run: |

--- a/distro/aster_nixos_installer/templates/aster-nixos-install
+++ b/distro/aster_nixos_installer/templates/aster-nixos-install
@@ -156,4 +156,11 @@ nixos-install --root ${BUILD_DIR} --no-root-passwd \
     --system "${SYSTEM_CLOSURE}" \
     "${COMMON_NIX_ARGS[@]}"
 
+# Retain only the current system generation. Reusing the disk image otherwise
+# preserves old system closures in its Nix store after every installation.
+nix-env --store "${BUILD_DIR}" \
+    -p "${BUILD_DIR}/nix/var/nix/profiles/system" \
+    --delete-generations old
+nix-store --store "${BUILD_DIR}" --gc
+
 echo "Congratulations! Asterinas NixOS has been installed successfully!"

--- a/distro/etc_nixos/modules/core.nix
+++ b/distro/etc_nixos/modules/core.nix
@@ -62,6 +62,7 @@ let
   };
 in {
   boot.loader.grub.enable = true;
+  boot.loader.grub.configurationLimit = 1;
   boot.loader.grub.efiSupport = true;
   boot.loader.grub.device = "nodev";
   boot.loader.grub.efiInstallAsRemovable = true;


### PR DESCRIPTION
## Problem

`make nixos` reuses `target/nixos/asterinas.img`. After changing kernel sources and rerunning it several times, the installer can fail while installing GRUB:

```text
cannot copy /nix/store/...-aster-kernel-osdk-bin to /boot/kernels/...-aster-kernel-osdk-bin.tmp: No space left on device
Failed to install bootloader
```

The image has a fixed 512 MB EFI `/boot` partition. Since `/boot` is separate from the Nix store, GRUB copies each referenced kernel there. Each Asterinas kernel is about 130 MB, while GRUB retains up to 100 configurations by default. GRUB copies a new kernel before removing obsolete files, so the partition fills after only a few kernel rebuilds. A failed copy also leaves a partial `.tmp` file behind.

The reused image also retains every NixOS system profile generation. Their referenced closures remain GC roots in the target Nix store, causing the root partition to grow across incremental installations.

## Fix

- Set `boot.loader.grub.configurationLimit = 1` to retain only the current boot configuration. This leaves enough temporary space for the next kernel copy and allows GRUB to remove the previous kernel afterward.
- After a successful installation, delete old target system profile generations and garbage-collect their unreachable Nix store paths. This retains the fast incremental-image workflow without accumulating obsolete system closures.
