### PR TITLE
Fix Python regression tests failing on read-only `/nix/store`

### DIFF
--- a/test/nixos/tests/development-tools-python/src/main.rs
+++ b/test/nixos/tests/development-tools-python/src/main.rs
@@ -16,7 +16,19 @@ fn python3_regrtest(nixos_shell: &mut Session) -> Result<(), Error> {
     nixos_shell.run_cmd("mkdir /tmp/python3-src")?;
     nixos_shell
         .run_cmd("tar xf /tmp/python3-src.tar.xz --strip-components=1 -C /tmp/python3-src")?;
-    nixos_shell.run_cmd("export PYTHONPATH=/tmp/python3-src/Lib")?;
+
+    // On NixOS, the Python interpreter's stdlib lives on the read-only `/nix/store`
+    // bind mount. Some `test.support` helpers `unlink()` `.pyc` files across every
+    // `sys.path` entry, which fails with `EROFS` there. The stdlib `sys.path`
+    // entries are derived from `sys.prefix`, so copying that prefix onto writable
+    // tmpfs moves them off the read-only mount.
+    nixos_shell.run_cmd("mkdir -p /tmp/pyhome")?;
+    nixos_shell.run_cmd("export PREFIX=$(python3 -c 'import sys; print(sys.prefix)')")?;
+    nixos_shell.run_cmd("cp -dR --preserve=mode $PREFIX/lib /tmp/pyhome/lib")?;
+    nixos_shell.run_cmd("cp -dR --preserve=mode $PREFIX/include /tmp/pyhome/include")?;
+    nixos_shell.run_cmd("rm -rf /tmp/pyhome/lib/python3.12/test")?;
+    nixos_shell.run_cmd("cp -a /tmp/python3-src/Lib/test /tmp/pyhome/lib/python3.12")?;
+    nixos_shell.run_cmd("export PYTHONHOME=/tmp/pyhome")?;
 
     // Printed once by regrtest at the end of every run as `Result: {state}`:
     //   https://github.com/python/cpython/blob/v3.12.12/Lib/test/libregrtest/main.py#L455-L456

--- a/test/nixos/tests/development-tools-python/src/main.rs
+++ b/test/nixos/tests/development-tools-python/src/main.rs
@@ -13,10 +13,26 @@ nixos_test_main!();
 
 #[nixos_test]
 fn python3_regrtest(nixos_shell: &mut Session) -> Result<(), Error> {
-    nixos_shell.run_cmd("mkdir /tmp/python3-src")?;
+    nixos_shell.run_cmd("py_src=/tmp/python3-src")?;
+    nixos_shell.run_cmd("mkdir -p $py_src")?;
+    nixos_shell.run_cmd("tar xf /tmp/python3-src.tar.xz --strip-components=1 -C $py_src")?;
+
+    // On NixOS, the Python interpreter's stdlib lives on the read-only `/nix/store`
+    // bind mount. Some `test.support` helpers `unlink()` `.pyc` files across every
+    // `sys.path` entry, which fails with `EROFS` there. The stdlib `sys.path`
+    // entries are derived from `sys.prefix`, so a writable copy of that prefix
+    // moves them off the read-only mount.
+    nixos_shell.run_cmd("pyhome=/tmp/pyhome")?;
     nixos_shell
-        .run_cmd("tar xf /tmp/python3-src.tar.xz --strip-components=1 -C /tmp/python3-src")?;
-    nixos_shell.run_cmd("export PYTHONPATH=/tmp/python3-src/Lib")?;
+        .run_cmd("cp -dR --preserve=mode $(python3 -c 'import sys; print(sys.prefix)') $pyhome")?;
+    // The packaged interpreter does not ship a usable test package, so overlay
+    // the one from the matching source tarball extracted above.
+    nixos_shell.run_cmd(
+        "py_testdir=$pyhome/lib/python$(python3 -c 'import sys; print(\"%d.%d\" % sys.version_info[:2])')",
+    )?;
+    nixos_shell.run_cmd("rm -rf $py_testdir/test")?;
+    nixos_shell.run_cmd("cp -a $py_src/Lib/test $py_testdir/")?;
+    nixos_shell.run_cmd("cp -a $py_src/Tools $pyhome/lib/Tools")?;
 
     // Printed once by regrtest at the end of every run as `Result: {state}`:
     //   https://github.com/python/cpython/blob/v3.12.12/Lib/test/libregrtest/main.py#L455-L456
@@ -34,7 +50,7 @@ fn python3_regrtest(nixos_shell: &mut Session) -> Result<(), Error> {
         .map(str::trim)
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
     {
-        let cmd = format!("python3 -m test -u all {testcase}");
+        let cmd = format!("$pyhome/bin/python3 -m test -u all {testcase}");
         if let Err(err) = nixos_shell.run_cmd_and_expect(&cmd, RESULT_SUCCESS) {
             failed_tests.push((testcase.to_string(), err));
         }


### PR DESCRIPTION
PR #3153 added a read-only check to the VFS: directory-modifying operations (`unlink`, `rmdir`, `rename`, ...) now verify that the target sits on a writable mount/filesystem *before* touching it, returning `EROFS` otherwise.

That check is correct and matches Linux: `do_unlinkat` calls `mnt_want_write` (the `EROFS` gate) *before* looking up the target, so on a read-only mount an `unlink()` returns `EROFS` regardless of whether the file exists.

### Problem

Once that check landed, a batch of Python regression tests started failing, e.g.:

```
test test_doctest failed -- Traceback (most recent call last):
  ...
  File ".../test/support/import_helper.py", line 48, in forget
    unlink(source + 'c')
OSError: [Errno 30] Read-only file system:
  '/nix/store/...-python3-3.12.10/lib/python3.12/doctest_empty_pkg.pyc'
```

Two facts combine to trigger this:

1. On NixOS, `/nix/store` is presented to processes as a **read-only bind mount** (`mount -o remount,ro,bind`) to enforce store immutability. The nix-installed interpreter's standard library therefore lives on a read-only mount.
2. Several `test.support` helpers (e.g. `import_helper.forget()`) walk **every** `sys.path` entry and `unlink()` candidate `.pyc` files in each, whether or not they exist. The helpers only swallow `ENOENT`/`ENOTDIR`; the read-only store's `EROFS` propagates as an `OSError` and fails the test.

This is not a kernel bug — a real Linux NixOS host behaves the same way. The tests pass in upstream CI because CPython runs its suite from a **writable build tree**, so no `sys.path` entry sits on a read-only mount. Our harness instead runs the nix-installed interpreter, whose stdlib is on the read-only store.

### Fix

Reconstruct a fully writable, self-contained install prefix on tmpfs and point `PYTHONHOME` at it, so `sys.prefix` — and thus the stdlib `sys.path` entries derived from them — resolve to writable tmpfs and no `sys.path` entry sits on a read-only mount:

- Copy the store's `lib` (pure-Python modules, the compiled `lib-dynload` extensions, and `config-*/Makefile`) and `include` (`pyconfig.h`) into the prefix.
- Overlay the `test` package from the extracted source tree (the store's stdlib omits it).
- Point `PYTHONHOME` at the copy.

While reconstructing the prefix, a few related failures surfaced and are handled by the same change:

- **`cp` drops timestamps.** Nix normalizes store mtimes to 1970; the ZIP format (exercised by `test_zipfile`) rejects timestamps before 1980. Copying without preserving timestamps gives the files the current time. (This test was previously *skipped* because the stdlib was read-only; making it writable runs it for real.)
- **`PYTHONPATH` is left unset.** With `PYTHONHOME` set, `test.support.interpreter_requires_environment()` returns true, which stops the helpers from re-launching sub-interpreters with `-E`; a stray `PYTHONPATH` would then leak into those children and break `test_cmd_line`'s `test_empty_PYTHONPATH_issue16309`.
- **`include` is copied too**, so `test_sysconfig`'s `get_config_h_filename()` check for `pyconfig.h` finds it under the relocated prefix.
