### PR TITLE
Support the PVH boot protocol

### DIFF
--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -30,6 +30,11 @@ PHDRS
     # segment to prevent this from happening.
     header PT_LOAD FLAGS(4);      # R__
 
+    # The PVH ELF note. VMMs that support the PVH boot protocol (e.g., Cloud
+    # Hypervisor, Firecracker, QEMU) locate the 32-bit entry point by scanning
+    # PT_NOTE segments, so the note must be covered by one.
+    note PT_NOTE FLAGS(4);        # R__
+
     # Boot segments. Addresses are physical.
     bsp_boot PT_LOAD FLAGS(7);    # RWE
     ap_boot PT_LOAD FLAGS(7);     # RWE
@@ -55,6 +60,13 @@ SECTIONS
     .multiboot2_header      : AT(ADDR(.multiboot2_header) - KERNEL_VMA) {
         KEEP(*(.multiboot2_header))
     } : header
+    # The PVH ELF note advertises the 32-bit entry point (`__pvh_boot`). It is
+    # assigned to both `header` and `note`: the former keeps it in a PT_LOAD
+    # segment (so llvm-strip does not relocate it), the latter provides the
+    # PT_NOTE segment that PVH-capable VMMs scan.
+    .note.Xen               : AT(ADDR(.note.Xen) - KERNEL_VMA) {
+        KEEP(*(.note.Xen))
+    } : header : note
 
 # --------------------------------------------------------------------------- #
 # These are 2 boot sections that need specific physical addresses.            #

--- a/ostd/src/arch/x86/boot/bsp_boot.S
+++ b/ostd/src/arch/x86/boot/bsp_boot.S
@@ -26,6 +26,7 @@ ENTRYTYPE_MULTIBOOT     = 1
 ENTRYTYPE_MULTIBOOT2    = 2
 ENTRYTYPE_LINUX_32      = 3
 ENTRYTYPE_LINUX_64      = 4
+ENTRYTYPE_PVH           = 5
 
 MULTIBOOT_ENTRY_MAGIC   = 0x2BADB002
 MULTIBOOT2_ENTRY_MAGIC  = 0x36D76289
@@ -78,6 +79,29 @@ __linux64_boot:
     // Switch to our own temporary GDT.
     lgdt [boot_gdtr]
     retf
+
+// The PVH entry point.
+//
+// The PVH boot protocol hands off in 32-bit protected mode with paging
+// disabled, flat segments, and EBX holding the physical address of the
+// `hvm_start_info` structure. Unlike the entry points above, its address is
+// not fixed by the ABI: it is advertised to the VMM through the PVH ELF note
+// (see `pvh/note.S`), which refers to this symbol.
+.code32
+.global __pvh_boot
+__pvh_boot:
+    cli
+    cld
+
+    // Set the kernel call stack.
+    mov esp, offset boot_stack_top
+
+    push 0      // Upper 32-bits.
+    push ebx    // `hvm_start_info` ptr
+    push 0      // Upper 32-bits.
+    push ENTRYTYPE_PVH
+
+    jmp initial_boot_setup
 
 // The multiboot & multiboot2 entry point.
 .code32
@@ -349,12 +373,15 @@ long_mode:
     je entry_type_linux
     cmp rax, ENTRYTYPE_LINUX_64
     je entry_type_linux
+    cmp rax, ENTRYTYPE_PVH
+    je entry_type_pvh
     // Unreachable!
     jmp halt
 
 .extern __linux_boot
 .extern __multiboot_entry
 .extern __multiboot2_entry
+.extern __pvh_entry
 
 entry_type_linux:
     pop rdi // boot_params ptr
@@ -376,6 +403,13 @@ entry_type_multiboot2:
     pop rdi // multiboot magic
 
     lea  rax, [rip + __multiboot2_entry]  // jump into Rust code
+    call rax
+    jmp halt
+
+entry_type_pvh:
+    pop rdi // the address of `hvm_start_info`
+
+    lea  rax, [rip + __pvh_entry]  // jump into Rust code
     call rax
     jmp halt
 

