### PR TITLE
Install firecracker in docker image

### DIFF
--- a/.github/workflows/test_x86_fc.yml
+++ b/.github/workflows/test_x86_fc.yml
@@ -1,0 +1,43 @@
+name: "Test x86-64 (Firecracker)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  boot-test:
+    runs-on: ubuntu-latest
+    container:
+      image: asterinas/asterinas:0.18.0-20260702
+      options: -v /dev:/dev --privileged
+    env:
+      FC_SERIAL_LOG: /var/log/fc-serial.log
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build kernel
+        run: make kernel BOOT_METHOD=direct-elf
+
+      - name: Run boot test with Firecracker
+        shell: bash
+        run: |
+          set -euo pipefail
+          trap 'kill $FC_PID 2>/dev/null || true; wait $FC_PID 2>/dev/null || true' EXIT
+
+          firecracker $(./tools/firecracker_args.sh boot) > "$FC_SERIAL_LOG" 2>&1 &
+          FC_PID=$!
+
+          TIMEOUT=60
+          for i in $(seq 1 $TIMEOUT); do
+              if grep -q "^Entered userspace" "$FC_SERIAL_LOG" 2>/dev/null; then
+                  echo "Firecracker boot test passed"
+                  exit 0
+              fi
+              sleep 1
+          done
+
+          echo "Firecracker boot test failed (timeout)"
+          exit 1

--- a/.github/workflows/test_x86_fc.yml
+++ b/.github/workflows/test_x86_fc.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
 
 jobs:
   boot-test:

--- a/.github/workflows/test_x86_fc.yml
+++ b/.github/workflows/test_x86_fc.yml
@@ -39,4 +39,6 @@ jobs:
           done
 
           echo "Firecracker boot test failed (timeout)"
+          echo "--- Firecracker serial log ---"
+          cat "$FC_SERIAL_LOG"
           exit 1

--- a/Makefile
+++ b/Makefile
@@ -156,11 +156,11 @@ CARGO_OSDK_COMMON_ARGS += --scheme tdx
 endif
 
 ifeq ($(BOOT_PROTOCOL), multiboot)
-BOOT_METHOD = qemu-direct
+BOOT_METHOD = direct-elf
 endif
 
 ifeq ($(SCHEME), microvm)
-BOOT_METHOD = qemu-direct
+BOOT_METHOD = direct-elf
 endif
 
 ifeq ($(SCHEME), "")

--- a/OSDK.toml
+++ b/OSDK.toml
@@ -31,7 +31,7 @@ args = "$(./tools/qemu_args.sh test)"
 # Other Schemes
 
 [scheme."microvm"]
-boot.method = "qemu-direct"
+boot.method = "direct-elf"
 build.strip_elf = true
 qemu.args = "$(./tools/qemu_args.sh microvm)"
 
@@ -48,14 +48,14 @@ qemu.args = "$(./tools/qemu_args.sh tdx)"
 
 [scheme."riscv"]
 supported_archs = ["riscv64"]
-boot.method = "qemu-direct"
+boot.method = "direct-elf"
 build.strip_elf = false
 qemu.args = "$(./tools/qemu_args.sh riscv)"
 
 [scheme."sifive_u"]
 supported_archs = ["riscv64"]
 build.features = ["riscv_sv39_mode"]
-boot.method = "qemu-direct"
+boot.method = "direct-elf"
 build.strip_elf = false
 qemu.with_monitor = true
 
@@ -72,7 +72,7 @@ qemu.args = """\
 """
 
 [scheme."loongarch"]
