### PR TITLE
Add `CONFORMANCE_TEST_SELECTOR` to run selected conformance tests

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -45,7 +45,7 @@ inputs:
   conformance_test_workdir:
     description: 'Conformance test working directory'
     required: false
-  extra_blocklists:
+  conformance_test_extra_blocklists:
     description: 'Extra blocklists directories or files'
     required: false
 
@@ -98,7 +98,7 @@ runs:
         [[ -n "${{ inputs.netdev }}" ]] && CMD+=" NETDEV=${{ inputs.netdev }}"
         [[ -n "${{ inputs.scheme }}" ]] && CMD+=" SCHEME=${{ inputs.scheme }}"
         [[ -n "${{ inputs.arch }}" ]] && CMD+=" TARGET_ARCH=${{ inputs.arch }}"
-        [[ -n "${{ inputs.extra_blocklists }}" ]] && CMD+=" EXTRA_BLOCKLISTS=${{ inputs.extra_blocklists }}"
+        [[ -n "${{ inputs.conformance_test_extra_blocklists }}" ]] && CMD+=" CONFORMANCE_TEST_EXTRA_BLOCKLISTS=${{ inputs.conformance_test_extra_blocklists }}"
         [[ -n "${{ inputs.conformance_test_suite }}" ]] && CMD+=" CONFORMANCE_TEST_SUITE=${{ inputs.conformance_test_suite }}"
         [[ -n "${{ inputs.conformance_test_workdir }}" ]] && CMD+=" CONFORMANCE_TEST_WORKDIR=${{ inputs.conformance_test_workdir }}"
         [[ -n "${{ inputs.boot_protocol }}" ]] && CMD+=" BOOT_PROTOCOL=${{ inputs.boot_protocol }}"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -48,7 +48,7 @@ inputs:
   conformance_test_workdir:
     description: 'Conformance test working directory'
     required: false
-  extra_blocklists:
+  conformance_test_extra_blocklists:
     description: 'Extra blocklists directories or files'
     required: false
 
@@ -104,9 +104,9 @@ runs:
         [[ -n "${{ inputs.netdev }}" ]] && CMD+=" NETDEV=${{ inputs.netdev }}"
         [[ -n "${{ inputs.scheme }}" ]] && CMD+=" SCHEME=${{ inputs.scheme }}"
         [[ -n "${{ inputs.arch }}" ]] && CMD+=" TARGET_ARCH=${{ inputs.arch }}"
-        [[ -n "${{ inputs.extra_blocklists }}" ]] && CMD+=" EXTRA_BLOCKLISTS=${{ inputs.extra_blocklists }}"
         [[ -n "${{ inputs.conformance_test_suite }}" ]] && CMD+=" CONFORMANCE_TEST_SUITE=${{ inputs.conformance_test_suite }}"
         [[ -n "${{ inputs.conformance_test_workdir }}" ]] && CMD+=" CONFORMANCE_TEST_WORKDIR=${{ inputs.conformance_test_workdir }}"
+        [[ -n "${{ inputs.conformance_test_extra_blocklists }}" ]] && CMD+=" CONFORMANCE_TEST_EXTRA_BLOCKLISTS=${{ inputs.conformance_test_extra_blocklists }}"
         [[ -n "${{ inputs.boot_protocol }}" ]] && CMD+=" BOOT_PROTOCOL=${{ inputs.boot_protocol }}"
         [[ -n "${{ inputs.mem }}" ]] && CMD+=" MEM=${{ inputs.mem }}"
         [[ "${{ inputs.rootfs_boot }}" == "true" ]] && CMD+=" INITRAMFS=off CMDLINE='root=/dev/vdd rootfstype=ext2 init=/init'"

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -127,9 +127,9 @@ jobs:
           - 'multiboot2-smp4'
         include:
           - { variant: 'debug', release: false, boot_protocol: 'linux-efi-pe64' }
-          - { variant: 'ext2-microvm', scheme: 'microvm', extra_blocklists: 'blocklists.ext2', conformance_test_workdir: '/ext2' }
-          - { variant: 'ext2-iommu-debug', scheme: 'iommu', extra_blocklists: 'blocklists.ext2', conformance_test_workdir: '/ext2', release: false }
-          - { variant: 'exfat-multiboot2-nokvm', boot_protocol: 'multiboot2', enable_kvm: false, extra_blocklists: 'blocklists.exfat', conformance_test_workdir: '/exfat' }
+          - { variant: 'ext2-microvm', scheme: 'microvm', conformance_test_extra_blocklists: 'blocklists.ext2', conformance_test_workdir: '/ext2' }
+          - { variant: 'ext2-iommu-debug', scheme: 'iommu', conformance_test_extra_blocklists: 'blocklists.ext2', conformance_test_workdir: '/ext2', release: false }
+          - { variant: 'exfat-multiboot2-nokvm', boot_protocol: 'multiboot2', enable_kvm: false, conformance_test_extra_blocklists: 'blocklists.exfat', conformance_test_workdir: '/exfat' }
           - { variant: 'multiboot2-smp4', boot_protocol: 'multiboot2', smp: 4 }
     steps:
       - name: Free disk space
@@ -145,7 +145,7 @@ jobs:
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
           scheme: ${{ matrix.scheme }}
-          extra_blocklists: ${{ matrix.extra_blocklists }}
+          conformance_test_extra_blocklists: ${{ matrix.conformance_test_extra_blocklists }}
           conformance_test_suite: ${{ matrix.suite }}
           conformance_test_workdir: ${{ matrix.conformance_test_workdir }}
           boot_protocol: ${{ matrix.boot_protocol || 'linux-efi-handover64' }}

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -136,9 +136,9 @@ jobs:
           - 'multiboot2-smp4'
         include:
           - { variant: 'debug', release: false, boot_protocol: 'linux-efi-pe64' }
-          - { variant: 'ext2-microvm', scheme: 'microvm', extra_blocklists: 'blocklists.ext2', conformance_test_workdir: '/ext2' }
-          - { variant: 'ext2-iommu-debug', scheme: 'iommu', extra_blocklists: 'blocklists.ext2', conformance_test_workdir: '/ext2', release: false }
-          - { variant: 'exfat-multiboot2-nokvm', boot_protocol: 'multiboot2', enable_kvm: false, extra_blocklists: 'blocklists.exfat', conformance_test_workdir: '/exfat' }
+          - { variant: 'ext2-microvm', scheme: 'microvm', conformance_test_workdir: '/ext2', conformance_test_extra_blocklists: 'blocklists.ext2' }
+          - { variant: 'ext2-iommu-debug', scheme: 'iommu', conformance_test_workdir: '/ext2', conformance_test_extra_blocklists: 'blocklists.ext2', release: false }
+          - { variant: 'exfat-multiboot2-nokvm', boot_protocol: 'multiboot2', enable_kvm: false, conformance_test_workdir: '/exfat', conformance_test_extra_blocklists: 'blocklists.exfat' }
           - { variant: 'multiboot2-smp4', boot_protocol: 'multiboot2', smp: 4 }
     steps:
       - name: Free disk space
@@ -154,9 +154,9 @@ jobs:
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
           scheme: ${{ matrix.scheme }}
-          extra_blocklists: ${{ matrix.extra_blocklists }}
           conformance_test_suite: ${{ matrix.suite }}
           conformance_test_workdir: ${{ matrix.conformance_test_workdir }}
+          conformance_test_extra_blocklists: ${{ matrix.conformance_test_extra_blocklists }}
           boot_protocol: ${{ matrix.boot_protocol || 'linux-efi-handover64' }}
 
   cross-compile-test:

--- a/.github/workflows/test_x86_tdx.yml
+++ b/.github/workflows/test_x86_tdx.yml
@@ -85,7 +85,7 @@ jobs:
           - 'tap-smp4'
         include:
           - { variant: 'ramfs' }
-          - { variant: 'exfat', extra_blocklists: 'blocklists.exfat', conformance_test_workdir: '/exfat' }
+          - { variant: 'exfat', conformance_test_extra_blocklists: 'blocklists.exfat', conformance_test_workdir: '/exfat' }
           - { variant: 'tap-smp4', netdev: 'tap', smp: 4 }
     steps:
       - uses: actions/checkout@v4
