### PR TITLE
Provide eventfd reference for in-kernel users

### DIFF
--- a/kernel/src/device/hypervisor/device.rs
+++ b/kernel/src/device/hypervisor/device.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The KVM-compatible hypervisor device.
+
+use device_id::{DeviceId, MajorId, MinorId};
+use ostd::task::Task;
+
+use super::{
+    KVM_MAJOR, KVM_MINOR,
+    ioctl::{CreateVm, GetApiVersion, KVM_API_VERSION},
+    vm::{Vm, VmFile},
+};
+use crate::{
+    device::{Device, DeviceType, DevtmpfsInodeMeta},
+    events::IoEvents,
+    fs::{
+        file::{PerOpenFileOps, StatusFlags, file_table::FdFlags},
+        vfs::inode::FileOps,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+    util::ioctl::{RawIoctl, dispatch_ioctl},
+};
+
+pub(super) struct HypervisorDevice;
+
+impl Device for HypervisorDevice {
+    fn type_(&self) -> DeviceType {
+        DeviceType::Char
+    }
+
+    fn id(&self) -> DeviceId {
+        DeviceId::new(MajorId::new(KVM_MAJOR), MinorId::new(u32::from(KVM_MINOR)))
+    }
+
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsInodeMeta<'_>> {
+        Some(DevtmpfsInodeMeta::new("kvm"))
+    }
+
+    fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {
+        Ok(Box::new(HypervisorDeviceFile))
+    }
+}
+
+struct HypervisorDeviceFile;
+
+impl Pollable for HypervisorDeviceFile {
+    fn poll(&self, mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        (IoEvents::IN | IoEvents::OUT) & mask
+    }
+}
+
+impl FileOps for HypervisorDeviceFile {
+    fn read_at(
+        &self,
+        _offset: usize,
+        _writer: &mut VmWriter,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "cannot read from KVM device");
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _reader: &mut VmReader,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "cannot write to KVM device");
+    }
+}
+
+impl PerOpenFileOps for HypervisorDeviceFile {
+    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        dispatch_ioctl!(match raw_ioctl {
+            GetApiVersion => {
+                Ok(KVM_API_VERSION)
+            }
+            CreateVm => {
+                if raw_ioctl.arg() != 0 {
+                    return_errno_with_message!(Errno::EINVAL, "unsupported KVM machine type");
+                }
+
+                let vm_file = Arc::new(VmFile::new(Vm::new()));
+                let current = Task::current().unwrap();
+                let mut file_table = current.as_thread_local().unwrap().borrow_file_table_mut();
+                let vm_fd = file_table
+                    .unwrap()
+                    .write()
+                    .insert(vm_file, FdFlags::empty());
+                Ok(vm_fd.into())
+            }
+            _ => return_errno_with_message!(Errno::ENOTTY, "unknown KVM device ioctl command"),
+        })
+    }
+
+    fn check_seekable(&self) -> Result<()> {
+        return_errno_with_message!(Errno::ESPIPE, "the device is not seekable");
+    }
+
+    fn is_offset_aware(&self) -> bool {
+        false
+    }
+}

--- a/kernel/src/device/hypervisor/ioctl.rs
+++ b/kernel/src/device/hypervisor/ioctl.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Minimal ioctl definitions compatible with the Linux KVM API.
+
+use crate::{
+    prelude::*,
+    util::ioctl::{InData, NoData, ioc},
+};
+
+pub(super) const KVM_API_VERSION: i32 = 12;
+pub(super) const KVM_IRQFD_FLAG_DEASSIGN: u32 = 1 << 0;
+
+pub(super) type GetApiVersion = ioc!(KVM_GET_API_VERSION, 0xAE, 0x00, NoData);
+pub(super) type CreateVm = ioc!(KVM_CREATE_VM, 0xAE, 0x01, NoData);
+pub(super) type IrqFd = ioc!(KVM_IRQFD, 0xAE, 0x76, InData<IrqFdConfig>);
+
+/// The common `struct kvm_irqfd`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(super) struct IrqFdConfig {
+    pub fd: u32,
+    pub gsi: u32,
+    pub flags: u32,
+    pub resamplefd: u32,
+    pub pad: [u8; 16],
+}