-boot.method = "qemu-direct"
+boot.method = "direct-elf"
 build.strip_elf = false
 
 qemu.args = """\

--- a/book/src/kernel/vm-based-containers/coco.md
+++ b/book/src/kernel/vm-based-containers/coco.md
@@ -237,16 +237,16 @@ Build the kernel and verify the output images:
 
 ```bash
 # Build the regular guest kernel
-cd /root/asterinas && make kernel BOOT_METHOD=qemu-direct
+cd /root/asterinas && make kernel BOOT_METHOD=direct-elf
 
 # Verify the regular build output
-ls /root/asterinas/target/osdk/aster-kernel-osdk-bin.qemu_elf
+ls /root/asterinas/target/osdk/aster-kernel-osdk-bin.elf
 
 # Build the TDX guest kernel (only needed for the CVM path)
-cd /root/asterinas && make kernel BOOT_METHOD=qemu-direct INTEL_TDX=1
+cd /root/asterinas && make kernel BOOT_METHOD=direct-elf INTEL_TDX=1
 
 # Verify the TDX build output
-# (Note that the TDX kernel uses a bzImage format without the `.qemu_elf` extension.)
+# (Note that the TDX kernel uses a bzImage format without the `.elf` extension.)
 ls /root/asterinas/target/osdk/aster-kernel-osdk-bin
 ```
 
@@ -260,7 +260,7 @@ and set `kernel` under `[hypervisor.qemu]`:
 
 ```toml
 [hypervisor.qemu]
-kernel = "/root/asterinas/target/osdk/aster-kernel-osdk-bin.qemu_elf"
+kernel = "/root/asterinas/target/osdk/aster-kernel-osdk-bin.elf"
 ```
 
 For the TDX runtime, edit:

--- a/book/src/kernel/vm-based-containers/kata.md
+++ b/book/src/kernel/vm-based-containers/kata.md
@@ -199,14 +199,14 @@ If you are using the image's default kernel,
 look for:
 
 ```text
-/opt/kata/share/kata-containers/aster-kernel-osdk-bin.qemu_elf
+/opt/kata/share/kata-containers/aster-kernel-osdk-bin.elf
 ```
 
 If you configured a locally built kernel in Step 4,
 look for:
 
 ```text
-/root/asterinas/target/osdk/aster-kernel-osdk-bin.qemu_elf
+/root/asterinas/target/osdk/aster-kernel-osdk-bin.elf
 ```
 
 This is the most direct check that Kata booted an Asterinas guest kernel.
@@ -237,20 +237,20 @@ so it assumes you entered the Kata-ready environment through the
 Build the kernel first:
 
 ```bash
-(cd /root/asterinas && make kernel BOOT_METHOD=qemu-direct)
+(cd /root/asterinas && make kernel BOOT_METHOD=direct-elf)
 ```
 
 Verify that the command produced the kernel image:
 
 ```bash
-ls /root/asterinas/target/osdk/aster-kernel-osdk-bin.qemu_elf
+ls /root/asterinas/target/osdk/aster-kernel-osdk-bin.elf
 ```
 
 Pass that path to `tools/kata/kata_env.sh install`:
 
 ```bash
 tools/kata/kata_env.sh install \
-    --kernel /root/asterinas/target/osdk/aster-kernel-osdk-bin.qemu_elf
+    --kernel /root/asterinas/target/osdk/aster-kernel-osdk-bin.elf
 ```
 
 Configuring a local kernel re-runs `tools/kata/kata_env.sh install`

--- a/book/src/osdk/reference/manifest.md
+++ b/book/src/osdk/reference/manifest.md
@@ -38,7 +38,7 @@ profile = "dev"                             # <5>
 strip_elf = false                           # <6>
 encoding = "raw"                            # <7>
 [boot]                                      # <8>
-method = "qemu-direct"                      # <9>
+method = "direct-elf"                       # <9>
 kcmd_args = ["SHELL=/bin/sh", "HOME=/"]     # <10>
 init_args = ["sh", "-l"]                    # <11>
 initramfs = "path/to/it"                    # <12>
@@ -123,9 +123,12 @@ Here are some additional notes for the fields:
 
 9. The boot method.
 
-    Optional. The default value is `qemu-direct`.
+    Optional. The default value is `direct-elf`.
 
-    Possible values are `grub-rescue-iso`, `grub-qcow2` and `qemu-direct`.
+    Possible values are `direct-elf`, `grub-rescue-iso`, and `grub-qcow2`.
+
+    The `direct-elf` method builds an ELF kernel image for loaders or VMMs
+    that can load a kernel image directly, without creating a GRUB boot device.
 
 10. The arguments provided will be passed to the guest kernel.
 

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -30,6 +30,11 @@ PHDRS
     # segment to prevent this from happening.
     header PT_LOAD FLAGS(4);      # R__
 
+    # The PVH ELF note. VMMs that support the PVH boot protocol (e.g., Cloud
+    # Hypervisor, Firecracker, QEMU) locate the 32-bit entry point by scanning
+    # PT_NOTE segments, so the note must be covered by one.
+    note PT_NOTE FLAGS(4);        # R__
+
     # Boot segments. Addresses are physical.
     bsp_boot PT_LOAD FLAGS(7);    # RWE
     ap_boot PT_LOAD FLAGS(7);     # RWE
@@ -55,6 +60,13 @@ SECTIONS
     .multiboot2_header      : AT(ADDR(.multiboot2_header) - KERNEL_VMA) {
         KEEP(*(.multiboot2_header))
     } : header
+    # The PVH ELF note advertises the 32-bit entry point (`__pvh_boot`). It is
+    # assigned to both `header` and `note`: the former keeps it in a PT_LOAD
+    # segment (so llvm-strip does not relocate it), the latter provides the
+    # PT_NOTE segment that PVH-capable VMMs scan.
+    .note.Xen               : AT(ADDR(.note.Xen) - KERNEL_VMA) {
+        KEEP(*(.note.Xen))
+    } : header : note
 
 # --------------------------------------------------------------------------- #
 # These are 2 boot sections that need specific physical addresses.            #

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -177,14 +177,14 @@ impl Bundle {
 
         // Checkout if the files on disk supports the boot method
         match config_action.boot.method {
-            BootMethod::QemuDirect => {
+            BootMethod::DirectElf => {
                 if self.manifest.aster_bin.is_none() {
-                    return Err("Kernel binary is required for direct QEMU booting".to_owned());
+                    return Err("Kernel ELF is required for direct ELF booting".to_owned());
                 };
 
                 // Validate the kernel binary type against the configured boot protocol.
                 // This prevents reusing an incompatible binary (e.g. ELF vs. `bzImage`) when
-                // switching boot methods (for example, from a Grub ISO to `qemu-direct`),
+                // switching boot methods (for example, from a Grub ISO to `direct-elf`),
                 // which would otherwise cause boot failures.
                 let aster_bin_type = self.manifest.aster_bin.as_ref().unwrap().typ();
                 let expects_linux = matches!(aster_bin_type, AsterBinType::BzImage(_));
@@ -266,7 +266,7 @@ impl Bundle {
         qemu_cmd.current_dir(&config.work_dir);
 
         match action.boot.method {
-            BootMethod::QemuDirect => {
+            BootMethod::DirectElf => {
                 let aster_bin = self.manifest.aster_bin.as_ref().unwrap();
                 qemu_cmd
                     .arg("-kernel")

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -93,7 +93,7 @@ pub fn make_stripped_boot_elf(
             .to_str()
             .unwrap()
             .to_string();
-        install_dir.as_ref().join(elf_name + ".qemu_elf")
+        install_dir.as_ref().join(elf_name + ".elf")
     };
 
     if strip {

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -184,7 +184,7 @@ pub fn do_cached_build(
             }
             bundle.consume_aster_bin(aster_elf);
         }
-        BootMethod::QemuDirect => {
+        BootMethod::DirectElf => {
             let aster_bin = match grub.boot_protocol {
                 BootProtocol::Linux => make_install_bzimage(
                     &osdk_output_directory,

--- a/osdk/src/commands/new/lib.OSDK.toml.template
+++ b/osdk/src/commands/new/lib.OSDK.toml.template
@@ -1,7 +1,7 @@
 project_type = "library"
 
 [boot]
-method = "qemu-direct"
+method = "direct-elf"
 
 [qemu]
 args = """\