--- a/ostd/src/arch/x86/boot/mod.rs
+++ b/ostd/src/arch/x86/boot/mod.rs
@@ -8,6 +8,7 @@
 //!  - Multiboot
 //!  - Multiboot2
 //!  - Linux x86 Boot Protocol
+//!  - PVH
 //!
 //! without any additional configurations.
 //!
@@ -21,6 +22,7 @@
 mod linux_boot;
 mod multiboot;
 mod multiboot2;
+mod pvh;
 
 pub(crate) mod smp;
 

--- a/ostd/src/arch/x86/boot/pvh/mod.rs
+++ b/ostd/src/arch/x86/boot/pvh/mod.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The PVH boot protocol supporting module.
+//!
+//! PVH is the direct boot protocol implemented by most modern virtual machine
+//! monitors (e.g., Cloud Hypervisor, Firecracker, QEMU). The VMM enters the
+//! kernel in 32-bit protected mode with paging disabled and passes the
+//! physical address of an [`HvmStartInfo`] structure in `EBX`. The entry point
+//! itself is advertised through the PVH ELF note (see `note.S`).
+//!
+//! Reference: <https://xenbits.xen.org/docs/unstable/misc/pvh.html>
+
+use core::arch::global_asm;
+
+use crate::{
+    boot::{
+        BootloaderAcpiArg,
+        memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
+    },
+    mm::{Paddr, kspace::paddr_to_vaddr},
+};
+
+global_asm!(include_str!("note.S"));
+
+/// The magic value of [`HvmStartInfo::magic`], which is "xEn3" in ASCII.
+const HVM_START_MAGIC_VALUE: u32 = 0x336e_c578;
+
+/// The start-of-day structure that a PVH-capable VMM passes to the guest.
+#[repr(C)]
+struct HvmStartInfo {
+    magic: u32,
+    version: u32,
+    flags: u32,
+    nr_modules: u32,
+    modlist_paddr: u64,
+    cmdline_paddr: u64,
+    rsdp_paddr: u64,
+    // The following fields are only present in version 1 and later.
+    memmap_paddr: u64,
+    memmap_entries: u32,
+    _reserved: u32,
+}
+
+/// An entry of the module list pointed to by [`HvmStartInfo::modlist_paddr`].
+#[repr(C)]
+struct HvmModlistEntry {
+    paddr: u64,
+    size: u64,
+    cmdline_paddr: u64,
+    _reserved: u64,
+}
+
+/// An entry of the memory map pointed to by [`HvmStartInfo::memmap_paddr`].
+#[repr(C)]
+struct HvmMemmapTableEntry {
+    addr: u64,
+    size: u64,
+    typ: u32,
+    _reserved: u32,
+}
+
+/// Converts a PVH memory map entry type, which mirrors the E820 types.
+fn parse_memory_region_type(typ: u32) -> MemoryRegionType {
+    match typ {
+        1 => MemoryRegionType::Usable,
+        2 => MemoryRegionType::Reserved,
+        3 => MemoryRegionType::Reclaimable,
+        4 => MemoryRegionType::NonVolatileSleep,
+        5 => MemoryRegionType::BadMemory,
+        // All other memory regions are reserved.
+        _ => MemoryRegionType::Reserved,
+    }
+}
+
+fn parse_kernel_commandline(start_info: &HvmStartInfo) -> Option<&'static str> {
+    if start_info.cmdline_paddr == 0 {
+        return None;
+    }
+
+    let cmdline_ptr = paddr_to_vaddr(start_info.cmdline_paddr as Paddr);
+    // SAFETY: The command line is a NUL-terminated string that is safe to read because of the
+    // contract with the VMM, and it lives for `'static`.
+    let cmdline = unsafe { core::ffi::CStr::from_ptr(cmdline_ptr as *const _) };
+
+    cmdline.to_str().ok()
+}
+
+fn parse_initramfs(start_info: &HvmStartInfo) -> Option<&'static [u8]> {
+    if start_info.nr_modules == 0 || start_info.modlist_paddr == 0 {
+        return None;
+    }
+
+    let modlist_ptr = paddr_to_vaddr(start_info.modlist_paddr as Paddr);
+    // SAFETY: The module list contains at least one entry (checked above) and is safe to read
+    // because of the contract with the VMM.
+    let module = unsafe { &*(modlist_ptr as *const HvmModlistEntry) };
+
+    if module.paddr == 0 || module.size == 0 {
+        return None;
+    }
+
+    let initramfs_ptr = paddr_to_vaddr(module.paddr as Paddr);
+    // SAFETY: The initramfs is safe to read because of the contract with the VMM.
+    let initramfs =
+        unsafe { core::slice::from_raw_parts(initramfs_ptr as *const u8, module.size as usize) };
+
+    Some(initramfs)
+}
+
+fn parse_acpi_arg(start_info: &HvmStartInfo) -> BootloaderAcpiArg {
+    if start_info.rsdp_paddr == 0 {
+        // The VMM did not provide the RSDP address, so fall back to scanning for it.
+        BootloaderAcpiArg::ScanBios
+    } else {
+        BootloaderAcpiArg::Rsdp(
+            start_info
+                .rsdp_paddr
+                .try_into()
+                .expect("RSDP address overflowed!"),
+        )
+    }
+}
+
+fn parse_memory_regions(start_info: &HvmStartInfo) -> MemoryRegionArray {
+    let mut regions = MemoryRegionArray::new();
+
+    // The memory map is only available in version 1 and later.
+    if start_info.version >= 1 && start_info.memmap_paddr != 0 {
+        let memmap_ptr = paddr_to_vaddr(start_info.memmap_paddr as Paddr);
+        // SAFETY: The memory map is safe to read because of the contract with the VMM.
+        let memmap = unsafe {
+            core::slice::from_raw_parts(
+                memmap_ptr as *const HvmMemmapTableEntry,
+                start_info.memmap_entries as usize,
+            )
+        };
+
+        for entry in memmap {
+            regions
+                .push(MemoryRegion::new(
+                    entry.addr.try_into().unwrap(),
+                    entry.size.try_into().unwrap(),
+                    parse_memory_region_type(entry.typ),
+                ))
+                .unwrap();
+        }
+    }
+
+    // Add the kernel region since the VMM does not specify it.
+    regions.push(MemoryRegion::kernel()).unwrap();
+
+    // Add the initramfs region.
+    if let Some(initramfs) = parse_initramfs(start_info) {
+        regions.push(MemoryRegion::module(initramfs)).unwrap();
+    }
+
+    // Add the AP boot code region that will be copied into by the BSP.
+    regions
+        .push(super::smp::reclaimable_memory_region())
+        .unwrap();
+
+    // Add the region of the kernel cmdline since the VMM does not specify it.
+    if let Some(kcmdline) = parse_kernel_commandline(start_info) {
+        regions
+            .push(MemoryRegion::module(kcmdline.as_bytes()))
+            .unwrap();
+    }
+
+    regions.into_non_overlapping()
+}
+
+/// The entry point of the Rust code portion of Asterinas (with PVH parameters).
+///
+/// # Safety
+///
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
+/// - If this function is called, entry points of other boot protocols must never be called.
+// SAFETY: The name does not collide with other symbols.
+#[unsafe(no_mangle)]
+unsafe extern "sysv64" fn __pvh_entry(start_info_ptr: *const HvmStartInfo) -> ! {
+    // SAFETY: We get the start-of-day structure from the VMM, so by contract the pointer is valid
+    // and the underlying memory is initialized.
+    let start_info = unsafe { &*start_info_ptr };
+    assert_eq!({ start_info.magic }, HVM_START_MAGIC_VALUE);
+
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
+
+    EARLY_INFO.call_once(|| EarlyBootInfo {
+        bootloader_name: "PVH-capable VMM",
+        kernel_cmdline: parse_kernel_commandline(start_info).unwrap_or(""),
+        initramfs: parse_initramfs(start_info),
+        acpi_arg: parse_acpi_arg(start_info),
+        framebuffer_arg: None,
+        memory_regions: parse_memory_regions(start_info),
+    });
+
+    // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
+    // once after setting up necessary resources.
+    unsafe { start_kernel() };
+}

