### PR TITLE
Always disable the legacy PIC instead of trusting PCAT_COMPAT

### DIFF
--- a/ostd/src/arch/x86/irq/chip/mod.rs
+++ b/ostd/src/arch/x86/irq/chip/mod.rs
@@ -170,12 +170,14 @@ pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
     let acpi_tables = get_acpi_tables().unwrap();
     let madt_table = acpi_tables.find_table::<Madt>().unwrap();
 
-    // "A one indicates that the system also has a PC-AT-compatible dual-8259 setup. The 8259
-    // vectors must be disabled (that is, masked) when enabling the ACPI APIC operation"
-    const PCAT_COMPAT: u32 = 1;
-    if madt_table.get().flags & PCAT_COMPAT != 0 {
-        pic::init_and_disable();
-    }
+    // A dual-8259 PIC, if present, must be remapped and masked before enabling APIC operation, or
+    // its interrupts may be delivered alongside the I/O APIC's. The MADT PCAT_COMPAT flag is meant
+    // to indicate whether such a PIC is present, but it cannot be relied upon: a VMM may leave an
+    // uninitialized 8259 in place without setting the flag (e.g., Firecracker reports the flag as
+    // clear while KVM still provides a PIC whose reset-state vector offset is 0, so its IRQ 5 would
+    // arrive as the #BR exception). Remap and mask the PIC unconditionally; doing so on a system
+    // that has no PIC is harmless, since the writes to its I/O ports are simply ignored.
+    pic::init_and_disable();
 
     let mut io_apics = Vec::with_capacity(2);
     let mut isa_overrides = Vec::new();


### PR DESCRIPTION
## Problem

A device interrupt can crash the kernel with a `BoundRangeExceeded` (`#BR`)
exception on a VMM that leaves an uninitialized legacy 8259 PIC in place.

The PIC was only remapped and masked when the MADT `PCAT_COMPAT` flag was set.
That flag is supposed to indicate whether a PC-AT-compatible dual-8259 is
present, but it cannot be relied upon.

Firecracker is a concrete example. It reports `PCAT_COMPAT` as clear (MADT
`flags = 0x0`), yet KVM still provides a PIC via `KVM_CREATE_IRQCHIP`, and its
reset-state vector offset is 0. Once APIC operation is enabled and a
virtio-mmio device is wired to, say, GSI 5, the interrupt is delivered by the
still-active PIC as vector 5 — the `#BR` exception — and the kernel panics:

```
Cannot handle kernel CPU exception: BoundRangeExceeded; trapframe: TrapFrame {
    ...
    trap_num: 0x5,
    error_code: 0x0,
    ...
}
```

This path is not hit under QEMU's `microvm` machine (no PIC) or under a VMM
that delivers device interrupts via MSI-X (e.g. Cloud Hypervisor, which bypasses
the I/O APIC pin path entirely).

## Fix

Remap and mask the PIC unconditionally, rather than gating on `PCAT_COMPAT`.
Remapping moves its vectors to `0x20..0x30`, away from the CPU exception range,
and masking silences it so the I/O APIC is the sole delivery path. Doing this on
a system with no PIC is harmless: the writes to the PIC's I/O ports are ignored.

## Testing

- `make check` (rustfmt + workspace lints + clippy) passes.
- Firecracker (PVH boot, virtio-mmio vsock on GSI 5): the `#BR` panic is gone,
  and a guest init process accepts a vsock connection and exchanges data.
- Cloud Hypervisor and QEMU (`microvm`): no change, still boot as before.