--- a/osdk/src/config/scheme/boot.rs
+++ b/osdk/src/config/scheme/boot.rs
@@ -25,10 +25,10 @@ pub enum BootMethod {
     GrubRescueIso,
     /// Boot the kernel by making a Qcow2 image with Grub as the bootloader.
     GrubQcow2,
-    /// Use the [QEMU direct boot](https://qemu-project.gitlab.io/qemu/system/linuxboot.html)
-    /// to boot the kernel with QEMU's built-in Seabios and Coreboot utilities.
+    /// Build a direct-load ELF image for VMMs or loaders that support loading
+    /// an ELF kernel image without a GRUB boot device.
     #[default]
-    QemuDirect,
+    DirectElf,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -65,7 +65,7 @@ impl BootScheme {
         Boot {
             kcmdline,
             initramfs: self.initramfs,
-            method: self.method.unwrap_or(BootMethod::QemuDirect),
+            method: self.method.unwrap_or(BootMethod::DirectElf),
         }
     }
 }

--- a/osdk/src/config/test/OSDK.toml.full
+++ b/osdk/src/config/test/OSDK.toml.full
@@ -18,7 +18,7 @@ boot.init_args = ["sh", "-l"]
 boot.initramfs = "/tmp/osdk_test_file"
 
 [test]
-boot.method = "qemu-direct"
+boot.method = "direct-elf"
 
 [grub]
 boot_protocol = "multiboot2"

--- a/osdk/tools/docker/Dockerfile
+++ b/osdk/tools/docker/Dockerfile
@@ -253,6 +253,15 @@ ENV PATH="/usr/local/grub/bin:${PATH}"
 # Make a symbolic link for `unicode.pf2` from the APT package
 RUN ln -sf /usr/share/grub/unicode.pf2 /usr/local/grub/share/grub/unicode.pf2
 
+# Download and install Firecracker VMM
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        curl -L "https://github.com/firecracker-microvm/firecracker/releases/download/v1.16.1/firecracker-v1.16.1-x86_64.tgz" \
+            | tar -xz && \
+        mv -f release-v1.16.1-x86_64/firecracker-v1.16.1-x86_64 /usr/local/bin/firecracker && \
+        chmod +x /usr/local/bin/firecracker && \
+        rm -rf release-v1.16.1-x86_64; \
+    fi
+
 VOLUME [ "/root/asterinas" ]
 
 WORKDIR /root/asterinas

--- a/ostd/src/arch/x86/boot/bsp_boot.S
+++ b/ostd/src/arch/x86/boot/bsp_boot.S
@@ -26,6 +26,7 @@ ENTRYTYPE_MULTIBOOT     = 1
 ENTRYTYPE_MULTIBOOT2    = 2
 ENTRYTYPE_LINUX_32      = 3
 ENTRYTYPE_LINUX_64      = 4
+ENTRYTYPE_PVH           = 5
 
 MULTIBOOT_ENTRY_MAGIC   = 0x2BADB002
 MULTIBOOT2_ENTRY_MAGIC  = 0x36D76289
@@ -78,6 +79,29 @@ __linux64_boot:
     // Switch to our own temporary GDT.
     lgdt [boot_gdtr]
     retf
+
+// The PVH entry point.
+//
+// The PVH boot protocol hands off in 32-bit protected mode with paging
+// disabled, flat segments, and EBX holding the physical address of the
+// `hvm_start_info` structure. Unlike the entry points above, its address is
+// not fixed by the ABI: it is advertised to the VMM through the PVH ELF note
+// (see `pvh/note.S`), which refers to this symbol.
+.code32
+.global __pvh_boot
+__pvh_boot:
+    cli
+    cld
+
+    // Set the kernel call stack.
+    mov esp, offset boot_stack_top
+
+    push 0      // Upper 32-bits.
+    push ebx    // `hvm_start_info` ptr
+    push 0      // Upper 32-bits.
+    push ENTRYTYPE_PVH
+
+    jmp initial_boot_setup
 
 // The multiboot & multiboot2 entry point.
 .code32
@@ -349,12 +373,15 @@ long_mode:
     je entry_type_linux
     cmp rax, ENTRYTYPE_LINUX_64
     je entry_type_linux
