### PR TITLE
Fix integer wrapping in `page_table` module

### DIFF
--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -189,9 +189,10 @@ impl<'rcu, C: PageTableConfig> Cursor<'rcu, C> {
         split_huge: bool,
     ) -> Option<Vaddr> {
         assert_eq!(len % C::BASE_PAGE_SIZE, 0);
+        assert!(self.va <= self.barrier_va.end);
+        assert!(len <= self.barrier_va.end - self.va);
 
         let end = self.va + len;
-        assert!(end <= self.barrier_va.end);
         debug_assert_eq!(end % C::BASE_PAGE_SIZE, 0);
 
         let rcu_guard = self.rcu_guard;

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -190,7 +190,10 @@ impl<'rcu, C: PageTableConfig> Cursor<'rcu, C> {
     ) -> Option<Vaddr> {
         assert_eq!(len % C::BASE_PAGE_SIZE, 0);
         assert!(self.va <= self.barrier_va.end);
-        assert!(len <= self.barrier_va.end - self.va);
+        assert!(
+            len <= self.barrier_va.end - self.va,
+            "len exceeds remaining cursor range"
+        );
 
         let end = self.va + len;
         debug_assert_eq!(end % C::BASE_PAGE_SIZE, 0);

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -424,9 +424,9 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
             0,
             "cursor virtual address not aligned for mapping"
         );
-        let end = self.0.va + size;
+
         assert!(
-            end <= self.0.barrier_va.end,
+            size <= self.0.barrier_va.end - self.0.va,
             "cursor virtual address out-of-bound for mapping"
         );
 

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -206,7 +206,9 @@ pub(crate) fn largest_pages<C: PageTableConfig>(
     assert_eq!(va % C::BASE_PAGE_SIZE, 0);
     assert_eq!(pa % C::BASE_PAGE_SIZE, 0);
     assert_eq!(len % C::BASE_PAGE_SIZE, 0);
-    assert!(is_valid_range::<C>(&(va..(va + len))));
+
+    let end = va.checked_add(len).expect("va + len overflow");
+    assert!(is_valid_range::<C>(&(va..end)));
 
     core::iter::from_fn(move || {
         if len == 0 {
@@ -284,7 +286,11 @@ pub(super) const fn vaddr_range<C: PageTableConfig>() -> RangeInclusive<Vaddr> {
 /// Checks if the given range is covered by the valid range of the page table.
 const fn is_valid_range<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
     let va_range = vaddr_range::<C>();
-    (r.start == 0 && r.end == 0) || (*va_range.start() <= r.start && r.end - 1 <= *va_range.end())
+    if r.end == 0 {
+        r.start == 0
+    } else {
+        *va_range.start() <= r.start && r.end - 1 <= *va_range.end()
+    }
 }
 
 // Here are some const values that are determined by the paging constants.

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -663,7 +663,7 @@ mod navigation {
     }
 
     #[ktest]
-    #[should_panic]
+    #[should_panic(expected = "len exceeds remaining cursor range")]
     fn find_next_rejects_overflowing_len() {
         let (page_table, _, _) = setup_pt_with_two_mappings();
         let preempt_guard = disable_preempt();

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -661,6 +661,30 @@ mod navigation {
         assert_eq!(va, SECOND_MAP_ADDR);
         assert_eq!(cursor.virt_addr(), SECOND_MAP_ADDR);
     }
+
+    #[ktest]
+    #[should_panic]
+    fn find_next_rejects_overflowing_len() {
+        let (page_table, _, _) = setup_pt_with_two_mappings();
+        let preempt_guard = disable_preempt();
+
+        let mut cursor = page_table
+            .cursor(&preempt_guard, &(0..SECOND_MAP_ADDR + PAGE_SIZE))
+            .unwrap();
+
+        cursor.jump(SECOND_MAP_ADDR).unwrap();
+        assert_eq!(cursor.virt_addr(), SECOND_MAP_ADDR);
+
+        let overflow_len = 0usize.wrapping_sub(SECOND_MAP_ADDR);
+        assert_eq!(overflow_len % PAGE_SIZE, 0);
+        assert_eq!(
+            SECOND_MAP_ADDR.wrapping_add(overflow_len),
+            0,
+            "test setup: va + len must wrap to 0"
+        );
+
+        let _ = cursor.find_next(overflow_len);
+    }
 }
 
 mod unmap {


### PR DESCRIPTION
Following https://github.com/asterinas/asterinas/pull/3587 I decided to audit `page_table` module and I found 4 potential instances which I fixed in this PR:

- `Cursor::find_next_impl`
- `Cursor::map`
- `page_table::largest_pages`
- `page_table::is_valid_range`

Let me know if I got any of these wrong or if you spotted any instance that I haven't covered in `page_table`. Happy to make follow-up changes if needed.