@@ -98,6 +98,6 @@ jobs:
           boot_protocol: 'linux-efi-handover64'
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
-          extra_blocklists: ${{ matrix.extra_blocklists }}
+          conformance_test_extra_blocklists: ${{ matrix.conformance_test_extra_blocklists }}
           conformance_test_suite: ${{ matrix.suite }}
           conformance_test_workdir: ${{ matrix.conformance_test_workdir }}

--- a/.github/workflows/test_x86_tdx.yml
+++ b/.github/workflows/test_x86_tdx.yml
@@ -85,7 +85,7 @@ jobs:
           - 'tap-smp4'
         include:
           - { variant: 'ramfs' }
-          - { variant: 'exfat', extra_blocklists: 'blocklists.exfat', conformance_test_workdir: '/exfat' }
+          - { variant: 'exfat', conformance_test_workdir: '/exfat', conformance_test_extra_blocklists: 'blocklists.exfat' }
           - { variant: 'tap-smp4', netdev: 'tap', smp: 4 }
     steps:
       - uses: actions/checkout@v4
@@ -98,6 +98,6 @@ jobs:
           boot_protocol: 'linux-efi-handover64'
           smp: ${{ matrix.smp }}
           netdev: ${{ matrix.netdev || 'tap' }}
-          extra_blocklists: ${{ matrix.extra_blocklists }}
           conformance_test_suite: ${{ matrix.suite }}
           conformance_test_workdir: ${{ matrix.conformance_test_workdir }}
+          conformance_test_extra_blocklists: ${{ matrix.conformance_test_extra_blocklists }}

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,21 @@ CONFORMANCE_TEST_WORKDIR ?= /tmp
 # - `kselftest` treats each entry as a blocklist file relative to its runner
 #   directory, and appends that file directly.
 EXTRA_BLOCKLISTS ?= ""
+# Comma-separated tests to run within the selected conformance suite.
+#
+# This variable allows one to select one or multiple tests to run.
+# When this environment variable is present,
+# the blocklist of a conformance test will be ignored.
+#
+# - gvisor:    a test *binary* name, e.g. `epoll_test` (narrow the cases inside
+#              it with `CONFORMANCE_TEST_GVISOR_FILTER`).
+# - kselftest: a `<collection>:<case>` entry, e.g. `timers:posix_timers`.
+# - ltp:       a syscall testcase id, e.g. `rename01`.
+# - xfstests:  a test id, e.g. `generic/001`.
+CONFORMANCE_TEST_SELECTOR ?= ""
+# gVisor-only positive gtest filter, applied inside one selected gVisor test
+# binary, e.g. `EpollTest.CloseFile:EpollTest.Oneshot`.
+CONFORMANCE_TEST_GVISOR_FILTER ?= ""
 # Parameters for xfstests.
 XFSTESTS_RUNLIST ?= /opt/xfstests/short.list
 XFSTESTS_DISK_SIZE ?= 12G
@@ -112,6 +127,8 @@ ENABLE_CONFORMANCE_TEST := true
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SUITE=$(CONFORMANCE_TEST_SUITE)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_WORKDIR=$(CONFORMANCE_TEST_WORKDIR)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="EXTRA_BLOCKLISTS=$(EXTRA_BLOCKLISTS)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SELECTOR=$(CONFORMANCE_TEST_SELECTOR)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_GVISOR_FILTER=$(CONFORMANCE_TEST_GVISOR_FILTER)"
 ifeq ($(CONFORMANCE_TEST_SUITE), xfstests)
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="XFSTESTS_RUNLIST=$(XFSTESTS_RUNLIST)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="XFSTESTS_TEST_DEV=$(XFSTESTS_TEST_DEV)"

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CONFORMANCE_TEST_WORKDIR ?= /tmp
 #   and loads a per-test blocklist file from that directory.
 # - `kselftest` treats each entry as a blocklist file relative to its runner
 #   directory, and appends that file directly.
-EXTRA_BLOCKLISTS ?= ""
+CONFORMANCE_TEST_EXTRA_BLOCKLISTS ?= ""
 # Comma-separated tests to run within the selected conformance suite.
 #
 # This variable allows one to select one or multiple tests to run.
@@ -126,7 +126,7 @@ ifeq ($(AUTO_TEST), conformance)
 ENABLE_CONFORMANCE_TEST := true
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SUITE=$(CONFORMANCE_TEST_SUITE)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_WORKDIR=$(CONFORMANCE_TEST_WORKDIR)"
-CARGO_OSDK_BUILD_ARGS += --kcmd-args="EXTRA_BLOCKLISTS=$(EXTRA_BLOCKLISTS)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_EXTRA_BLOCKLISTS=$(CONFORMANCE_TEST_EXTRA_BLOCKLISTS)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SELECTOR=$(CONFORMANCE_TEST_SELECTOR)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_GVISOR_FILTER=$(CONFORMANCE_TEST_GVISOR_FILTER)"
 ifeq ($(CONFORMANCE_TEST_SUITE), xfstests)

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,21 @@ CONFORMANCE_TEST_WORKDIR ?= /tmp
 # - `kselftest` treats each entry as a blocklist file relative to its runner
 #   directory, and appends that file directly.
 EXTRA_BLOCKLISTS ?= ""
+# Comma-separated tests to run within the selected conformance suite.
+#
+# This variable allows one to select one or multiple tests to run.
+# When this environment variable is present,
+# the blocklist of a conformance test will be ignored.
+#
+# - gvisor:    a test *binary* name, e.g. `epoll_test` (narrow the cases inside
+#              it with `CONFORMANCE_TEST_GVISOR_FILTER`).
+# - kselftest: a `<collection>:<case>` entry, e.g. `timers:posix_timers`.
+# - ltp:       a syscall testcase id, e.g. `rename01`.
+# - xfstests:  a test id, e.g. `generic/001`.
+CONFORMANCE_TEST_SELECTOR ?= ""
+# gVisor-only positive gtest filter, applied inside one selected gVisor test
+# binary, e.g. `EpollTest.CloseFile:EpollTest.Oneshot`.
+CONFORMANCE_TEST_GVISOR_FILTER ?= ""
 # Parameters for xfstests.
 XFSTESTS_FS_TYPE ?= ext2
 XFSTESTS_RUNLIST ?= short.list
@@ -118,6 +133,8 @@ ENABLE_CONFORMANCE_TEST := true
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SUITE=$(CONFORMANCE_TEST_SUITE)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_WORKDIR=$(CONFORMANCE_TEST_WORKDIR)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="EXTRA_BLOCKLISTS=$(EXTRA_BLOCKLISTS)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SELECTOR=$(CONFORMANCE_TEST_SELECTOR)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_GVISOR_FILTER=$(CONFORMANCE_TEST_GVISOR_FILTER)"
 ifeq ($(CONFORMANCE_TEST_SUITE), xfstests)
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="XFSTESTS_FS_TYPE=$(XFSTESTS_FS_TYPE)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="XFSTESTS_RUNLIST=$(XFSTESTS_RUNLIST)"

--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,12 @@ AUTO_TEST ?= none
 ENABLE_CONFORMANCE_TEST ?= false
 CONFORMANCE_TEST_SUITE ?= ltp
 CONFORMANCE_TEST_WORKDIR ?= /tmp
-# Whitespace-separated extra blocklist paths for conformance runners.
+# Comma-separated extra blocklists for conformance runners.
 # - `gvisor` treats each entry as a directory relative to its runner directory,
 #   and loads a per-test blocklist file from that directory.
 # - `kselftest` treats each entry as a blocklist file relative to its runner
 #   directory, and appends that file directly.
-EXTRA_BLOCKLISTS ?= ""
+CONFORMANCE_TEST_EXTRA_BLOCKLISTS ?= ""
 # Comma-separated tests to run within the selected conformance suite.
 #
 # This variable allows one to select one or multiple tests to run.