+    cmp rax, ENTRYTYPE_PVH
+    je entry_type_pvh
     // Unreachable!
     jmp halt
 
 .extern __linux_boot
 .extern __multiboot_entry
 .extern __multiboot2_entry
+.extern __pvh_entry
 
 entry_type_linux:
     pop rdi // boot_params ptr
@@ -376,6 +403,13 @@ entry_type_multiboot2:
     pop rdi // multiboot magic
 
     lea  rax, [rip + __multiboot2_entry]  // jump into Rust code
+    call rax
+    jmp halt
+
+entry_type_pvh:
+    pop rdi // the address of `hvm_start_info`
+
+    lea  rax, [rip + __pvh_entry]  // jump into Rust code
     call rax
     jmp halt
 

--- a/ostd/src/arch/x86/boot/mod.rs
+++ b/ostd/src/arch/x86/boot/mod.rs
@@ -8,6 +8,7 @@
 //!  - Multiboot
 //!  - Multiboot2
 //!  - Linux x86 Boot Protocol
+//!  - PVH
 //!
 //! without any additional configurations.
 //!
@@ -21,6 +22,7 @@
 mod linux_boot;
 mod multiboot;
 mod multiboot2;
+mod pvh;
 
 pub(crate) mod smp;
 

--- a/ostd/src/arch/x86/boot/pvh/mod.rs
+++ b/ostd/src/arch/x86/boot/pvh/mod.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The PVH boot protocol supporting module.
+//!
+//! PVH is the direct boot protocol implemented by most modern virtual machine
+//! monitors (e.g., Cloud Hypervisor, Firecracker, QEMU). The VMM enters the
+//! kernel in 32-bit protected mode with paging disabled and passes the
+//! physical address of an [`HvmStartInfo`] structure in `EBX`. The entry point
+//! itself is advertised through the PVH ELF note (see `note.S`).
+//!
+//! Reference: <https://xenbits.xen.org/docs/unstable/misc/pvh.html>
+
+use core::arch::global_asm;
+
+use crate::{
+    boot::{
+        BootloaderAcpiArg,
+        memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
+    },
+    mm::{Paddr, kspace::paddr_to_vaddr},
+};
+
+global_asm!(include_str!("note.S"));
+
+/// The magic value of [`HvmStartInfo::magic`], which is "xEn3" in ASCII.
+const HVM_START_MAGIC_VALUE: u32 = 0x336e_c578;
+
+/// The start-of-day structure that a PVH-capable VMM passes to the guest.
+#[repr(C)]
+struct HvmStartInfo {
+    magic: u32,
+    version: u32,
+    flags: u32,
+    nr_modules: u32,
+    modlist_paddr: u64,
+    cmdline_paddr: u64,
+    rsdp_paddr: u64,
+    // The following fields are only present in version 1 and later.
+    memmap_paddr: u64,
+    memmap_entries: u32,
+    _reserved: u32,
+}
+
+/// An entry of the module list pointed to by [`HvmStartInfo::modlist_paddr`].
+#[repr(C)]
+struct HvmModlistEntry {
+    paddr: u64,
+    size: u64,
+    cmdline_paddr: u64,
+    _reserved: u64,
+}
+
+/// An entry of the memory map pointed to by [`HvmStartInfo::memmap_paddr`].
+#[repr(C)]
+struct HvmMemmapTableEntry {
+    addr: u64,
+    size: u64,
+    typ: u32,
+    _reserved: u32,
+}
+
+/// Converts a PVH memory map entry type, which mirrors the E820 types.
+fn parse_memory_region_type(typ: u32) -> MemoryRegionType {
+    match typ {
+        1 => MemoryRegionType::Usable,
+        2 => MemoryRegionType::Reserved,
+        3 => MemoryRegionType::Reclaimable,
+        4 => MemoryRegionType::NonVolatileSleep,
+        5 => MemoryRegionType::BadMemory,
+        // All other memory regions are reserved.
+        _ => MemoryRegionType::Reserved,
+    }
+}
+
+fn parse_kernel_commandline(start_info: &HvmStartInfo) -> Option<&'static str> {
+    if start_info.cmdline_paddr == 0 {
+        return None;
+    }
+
+    let cmdline_ptr = paddr_to_vaddr(start_info.cmdline_paddr as Paddr);
+    // SAFETY: The command line is a NUL-terminated string that is safe to read because of the
+    // contract with the VMM, and it lives for `'static`.
+    let cmdline = unsafe { core::ffi::CStr::from_ptr(cmdline_ptr as *const _) };
+
+    cmdline.to_str().ok()
+}
+
+fn parse_initramfs(start_info: &HvmStartInfo) -> Option<&'static [u8]> {
+    if start_info.nr_modules == 0 || start_info.modlist_paddr == 0 {
+        return None;
+    }
+
+    let modlist_ptr = paddr_to_vaddr(start_info.modlist_paddr as Paddr);
+    // SAFETY: The module list contains at least one entry (checked above) and is safe to read
+    // because of the contract with the VMM.
+    let module = unsafe { &*(modlist_ptr as *const HvmModlistEntry) };
+
+    if module.paddr == 0 || module.size == 0 {
+        return None;
+    }
+
+    let initramfs_ptr = paddr_to_vaddr(module.paddr as Paddr);
+    // SAFETY: The initramfs is safe to read because of the contract with the VMM.
+    let initramfs =
+        unsafe { core::slice::from_raw_parts(initramfs_ptr as *const u8, module.size as usize) };
+
+    Some(initramfs)
+}
+
+fn parse_acpi_arg(start_info: &HvmStartInfo) -> BootloaderAcpiArg {
+    if start_info.rsdp_paddr == 0 {
+        // The VMM did not provide the RSDP address, so fall back to scanning for it.
+        BootloaderAcpiArg::ScanBios
+    } else {
+        BootloaderAcpiArg::Rsdp(
+            start_info
+                .rsdp_paddr
+                .try_into()
+                .expect("RSDP address overflowed!"),
+        )
+    }
+}
+
+fn parse_memory_regions(start_info: &HvmStartInfo) -> MemoryRegionArray {
+    let mut regions = MemoryRegionArray::new();
+
+    // The memory map is only available in version 1 and later.
+    if start_info.version >= 1 && start_info.memmap_paddr != 0 {
+        let memmap_ptr = paddr_to_vaddr(start_info.memmap_paddr as Paddr);
+        // SAFETY: The memory map is safe to read because of the contract with the VMM.
+        let memmap = unsafe {
+            core::slice::from_raw_parts(
+                memmap_ptr as *const HvmMemmapTableEntry,
+                start_info.memmap_entries as usize,
+            )
+        };
+
+        for entry in memmap {
+            regions
+                .push(MemoryRegion::new(
+                    entry.addr.try_into().unwrap(),
+                    entry.size.try_into().unwrap(),
+                    parse_memory_region_type(entry.typ),
+                ))
+                .unwrap();
+        }
+    }
+
+    // Add the kernel region since the VMM does not specify it.
+    regions.push(MemoryRegion::kernel()).unwrap();
+
+    // Add the initramfs region.
+    if let Some(initramfs) = parse_initramfs(start_info) {
+        regions.push(MemoryRegion::module(initramfs)).unwrap();
+    }
+
+    // Add the AP boot code region that will be copied into by the BSP.
+    regions
+        .push(super::smp::reclaimable_memory_region())
+        .unwrap();
+
+    // Add the region of the kernel cmdline since the VMM does not specify it.
+    if let Some(kcmdline) = parse_kernel_commandline(start_info) {
+        regions
+            .push(MemoryRegion::module(kcmdline.as_bytes()))
+            .unwrap();
+    }
+
+    regions.into_non_overlapping()
+}
+
+/// The entry point of the Rust code portion of Asterinas (with PVH parameters).
+///
+/// # Safety
+///
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
+/// - If this function is called, entry points of other boot protocols must never be called.
+// SAFETY: The name does not collide with other symbols.
+#[unsafe(no_mangle)]
+unsafe extern "sysv64" fn __pvh_entry(start_info_ptr: *const HvmStartInfo) -> ! {
+    // SAFETY: We get the start-of-day structure from the VMM, so by contract the pointer is valid
+    // and the underlying memory is initialized.
+    let start_info = unsafe { &*start_info_ptr };
+    assert_eq!({ start_info.magic }, HVM_START_MAGIC_VALUE);
+
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
+
+    EARLY_INFO.call_once(|| EarlyBootInfo {
+        bootloader_name: "PVH-capable VMM",
+        kernel_cmdline: parse_kernel_commandline(start_info).unwrap_or(""),
+        initramfs: parse_initramfs(start_info),
+        acpi_arg: parse_acpi_arg(start_info),
+        framebuffer_arg: None,
+        memory_regions: parse_memory_regions(start_info),
+    });
+
+    // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
+    // once after setting up necessary resources.
+    unsafe { start_kernel() };
+}

