### PR TITLE
Remove trailing whitespace in OSDK reference docs

### DIFF
--- a/book/src/osdk/reference/commands/README.md
+++ b/book/src/osdk/reference/commands/README.md
@@ -17,5 +17,5 @@ Currently, OSDK supports the following subcommands:
 
 The **new**, **build**, **run**, **test** and **debug** subcommands
 can accept additional options,
-while the **check** and **clippy** subcommands can only accept arguments 
+while the **check** and **clippy** subcommands can only accept arguments
 that are compatible with the corresponding Cargo subcommands.

--- a/book/src/osdk/reference/commands/new.md
+++ b/book/src/osdk/reference/commands/new.md
@@ -27,7 +27,7 @@ Use the library template. This is the default option.
 
 ## Examples
 
-- Create a new kernel named `myos`: 
+- Create a new kernel named `myos`:
 
 ```bash
 cargo osdk new --kernel myos

--- a/book/src/osdk/reference/commands/test.md
+++ b/book/src/osdk/reference/commands/test.md
@@ -5,10 +5,10 @@ execute kernel mode unit test by starting QEMU.
 The usage is as follows:
 
 ```bash
-cargo osdk test [TESTNAME] [OPTIONS] 
+cargo osdk test [TESTNAME] [OPTIONS]
 ```
 
-## Arguments 
+## Arguments
 
 `TESTNAME`:
 Only run tests containing this string in their names
@@ -20,7 +20,7 @@ Refer to the [documentation](build.md) of `cargo osdk build`
 for more details.
 
 ## Examples
-- Execute tests that include *foo* in their names 
+- Execute tests that include *foo* in their names
 using QEMU with 3GB of memory
 
 ```bash

--- a/book/src/osdk/reference/environment-variables.md
+++ b/book/src/osdk/reference/environment-variables.md
@@ -1,7 +1,7 @@
 # Environment Variables
 
-The OSDK tool uses the following environment variables to customize compilation and target behavior. 
+The OSDK tool uses the following environment variables to customize compilation and target behavior.
 
 ## OSDK-Specific Variables
-- `OSDK_TARGET_ARCH`: If set, OSDK will use the specified value as its default target architecture (e.g., x86_64, riscv64). 
+- `OSDK_TARGET_ARCH`: If set, OSDK will use the specified value as its default target architecture (e.g., x86_64, riscv64).
 If not set, OSDK will default to the host architecture.

--- a/book/src/osdk/reference/manifest.md
+++ b/book/src/osdk/reference/manifest.md
@@ -26,12 +26,12 @@ Below, you will find a comprehensive version of
 the available configurations in the manifest.
 
 ```toml
-project_type = "kernel"                     # <1> 
+project_type = "kernel"                     # <1>
 
 # --------------------------- the default scheme settings -------------------------------
 supported_archs = ["x86_64", "riscv64"]     # <2>
 
-# The common options for all build, run and test subcommands 
+# The common options for all build, run and test subcommands
 [build]                                     # <3>
 features = ["no_std", "alloc"]              # <4>
 profile = "dev"                             # <5>
@@ -42,9 +42,9 @@ method = "qemu-direct"                      # <9>
 kcmd_args = ["SHELL=/bin/sh", "HOME=/"]     # <10>
 init_args = ["sh", "-l"]                    # <11>
 initramfs = "path/to/it"                    # <12>
-[grub]                                      # <13>  
+[grub]                                      # <13>
 mkrescue_path = "path/to/it"                # <14>
-boot_protocol = "multiboot2"                # <15> 
+boot_protocol = "multiboot2"                # <15>
 display_grub_menu = false                   # <16>
 [qemu]                                      # <17>
 path = "path/to/it"                         # <18>
@@ -80,7 +80,7 @@ Here are some additional notes for the fields:
     the default value is inferred from the usage of the macro `#[ostd::main]`.
     if the macro is used, the default value is `kernel`.
     Otherwise, the default value is `library`.
-    
+
     Possible values are `library` or `kernel`.
 
 2. The architectures that can be supported.
@@ -104,7 +104,7 @@ Here are some additional notes for the fields:
 
     Optional. The default value is `dev`.
 
-    Possible values are `dev`, `release`, `test`, and `bench` 
+    Possible values are `dev`, `release`, `test`, and `bench`
     and other profiles defined in `Cargo.toml`.
 
 6. Whether to strip the built kernel ELF using `rust-strip`.
@@ -193,23 +193,23 @@ can include any POSIX shell compliant separators.
 
 20. Special settings for running. Only take effect when running `cargo osdk run`.
 
-    By default, it inherits common options. 
-    
+    By default, it inherits common options.
+
     Values set here are used to override common options.
 
-21. Special settings for testing. 
+21. Special settings for testing.
 
     Similar to `20`, but only take effect when running `cargo osdk test`.
 
-22. The definition of customized scheme. 
+22. The definition of customized scheme.
 
-    A customized scheme has the same fields as the default scheme. 
+    A customized scheme has the same fields as the default scheme.
     By default, a customized scheme will inherit all options from the default scheme,
     unless overridden by new options.
 
 ### Example
 
-Here is a sound, self-explanatory example which is used by OSDK 
+Here is a sound, self-explanatory example which is used by OSDK
 in the Asterinas project.
 
 In the script `./tools/qemu_args.sh`, the environment variables will be


### PR DESCRIPTION
Clean up trailing whitespace in `book/src/osdk/reference/`.