@@ -132,7 +132,7 @@ ifeq ($(AUTO_TEST), conformance)
 ENABLE_CONFORMANCE_TEST := true
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SUITE=$(CONFORMANCE_TEST_SUITE)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_WORKDIR=$(CONFORMANCE_TEST_WORKDIR)"
-CARGO_OSDK_BUILD_ARGS += --kcmd-args="EXTRA_BLOCKLISTS=$(EXTRA_BLOCKLISTS)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_EXTRA_BLOCKLISTS=$(CONFORMANCE_TEST_EXTRA_BLOCKLISTS)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_SELECTOR=$(CONFORMANCE_TEST_SELECTOR)"
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="CONFORMANCE_TEST_GVISOR_FILTER=$(CONFORMANCE_TEST_GVISOR_FILTER)"
 ifeq ($(CONFORMANCE_TEST_SUITE), xfstests)

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -6,6 +6,7 @@ VERBOSE ?= 1
 ENABLE_CONFORMANCE_TEST ?= false
 CONFORMANCE_TEST_SUITE ?= ltp
 CONFORMANCE_TEST_WORKDIR ?= /tmp
+CONFORMANCE_TEST_SELECTOR ?=
 ENABLE_REGRESSION_TEST ?= false
 # Specify platform macros when building regression tests (supported: asterinas, linux).
 # - asterinas: Define both `__asterinas__` and `__linux__`. Tests may fail in Linux.
@@ -78,6 +79,7 @@ $(INITRAMFS_IMAGE): $(INITRAMFS)
 		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
 		--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
 		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
+		--argstr conformanceTestSelector "$(CONFORMANCE_TEST_SELECTOR)" \
 		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
 		--argstr dnsServer ${DNS_SERVER} \
 		--arg initramfsCompressed $(INITRAMFS_COMPRESSED) \
@@ -95,6 +97,7 @@ $(INITRAMFS):
 		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
 		--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
 		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
+		--argstr conformanceTestSelector "$(CONFORMANCE_TEST_SELECTOR)" \
 		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
 		--argstr dnsServer ${DNS_SERVER} \
 		--arg smp $(SMP) \

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -6,6 +6,7 @@ VERBOSE ?= 1
 ENABLE_CONFORMANCE_TEST ?= false
 CONFORMANCE_TEST_SUITE ?= ltp
 CONFORMANCE_TEST_WORKDIR ?= /tmp
+CONFORMANCE_TEST_SELECTOR ?=
 ENABLE_REGRESSION_TEST ?= false
 # Specify platform macros when building regression tests (supported: asterinas, linux).
 # - asterinas: Define both `__asterinas__` and `__linux__`. Tests may fail in Linux.
@@ -58,6 +59,7 @@ BOOT_IMAGE_NIX_ARGS := \
 	--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
 	--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
 	--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
+	--argstr conformanceTestSelector "$(CONFORMANCE_TEST_SELECTOR)" \
 	--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
 	--argstr dnsServer ${DNS_SERVER} \
 	--arg smp $(SMP)