--- a/ostd/src/arch/x86/boot/pvh/note.S
+++ b/ostd/src/arch/x86/boot/pvh/note.S
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+// The PVH ELF note.
+//
+// VMMs that implement the PVH boot protocol (e.g., Cloud Hypervisor,
+// Firecracker, QEMU) discover the kernel's 32-bit entry point by scanning the
+// PT_NOTE segments of the ELF image for a note named "Xen" with the type
+// `XEN_ELFNOTE_PHYS32_ENTRY`. The descriptor holds the physical address to
+// jump to.
+//
+// Reference: https://xenbits.xen.org/docs/unstable/misc/pvh.html
+
+XEN_ELFNOTE_PHYS32_ENTRY = 18
+
+.section ".note.Xen", "a", @note
+.align 4
+
+    .long name_end - name_start     // namesz
+    .long desc_end - desc_start     // descsz
+    .long XEN_ELFNOTE_PHYS32_ENTRY  // type
+
+name_start:
+    .asciz "Xen"
+name_end:
+    .align 4
+
+.extern __pvh_boot
+desc_start:
+    // `__pvh_boot` lives in the `.bsp_boot` section, which is linked at its
+    // physical load address, so the symbol value is already the physical
+    // address that the VMM must jump to.
+    .long __pvh_boot
+desc_end:
+    .align 4

--- a/ostd/src/arch/x86/irq/chip/mod.rs
+++ b/ostd/src/arch/x86/irq/chip/mod.rs
@@ -4,10 +4,13 @@ use alloc::{boxed::Box, vec::Vec};
 use core::{
     fmt,
     ops::{Deref, DerefMut},
+    pin::Pin,
 };
 
