### PR TITLE
net/syscall: fix timeout-aware EINTR mapping for socket syscalls

### DIFF
--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -307,6 +307,14 @@ impl Socket for DatagramSocket {
     fn common(&self) -> &FileCommon {
         &self.common
     }
+
+    fn recv_timeout(&self) -> Option<Duration> {
+        self.timeouts.recv_timeout()
+    }
+
+    fn send_timeout(&self) -> Option<Duration> {
+        self.timeouts.send_timeout()
+    }
 }
 
 impl GetSocketLevelOption for (&Inner<UnboundDatagram, BoundDatagram>, &SocketTimeouts) {

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -778,6 +778,14 @@ impl Socket for StreamSocket {
     fn common(&self) -> &FileCommon {
         &self.common
     }
+
+    fn recv_timeout(&self) -> Option<Duration> {
+        self.timeouts.recv_timeout()
+    }
+
+    fn send_timeout(&self) -> Option<Duration> {
+        self.timeouts.send_timeout()
+    }
 }
 
 fn do_tcp_setsockopt(

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::fmt::Display;
+use core::{fmt::Display, time::Duration};
 
 use options::SocketOption;
 use util::{MessageHeader, SendRecvFlags, SockShutdownCmd, SocketAddr};
@@ -116,6 +116,23 @@ pub trait Socket: private::SocketPrivate + Send + Sync {
     /// Sets options on the socket.
     fn set_option(&self, _option: &dyn SocketOption) -> Result<()> {
         return_errno_with_message!(Errno::EOPNOTSUPP, "setsockopt() is not supported");
+    }
+
+    /// Returns the receive timeout (`SO_RCVTIMEO`) for this socket.
+    ///
+    /// A return value of `None` means no timeout is set (blocking calls wait
+    /// indefinitely). Socket implementations that support timeouts should
+    /// override this method.
+    fn recv_timeout(&self) -> Option<Duration> {
+        None
+    }
+
+    /// Returns the send timeout (`SO_SNDTIMEO`) for this socket.
+    ///
+    /// A return value of `None` means no timeout is set. Socket
+    /// implementations that support timeouts should override this method.
+    fn send_timeout(&self) -> Option<Duration> {
+        None
     }
 
     /// Sends a message on the socket.

--- a/kernel/src/net/socket/unix/datagram/socket.rs
+++ b/kernel/src/net/socket/unix/datagram/socket.rs
@@ -327,6 +327,14 @@ impl Socket for UnixDatagramSocket {
     fn common(&self) -> &FileCommon {
         &self.common
     }
+
+    fn recv_timeout(&self) -> Option<Duration> {
+        self.timeouts.recv_timeout()
+    }
+
+    fn send_timeout(&self) -> Option<Duration> {
+        self.timeouts.send_timeout()
+    }
 }
 
 fn do_unix_getsockopt(option: &mut dyn SocketOption, socket: &UnixDatagramSocket) -> Result<()> {

--- a/kernel/src/net/socket/unix/stream/socket.rs
+++ b/kernel/src/net/socket/unix/stream/socket.rs
@@ -548,6 +548,14 @@ impl Socket for UnixStreamSocket {
     fn common(&self) -> &FileCommon {
         &self.common
     }
+
+    fn recv_timeout(&self) -> Option<Duration> {
+        self.timeouts.recv_timeout()
+    }
+
+    fn send_timeout(&self) -> Option<Duration> {
+        self.timeouts.send_timeout()
+    }
 }
 
 fn do_unix_getsockopt(option: &mut dyn SocketOption, state: &State) -> Result<()> {

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -10,17 +10,28 @@ use crate::{
     util::net::write_socket_addr_to_user,
 };
 
+/// Accepts a connection on a listening socket.
+///
+/// This is equivalent to `accept4(sockfd, addr, addrlen, 0)`.
+/// See `accept4(2)` for the full specification.
 pub fn sys_accept(
     sockfd: RawFileDesc,
     sockaddr_ptr: Vaddr,
     addrlen_ptr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    debug!("sockfd = {sockfd}, sockaddr_ptr = 0x{sockaddr_ptr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
+    debug!(
+        "sockfd = {sockfd}, sockaddr_ptr = 0x{sockaddr_ptr:x}, addrlen_ptr = 0x{addrlen_ptr:x}"
+    );
 
     do_accept(sockfd, sockaddr_ptr, addrlen_ptr, Flags::empty(), ctx)
 }
 
+/// Accepts a connection on a listening socket, with additional flags.
+///
+/// Extends `accept(2)` by allowing `SOCK_NONBLOCK` and `SOCK_CLOEXEC` to be
+/// set atomically on the new file descriptor, avoiding a separate `fcntl(2)`
+/// call. See `accept4(2)` for the full specification.
 pub fn sys_accept4(
     sockfd: RawFileDesc,
     sockaddr_ptr: Vaddr,
@@ -28,17 +39,20 @@ pub fn sys_accept4(
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    debug!("raw flags = 0x{:x}", flags);
     let flags = Flags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid accept4 flags"))?;
     debug!(
-        "sockfd = {}, sockaddr_ptr = 0x{:x}, addrlen_ptr = 0x{:x}, flags = {:?}",
-        sockfd, sockaddr_ptr, addrlen_ptr, flags
+        "sockfd = {sockfd}, sockaddr_ptr = 0x{sockaddr_ptr:x}, addrlen_ptr = 0x{addrlen_ptr:x}, flags = {flags:?}"
     );
 
     do_accept(sockfd, sockaddr_ptr, addrlen_ptr, flags, ctx)
 }
 
+/// Core implementation shared by [`sys_accept`] and [`sys_accept4`].
+///
+/// Waits for an incoming connection on `sockfd`, inserts the new socket into
+/// the file table with the requested `flags`, and writes the peer address to
+/// user space when `sockaddr_ptr` is non-null.
 fn do_accept(
     sockfd: RawFileDesc,
     sockaddr_ptr: Vaddr,
@@ -52,15 +66,14 @@ fn do_accept(
 
     let is_nonblocking = flags.contains(Flags::SOCK_NONBLOCK);
 
-    let (connected_socket, socket_addr) = {
-        socket
-            .accept(is_nonblocking)
-            .map_err(|err| match err.error() {
-                // FIXME: `accept` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
-                _ => err,
-            })?
-    };
+    let (connected_socket, socket_addr) = socket
+        .accept(is_nonblocking)
+        .map_err(|err| match err.error() {
+            // Per accept(2) and restart_syscall(2): `accept` should surface `EINTR`
+            // instead of restarting if a timeout has been set via `setsockopt(SO_RCVTIMEO)`.
+            Errno::EINTR if socket.recv_timeout().is_none() => Error::new(Errno::ERESTARTSYS),
+            _ => err,
+        })?;
 
     let fd_flags = if flags.contains(Flags::SOCK_CLOEXEC) {
         FdFlags::CLOEXEC
@@ -68,21 +81,29 @@ fn do_accept(
         FdFlags::empty()
     };
 
+    // Per accept(2): if `sockaddr_ptr` is null, neither the address nor the
+    // address length is written to user space. When `sockaddr_ptr` is non-null
+    // but `addrlen_ptr` is null, `write_socket_addr_to_user` dereferences it
+    // and correctly surfaces `EFAULT`, matching Linux behaviour.
     if sockaddr_ptr != 0 {
         write_socket_addr_to_user(&socket_addr, sockaddr_ptr, addrlen_ptr)?;
     }
 
-    let fd = {
-        let mut file_table_locked = file_table.unwrap().write();
-        file_table_locked.insert(connected_socket, fd_flags)
-    };
+    let fd = file_table.unwrap().write().insert(connected_socket, fd_flags);
 
     Ok(SyscallReturn::Return(fd.into()))
 }
 
 bitflags! {
+    /// Flags accepted by [`sys_accept4`].
+    ///
+    /// These flags are applied atomically to the new file descriptor returned
+    /// by the call, avoiding a separate `fcntl(2)` invocation.
     struct Flags: u32 {
+        /// Sets `O_NONBLOCK` on the new socket file descriptor.
         const SOCK_NONBLOCK = NONBLOCK;
+        /// Sets `FD_CLOEXEC` on the new socket file descriptor,
+        /// causing it to be closed automatically on `execve(2)`.
         const SOCK_CLOEXEC = CLOEXEC;
     }
 }

--- a/kernel/src/syscall/connect.rs
+++ b/kernel/src/syscall/connect.rs
@@ -23,8 +23,8 @@ pub fn sys_connect(
     socket
         .connect(socket_addr)
         .map_err(|err| match err.error() {
-            // FIXME: `connect` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-            Errno::EINTR => Error::new(Errno::ERESTARTSYS),
+            // If a timeout is set, `connect` surfaces `EINTR` instead of being restarted.
+            Errno::EINTR if socket.send_timeout().is_none() => Error::new(Errno::ERESTARTSYS),
             _ => err,
         })?;
 

--- a/kernel/src/syscall/recvfrom.rs
+++ b/kernel/src/syscall/recvfrom.rs
@@ -33,8 +33,8 @@ pub fn sys_recvfrom(
         socket
             .recvmsg(&mut writers, flags)
             .map_err(|err| match err.error() {
-                // FIXME: `recvfrom` should not be restarted if a timeout has been set on the socket using `setsockopt`.
-                Errno::EINTR => Error::new(Errno::ERESTARTSYS),
+                // If a timeout is set, `recvfrom` surfaces `EINTR` instead of being restarted.
+                Errno::EINTR if socket.recv_timeout().is_none() => Error::new(Errno::ERESTARTSYS),
                 _ => err,
             })?;
 


### PR DESCRIPTION
When a blocking socket syscall (e.g., accept, connect, recvfrom) is interrupted by a signal, Linux standard behavior dictates that it should return `EINTR` to the caller if a socket timeout (`SO_RCVTIMEO` or `SO_SNDTIMEO`) has been configured. Otherwise, the kernel transparently restarts the syscall by returning `ERESTARTSYS`.
Previously, the syscall layer unconditionally mapped `EINTR` to `ERESTARTSYS` because it had no access to the socket's timeout state, leading to incorrect behavior on sockets with configured timeouts. This commit introduces a full architectural fix to correctly handle timeout-aware restarts:
1. Exposed `recv_timeout()` and `send_timeout()` in the `Socket` trait with default `None` implementations to prevent breaking existing timeout-less sockets (e.g. Vsock, Netlink).
2. Delegated timeout state retrieval in IP and Unix socket implementations (Stream and Datagram) to their respective `SocketTimeouts` fields.
3. Updated `sys_accept`, `sys_connect`, and `sys_recvfrom` to conditionally map `EINTR` to `ERESTARTSYS` only when no timeout is set, resolving all related FIXME comments. Fixes Linux compatibility for interrupted socket syscalls with timeouts.