--- a/kernel/src/device/hypervisor/irqfd.rs
+++ b/kernel/src/device/hypervisor/irqfd.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ostd::sync::WaitQueue;
+
+use super::vm::Vm;
+use crate::{
+    events::{IoEvents, Observer},
+    prelude::*,
+    process::signal::{PollAdaptor, Pollable},
+    syscall::eventfd::EventFile,
+    thread::work_queue::{WorkPriority, submit_work_item, work_item::WorkItem},
+};
+
+pub(super) struct IrqFdBinding {
+    eventfd: Arc<EventFile>,
+    gsi: u32,
+    // vm: Weak<Vm>,
+    poll_adaptor: Mutex<Option<PollAdaptor<IrqFdObserver>>>,
+    work_item: Arc<WorkItem>,
+    /// Whether this binding is still active.
+    active: AtomicBool,
+    /// Whether a work item is currently scheduled for this binding.
+    scheduled: AtomicBool,
+    work_done: WaitQueue,
+}
+
+impl IrqFdBinding {
+    pub(super) fn new(eventfd: Arc<EventFile>, gsi: u32, _vm: Weak<Vm>) -> Arc<Self> {
+        Arc::new_cyclic(|binding| {
+            let observer = IrqFdObserver {
+                binding: binding.clone(),
+            };
+            let work_binding = binding.clone();
+            Self {
+                eventfd,
+                gsi,
+                // vm,
+                poll_adaptor: Mutex::new(Some(PollAdaptor::with_observer(observer))),
+                work_item: WorkItem::new(Box::new(move || {
+                    if let Some(binding) = work_binding.upgrade() {
+                        binding.run_work();
+                    }
+                })),
+                active: AtomicBool::new(true),
+                scheduled: AtomicBool::new(false),
+                work_done: WaitQueue::new(),
+            }
+        })
+    }
+
+    pub(super) fn start(&self) {
+        let ready = {
+            let mut poll_adaptor = self.poll_adaptor.lock();
+            let poll_adaptor = poll_adaptor.as_mut().unwrap();
+            self.eventfd
+                .poll(IoEvents::IN, Some(poll_adaptor.as_handle_mut()))
+        };
+        if ready.contains(IoEvents::IN) {
+            self.schedule();
+        }
+    }
+
+    pub(super) fn matches(&self, eventfd: &Arc<EventFile>, gsi: u32) -> bool {
+        self.gsi == gsi && Arc::ptr_eq(&self.eventfd, eventfd)
+    }
+
+    pub(super) fn uses_eventfd(&self, eventfd: &Arc<EventFile>) -> bool {
+        Arc::ptr_eq(&self.eventfd, eventfd)
+    }
+
+    pub(super) fn deactivate(&self) {
+        self.active.store(false, Ordering::Release);
+        self.poll_adaptor.lock().take();
+        self.work_done
+            .wait_until(|| (!self.scheduled.load(Ordering::Acquire)).then_some(()));
+    }
+
+    fn schedule(&self) {
+        if !self.active.load(Ordering::Acquire)
+            || self
+                .scheduled
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+        {
+            return;
+        }
+
+        if !submit_work_item(self.work_item.clone(), WorkPriority::High) {
+            // If we failed to submit the work item
+            self.scheduled.store(false, Ordering::Release);
+            self.work_done.wake_all();
+        }
+    }
+
+    fn run_work(&self) {
+        #[expect(
+            clippy::missing_spin_loop,
+            reason = "GSI injection will be implemented here"
+        )]
+        while self.active.load(Ordering::Acquire) && self.eventfd.consume().is_some() {
+            // TODO: Inject a GSI interrupt into `_vm` for `self.gsi` here.
+        }
+
+        // All signal is consumed or the binding is no longer active.
+        self.scheduled.store(false, Ordering::Release);
+        self.work_done.wake_all();
+
+        // A signal between the last consume and clearing `scheduled` may fail to enqueue the
+        // work item. Recheck the eventfd to catch that case.
+        if self.active.load(Ordering::Acquire)
+            && self.eventfd.poll(IoEvents::IN, None).contains(IoEvents::IN)
+        {
+            self.schedule();
+        }
+    }
+}
+
+struct IrqFdObserver {
+    binding: Weak<IrqFdBinding>,
+}
+
+impl Observer<IoEvents> for IrqFdObserver {
+    fn on_events(&self, events: &IoEvents) {
+        if events.contains(IoEvents::IN)
+            && let Some(binding) = self.binding.upgrade()
+        {
+            binding.schedule();
+        }
+    }
+}

--- a/kernel/src/device/hypervisor/mod.rs
+++ b/kernel/src/device/hypervisor/mod.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod device;
+mod ioctl;
+mod irqfd;
+mod vm;
+
+use crate::{device::registry::char, prelude::*};
+
+const KVM_MAJOR: u16 = 10;
+const KVM_MINOR: u16 = 232;
+
+pub(super) fn init_in_first_process() -> Result<()> {
+    char::register(Arc::new(device::HypervisorDevice))
+}