+use acpi::madt::{Madt, MadtEntry};
 use ioapic::IoApic;
 use spin::Once;
+use x86_64::instructions::port::{PortGeneric, ReadOnlyAccess, WriteOnlyAccess};
 
 use crate::{
     Error, Result, arch::kernel::acpi::get_acpi_tables, info, io::IoMemAllocatorBuilder,
@@ -160,9 +163,53 @@ impl Drop for MappedIrqLine {
 /// The [`IrqChip`] singleton.
 pub static IRQ_CHIP: Once<IrqChip> = Once::new();
 
-pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
-    use acpi::madt::{Madt, MadtEntry};
+fn should_init_and_disable_pic(madt_table: Pin<&Madt>) -> bool {
+    // "A one indicates that the system also has a PC-AT-compatible dual-8259 setup. The 8259
+    // vectors must be disabled (that is, masked) when enabling the ACPI APIC operation."
+    const PCAT_COMPAT: u32 = 1;
+    if madt_table.flags & PCAT_COMPAT != 0 {
+        return true;
+    }
 
+    is_legacy_pic_present()
+}
+
+/// Detects whether a legacy 8259A PIC is present via I/O port probing.
+///
+/// If the I/O ports return the written mask value, we assume the PIC is present.
+/// This serves as a fallback when MADT does not declare `PCAT_COMPAT` but the hardware
+/// (e.g., in some Hypervisors like Firecracker) still emulates it.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/x86/kernel/i8259.c#L306>
+fn is_legacy_pic_present() -> bool {
+    // Mask all except cascade (IRQ 2) on master IMR.
+    const PROBE_VAL: u8 = 0xFB;
+
+    unsafe {
+        // SAFETY: We are in early boot and writing to the legacy PIC ports (0x21, 0xA1) is safe
+        // as long as we verify they respond correctly.
+
+        // Mask slave PIC first to avoid interrupts during probe
+        let mut slave_port = PortGeneric::<u8, WriteOnlyAccess>::new(0xA1);
+        slave_port.write(0xFF);
+
+        // Mask master PIC except cascade (IRQ 2)
+        let mut master_write_port = PortGeneric::<u8, WriteOnlyAccess>::new(0x21);
+        master_write_port.write(PROBE_VAL);
+
+        // Read back from master PIC. If the port exists, it returns what we wrote.
+        // If it's a memory hole (no PIC), it usually returns 0xFF or 0x00.
+        let mut master_read_port = PortGeneric::<u8, ReadOnlyAccess>::new(0x21);
+        let read_val = master_read_port.read();
+
+        if read_val == PROBE_VAL {
+            return true;
+        }
+    }
+    false
+}
+
+pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
     // If there are no ACPI tables, or the ACPI tables do not provide us with information about
     // the I/O APIC, we may need to find another way to determine the I/O APIC address
     // correctly and reliably (e.g., by parsing the MultiProcessor Specification, which has
@@ -170,10 +217,7 @@ pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
     let acpi_tables = get_acpi_tables().unwrap();
     let madt_table = acpi_tables.find_table::<Madt>().unwrap();
 
-    // "A one indicates that the system also has a PC-AT-compatible dual-8259 setup. The 8259
-    // vectors must be disabled (that is, masked) when enabling the ACPI APIC operation"
-    const PCAT_COMPAT: u32 = 1;
-    if madt_table.get().flags & PCAT_COMPAT != 0 {
+    if should_init_and_disable_pic(madt_table.get()) {
         pic::init_and_disable();
     }
 

--- a/ostd/src/arch/x86/kernel/kvm_clock.rs
+++ b/ostd/src/arch/x86/kernel/kvm_clock.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::sync::atomic::{Ordering, compiler_fence};
+
+use spin::Once;
+use x86::msr;
+
+use crate::mm::{Frame, FrameAllocOptions, HasPaddr, paddr_to_vaddr};
+
+// KVM CPUID leaves, signature, feature bits, and MSR values.
+// Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/x86/include/uapi/asm/kvm_para.h>.
+const KVM_CPUID_SIGNATURE: u32 = 0x4000_0000;
+const KVM_CPUID_FEATURES: u32 = 0x4000_0001;
+const KVM_SIGNATURE: &[u8; 12] = b"KVMKVMKVM\0\0\0";
+const KVM_FEATURE_CLOCKSOURCE2: u32 = 3;
+const MSR_KVM_SYSTEM_TIME_NEW: u32 = 0x4b56_4d01;
+const KVM_MSR_ENABLED: u64 = 1;
+
+static PVCLOCK_FRAME: Once<Option<Frame<()>>> = Once::new();
+
+#[repr(C, align(4))]
+struct PvclockVcpuTimeInfo {
+    version: u32,
+    _pad0: u32,
+    _tsc_timestamp: u64,
+    _system_time: u64,
+    tsc_to_system_mul: u32,
+    tsc_shift: i8,
+    _flags: u8,
+    _pad: [u8; 2],
+}
+
+struct PvclockTimeSnapshot {
+    tsc_to_system_mul: u32,
+    tsc_shift: i8,
+}
+
+/// Determines the TSC frequency from KVM's paravirtual clock.
+pub(super) fn determine_tsc_freq() -> Option<u64> {
+    if !has_kvm_clocksource2() {
+        return None;
+    }
+
+    let pvclock_info = enable_system_time_msr()?;
+    let time_info = read_stable_time_info(pvclock_info)?;
+    freq_from_time_info(&time_info)
+}
+
+fn has_kvm_clocksource2() -> bool {
+    let Some(signature_leaf) = crate::arch::cpu::cpuid::cpuid(KVM_CPUID_SIGNATURE, 0) else {
+        return false;
+    };
+
+    let mut signature = [0u8; 12];
+    signature[0..4].copy_from_slice(&signature_leaf.ebx.to_le_bytes());
+    signature[4..8].copy_from_slice(&signature_leaf.ecx.to_le_bytes());
+    signature[8..12].copy_from_slice(&signature_leaf.edx.to_le_bytes());
+    if &signature != KVM_SIGNATURE {
+        return false;
+    }
+
+    let Some(features) = crate::arch::cpu::cpuid::cpuid(KVM_CPUID_FEATURES, 0) else {
+        return false;
+    };
+    features.eax & (1 << KVM_FEATURE_CLOCKSOURCE2) != 0
+}
+
+fn enable_system_time_msr() -> Option<*const PvclockVcpuTimeInfo> {
+    let frame = PVCLOCK_FRAME.call_once(|| FrameAllocOptions::new().alloc_frame().ok());
+    let frame = frame.as_ref()?;
+    let paddr = frame.paddr();
+
+    // SAFETY: `paddr` is the physical address of a live, zeroed page retained by
+    // `PVCLOCK_FRAME`. KVM owns updates to the `PvclockVcpuTimeInfo` fields after
+    // this MSR is enabled.
+    unsafe {
+        msr::wrmsr(MSR_KVM_SYSTEM_TIME_NEW, paddr as u64 | KVM_MSR_ENABLED);
+        Some(paddr_to_vaddr(paddr) as *const PvclockVcpuTimeInfo)
+    }
+}
+
+fn read_stable_time_info(pvclock_info: *const PvclockVcpuTimeInfo) -> Option<PvclockTimeSnapshot> {
+    const MAX_RETRIES: usize = 1_000_000;
+
+    for _ in 0..MAX_RETRIES {
+        // KVM marks an in-progress pvclock update with an odd `version`.
+        // Accept fields only when `version` is even and unchanged across the read.
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/Documentation/virt/kvm/x86/msr.rst#L87-L90>.
+        let version_before = volatile_read_version(pvclock_info);
+        if version_before & 1 != 0 {
+            core::hint::spin_loop();
+            continue;
+        }
+
+        compiler_fence(Ordering::Acquire);
+        let tsc_to_system_mul = volatile_read_tsc_to_system_mul(pvclock_info);
+        let tsc_shift = volatile_read_tsc_shift(pvclock_info);
+        compiler_fence(Ordering::Acquire);
+
+        let version_after = volatile_read_version(pvclock_info);
+        if version_before == version_after && tsc_to_system_mul != 0 {
+            return Some(PvclockTimeSnapshot {
+                tsc_to_system_mul,
+                tsc_shift,
+            });
+        }
+
+        core::hint::spin_loop();
+    }
+
+    None
+}
+
+fn volatile_read_version(pvclock_info: *const PvclockVcpuTimeInfo) -> u32 {
+    // SAFETY: `pvclock_info` points to a live KVM pvclock page.
+    unsafe { core::ptr::addr_of!((*pvclock_info).version).read_volatile() }
+}
+
+fn volatile_read_tsc_to_system_mul(pvclock_info: *const PvclockVcpuTimeInfo) -> u32 {
+    // SAFETY: `pvclock_info` points to a live KVM pvclock page.
+    unsafe { core::ptr::addr_of!((*pvclock_info).tsc_to_system_mul).read_volatile() }
+}
+
+fn volatile_read_tsc_shift(pvclock_info: *const PvclockVcpuTimeInfo) -> i8 {
+    // SAFETY: `pvclock_info` points to a live KVM pvclock page.
+    unsafe { core::ptr::addr_of!((*pvclock_info).tsc_shift).read_volatile() }
+}
+
+fn freq_from_time_info(time_info: &PvclockTimeSnapshot) -> Option<u64> {
+    let mut numerator = 1_000_000_000u128.checked_shl(32)?;
+    let mut denominator = time_info.tsc_to_system_mul as u128;
+
+    let shift = i32::from(time_info.tsc_shift);
+    // Reverse KVM's TSC-to-ns formula. A positive shift scales the multiplier,
+    // while a negative shift scales the input cycles before multiplication.
+    // Reference: <https://elixir.bootlin.com/linux/v7.0/source/Documentation/virt/kvm/x86/msr.rst#L106-L117>.
+    if shift >= 0 {
+        denominator = denominator.checked_shl(shift as u32)?;
+    } else {
+        numerator = numerator.checked_shl((-shift) as u32)?;
+    }
+
+    let freq = numerator.checked_div(denominator)?;
+    u64::try_from(freq).ok().filter(|freq| *freq != 0)
+}

--- a/ostd/src/arch/x86/kernel/mod.rs
+++ b/ostd/src/arch/x86/kernel/mod.rs
@@ -7,6 +7,7 @@
 
 pub(super) mod acpi;
 pub(super) mod apic;
+pub(super) mod kvm_clock;
 pub(super) mod tsc;
 
 pub use acpi::{ACPI_INFO, AcpiInfo};

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -16,9 +16,12 @@ use crate::{
 pub(in crate::arch) static TSC_FREQ: AtomicU64 = AtomicU64::new(0);
 
 pub fn init_tsc_freq() {
+    use super::kvm_clock::determine_tsc_freq as determine_tsc_freq_via_kvmclock;
     use crate::arch::cpu::cpuid::query_tsc_freq as determine_tsc_freq_via_cpuid;
 
-    let tsc_freq = determine_tsc_freq_via_cpuid().unwrap_or_else(determine_tsc_freq_via_pit);
+    let tsc_freq = determine_tsc_freq_via_kvmclock()
+        .or_else(determine_tsc_freq_via_cpuid)
+        .unwrap_or_else(determine_tsc_freq_via_pit);
     TSC_FREQ.store(tsc_freq, Ordering::Relaxed);
     info!("TSC frequency: {:?} Hz", tsc_freq);
 }

--- a/tools/firecracker_args.sh
+++ b/tools/firecracker_args.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# This script generates Firecracker command-line arguments.
+# Usage: `firecracker_args.sh [scheme]`
+#  - scheme: "boot" (default) — boot test with a minimal initrd.
+# Other arguments are configured via environmental variables:
+#  - KERNEL_PATH: path to the kernel ELF binary;
+#  - INITRD_PATH: path to the initramfs cpio archive;
+#  - BOOT_ARGS: kernel command line arguments;
+#  - VCPU: number of vCPUs (default: 2);
+#  - MEM: memory size in MiB (default: 1024);
+#  - FC_CONFIG_FILE: path to the generated Firecracker VM config JSON.
+#    Defaults to /tmp/fc-vm.json.
+
+SCHEME=${1:-"boot"}
+
+KERNEL_PATH=${KERNEL_PATH:-"./target/osdk/aster-kernel/aster-kernel-osdk-bin.elf"}
+INITRD_PATH=${INITRD_PATH:-"./test/initramfs/build/initramfs.cpio.gz"}
+BOOT_ARGS=${BOOT_ARGS:-"console=ttyS0 earlycon loglevel=error init=/bin/echo Entered userspace"}
+VCPU=${VCPU:-2}
+MEM=${MEM:-1024}
+FC_CONFIG_FILE=${FC_CONFIG_FILE:-/tmp/fc-vm.json}
+
+# Generate the VM configuration JSON as a side effect.
+cat > "$FC_CONFIG_FILE" << EOF
+{
+  "boot-source": {
+    "kernel_image_path": "$KERNEL_PATH",
+    "initrd_path": "$INITRD_PATH",
+    "boot_args": "$BOOT_ARGS"
+  },
+  "drives": [],
+  "machine-config": {
+    "vcpu_count": $VCPU,
+    "mem_size_mib": $MEM
+  }
+}
+EOF
+
+# Output Firecracker CLI arguments.
+FC_ARGS="--no-api --config-file $FC_CONFIG_FILE"
+
+echo $FC_ARGS

--- a/tools/firecracker_args.sh
+++ b/tools/firecracker_args.sh
@@ -23,6 +23,20 @@ VCPU=${VCPU:-2}
 MEM=${MEM:-1024}
 FC_CONFIG_FILE=${FC_CONFIG_FILE:-/tmp/fc-vm.json}
 
+do_install_fc()
+{
+    TARGETARCH=amd64
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+        curl -L "https://github.com/firecracker-microvm/firecracker/releases/download/v1.16.1/firecracker-v1.16.1-x86_64.tgz" \
+        | tar -xz && \
+        mv -f release-v1.16.1-x86_64/firecracker-v1.16.1-x86_64 /usr/local/bin/firecracker && \
+        chmod +x /usr/local/bin/firecracker && \
+        rm -rf release-v1.16.1-x86_64; \
+    fi
+}
+
+do_install_fc >/dev/null 2>&1
+
 # Generate the VM configuration JSON as a side effect.
 cat > "$FC_CONFIG_FILE" << EOF
 {

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -7,7 +7,7 @@
 #  - scheme: "normal", "test", "microvm" or "iommu";
 # Other arguments are configured via environmental variables:
 #  - OVMF: "on" or "off";
-#  - BOOT_METHOD: "qemu-direct", "grub-rescue-iso" or "grub-qcow2";
+#  - BOOT_METHOD: "direct-elf", "grub-rescue-iso" or "grub-qcow2";
 #  - BOOT_PROTOCOL: "multiboot", "multiboot2", "linux-legacy32", "linux-efi-pe64" or "linux-efi-handover64";
 #  - NETDEV: "user" or "tap";
 #  - VHOST: "off" or "on";
@@ -245,9 +245,9 @@ if [ "$VSOCK" = "on" ]; then
     fi
 fi
 
-# When using qemu-direct boot, OVMF depends on the boot protocol:
+# When using direct ELF boot, OVMF depends on the boot protocol:
 # linux-efi-* protocols require OVMF; other protocols (e.g. multiboot) do not.
-if [ "$BOOT_METHOD" = "qemu-direct" ]; then
+if [ "$BOOT_METHOD" = "direct-elf" ]; then
     if [ "$BOOT_PROTOCOL" = "linux-efi-pe64" ] || [ "$BOOT_PROTOCOL" = "linux-efi-handover64" ]; then
         OVMF="on"
     else


### PR DESCRIPTION
This PR adds the Firecracker VMM to the Dockerfile to support subsequent Firecracker CI tests. It is part of #3429.