--- a/ostd/src/arch/x86/boot/pvh/note.S
+++ b/ostd/src/arch/x86/boot/pvh/note.S
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+// The PVH ELF note.
+//
+// VMMs that implement the PVH boot protocol (e.g., Cloud Hypervisor,
+// Firecracker, QEMU) discover the kernel's 32-bit entry point by scanning the
+// PT_NOTE segments of the ELF image for a note named "Xen" with the type
+// `XEN_ELFNOTE_PHYS32_ENTRY`. The descriptor holds the physical address to
+// jump to.
+//
+// Reference: https://xenbits.xen.org/docs/unstable/misc/pvh.html
+
+XEN_ELFNOTE_PHYS32_ENTRY = 18
+
+.section ".note.Xen", "a", @note
+.align 4
+
+    .long name_end - name_start     // namesz
+    .long desc_end - desc_start     // descsz
+    .long XEN_ELFNOTE_PHYS32_ENTRY  // type
+
+name_start:
+    .asciz "Xen"
+name_end:
+    .align 4
+
+.extern __pvh_boot
+desc_start:
+    // `__pvh_boot` lives in the `.bsp_boot` section, which is linked at its
+    // physical load address, so the symbol value is already the physical
+    // address that the VMM must jump to.
+    .long __pvh_boot
+desc_end:
+    .align 4