--- a/kernel/src/device/hypervisor/vm.rs
+++ b/kernel/src/device/hypervisor/vm.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::fmt::Display;
+
+use ostd::task::Task;
+
+use super::{
+    ioctl::{IrqFd, IrqFdConfig, KVM_IRQFD_FLAG_DEASSIGN},
+    irqfd::IrqFdBinding,
+};
+use crate::{
+    events::IoEvents,
+    fs::{
+        file::{
+            AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags,
+            file_table::{FdFlags, FileDesc, get_file_fast},
+        },
+        pseudofs::AnonInodeFs,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable},
+    syscall::eventfd::EventFile,
+    util::ioctl::{RawIoctl, dispatch_ioctl},
+};
+
+pub(super) struct Vm {
+    irqfds: Mutex<Vec<Arc<IrqFdBinding>>>,
+}
+
+impl Vm {
+    pub(super) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            irqfds: Mutex::new(Vec::new()),
+        })
+    }
+
+    pub(super) fn configure_irqfd(
+        self: &Arc<Self>,
+        config: IrqFdConfig,
+        eventfd: Arc<EventFile>,
+    ) -> Result<()> {
+        if config.flags & KVM_IRQFD_FLAG_DEASSIGN != 0 {
+            let binding = {
+                let mut bindings = self.irqfds.lock();
+                let index = bindings
+                    .iter()
+                    .position(|binding| binding.matches(&eventfd, config.gsi));
+                index.map(|index| bindings.remove(index))
+            };
+            if let Some(binding) = binding {
+                binding.deactivate();
+            }
+            return Ok(());
+        }
+
+        let binding = IrqFdBinding::new(eventfd.clone(), config.gsi, Arc::downgrade(self));
+        {
+            let mut bindings = self.irqfds.lock();
+            if bindings
+                .iter()
+                .any(|binding| binding.uses_eventfd(&eventfd))
+            {
+                return_errno_with_message!(Errno::EBUSY, "eventfd already has an irqfd binding");
+            }
+            bindings.push(binding.clone());
+        }
+        binding.start();
+        Ok(())
+    }
+}
+
+impl Drop for Vm {
+    fn drop(&mut self) {
+        let bindings = core::mem::take(self.irqfds.get_mut());
+        for binding in bindings {
+            binding.deactivate();
+        }
+    }
+}
+
+pub(super) struct VmFile {
+    vm: Arc<Vm>,
+    common: FileCommon,
+}
+
+impl VmFile {
+    pub(super) fn new(vm: Arc<Vm>) -> Self {
+        let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[kvm-vm]".to_string());
+        Self {
+            vm,
+            common: FileCommon::new(pseudo_path, StatusFlags::empty()),
+        }
+    }
+
+    fn get_eventfd(raw_fd: i32) -> Result<Arc<EventFile>> {
+        let fd = FileDesc::try_from(raw_fd)?;
+        let current = Task::current().unwrap();
+        let thread_local = current.as_thread_local().unwrap();
+        let mut file_table = thread_local.borrow_file_table_mut();
+        let file = get_file_fast!(&mut file_table, fd).into_owned();
+        let file: Arc<dyn Any + Send + Sync> = file;
+        file.downcast::<EventFile>()
+            .map_err(|_| Error::with_message(Errno::EINVAL, "file descriptor is not an eventfd"))
+    }
+}
+
+impl Pollable for VmFile {
+    fn poll(&self, _mask: IoEvents, _poller: Option<&mut PollHandle>) -> IoEvents {
+        IoEvents::empty()
+    }
+}
+
+impl FileLike for VmFile {
+    fn read(&self, _writer: &mut VmWriter) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "cannot read from VM file");
+    }
+
+    fn write(&self, _reader: &mut VmReader) -> Result<usize> {
+        return_errno_with_message!(Errno::EINVAL, "cannot write to VM file");
+    }
+
+    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        dispatch_ioctl!(match raw_ioctl {
+            cmd @ IrqFd => {
+                let config: IrqFdConfig = cmd.read()?;
+                let eventfd = Self::get_eventfd(i32::try_from(config.fd)?)?;
+                self.vm.configure_irqfd(config, eventfd)?;
+                Ok(0)
+            }
+            _ => return_errno_with_message!(Errno::ENOTTY, "unknown KVM VM ioctl command"),
+        })
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        AccessMode::O_RDWR
+    }
+
+    fn common(&self) -> &FileCommon {
+        &self.common
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
+        struct FdInfo {
+            inner: Arc<VmFile>,
+            fd_flags: FdFlags,
+        }
+
+        impl Display for FdInfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
+                if self.fd_flags.contains(FdFlags::CLOEXEC) {
+                    flags |= CreationFlags::O_CLOEXEC.bits();
+                }
+
+                writeln!(f, "pos:\t{}", 0)?;
+                writeln!(f, "flags:\t0{:o}", flags)?;
+                writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
+                writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())
+            }
+        }
+
+        Box::new(FdInfo {
+            inner: self,
+            fd_flags,
+        })
+    }
+}

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -2,6 +2,7 @@
 
 mod evdev;
 mod fb;
