### PR TITLE
Fix fsconfig reconfiguration after fsmount

### DIFF
--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -128,16 +128,8 @@ impl FsConfigFile {
             return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
         };
 
-        let args_cstr = if config.extra_options.is_empty() {
-            None
-        } else {
-            Some(CString::new(config.extra_options.as_str()).map_err(|_| {
-                Error::with_message(Errno::EINVAL, "mount options contain null byte")
-            })?)
-        };
-        let args_ref = args_cstr.as_deref();
-        let fs_creation_ctx =
-            FsCreationCtx::new(config.source.as_deref(), config.flags, args_ref, ctx);
+        let args = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
+        let fs_creation_ctx = FsCreationCtx::new(config.source.as_deref(), config.flags, args, ctx);
         let fs = self.fs_type.create(&fs_creation_ctx)?;
         if Arc::strong_count(&fs) > 1 {
             let extant_readonly = fs.flags().contains(FsFlags::RDONLY);

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -2,7 +2,7 @@
 
 use core::fmt::Display;
 
-use super::{AccessMode, CreationFlags, FileCommon, FileLike, InodeMode, StatusFlags};
+use super::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags};
 use crate::{
     events::IoEvents,
     fs::{
@@ -18,35 +18,56 @@ use crate::{
     process::signal::{PollHandle, Pollable},
 };
 
-/// Represents a filesystem configuration context opened by `fsopen`.
+/// Represents a filesystem configuration context.
 ///
-/// The file stores configuration supplied through `fsconfig` until the
-/// filesystem is created. Once creation succeeds, further configuration is
-/// rejected unless it is an explicit reconfiguration request.
+/// The file stores configuration until the filesystem is created. Once creation
+/// succeeds, further configuration is rejected unless it is an explicit
+/// reconfiguration request.
+///
+/// The context has four states:
+///
+/// - `Configuring`: accepts parameters for filesystem creation.
+/// - `AwaitingMount`: contains a created filesystem and accepts a request to
+///   create one detached mount. A failed request leaves the context in this
+///   state so that it can be retried.
+/// - `Reconfiguring`: accepts parameters for reconfiguring the created
+///   filesystem. A successful reconfiguration leaves the context in this state.
+/// - `Failed`: indicates that filesystem creation or reconfiguration failed and
+///   rejects further operations.
+///
+/// The state transitions are:
+///
+/// ```text
+/// ┌─────────────┐  create_fs  ┌───────────────┐  create_detached_mount  ┌───────────────┐
+/// │ Configuring │ ──────────> │ AwaitingMount │ ──────────────────────> │ Reconfiguring │
+/// └──────┬──────┘             └───────────────┘                         └───────┬───────┘
+///        │ create_fs fails                                 reconfigure_fs fails │
+///        └──────────────────────────────┬───────────────────────────────────────┘
+///                                       ▼
+///                              ┌────────────────┐
+///                              │     Failed     │
+///                              └────────────────┘
+/// ```
 pub struct FsConfigFile {
     fs_type: &'static dyn FsType,
-    state: Mutex<FsConfigState>,
+    config: Mutex<FsConfig>,
     common: FileCommon,
 }
 
-enum FsConfigState {
-    Configuring(FsCreationConfig),
-    Created(Option<CreatedFs>),
-}
-
-struct FsCreationConfig {
+struct FsConfig {
     flags: FsFlags,
     source: Option<String>,
-    mode: Option<InodeMode>,
-    /// Accumulates filesystem-specific mount options as a comma-separated
-    /// string, so they can be forwarded to `FsCreationCtx`.
+    /// Accumulates filesystem-specific mount options as a comma-separated string
+    /// until filesystem creation or reconfiguration.
     extra_options: String,
+    state: FsConfigState,
 }
 
-struct CreatedFs {
-    fs: Arc<dyn FileSystem>,
-    flags: FsFlags,
-    source: Option<String>,
+enum FsConfigState {
+    Configuring,
+    Failed,
+    AwaitingMount(Arc<dyn FileSystem>),
+    Reconfiguring(Arc<dyn FileSystem>),
 }
 
 impl FsConfigFile {
@@ -55,154 +76,182 @@ impl FsConfigFile {
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[fscontext]".to_string());
         Self {
             fs_type,
-            state: Mutex::new(FsConfigState::Configuring(FsCreationConfig {
+            config: Mutex::new(FsConfig {
                 flags: FsFlags::empty(),
                 source: None,
-                mode: None,
                 extra_options: String::new(),
-            })),
+                state: FsConfigState::Configuring,
+            }),
             common: FileCommon::new(pseudo_path, StatusFlags::empty()),
         }
     }
 
     /// Sets a flag-style filesystem configuration option.
     ///
-    /// This is only valid while the context is still configuring the filesystem.
-    /// It returns `EBUSY` after the filesystem has been created.
+    /// This is valid in the `Configuring` and `Reconfiguring` states.
     pub fn set_flag(&self, key: &str) -> Result<()> {
-        let mut state = self.state.lock();
-        let FsConfigState::Configuring(config) = &mut *state else {
-            return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
-        };
-
-        match key {
-            "ro" => {
-                config.flags |= FsFlags::RDONLY;
-                Ok(())
+        let mut config = self.config.lock();
+        match &config.state {
+            FsConfigState::Configuring | FsConfigState::Reconfiguring(_) => match key {
+                "ro" => {
+                    config.flags |= FsFlags::RDONLY;
+                    Ok(())
+                }
+                _ => {
+                    // TODO: Validate filesystem-specific mount options when filesystem APIs
+                    // expose their supported options.
+                    append_option(&mut config.extra_options, key, None);
+                    Ok(())
+                }
+            },
+            FsConfigState::AwaitingMount(_) => {
+                return_errno_with_message!(Errno::EBUSY, "the file system is awaiting fsmount");
             }
-            _ => {
-                append_option(&mut config.extra_options, key, None);
-                Ok(())
+            FsConfigState::Failed => {
+                return_errno_with_message!(Errno::EBUSY, "the file system configuration failed");
             }
         }
     }
 
     /// Sets a string filesystem configuration option.
     ///
-    /// This is only valid while the context is still configuring the filesystem.
-    /// It returns `EBUSY` after the filesystem has been created. The `source`
-    /// option may only be specified once.
+    /// This is valid in the `Configuring` and `Reconfiguring` states. The
+    /// `source` option may only be specified once in the `Configuring` state.
     pub fn set_string(&self, key: &str, value: &str) -> Result<()> {
-        let mut state = self.state.lock();
-        let FsConfigState::Configuring(config) = &mut *state else {
-            return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
-        };
-
-        match key {
-            "source" => {
-                if config.source.is_some() {
-                    return_errno_with_message!(Errno::EINVAL, "the source is already specified");
+        let mut config = self.config.lock();
+        match &config.state {
+            FsConfigState::Configuring => match key {
+                "source" => {
+                    if config.source.is_some() {
+                        return_errno_with_message!(
+                            Errno::EINVAL,
+                            "the source is already specified"
+                        );
+                    }
+                    config.source = Some(value.to_string());
+                    Ok(())
                 }
-                config.source = Some(value.to_string());
-                Ok(())
-            }
-            "mode" => {
-                config.mode = Some(parse_octal_mode(value)?);
-                Ok(())
-            }
-            _ => {
+                _ => {
+                    // TODO: Validate filesystem-specific mount options when filesystem APIs
+                    // expose their supported options.
+                    append_option(&mut config.extra_options, key, Some(value));
+                    Ok(())
+                }
+            },
+            FsConfigState::Reconfiguring(_) => {
                 append_option(&mut config.extra_options, key, Some(value));
                 Ok(())
+            }
+            FsConfigState::AwaitingMount(_) => {
+                return_errno_with_message!(Errno::EBUSY, "the file system is awaiting fsmount");
+            }
+            FsConfigState::Failed => {
+                return_errno_with_message!(Errno::EBUSY, "the file system configuration failed");
             }
         }
     }
 
     /// Creates the configured filesystem.
     ///
-    /// This consumes the current creation configuration and moves the context
-    /// into the created state. It returns `EBUSY` if the filesystem has already
-    /// been created.
+    /// This is only valid in the `Configuring` state. Success transitions to
+    /// `AwaitingMount`, while failure transitions to `Failed`. It returns
+    /// `EBUSY` in all other states.
     pub fn create_fs(&self, ctx: &Context) -> Result<()> {
-        let mut state = self.state.lock();
-        let FsConfigState::Configuring(config) = &mut *state else {
+        let mut config = self.config.lock();
+        if !matches!(&config.state, FsConfigState::Configuring) {
             return_errno_with_message!(Errno::EBUSY, "the file system has already been created");
-        };
+        }
 
-        let args = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
-        let fs_creation_ctx = FsCreationCtx::new(config.source.as_deref(), config.flags, args, ctx);
-        let fs = self.fs_type.create(&fs_creation_ctx)?;
-        if Arc::strong_count(&fs) > 1 {
-            let extant_readonly = fs.flags().contains(FsFlags::RDONLY);
-            let context_readonly = config.flags.contains(FsFlags::RDONLY);
-            if extant_readonly != context_readonly {
-                return_errno_with_message!(
-                    Errno::EBUSY,
-                    "the read-only flag of the extant filesystem does not match"
-                );
+        let result = (|| {
+            let args = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
+            let fs_creation_ctx =
+                FsCreationCtx::new(config.source.as_deref(), config.flags, args, ctx);
+            let fs = self.fs_type.create(&fs_creation_ctx)?;
+            if Arc::strong_count(&fs) > 1 {
+                let extant_readonly = fs.flags().contains(FsFlags::RDONLY);
+                let context_readonly = config.flags.contains(FsFlags::RDONLY);
+                if extant_readonly != context_readonly {
+                    return_errno_with_message!(
+                        Errno::EBUSY,
+                        "the read-only flag of the extant filesystem does not match"
+                    );
+                }
             }
-        } else {
-            if let Some(mode) = config.mode {
-                fs.root_inode().set_mode(mode)?;
+            Ok(fs)
+        })();
+
+        match result {
+            Ok(fs) => {
+                config.state = FsConfigState::AwaitingMount(fs);
+                Ok(())
+            }
+            Err(err) => {
+                config.state = FsConfigState::Failed;
+                Err(err)
             }
         }
-        let flags = config.flags;
-        let source = config.source.clone();
-        *state = FsConfigState::Created(Some(CreatedFs { fs, flags, source }));
-        Ok(())
-    }
-
-    /// Reconfigures the created filesystem with the current flags.
-    ///
-    /// This is only valid after the filesystem has been created and before it
-    /// has been consumed by `create_detached_mount`. It returns `EINVAL` if the
-    /// filesystem has not been created yet, and `EBUSY` if it has already been
-    /// consumed.
-    pub fn reconfigure_fs(&self, ctx: &Context) -> Result<()> {
-        let state = self.state.lock();
-        let (fs, flags) = match &*state {
-            FsConfigState::Created(Some(created)) => (&created.fs, created.flags),
-            FsConfigState::Created(None) => {
-                return_errno_with_message!(
-                    Errno::EBUSY,
-                    "the file system has already been mounted"
-                );
-            }
-            FsConfigState::Configuring(_) => {
-                return_errno_with_message!(Errno::EINVAL, "the file system is not created");
-            }
-        };
-
-        fs.set_fs_flags(flags, None, ctx)
     }
 
     /// Creates a detached mount from the created filesystem.
     ///
-    /// This is only valid after `create_fs` has succeeded and before a
-    /// detached mount has already been created from this file. On success, the
-    /// filesystem is consumed and subsequent calls return `EBUSY`. On failure,
-    /// the filesystem remains available for a later `fsmount`.
+    /// This is only valid in the `AwaitingMount` state. Success transitions to
+    /// `Reconfiguring`, while failure leaves the context in `AwaitingMount` so
+    /// that the operation can be retried.
     pub fn create_detached_mount(
         &self,
         flags: PerMountFlags,
         mnt_ns: Weak<MountNamespace>,
     ) -> Result<Arc<Mount>> {
-        let mut state = self.state.lock();
-        let FsConfigState::Created(created) = &mut *state else {
-            return_errno_with_message!(Errno::EINVAL, "the file system is not created");
-        };
-        let Some(created_fs) = created.as_ref() else {
-            return_errno_with_message!(Errno::EBUSY, "the file system has already been mounted");
+        let mut config = self.config.lock();
+        let fs = match &config.state {
+            FsConfigState::AwaitingMount(fs) => fs.clone(),
+            FsConfigState::Configuring => {
+                return_errno_with_message!(Errno::EINVAL, "the file system is not created");
+            }
+            FsConfigState::Reconfiguring(_) => {
+                return_errno_with_message!(
+                    Errno::EBUSY,
+                    "a detached mount has already been created"
+                );
+            }
+            FsConfigState::Failed => {
+                return_errno_with_message!(Errno::EBUSY, "the file system configuration failed");
+            }
         };
 
-        let detached_mount = Mount::new_detached(
-            created_fs.fs.clone(),
-            flags,
-            mnt_ns,
-            created_fs.source.clone(),
-        )?;
-        *created = None;
+        let detached_mount = Mount::new_detached(fs.clone(), flags, mnt_ns, config.source.clone())?;
+        config.source = None;
+        config.flags = fs.flags();
+        config.extra_options.clear();
+        config.state = FsConfigState::Reconfiguring(fs);
 
         Ok(detached_mount)
+    }
+
+    /// Reconfigures the created filesystem with the current parameters.
+    ///
+    /// This is only valid in the `Reconfiguring` state. Success leaves the
+    /// context in `Reconfiguring`, while failure transitions to `Failed`.
+    pub fn reconfigure_fs(&self, ctx: &Context) -> Result<()> {
+        let mut config = self.config.lock();
+        let FsConfigState::Reconfiguring(fs) = &config.state else {
+            return_errno_with_message!(Errno::EBUSY, "the file system is not reconfiguring");
+        };
+        let fs = fs.clone();
+
+        let data = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
+        let result = fs.set_fs_flags(config.flags, data, ctx);
+        if let Err(err) = result {
+            config.state = FsConfigState::Failed;
+            return Err(err);
+        }
+
+        // Discard parameters after a successful reconfiguration.
+        // Reference:
+        // <https://elixir.bootlin.com/linux/v7.0/source/fs/fs_context.c#L536>.
+        config.flags = fs.flags();
+        config.extra_options.clear();
+        Ok(())
     }
 }
 
@@ -251,7 +300,7 @@ impl FileLike for FsConfigFile {
     }
 }
 
-/// Represents a detached mount returned by `fsmount`.
+/// Represents a detached mount.
 pub struct DetachedMountFile {
     mount: Arc<Mount>,
     common: FileCommon,
@@ -316,17 +365,6 @@ impl FileLike for DetachedMountFile {
             fd_flags,
         })
     }
-}
-
-fn parse_octal_mode(value: &str) -> Result<InodeMode> {
-    const MAX_MODE_BITS: u16 = 0o7777;
-
-    let mode = u16::from_str_radix(value, 8)
-        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid octal mode"))?;
-    if mode & !MAX_MODE_BITS != 0 {
-        return_errno_with_message!(Errno::EINVAL, "invalid mode bits");
-    }
-    Ok(InodeMode::from_bits_truncate(mode))
 }
 
 fn append_option(options: &mut String, key: &str, value: Option<&str>) {

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -90,13 +90,12 @@ struct Ext2MountOptions {
 
 impl Ext2MountOptions {
     /// Parses ext2 mount options that control block-count reporting.
-    fn parse(data: Option<&CStr>) -> Self {
+    fn parse(data: Option<&str>) -> Self {
         let mut options = Self::default();
         let Some(data) = data else {
             return options;
         };
 
-        let data = data.to_string_lossy();
         for token in data.split(',') {
             match token.trim() {
                 "bsddf" => options.stat_block_accounting = StatBlockAccounting::ExcludeOverhead,
@@ -111,7 +110,7 @@ impl Ext2MountOptions {
 
 impl Ext2 {
     /// Opens and loads an Ext2 filesystem from a block device.
-    pub(super) fn open(device: Arc<dyn BlockDevice>, data: Option<&CStr>) -> Result<Arc<Self>> {
+    pub(super) fn open(device: Arc<dyn BlockDevice>, data: Option<&str>) -> Result<Arc<Self>> {
         let super_block = {
             let raw_super_block = device.read_val::<RawSuperBlock>(SUPER_BLOCK_OFFSET)?;
             SuperBlock::try_from(raw_super_block)?
@@ -722,13 +721,7 @@ mod test {
     #[ktest]
     fn stat_minixdf_reports_total() {
         let f = Ext2FixtureBuilder::new(3, 512).build().unwrap();
-        let minixdf = CString::new("minixdf").unwrap();
-
-        let ext2 = Ext2::open(
-            f.disk.clone() as Arc<dyn BlockDevice>,
-            Some(minixdf.as_c_str()),
-        )
-        .unwrap();
+        let ext2 = Ext2::open(f.disk.clone() as Arc<dyn BlockDevice>, Some("minixdf")).unwrap();
 
         let stat = FileSystemTrait::sb(ext2.as_ref());
         assert_eq!(stat.blocks, f.sb.total_blocks() as usize);

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -1188,7 +1188,6 @@ impl FsType for OverlayFsType {
         let mut work = "";
 
         let args = fs_creation_ctx.args().ok_or(Error::new(Errno::EINVAL))?;
-        let args = args.to_string_lossy();
         let entries = args.split(',');
 
         for entry in entries {

--- a/kernel/src/fs/vfs/fs_apis/file_system.rs
+++ b/kernel/src/fs/vfs/fs_apis/file_system.rs
@@ -40,7 +40,7 @@ pub trait FileSystem: Any + Sync + Send {
     }
 
     /// Sets the flags of this file system.
-    fn set_fs_flags(&self, _flags: FsFlags, _data: Option<CString>, _ctx: &Context) -> Result<()> {
+    fn set_fs_flags(&self, _flags: FsFlags, _data: Option<&str>, _ctx: &Context) -> Result<()> {
         // TODO: Remove the default empty implementation in the future.
         warn!("setting file system flags is not implemented");
         Ok(())

--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -44,7 +44,7 @@ pub trait FsType: Send + Sync + 'static {
 pub struct FsCreationCtx<'a> {
     source: Option<&'a str>,
     flags: FsFlags,
-    args: Option<&'a CStr>,
+    args: Option<&'a str>,
     task_ctx: &'a Context<'a>,
 }
 
@@ -53,7 +53,7 @@ impl<'a> FsCreationCtx<'a> {
     pub fn new(
         source: Option<&'a str>,
         flags: FsFlags,
-        args: Option<&'a CStr>,
+        args: Option<&'a str>,
         task_ctx: &'a Context<'a>,
     ) -> Self {
         Self {
@@ -76,7 +76,7 @@ impl<'a> FsCreationCtx<'a> {
     }
 
     /// Returns the filesystem-specific mount arguments.
-    pub(in crate::fs) fn args(&self) -> Option<&CStr> {
+    pub(in crate::fs) fn args(&self) -> Option<&str> {
         self.args
     }
 

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -426,7 +426,7 @@ impl Path {
         &self,
         mount_flags: PerMountFlags,
         fs_flags: Option<FsFlags>,
-        data: Option<CString>,
+        data: Option<&str>,
         ctx: &Context,
     ) -> Result<()> {
         if !self.is_mount_root() {

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -574,7 +574,7 @@ impl Mount {
         &self,
         mount_flags: PerMountFlags,
         fs_flags: Option<FsFlags>,
-        data: Option<CString>,
+        data: Option<&str>,
         ctx: &Context,
         _topology: &mut MountTopology,
     ) -> Result<()> {

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -97,8 +97,9 @@ fn do_remount_mnt_and_fs(
     } else {
         Some(ctx.user_space().read_cstring(data_addr, MAX_FILENAME_LEN)?)
     };
+    let data = data.as_deref().map(CStr::to_string_lossy);
 
-    path.remount(per_mount_flags, Some(fs_flags), data, ctx)
+    path.remount(per_mount_flags, Some(fs_flags), data.as_deref(), ctx)
 }
 
 /// Binds a mount to a dst location.
@@ -241,6 +242,7 @@ fn open_fs(
     } else {
         Some(user_space.read_cstring(data_addr, MAX_FILENAME_LEN)?)
     };
+    let data = data.as_deref().map(CStr::to_string_lossy);
 
     let fs_creation_ctx = FsCreationCtx::new(source, flags.into(), data.as_deref(), ctx);
     fs_type.create(&fs_creation_ctx)

--- a/test/initramfs/src/regression/fs/mount/mount_api.c
+++ b/test/initramfs/src/regression/fs/mount/mount_api.c
@@ -67,6 +67,54 @@ FN_TEST(fsconfig_and_fsmount)
 }
 END_TEST()
 
+FN_TEST(fsconfig_reconfigures_after_fsmount)
+{
+	int fs_fd = TEST_SUCC(syscall(SYS_fsopen, "tmpfs", FSOPEN_CLOEXEC));
+
+	TEST_ERRNO(syscall(SYS_fsconfig, fs_fd, FSCONFIG_CMD_RECONFIGURE, NULL,
+			   NULL, 0),
+		   EBUSY);
+	TEST_SUCC(syscall(SYS_fsconfig, fs_fd, FSCONFIG_SET_STRING, "nr_inodes",
+			  "1024", 0));
+	TEST_SUCC(syscall(SYS_fsconfig, fs_fd, FSCONFIG_CMD_CREATE, NULL, NULL,
+			  0));
+	TEST_ERRNO(syscall(SYS_fsconfig, fs_fd, FSCONFIG_SET_STRING, "size",
+			   "1048576", 0),
+		   EBUSY);
+
+	int mount_fd =
+		TEST_SUCC(syscall(SYS_fsmount, fs_fd, FSMOUNT_CLOEXEC, 0));
+	TEST_ERRNO(syscall(SYS_fsmount, fs_fd, FSMOUNT_CLOEXEC, 0), EBUSY);
+
+	TEST_SUCC(syscall(SYS_fsconfig, fs_fd, FSCONFIG_SET_STRING, "size",
+			  "1048576", 0));
+	TEST_SUCC(syscall(SYS_fsconfig, fs_fd, FSCONFIG_CMD_RECONFIGURE, NULL,
+			  NULL, 0));
+	TEST_SUCC(
+		syscall(SYS_fsconfig, fs_fd, FSCONFIG_SET_FLAG, "ro", NULL, 0));
+	TEST_SUCC(syscall(SYS_fsconfig, fs_fd, FSCONFIG_CMD_RECONFIGURE, NULL,
+			  NULL, 0));
+
+	TEST_SUCC(close(mount_fd));
+	TEST_SUCC(close(fs_fd));
+}
+END_TEST()
+
+FN_TEST(fsconfig_rejects_operations_after_creation_failure)
+{
+	int fs_fd = TEST_SUCC(syscall(SYS_fsopen, "ext2", FSOPEN_CLOEXEC));
+
+	TEST_ERRNO(syscall(SYS_fsconfig, fs_fd, FSCONFIG_CMD_CREATE, NULL, NULL,
+			   0),
+		   EINVAL);
+	TEST_ERRNO(syscall(SYS_fsconfig, fs_fd, FSCONFIG_SET_FLAG, "ro", NULL,
+			   0),
+		   EBUSY);
+
+	TEST_SUCC(close(fs_fd));
+}
+END_TEST()
+
 FN_TEST(move_mount_flags_zero_nonempty_from_path)
 {
 	const char *src = "/tmp/move_mount_flags_zero_src";


### PR DESCRIPTION
This is part of the groundwork for #3488.

## Problem

NixOS 26.05 exercises the new mount API sequence in which `fsmount()` is followed by more `fsconfig()` calls and `FSCONFIG_CMD_RECONFIGURE`. Linux moves an fs context into `FS_CONTEXT_AWAITING_RECONF` after `fsmount()`. The previous Asterinas state model instead consumed the created filesystem at `fsmount()`, so the later reconfiguration request could not be represented and was rejected before reaching the filesystem.

## Approach

- Model the Linux lifecycle explicitly with `Configuring`, `AwaitingMount`, and `Reconfiguring` states.
- After `fsmount()`, retain the filesystem in `Reconfiguring` rather than treating the context as permanently consumed.
- Permit further flag and string configuration in that state, then dispatch `FSCONFIG_CMD_RECONFIGURE` to `FileSystem::set_fs_flags()`.
- Reset the accumulated reconfiguration parameters after a successful dispatch, following Linux `vfs_clean_context()`.
- Factor common mount flags/options and parse generic creation-time `mode` through `InodeMode::from_octal()`.

## Important scope boundaries

### `source` during reconfiguration

`source` is special only while creating a filesystem: it becomes the source recorded for the detached mount. In `Reconfiguring`, this PR deliberately does not update that stored source. Linux first gives a parameter to the filesystem parser and only then uses a VFS fallback for `source`; Asterinas currently has a two-valued validation interface and cannot express Linux's `not handled` result. Forwarding `source` as a filesystem option is therefore preferable to silently mutating no mount state or claiming a source change that cannot take effect. Filesystems that ignore reconfiguration data, including ramfs, simply ignore it.

### tmpfs/ramfs options

This PR fixes the fscontext lifecycle, not every filesystem-specific reconfiguration semantic. Asterinas tmpfs is currently an alias of ramfs and has no swap implementation, so a forwarded `noswap` option is effectively a no-op. Proper Linux-like tmpfs support would require separating tmpfs from ramfs, giving tmpfs its own superblock state and accounting/swap behavior, and untangling ramfs inodes' `Weak<RamFs>` ownership. That is a substantially larger follow-up and is intentionally out of scope here.

Likewise, a filesystem may currently ignore forwarded flags/data if it has not implemented `set_fs_flags()`. This change ensures the request reaches that filesystem; it does not claim to implement every remount option.