### PR TITLE
Treat the VirtIO device configuration capability as optional

### DIFF
--- a/kernel/comps/virtio/src/transport/pci/device.rs
+++ b/kernel/comps/virtio/src/transport/pci/device.rs
@@ -53,7 +53,12 @@ pub struct VirtioPciModernTransport {
     device_type: VirtioDeviceType,
     common_device: PciCommonDevice,
     common_cfg: SafePtr<VirtioPciCommonCfg, IoMem>,
-    device_cfg: VirtioPciCapabilityData,
+    /// The device-specific configuration.
+    ///
+    /// This is `None` if the device does not expose a device-specific configuration capability,
+    /// which the VirtIO specification permits for devices that have no device-specific
+    /// configuration layout (e.g., the entropy device).
+    device_cfg: Option<VirtioPciCapabilityData>,
     notify: VirtioPciNotify,
     msix_manager: VirtioMsixManager,
 }
@@ -128,10 +133,10 @@ impl VirtioTransport for VirtioPciModernTransport {
     }
 
     fn device_config_mem(&self) -> Option<IoMem> {
-        let offset = self.device_cfg.offset() as usize;
-        let length = self.device_cfg.length() as usize;
-        let io_mem = self
-            .device_cfg
+        let device_cfg = self.device_cfg.as_ref()?;
+        let offset = device_cfg.offset() as usize;
+        let length = device_cfg.length() as usize;
+        let io_mem = device_cfg
             .memory_bar()
             .unwrap()
             .slice(offset..offset + length);
@@ -310,7 +315,6 @@ impl VirtioPciModernTransport {
         }
         let notify = notify.unwrap();
         let common_cfg = common_cfg.unwrap();
-        let device_cfg = device_cfg.unwrap();
 
         // TODO: Support interrupt without MSI-X.
         let msix = common_device.acquire_msix_capability().unwrap().unwrap();


### PR DESCRIPTION
## Problem

Probing a VirtIO PCI device panics if the device does not expose a
device-specific configuration capability:

```
Uncaught panic:
	called `Option::unwrap()` on a `None` value
	at kernel/comps/virtio/src/transport/pci/device.rs:313
```

`VIRTIO_PCI_CAP_DEVICE_CFG` is optional. The specification only requires it for
devices that actually have a device-specific configuration layout, and the
entropy device has none (VirtIO 1.3, 5.4 "Entropy Device", which defines no
device configuration layout).

This is easy to hit in practice: Cloud Hypervisor attaches a virtio-rng device
by default and omits the capability accordingly, so the kernel panics during
device probing before reaching user space.

## Fix

Make the capability optional. `device_config_mem` already returns an `Option`,
so it simply returns `None` when the device does not provide the capability.

## Testing

- `make check` (rustfmt + workspace lints + clippy) passes.
- Booted on Cloud Hypervisor: the entropy device is now probed without
  panicking (`virtio: Found device: Entropy`), and the boot proceeds to user
  space.
- Booted under QEMU with the existing `microvm` scheme to confirm no
  regression for devices that do provide the capability.