--- a/test/initramfs/nix/conformance/default.nix
+++ b/test/initramfs/nix/conformance/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenvNoCC, callPackage, testSuite ? "ltp", workDir ? "/tmp", smp ? 1,
-}: rec {
+{ lib, stdenvNoCC, callPackage, testSuite ? "ltp", workDir ? "/tmp"
+, testSelector ? "", smp ? 1, }: rec {
   inherit testSuite;
   ltp = callPackage ./ltp.nix { };
   # FIXME: Build gvisor syscall test with nix.
@@ -25,6 +25,7 @@
       export INITRAMFS=$out
       export CONFORMANCE_TEST_SUITE=${testSuite}
       export CONFORMANCE_TEST_WORKDIR=${workDir}
+      export CONFORMANCE_TEST_SELECTOR=${testSelector}
       export SMP=${toString smp}
       ${lib.optionalString (testSuite == "ltp")
       "export LTP_PREBUILT_DIR=${ltp}"}

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -1,7 +1,8 @@
 { target ? "x86_64", enableBenchmarkTest ? false, enableConformanceTest ? false
 , enableRegressionTest ? false, conformanceTestSuite ? "ltp"
-, conformanceTestWorkDir ? "/tmp", regressionTestPlatform ? "asterinas"
-, dnsServer ? "none", smp ? 1, initramfsCompressed ? true, }:
+, conformanceTestWorkDir ? "/tmp", conformanceTestSelector ? ""
+, regressionTestPlatform ? "asterinas", dnsServer ? "none", smp ? 1
+, initramfsCompressed ? true, }:
 let
   crossSystem.config = if target == "x86_64" then
     "x86_64-unknown-linux-gnu"
@@ -29,6 +30,7 @@ in rec {
     inherit smp;
     testSuite = conformanceTestSuite;
     workDir = conformanceTestWorkDir;
+    testSelector = conformanceTestSelector;
   };
   regression =
     pkgs.callPackage ./regression { testPlatform = regressionTestPlatform; };

--- a/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
+++ b/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
@@ -15,6 +15,10 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+# When a selector is set, run only the selected test binaries and ignore the blocklist.
+CONFORMANCE_TEST_SELECTOR=${CONFORMANCE_TEST_SELECTOR:-}
+CONFORMANCE_TEST_GVISOR_FILTER=${CONFORMANCE_TEST_GVISOR_FILTER:-}
+
 get_blocklist_subtests(){
     if [ -f $BLOCKLIST_DIR/$1 ]; then
         BLOCK=$(grep -v '^#' $BLOCKLIST_DIR/$1 | tr '\n' ':')
@@ -37,8 +41,13 @@ run_one_test(){
     export TEST_TMPDIR=$TEST_TMP_DIR
     ret=0
     if [ -f $TEST_BIN_DIR/$1 ]; then
-        get_blocklist_subtests $1
-        cd $TEST_BIN_DIR && ./$1 --gtest_filter=-$BLOCK
+        if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+            gtest_filter=${CONFORMANCE_TEST_GVISOR_FILTER:-*}
+        else
+            get_blocklist_subtests $1
+            gtest_filter="-$BLOCK"
+        fi
+        cd $TEST_BIN_DIR && ./$1 --gtest_filter="$gtest_filter"
         ret=$?
         #After executing the test, it is necessary to clean the directory to ensure no residual data remains
         rm -rf $TEST_TMP_DIR/*
@@ -53,8 +62,14 @@ run_one_test(){
 rm -f $FAIL_CASES && touch $FAIL_CASES
 rm -rf $TEST_TMP_DIR/*
 
-for syscall_test in $(find $TEST_BIN_DIR/. -name \*_test) ; do
-    test_name=$(basename "$syscall_test")
+# Build the list of test binaries to run: the selected ones, or every `*_test`.
+if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+    TEST_LIST=$(echo "$CONFORMANCE_TEST_SELECTOR" | tr ',' ' ')
+else
+    TEST_LIST=$(find $TEST_BIN_DIR/. -name \*_test -exec basename {} \;)
+fi
+
+for test_name in $TEST_LIST ; do
     run_one_test $test_name
     if [ $? -eq 0 ] && PASSED_TESTS=$((PASSED_TESTS+1));then
         TESTS=$((TESTS+1))

--- a/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
+++ b/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
@@ -26,7 +26,7 @@ get_blocklist_subtests(){
         BLOCK=""
     fi
 
-    for extra_dir in $EXTRA_BLOCKLISTS ; do
+    for extra_dir in $CONFORMANCE_TEST_EXTRA_BLOCKLISTS ; do
         if [ -f $SCRIPT_DIR/$extra_dir/$1 ]; then
             BLOCK="${BLOCK}:$(grep -v '^#' $SCRIPT_DIR/$extra_dir/$1 | tr '\n' ':')"
         fi

--- a/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
+++ b/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
@@ -15,6 +15,13 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+# When a selector is set, run only the selected test binaries and ignore the blocklist.
+CONFORMANCE_TEST_SELECTOR=${CONFORMANCE_TEST_SELECTOR:-}
+CONFORMANCE_TEST_GVISOR_FILTER=${CONFORMANCE_TEST_GVISOR_FILTER:-}
+SELECTED_TESTS=$(mktemp "$SCRIPT_DIR/selected_tests.XXXXXX")
+
+trap 'rm -f "$SELECTED_TESTS"' EXIT
+
 get_blocklist_subtests(){
     if [ -f $BLOCKLIST_DIR/$1 ]; then
         BLOCK=$(grep -v '^#' $BLOCKLIST_DIR/$1 | tr '\n' ':')
@@ -36,33 +43,78 @@ run_one_test(){
     # The gvisor test framework utilizes the "TEST_TMPDIR" environment variable to dictate the directory's location.
     export TEST_TMPDIR=$TEST_TMP_DIR
     ret=0
-    if [ -f $TEST_BIN_DIR/$1 ]; then
-        get_blocklist_subtests $1
-        cd $TEST_BIN_DIR && ./$1 --gtest_filter=-$BLOCK
+    if [ -x "$TEST_BIN_DIR/$1" ]; then
+        if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+            gtest_filter=${CONFORMANCE_TEST_GVISOR_FILTER:-*}
+        else
+            get_blocklist_subtests $1
+            gtest_filter="-$BLOCK"
+        fi
+        cd "$TEST_BIN_DIR" && "./$1" --gtest_filter="$gtest_filter"
         ret=$?
         #After executing the test, it is necessary to clean the directory to ensure no residual data remains
         rm -rf $TEST_TMP_DIR/*
     else
-        echo -e "Warning: $1 test does not exit"
+        echo "Error: gVisor test is not executable: $1" >&2
         ret=1
     fi
     echo ""
     return $ret
 }
 
-rm -f $FAIL_CASES && touch $FAIL_CASES
-rm -rf $TEST_TMP_DIR/*
+if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+    REQUESTED_TESTS=$(mktemp "$SCRIPT_DIR/requested_tests.XXXXXX")
+    trap 'rm -f "$SELECTED_TESTS" "$REQUESTED_TESTS"' EXIT
+    printf '%s\n' "$CONFORMANCE_TEST_SELECTOR" | tr ',' '\n' > "$REQUESTED_TESTS"
 
-for syscall_test in $(find $TEST_BIN_DIR/. -name \*_test) ; do
-    test_name=$(basename "$syscall_test")
-    run_one_test $test_name
+    selected_count=0
+    invalid_selector=0
+    while IFS= read -r test_name || [ -n "$test_name" ]; do
+        test_name=${test_name#"${test_name%%[![:space:]]*}"}
+        test_name=${test_name%"${test_name##*[![:space:]]}"}
+        [ -z "$test_name" ] && continue
+        test_name=$(basename "$test_name")
+
+        selected_count=$((selected_count + 1))
+        case "$test_name" in
+            *_test)
+                if [ -x "$TEST_BIN_DIR/$test_name" ]; then
+                    printf '%s\n' "$test_name" >> "$SELECTED_TESTS"
+                    continue
+                fi
+                ;;
+        esac
+
+        echo "Error: unknown gVisor test: $test_name" >&2
+        invalid_selector=1
+    done < "$REQUESTED_TESTS"
+
+    if [ "$selected_count" -eq 0 ]; then
+        echo "Error: CONFORMANCE_TEST_SELECTOR contains no test names" >&2
+        exit 2
+    fi
+    if [ "$invalid_selector" -ne 0 ]; then
+        exit 2
+    fi
+
+    sort -u -o "$SELECTED_TESTS" "$SELECTED_TESTS"
+else
+    find "$TEST_BIN_DIR" -maxdepth 1 -type f -name '*_test' \
+        -exec basename {} \; | sort -u > "$SELECTED_TESTS"
+fi
+
+rm -f "$FAIL_CASES" && touch "$FAIL_CASES"
+rm -rf "$TEST_TMP_DIR"/*
+
+while IFS= read -r test_name; do
+    run_one_test "$test_name"
     if [ $? -eq 0 ] && PASSED_TESTS=$((PASSED_TESTS+1));then
         TESTS=$((TESTS+1))
     else
-        echo -e "$test_name" >> $FAIL_CASES
+        echo "$test_name" >> "$FAIL_CASES"
         TESTS=$((TESTS+1))
     fi
-done
+done < "$SELECTED_TESTS"
 
 echo -e "$GREEN$PASSED_TESTS$NC of $GREEN$TESTS$NC test cases passed."
 [ $PASSED_TESTS -ne $TESTS ] && RESULT=1

--- a/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
+++ b/test/initramfs/src/conformance/gvisor/run_gvisor_test.sh
@@ -29,9 +29,14 @@ get_blocklist_subtests(){
         BLOCK=""
     fi
 
-    for extra_dir in $EXTRA_BLOCKLISTS ; do
-        if [ -f $SCRIPT_DIR/$extra_dir/$1 ]; then
-            BLOCK="${BLOCK}:$(grep -v '^#' $SCRIPT_DIR/$extra_dir/$1 | tr '\n' ':')"
+    remaining_blocklists="${CONFORMANCE_TEST_EXTRA_BLOCKLISTS:-},"
+    while [ -n "$remaining_blocklists" ]; do
+        extra_dir=${remaining_blocklists%%,*}
+        remaining_blocklists=${remaining_blocklists#*,}
+        [ -z "$extra_dir" ] && continue
+
+        if [ -f "$SCRIPT_DIR/$extra_dir/$1" ]; then
+            BLOCK="${BLOCK}:$(grep -v '^#' "$SCRIPT_DIR/$extra_dir/$1" | tr '\n' ':')"
         fi
     done
 

--- a/test/initramfs/src/conformance/kselftest/run_kselftest.sh
+++ b/test/initramfs/src/conformance/kselftest/run_kselftest.sh
@@ -31,54 +31,61 @@ else
     echo "Found $available_count available test cases"
 fi
 
-if [ ! -r "$DEFAULT_BLOCKLISTS" ]; then
-    echo "$0: missing $DEFAULT_BLOCKLISTS; kselftest blocklist is broken" >&2
-    exit 1
-fi
+# When a selector is set, run only the selected entries and ignore the blocklist.
+CONFORMANCE_TEST_SELECTOR=${CONFORMANCE_TEST_SELECTOR:-}
 
-cat "$DEFAULT_BLOCKLISTS" > "$COMBINED_BLOCKLISTS"
-for extra_file in $EXTRA_BLOCKLISTS ; do
-    extra_blocklists="$KSELFTEST_DIR/$extra_file"
-    if [ -r "$extra_blocklists" ]; then
-        printf '\n' >> "$COMBINED_BLOCKLISTS"
-        cat "$extra_blocklists" >> "$COMBINED_BLOCKLISTS"
-    else
-        echo "Warning: extra blocklist not found: $extra_blocklists" >&2
-    fi
-done
-
-echo "Processing blocklists..."
-while IFS= read -r line || [ -n "$line" ]; do
-    line=${line#"${line%%[![:space:]]*}"}
-    line=${line%"${line##*[![:space:]]}"}
-    case "$line" in
-        "" | "#"*)
-            continue ;;
-        *:*)
-            dir="${line%%:*}"
-            command="${line#*:}"
-            if [ "$command" = "*" ]; then
-                awk -F: -v d="$dir" '$1 == d { print }' "$TESTS" >> "$RESOLVED_BLOCKLISTS"
-            else
-                printf '%s\n' "$line" >> "$RESOLVED_BLOCKLISTS"
-            fi
-            ;;
-        *)
-            echo "Error: Invalid format in blocklist: $line" >&2
-            exit 1
-            ;;
-    esac
-done < "$COMBINED_BLOCKLISTS"
-
-sort -u -o "$RESOLVED_BLOCKLISTS" "$RESOLVED_BLOCKLISTS"
-if [ -s "$RESOLVED_BLOCKLISTS" ]; then
-    blocked_count=$(wc -l < "$RESOLVED_BLOCKLISTS")
-    grep -vxFf "$RESOLVED_BLOCKLISTS" "$TESTS" | grep -v '^$' > "$AVAILABLE_TESTS"
+if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+    echo "$CONFORMANCE_TEST_SELECTOR" | tr ',' '\n' | grep -v '^$' > "$AVAILABLE_TESTS"
 else
-    blocked_count=0
-    grep -v '^$' "$TESTS" > "$AVAILABLE_TESTS"
+    if [ ! -r "$DEFAULT_BLOCKLISTS" ]; then
+        echo "$0: missing $DEFAULT_BLOCKLISTS; kselftest blocklist is broken" >&2
+        exit 1
+    fi
+
+    cat "$DEFAULT_BLOCKLISTS" > "$COMBINED_BLOCKLISTS"
+    for extra_file in $EXTRA_BLOCKLISTS ; do
+        extra_blocklists="$KSELFTEST_DIR/$extra_file"
+        if [ -r "$extra_blocklists" ]; then
+            printf '\n' >> "$COMBINED_BLOCKLISTS"
+            cat "$extra_blocklists" >> "$COMBINED_BLOCKLISTS"
+        else
+            echo "Warning: extra blocklist not found: $extra_blocklists" >&2
+        fi
+    done
+
+    echo "Processing blocklists..."
+    while IFS= read -r line || [ -n "$line" ]; do
+        line=${line#"${line%%[![:space:]]*}"}
+        line=${line%"${line##*[![:space:]]}"}
+        case "$line" in
+            "" | "#"*)
+                continue ;;
+            *:*)
+                dir="${line%%:*}"
+                command="${line#*:}"
+                if [ "$command" = "*" ]; then
+                    awk -F: -v d="$dir" '$1 == d { print }' "$TESTS" >> "$RESOLVED_BLOCKLISTS"
+                else
+                    printf '%s\n' "$line" >> "$RESOLVED_BLOCKLISTS"
+                fi
+                ;;
+            *)
+                echo "Error: Invalid format in blocklist: $line" >&2
+                exit 1
+                ;;
+        esac
+    done < "$COMBINED_BLOCKLISTS"
+
+    sort -u -o "$RESOLVED_BLOCKLISTS" "$RESOLVED_BLOCKLISTS"
+    if [ -s "$RESOLVED_BLOCKLISTS" ]; then
+        blocked_count=$(wc -l < "$RESOLVED_BLOCKLISTS")
+        grep -vxFf "$RESOLVED_BLOCKLISTS" "$TESTS" | grep -v '^$' > "$AVAILABLE_TESTS"
+    else
+        blocked_count=0
+        grep -v '^$' "$TESTS" > "$AVAILABLE_TESTS"
+    fi
+    echo "Total blocklist entries processed: $blocked_count"
 fi
-echo "Total blocklist entries processed: $blocked_count"
 
 run_count=$(wc -l < "$AVAILABLE_TESTS")
 if [ "$run_count" -eq 0 ]; then

--- a/test/initramfs/src/conformance/kselftest/run_kselftest.sh
+++ b/test/initramfs/src/conformance/kselftest/run_kselftest.sh
@@ -43,7 +43,7 @@ else
     fi
 
     cat "$DEFAULT_BLOCKLISTS" > "$COMBINED_BLOCKLISTS"
-    for extra_file in $EXTRA_BLOCKLISTS ; do
+    for extra_file in $CONFORMANCE_TEST_EXTRA_BLOCKLISTS ; do
         extra_blocklists="$KSELFTEST_DIR/$extra_file"
         if [ -r "$extra_blocklists" ]; then
             printf '\n' >> "$COMBINED_BLOCKLISTS"

--- a/test/initramfs/src/conformance/kselftest/run_kselftest.sh
+++ b/test/initramfs/src/conformance/kselftest/run_kselftest.sh
@@ -69,7 +69,12 @@ else
     fi
 
     cat "$DEFAULT_BLOCKLISTS" > "$COMBINED_BLOCKLISTS"
-    for extra_file in $EXTRA_BLOCKLISTS ; do
+    remaining_blocklists="${CONFORMANCE_TEST_EXTRA_BLOCKLISTS:-},"
+    while [ -n "$remaining_blocklists" ]; do
+        extra_file=${remaining_blocklists%%,*}
+        remaining_blocklists=${remaining_blocklists#*,}
+        [ -z "$extra_file" ] && continue
+
         extra_blocklists="$KSELFTEST_DIR/$extra_file"
         if [ -r "$extra_blocklists" ]; then
             printf '\n' >> "$COMBINED_BLOCKLISTS"

--- a/test/initramfs/src/conformance/kselftest/run_kselftest.sh
+++ b/test/initramfs/src/conformance/kselftest/run_kselftest.sh
@@ -31,54 +31,87 @@ else
     echo "Found $available_count available test cases"
 fi
 
-if [ ! -r "$DEFAULT_BLOCKLISTS" ]; then
-    echo "$0: missing $DEFAULT_BLOCKLISTS; kselftest blocklist is broken" >&2
-    exit 1
-fi
+# When a selector is set, run only the selected entries and ignore the blocklist.
+CONFORMANCE_TEST_SELECTOR=${CONFORMANCE_TEST_SELECTOR:-}
 
-cat "$DEFAULT_BLOCKLISTS" > "$COMBINED_BLOCKLISTS"
-for extra_file in $EXTRA_BLOCKLISTS ; do
-    extra_blocklists="$KSELFTEST_DIR/$extra_file"
-    if [ -r "$extra_blocklists" ]; then
-        printf '\n' >> "$COMBINED_BLOCKLISTS"
-        cat "$extra_blocklists" >> "$COMBINED_BLOCKLISTS"
-    else
-        echo "Warning: extra blocklist not found: $extra_blocklists" >&2
+if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+    printf '%s\n' "$CONFORMANCE_TEST_SELECTOR" | tr ',' '\n' > "$COMBINED_BLOCKLISTS"
+
+    selected_count=0
+    invalid_selector=0
+    while IFS= read -r test_name || [ -n "$test_name" ]; do
+        test_name=${test_name#"${test_name%%[![:space:]]*}"}
+        test_name=${test_name%"${test_name##*[![:space:]]}"}
+        [ -z "$test_name" ] && continue
+
+        selected_count=$((selected_count + 1))
+        if grep -qxF "$test_name" "$TESTS"; then
+            printf '%s\n' "$test_name" >> "$AVAILABLE_TESTS"
+        else
+            echo "Error: unknown kselftest test: $test_name" >&2
+            invalid_selector=1
+        fi
+    done < "$COMBINED_BLOCKLISTS"
+
+    if [ "$selected_count" -eq 0 ]; then
+        echo "$0: CONFORMANCE_TEST_SELECTOR contains no test names" >&2
+        exit 2
     fi
-done
+    if [ "$invalid_selector" -ne 0 ]; then
+        exit 2
+    fi
 
-echo "Processing blocklists..."
-while IFS= read -r line || [ -n "$line" ]; do
-    line=${line#"${line%%[![:space:]]*}"}
-    line=${line%"${line##*[![:space:]]}"}
-    case "$line" in
-        "" | "#"*)
-            continue ;;
-        *:*)
-            dir="${line%%:*}"
-            command="${line#*:}"
-            if [ "$command" = "*" ]; then
-                awk -F: -v d="$dir" '$1 == d { print }' "$TESTS" >> "$RESOLVED_BLOCKLISTS"
-            else
-                printf '%s\n' "$line" >> "$RESOLVED_BLOCKLISTS"
-            fi
-            ;;
-        *)
-            echo "Error: Invalid format in blocklist: $line" >&2
-            exit 1
-            ;;
-    esac
-done < "$COMBINED_BLOCKLISTS"
-
-sort -u -o "$RESOLVED_BLOCKLISTS" "$RESOLVED_BLOCKLISTS"
-if [ -s "$RESOLVED_BLOCKLISTS" ]; then
-    blocked_count=$(wc -l < "$RESOLVED_BLOCKLISTS")
-    grep -vxFf "$RESOLVED_BLOCKLISTS" "$TESTS" | grep -v '^$' > "$AVAILABLE_TESTS"
+    sort -u -o "$AVAILABLE_TESTS" "$AVAILABLE_TESTS"
 else
-    blocked_count=0
-    grep -v '^$' "$TESTS" > "$AVAILABLE_TESTS"
+    if [ ! -r "$DEFAULT_BLOCKLISTS" ]; then
+        echo "$0: missing $DEFAULT_BLOCKLISTS; kselftest blocklist is broken" >&2
+        exit 1
+    fi
+
+    cat "$DEFAULT_BLOCKLISTS" > "$COMBINED_BLOCKLISTS"
+    for extra_file in $EXTRA_BLOCKLISTS ; do
+        extra_blocklists="$KSELFTEST_DIR/$extra_file"
+        if [ -r "$extra_blocklists" ]; then
+            printf '\n' >> "$COMBINED_BLOCKLISTS"
+            cat "$extra_blocklists" >> "$COMBINED_BLOCKLISTS"
+        else
+            echo "Warning: extra blocklist not found: $extra_blocklists" >&2
+        fi
+    done
+
+    echo "Processing blocklists..."
+    while IFS= read -r line || [ -n "$line" ]; do
+        line=${line#"${line%%[![:space:]]*}"}
+        line=${line%"${line##*[![:space:]]}"}
+        case "$line" in
+            "" | "#"*)
+                continue ;;
+            *:*)
+                dir="${line%%:*}"
+                command="${line#*:}"
+                if [ "$command" = "*" ]; then
+                    awk -F: -v d="$dir" '$1 == d { print }' "$TESTS" >> "$RESOLVED_BLOCKLISTS"
+                else
+                    printf '%s\n' "$line" >> "$RESOLVED_BLOCKLISTS"
+                fi
+                ;;
+            *)
+                echo "Error: Invalid format in blocklist: $line" >&2
+                exit 1
+                ;;
+        esac
+    done < "$COMBINED_BLOCKLISTS"
+
+    sort -u -o "$RESOLVED_BLOCKLISTS" "$RESOLVED_BLOCKLISTS"
+    if [ -s "$RESOLVED_BLOCKLISTS" ]; then
+        blocked_count=$(wc -l < "$RESOLVED_BLOCKLISTS")
+        grep -vxFf "$RESOLVED_BLOCKLISTS" "$TESTS" | grep -v '^$' > "$AVAILABLE_TESTS"
+    else
+        blocked_count=0
+        grep -v '^$' "$TESTS" > "$AVAILABLE_TESTS"
+    fi
+    echo "Total blocklist entries processed: $blocked_count"
 fi
-echo "Total blocklist entries processed: $blocked_count"
 
 run_count=$(wc -l < "$AVAILABLE_TESTS")
 if [ "$run_count" -eq 0 ]; then

--- a/test/initramfs/src/conformance/ltp/Makefile
+++ b/test/initramfs/src/conformance/ltp/Makefile
@@ -18,13 +18,15 @@ $(TARGET_DIR): $(RUN_BASH) $(ALL_TESTS) $(EXT2_BLOCKLIST) $(EXFAT_BLOCKLIST)
 	@# Prepare tests dir for test binaries
 	@mkdir -p $@/testcases/bin
 	@mkdir -p $@/runtest
-	@awk '!/^#/ && NF' $(ALL_TESTS) > $@/all.txt
-	@if [ "$(CONFORMANCE_TEST_WORKDIR)" = "/ext2" ]; then \
-		grep -vxF -f $(EXT2_BLOCKLIST) $@/all.txt > $@/filtered.txt; \
+	@# When a selector is set, package only the selected tests and ignore the blocklist.
+	@if [ -n "$(CONFORMANCE_TEST_SELECTOR)" ]; then \
+		echo "$(CONFORMANCE_TEST_SELECTOR)" | tr ',' '\n' | grep -v '^$$' > $@/filtered.txt; \
+	elif [ "$(CONFORMANCE_TEST_WORKDIR)" = "/ext2" ]; then \
+		awk '!/^#/ && NF' $(ALL_TESTS) | grep -vxF -f $(EXT2_BLOCKLIST) > $@/filtered.txt; \
 	elif [ "$(CONFORMANCE_TEST_WORKDIR)" = "/exfat" ]; then \
-		grep -vxF -f $(EXFAT_BLOCKLIST) $@/all.txt > $@/filtered.txt; \
+		awk '!/^#/ && NF' $(ALL_TESTS) | grep -vxF -f $(EXFAT_BLOCKLIST) > $@/filtered.txt; \
 	else \
-		cp -f $@/all.txt $@/filtered.txt; \
+		awk '!/^#/ && NF' $(ALL_TESTS) > $@/filtered.txt; \
 	fi;
 	@# Process syscall testcases and copy binaries
 	@while read -r syscall binary params; do \
@@ -38,7 +40,7 @@ $(TARGET_DIR): $(RUN_BASH) $(ALL_TESTS) $(EXT2_BLOCKLIST) $(EXFAT_BLOCKLIST)
 		fi; \
 	done < $(LTP_PREBUILT_DIR)/runtest/syscalls
 	@# Remove intermediate files
-	@rm -f $@/all.txt $@/filtered.txt
+	@rm -f $@/filtered.txt
 	@# Copy bash scripts
 	@if [ -d $(LTP_PREBUILT_DIR)/bin ]; then \
 		cp -r $(LTP_PREBUILT_DIR)/bin $@; \

--- a/test/initramfs/src/conformance/ltp/Makefile
+++ b/test/initramfs/src/conformance/ltp/Makefile
@@ -6,6 +6,7 @@ CUR_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 INITRAMFS ?= $(CUR_DIR)/../../../build/initramfs
 TARGET_DIR := $(INITRAMFS)/opt/ltp
 RUN_BASH := $(CUR_DIR)/run_ltp_test.sh
+BUILD_LTP_PACKAGE := $(CUR_DIR)/build_ltp_package.sh
 ALL_TESTS := $(CUR_DIR)/testcases/all.txt
 EXT2_BLOCKLIST := $(CUR_DIR)/testcases/blocked/ext2.txt
 EXFAT_BLOCKLIST := $(CUR_DIR)/testcases/blocked/exfat.txt
@@ -13,42 +14,8 @@ EXFAT_BLOCKLIST := $(CUR_DIR)/testcases/blocked/exfat.txt
 .PHONY: all
 all: $(TARGET_DIR)
 
-$(TARGET_DIR): $(RUN_BASH) $(ALL_TESTS) $(EXT2_BLOCKLIST) $(EXFAT_BLOCKLIST)
-	@rm -rf $@ && mkdir -p $@
-	@# Prepare tests dir for test binaries
-	@mkdir -p $@/testcases/bin
-	@mkdir -p $@/runtest
-	@awk '!/^#/ && NF' $(ALL_TESTS) > $@/all.txt
-	@if [ "$(CONFORMANCE_TEST_WORKDIR)" = "/ext2" ]; then \
-		grep -vxF -f $(EXT2_BLOCKLIST) $@/all.txt > $@/filtered.txt; \
-	elif [ "$(CONFORMANCE_TEST_WORKDIR)" = "/exfat" ]; then \
-		grep -vxF -f $(EXFAT_BLOCKLIST) $@/all.txt > $@/filtered.txt; \
-	else \
-		cp -f $@/all.txt $@/filtered.txt; \
-	fi;
-	@# Process syscall testcases and copy binaries
-	@while read -r syscall binary params; do \
-		if grep -q "^$$syscall$$" $@/filtered.txt; then \
-			if [ -f $(LTP_PREBUILT_DIR)/testcases/bin/$$binary ]; then \
-				cp -f $(LTP_PREBUILT_DIR)/testcases/bin/$$binary $@/testcases/bin; \
-				echo "$$syscall $$binary $$params" >> $@/runtest/syscalls; \
-			else \
-				echo "Warning: $$binary not found (skipping)"; \
-			fi; \
-		fi; \
-	done < $(LTP_PREBUILT_DIR)/runtest/syscalls
-	@# Remove intermediate files
-	@rm -f $@/all.txt $@/filtered.txt
-	@# Copy bash scripts
-	@if [ -d $(LTP_PREBUILT_DIR)/bin ]; then \
-		cp -r $(LTP_PREBUILT_DIR)/bin $@; \
-	fi
-	@cp -r $(LTP_PREBUILT_DIR)/libkirk $@
-	@cp -f $(LTP_PREBUILT_DIR)/kirk $@
-	@cp -f $(LTP_PREBUILT_DIR)/Version $@
-	@cp -f $(LTP_PREBUILT_DIR)/ver_linux $@
-	@cp -f $(LTP_PREBUILT_DIR)/IDcheck.sh $@
-	@cp -f $(RUN_BASH) $@
+$(TARGET_DIR): $(BUILD_LTP_PACKAGE) $(RUN_BASH) $(ALL_TESTS) $(EXT2_BLOCKLIST) $(EXFAT_BLOCKLIST)
+	@"$(BUILD_LTP_PACKAGE)" "$@"
 
 .PHONY: clean
 clean:

--- a/test/initramfs/src/conformance/ltp/build_ltp_package.sh
+++ b/test/initramfs/src/conformance/ltp/build_ltp_package.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 TARGET_DIR" >&2
+    exit 2
+fi
+
+TARGET_DIR=$1
+LTP_PREBUILT_DIR=${LTP_PREBUILT_DIR:-/opt/ltp}
+CONFORMANCE_TEST_WORKDIR=${CONFORMANCE_TEST_WORKDIR:-/tmp}
+CONFORMANCE_TEST_SELECTOR=${CONFORMANCE_TEST_SELECTOR:-}
+
+SCRIPT_DIR=$(dirname "$0")
+ALL_TESTS="$SCRIPT_DIR/testcases/all.txt"
+EXT2_BLOCKLIST="$SCRIPT_DIR/testcases/blocked/ext2.txt"
+EXFAT_BLOCKLIST="$SCRIPT_DIR/testcases/blocked/exfat.txt"
+RUN_BASH="$SCRIPT_DIR/run_ltp_test.sh"
+SYSCALLS="$LTP_PREBUILT_DIR/runtest/syscalls"
+
+REQUESTED_TESTS=$(mktemp)
+SELECTED_TESTS=$(mktemp)
+
+trap 'rm -f "$REQUESTED_TESTS" "$SELECTED_TESTS"' EXIT
+
+if [ ! -r "$SYSCALLS" ]; then
+    echo "Missing LTP syscall definitions: $SYSCALLS" >&2
+    exit 1
+fi
+
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR/testcases/bin" "$TARGET_DIR/runtest"
+
+filter_tests_by_blocklist() {
+    blocklist=$1
+
+    awk '
+        FILENAME == ARGV[1] {
+            if (!/^#/ && NF) {
+                blocked[$0] = 1
+            }
+            next
+        }
+        !/^#/ && NF && !($0 in blocked)
+    ' "$blocklist" "$ALL_TESTS" > "$SELECTED_TESTS"
+}
+
+if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+    printf '%s\n' "$CONFORMANCE_TEST_SELECTOR" | tr ',' '\n' > "$REQUESTED_TESTS"
+
+    selected_count=0
+    invalid_selector=0
+    while IFS= read -r syscall || [ -n "$syscall" ]; do
+        syscall=${syscall#"${syscall%%[![:space:]]*}"}
+        syscall=${syscall%"${syscall##*[![:space:]]}"}
+        [ -z "$syscall" ] && continue
+
+        selected_count=$((selected_count + 1))
+        binary=$(awk -v selected="$syscall" '$1 == selected { print $2; exit }' "$SYSCALLS")
+        if [ -z "$binary" ]; then
+            echo "Error: unknown LTP test: $syscall" >&2
+            invalid_selector=1
+            continue
+        fi
+        if [ ! -f "$LTP_PREBUILT_DIR/testcases/bin/$binary" ]; then
+            echo "Error: LTP test binary is not available: $syscall ($binary)" >&2
+            invalid_selector=1
+            continue
+        fi
+        printf '%s\n' "$syscall" >> "$SELECTED_TESTS"
+    done < "$REQUESTED_TESTS"
+
+    if [ "$selected_count" -eq 0 ]; then
+        echo "Error: CONFORMANCE_TEST_SELECTOR contains no test names" >&2
+        exit 2
+    fi
+    if [ "$invalid_selector" -ne 0 ]; then
+        exit 2
+    fi
+elif [ "$CONFORMANCE_TEST_WORKDIR" = "/ext2" ]; then
+    filter_tests_by_blocklist "$EXT2_BLOCKLIST"
+elif [ "$CONFORMANCE_TEST_WORKDIR" = "/exfat" ]; then
+    filter_tests_by_blocklist "$EXFAT_BLOCKLIST"
+else
+    awk '!/^#/ && NF' "$ALL_TESTS" > "$SELECTED_TESTS"
+fi
+
+: > "$TARGET_DIR/runtest/syscalls"
+while read -r syscall binary params; do
+    if grep -qxF "$syscall" "$SELECTED_TESTS"; then
+        if [ -f "$LTP_PREBUILT_DIR/testcases/bin/$binary" ]; then
+            cp -f "$LTP_PREBUILT_DIR/testcases/bin/$binary" "$TARGET_DIR/testcases/bin"
+            echo "$syscall $binary $params" >> "$TARGET_DIR/runtest/syscalls"
+        else
+            echo "Warning: $binary not found (skipping)"
+        fi
+    fi
+done < "$SYSCALLS"
+
+if [ -d "$LTP_PREBUILT_DIR/bin" ]; then
+    cp -r "$LTP_PREBUILT_DIR/bin" "$TARGET_DIR"
+fi
+cp -r "$LTP_PREBUILT_DIR/libkirk" "$TARGET_DIR"
+cp -f "$LTP_PREBUILT_DIR/kirk" "$TARGET_DIR"
+cp -f "$LTP_PREBUILT_DIR/Version" "$TARGET_DIR"
+cp -f "$LTP_PREBUILT_DIR/ver_linux" "$TARGET_DIR"
+cp -f "$LTP_PREBUILT_DIR/IDcheck.sh" "$TARGET_DIR"
+cp -f "$RUN_BASH" "$TARGET_DIR"

--- a/test/initramfs/src/conformance/xfstests/run_xfstests.sh
+++ b/test/initramfs/src/conformance/xfstests/run_xfstests.sh
@@ -61,22 +61,29 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -n "$RUNLIST_FILE" ]; then
-  if [ ! -f "$RUNLIST_FILE" ]; then
-    echo "Run list file not found: $RUNLIST_FILE" >&2
-    exit 2
-  fi
-  while IFS= read -r test; do
-    case "$test" in
-      ""|\#*) continue ;;
-    esac
-    TEST_ARGS="$TEST_ARGS $test"
-  done < "$RUNLIST_FILE"
-fi
+# When a selector is set, run only the selected test ids and ignore the blocklist.
+CONFORMANCE_TEST_SELECTOR=${CONFORMANCE_TEST_SELECTOR:-}
 
-# Prepend block-list exclusion so blocked tests are skipped.
-if [ -f "$XFSTESTS_DIR/block.list" ]; then
-    TEST_ARGS="-E $XFSTESTS_DIR/block.list $TEST_ARGS"
+if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+    TEST_ARGS=$(echo "$CONFORMANCE_TEST_SELECTOR" | tr ',' ' ')
+else
+    if [ -n "$RUNLIST_FILE" ]; then
+        if [ ! -f "$RUNLIST_FILE" ]; then
+            echo "Run list file not found: $RUNLIST_FILE" >&2
+            exit 2
+        fi
+        while IFS= read -r test; do
+            case "$test" in
+                ""|\#*) continue ;;
+            esac
+            TEST_ARGS="$TEST_ARGS $test"
+        done < "$RUNLIST_FILE"
+    fi
+
+    # Prepend block-list exclusion so blocked tests are skipped.
+    if [ -f "$XFSTESTS_DIR/block.list" ]; then
+        TEST_ARGS="-E $XFSTESTS_DIR/block.list $TEST_ARGS"
+    fi
 fi
 
 # Word-splitting is intentional here: TEST_ARGS contains only test names

--- a/test/initramfs/src/conformance/xfstests/run_xfstests.sh
+++ b/test/initramfs/src/conformance/xfstests/run_xfstests.sh
@@ -41,11 +41,12 @@ export HOST_OPTIONS="$XFSTESTS_CONFIG"
 . "$XFSTESTS_PREPARE"
 
 RUNLIST_FILE=""
-TEST_ARGS=""
+REQUESTED_TESTS=$(mktemp)
+SELECTED_TESTS=$(mktemp)
+
+trap 'rm -f "$REQUESTED_TESTS" "$SELECTED_TESTS"' EXIT
 
 # Parse -R flag and collect direct test names.
-# Test names are simple identifiers (e.g. "generic/001") so accumulating
-# them in a space-separated string is safe.
 while [ $# -gt 0 ]; do
   case "$1" in
     -R|--runlist)
@@ -58,44 +59,89 @@ while [ $# -gt 0 ]; do
       ;;
     --)
       shift
-      TEST_ARGS="$TEST_ARGS $*"
+      while [ $# -gt 0 ]; do
+        printf '%s\n' "$1" >> "$REQUESTED_TESTS"
+        shift
+      done
       break
       ;;
     *)
-      TEST_ARGS="$TEST_ARGS $1"
+      printf '%s\n' "$1" >> "$REQUESTED_TESTS"
       shift
       ;;
   esac
 done
 
-if [ -n "$RUNLIST_FILE" ]; then
-  case "$RUNLIST_FILE" in
-    */*)
-      echo "Run list must be a filename: $RUNLIST_FILE" >&2
-      exit 2
-      ;;
-  esac
-  RUNLIST_FILE="$XFSTESTS_FS_DIR/run_list/$RUNLIST_FILE"
-  if [ ! -f "$RUNLIST_FILE" ]; then
-    echo "Run list file not found: $RUNLIST_FILE" >&2
+# When a selector is set, run only the selected test ids and ignore the blocklist.
+CONFORMANCE_TEST_SELECTOR=${CONFORMANCE_TEST_SELECTOR:-}
+
+if [ -n "$CONFORMANCE_TEST_SELECTOR" ]; then
+  printf '%s\n' "$CONFORMANCE_TEST_SELECTOR" | tr ',' '\n' > "$REQUESTED_TESTS"
+
+  selected_count=0
+  invalid_selector=0
+  while IFS= read -r test_name || [ -n "$test_name" ]; do
+    test_name=${test_name#"${test_name%%[![:space:]]*}"}
+    test_name=${test_name%"${test_name##*[![:space:]]}"}
+    [ -z "$test_name" ] && continue
+
+    selected_count=$((selected_count + 1))
+    case "$test_name" in
+      /*|-*|.|..|./*|../*|*/.|*/..|*/./*|*/../*|*//*|*/*/*)
+        ;;
+      */*)
+        if [ -f "$XFSTESTS_DIR/tests/$test_name" ]; then
+          printf '%s\n' "$test_name" >> "$SELECTED_TESTS"
+          continue
+        fi
+        ;;
+    esac
+
+    echo "Error: unknown xfstests test: $test_name" >&2
+    invalid_selector=1
+  done < "$REQUESTED_TESTS"
+
+  if [ "$selected_count" -eq 0 ]; then
+    echo "$0: CONFORMANCE_TEST_SELECTOR contains no test names" >&2
     exit 2
   fi
-  while IFS= read -r test; do
-    test=${test%%#*}
-    case "$test" in
-      *[![:space:]]*) ;;
-      *) continue ;;
+  if [ "$invalid_selector" -ne 0 ]; then
+    exit 2
+  fi
+
+  sort -u -o "$SELECTED_TESTS" "$SELECTED_TESTS"
+else
+  cat "$REQUESTED_TESTS" > "$SELECTED_TESTS"
+  if [ -n "$RUNLIST_FILE" ]; then
+    case "$RUNLIST_FILE" in
+      */*)
+        echo "Run list must be a filename: $RUNLIST_FILE" >&2
+        exit 2
+        ;;
     esac
-    TEST_ARGS="$TEST_ARGS $test"
-  done < "$RUNLIST_FILE"
+    RUNLIST_FILE="$XFSTESTS_FS_DIR/run_list/$RUNLIST_FILE"
+    if [ ! -f "$RUNLIST_FILE" ]; then
+      echo "Run list file not found: $RUNLIST_FILE" >&2
+      exit 2
+    fi
+    while IFS= read -r test; do
+      test=${test%%#*}
+      case "$test" in
+        *[![:space:]]*) ;;
+        *) continue ;;
+      esac
+      printf '%s\n' "$test" >> "$SELECTED_TESTS"
+    done < "$RUNLIST_FILE"
+  fi
 fi
 
-# Prepend block-list exclusion so blocked tests are skipped.
-if [ -f "$XFSTESTS_BLOCK_LIST" ]; then
-    TEST_ARGS="-E $XFSTESTS_BLOCK_LIST $TEST_ARGS"
+set --
+if [ -z "$CONFORMANCE_TEST_SELECTOR" ] && [ -f "$XFSTESTS_BLOCK_LIST" ]; then
+    set -- -E "$XFSTESTS_BLOCK_LIST"
 fi
+while IFS= read -r test_name || [ -n "$test_name" ]; do
+    [ -z "$test_name" ] && continue
+    set -- "$@" "$test_name"
+done < "$SELECTED_TESTS"
 
-# Word-splitting is intentional here: TEST_ARGS contains only test names
-# and the -E flag, none of which contain whitespace or shell metacharacters.
-# shellcheck disable=SC2086
-./check $TEST_ARGS
+./check "$@"


### PR DESCRIPTION
This PR continues the work started in #3396, thanks to the original author, @co63oc, for driving the initial implementation.

## Motivation

When developing a feature or fixing a bug, a kernel developer often needs to re-run only one or a few conformance tests, not the entire suite. Today the conformance harness can only run a whole suite (gvisor / LTP / kselftest / xfstests), so iterating on a single failing test is slow.

There is a related pain: a test on a suite's blocklist cannot be run at all through the harness, even deliberately — which is exactly what a developer needs while *fixing* the bug that got the test blocklisted.

## What this PR does

Introduces a single, suite-agnostic selector knob:

- **`CONFORMANCE_TEST_SELECTOR`** — a comma-separated list of tests to run within the selected suite. When set, only the selected tests run and the suite's blocklist is **ignored** (the selector takes priority). When empty, behavior is unchanged: the whole suite runs minus its blocklist. The token format is per-suite:
  - `gvisor`: a test *binary* name, e.g. `epoll_test`.
  - `kselftest`: a `<collection>:<case>` entry, e.g. `timers:posix_timers`.
  - `ltp`: a syscall testcase id, e.g. `rename01`.
  - `xfstests`: a test id, e.g. `generic/001`.
- **`CONFORMANCE_TEST_GVISOR_FILTER`** — a gVisor-only positive gtest filter, applied inside one selected gVisor binary, e.g. `EpollTest.CloseFile:EpollTest.Oneshot`.

It also renames **`EXTRA_BLOCKLISTS` → `CONFORMANCE_TEST_EXTRA_BLOCKLISTS`** so all conformance knobs share a consistent prefix. 

### Usage

```sh
# Run a single LTP testcase (even if it is blocklisted).
make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=ltp \
    CONFORMANCE_TEST_SELECTOR=rename01

# Run one gVisor binary, narrowed to specific cases.
make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=gvisor \
    CONFORMANCE_TEST_SELECTOR=epoll_test \
    CONFORMANCE_TEST_GVISOR_FILTER=EpollTest.CloseFile

# Run selected xfstests / kselftest cases.
make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=xfstests \
    CONFORMANCE_TEST_SELECTOR=generic/001,generic/002
make run_kernel AUTO_TEST=conformance CONFORMANCE_TEST_SUITE=kselftest \
    CONFORMANCE_TEST_SELECTOR=timers:posix_timers
```