### PR DESCRIPTION
## Problem

Asterinas cannot be booted by the VMMs commonly used for lightweight virtual
machines, such as Cloud Hypervisor and Firecracker. They implement neither
Multiboot nor Multiboot2, and they cannot use the bzImage built for the Linux
boot protocol either: the setup header advertises `XLF_KERNEL_64` while
`header.S` notes that the 64-bit entry point is not actually implemented, so a
VMM that honours the flag enters the non-relocatable setup code at an address
it was not linked for, where the load-address check stops the machine without
any output.

Both VMMs do implement PVH, which is the usual direct boot protocol for this
class of VMM.

## Change

Add a PVH entry point:

- `boot/pvh/note.S` emits the PVH ELF note (`XEN_ELFNOTE_PHYS32_ENTRY`), and
  the OSDK linker template places it in a `PT_NOTE` segment, since that is
  where VMMs look for it.
- `__pvh_boot` in `bsp_boot.S` is entered in 32-bit protected mode with the
  physical address of `hvm_start_info` in `EBX`. That matches the machine state
  of the Multiboot entry point closely enough to share `initial_boot_setup`,
  so the paging and long mode transition are unchanged.
- `boot/pvh/mod.rs` parses `hvm_start_info` into `EarlyBootInfo`: the memory
  map, the command line, the initramfs module, and the RSDP address.

The entry point is additive; the existing Multiboot, Multiboot2, and Linux
entry points are untouched.

## Testing

Booted on Cloud Hypervisor, which reports it takes the PVH path:

```
cloud-hypervisor: PVH kernel loaded: entry_addr = 0x8001238
```

The kernel then parses ACPI (x2APIC found via MADT), honours the PVH memory
map, enumerates VirtIO devices, and reaches user space, where a statically
linked init process runs and serves on vsock.

QEMU with the existing `microvm` scheme (Multiboot2) still boots unchanged.
`make check` (rustfmt + workspace lints + clippy) passes.

## Note

Two other fixes are needed before a boot on Cloud Hypervisor completes; they
are independent of this change and sent separately:

- #3613 — the TSC calibration otherwise stalls, because that VMM emulates no PIT.
- #3612 — probing its default virtio-rng device otherwise panics.