+mod hypervisor;
 mod mem;
 pub mod misc;
 mod pty;
@@ -186,6 +187,7 @@ pub fn init_in_first_process(ctx: &Context) -> Result<()> {
     tty::init_in_first_process()?;
     pty::init_in_first_process(&path_resolver, ctx)?;
     shm::init_in_first_process(&path_resolver, ctx)?;
+    hypervisor::init_in_first_process()?;
     registry::init_in_first_process(&path_resolver)?;
 
     Ok(())

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -66,7 +66,8 @@ bitflags! {
     }
 }
 
-struct EventFile {
+/// An eventfd file that can also be consumed by in-kernel users.
+pub struct EventFile {
     counter: Mutex<u64>,
     pollee: Pollee,
     is_semaphore: bool,
@@ -111,6 +112,10 @@ impl EventFile {
             events |= IoEvents::IN;
         }
 
+        if *counter == u64::MAX {
+            events |= IoEvents::ERR;
+        }
+
         // If it is possible to write a value of at least "1"
         // without blocking, the file is writable
         let is_writable = *counter < Self::MAX_COUNTER_VALUE;
@@ -121,15 +126,49 @@ impl EventFile {
         events
     }
 
+    /// Consumes and returns the current counter value, if it is nonzero.
+    pub fn consume(&self) -> Option<u64> {
+        let mut counter = self.counter.lock();
+        if *counter == 0 {
+            return None;
+        }
+
+        let value = if self.is_semaphore {
+            *counter -= 1;
+            1
+        } else {
+            let value = *counter;
+            *counter = 0;
+            value
+        };
+        drop(counter);
+
+        self.pollee.notify(IoEvents::OUT);
+        self.write_wait_queue.wake_all();
+        Some(value)
+    }
+
+    /// Adds one to the counter without blocking, saturating at `u64::MAX`.
+    #[expect(dead_code, reason = "Reserved for future in-kernel eventfd users")]
+    pub fn signal(&self) {
+        let mut counter = self.counter.lock();
+        *counter = counter.saturating_add(1);
+        let events = if *counter == u64::MAX {
+            IoEvents::IN | IoEvents::ERR
+        } else {
+            IoEvents::IN
+        };
+        drop(counter);
+
+        self.pollee.notify(events);
+    }
+
     fn try_read(&self, writer: &mut VmWriter) -> Result<()> {
         let mut counter = self.counter.lock();
-
-        // Wait until the counter becomes non-zero
         if *counter == 0 {
             return_errno_with_message!(Errno::EAGAIN, "the counter is zero");
         }
 
-        // Copy the value from the counter and set the new counter value
         if self.is_semaphore {
             writer.write_fallible(&mut 1u64.as_bytes().into())?;
             *counter -= 1;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -38,7 +38,7 @@ mod connect;
 mod constants;
 mod dup;
 mod epoll;
-mod eventfd;
+pub mod eventfd;
 mod execve;
 mod exit;
 mod exit_group;


### PR DESCRIPTION
Provide an interface for kernel to `signal/consume` eventfd, similar to [eventfd_signal in Linux](https://elixir.bootlin.com/linux/v7.1.3/source/fs/eventfd.c#L46).

I would use this interface to implement `irqfd` and `ioeventfd` in hypervisor. For instance, in-kernel hypervisor use `ioeventfd` to signal eventfd to notify virtio device backend to handle guest's requests.

Use `SpinLock` for `counter` because in-kernel functions are supposed to be called by the kernel in paths that do not allow sleeping, refer to [eventfd_signal in Linux](https://elixir.bootlin.com/linux/v7.1.3/source/fs/eventfd.c#L46).