### PR TITLE
Add and apply `cargo osdk udeps`

### DIFF
--- a/osdk/src/cli.rs
+++ b/osdk/src/cli.rs
@@ -64,6 +64,7 @@ pub fn main() {
             execute_forwarded_command("clippy", &args.args, args.ktests)
         }
         OsdkSubcommand::Doc(args) => execute_forwarded_command("doc", &args.args, false),
+        OsdkSubcommand::Udeps(args) => execute_forwarded_command("udeps", &args.args, true),
     }
 }
 
@@ -97,10 +98,12 @@ pub enum OsdkSubcommand {
     Test(TestArgs),
     #[command(about = "Check a local package and all of its dependencies for errors")]
     Check(KtestWithForwardedArguments),
-    #[command(about = "Checks a package to catch common mistakes and improve your Rust code")]
+    #[command(about = "Check a package to catch common mistakes and improve your Rust code")]
     Clippy(KtestWithForwardedArguments),
     #[command(about = "Build a package's documentation")]
     Doc(ForwardedArguments),
+    #[command(about = "Check unused dependencies")]
+    Udeps(ForwardedArguments),
 }
 
 #[derive(Debug, Parser)]

--- a/osdk/src/commands/mod.rs
+++ b/osdk/src/commands/mod.rs
@@ -22,7 +22,10 @@ use crate::{arch::get_default_arch, error_msg};
 /// The `cfg_ktest` parameter controls whether `cfg(ktest)` is enabled.
 pub fn execute_forwarded_command(subcommand: &str, args: &Vec<String>, cfg_ktest: bool) {
     let mut cargo = util::cargo();
-    cargo.arg(subcommand).args(util::COMMON_CARGO_ARGS);
+    cargo.arg(subcommand);
+    if subcommand != "udeps" {
+        cargo.args(util::COMMON_CARGO_ARGS);
+    }
     if !args.contains(&"--target".to_owned()) {
         cargo.arg("--target").arg(get_default_arch().triple());
     }

--- a/tools/clippy_check.sh
+++ b/tools/clippy_check.sh
@@ -75,6 +75,9 @@ run_workspace_clippy() {
         cd "$PROJECT_ROOT"
         RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps
         RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps
+        cargo osdk udeps --target x86_64-unknown-none
+        cargo osdk udeps --target riscv64imac-unknown-none-elf
+        cargo osdk udeps --target loongarch64-unknown-none-softfloat
     )
 
     build_package_args "--non-default-ones" non_default_package_args
@@ -94,6 +97,7 @@ run_workspace_clippy() {
         (
             cd "$PROJECT_ROOT"
             RUSTFLAGS="-Dwarnings" cargo clippy "${filtered_non_default_package_args[@]}" --all-targets --no-deps
+            cargo udeps "${filtered_non_default_package_args[@]}"
         )
     fi
 


### PR DESCRIPTION
Wrap the command `cargo-udeps` in osdk, because some crates need extra compilation flags from osdk to compile.

Also see https://github.com/asterinas/asterinas/pull/3595 :  `cargo-udeps` is required in the docker before merging this PR.