### PR TITLE
Flush kvirt mappings before recycling the range and frames

### DIFF
--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -2,18 +2,23 @@
 
 //! Kernel virtual memory allocation
 
+use alloc::sync::Arc;
 use core::ops::Range;
 
 use self::allocator::kvirt_area_allocator;
 use super::{KERNEL_PAGE_TABLE, KernelPtConfig, MappedItem};
 use crate::{
+    cpu::{AtomicCpuSet, CpuSet},
     irq,
     mm::{
         HasSize, PAGE_SIZE, Paddr, Split, Vaddr,
         frame::{Frame, meta::AnyFrameMeta},
         page_prop::PageProperty,
-        page_table::largest_pages,
+        page_table::{PageTableFrag, largest_pages},
+        tlb::{TlbFlushOp, TlbFlusher},
     },
+    sync::RcuDrop,
+    task::disable_preempt,
 };
 
 mod allocator {
@@ -35,6 +40,22 @@ mod allocator {
     /// disabled. This requires extra care.
     pub(super) fn kvirt_area_allocator(_guard: &DisabledLocalIrqGuard) -> &RangeAllocator {
         &KVIRT_AREA_ALLOCATOR
+    }
+}
+
+/// Frees a kvirt range on drop; a flusher holds it until the flush completes.
+struct KVirtRangeReclaim(Range<Vaddr>);
+
+impl KVirtRangeReclaim {
+    fn new(range: Range<Vaddr>) -> Arc<Self> {
+        Arc::new(Self(range))
+    }
+}
+
+impl Drop for KVirtRangeReclaim {
+    fn drop(&mut self) {
+        let guard = irq::disable_local();
+        kvirt_area_allocator(&guard).free(self.0.clone());
     }
 }
 
@@ -202,21 +223,51 @@ impl KVirtArea {
 impl Drop for KVirtArea {
     fn drop(&mut self) {
         let irq_guard = irq::disable_local();
-
-        // 1. Unmap all mapped pages.
-        let page_table = KERNEL_PAGE_TABLE.get().unwrap();
         let range = self.start()..self.end();
-        let mut cursor = page_table.cursor_mut(&irq_guard, &range).unwrap();
-        loop {
-            // SAFETY: The range is under `KVirtArea` so it is safe to unmap.
-            // FIXME: Need to ensure that the unmapped item outlives the TLB entries.
-            let Some(frag) = (unsafe { cursor.take_next(self.end() - cursor.virt_addr()) }) else {
-                break;
-            };
-            drop(frag);
+
+        // The kernel page table is shared, so any CPU may hold stale entries.
+        let target_cpus = AtomicCpuSet::new(CpuSet::new_full());
+        let mut flusher = TlbFlusher::new(&target_cpus, disable_preempt());
+
+        // 1. Unmap all pages, keeping the items alive until the flush completes.
+        let page_table = KERNEL_PAGE_TABLE.get().unwrap();
+        {
+            let mut cursor = page_table.cursor_mut(&irq_guard, &range).unwrap();
+            loop {
+                // SAFETY: The range is under `KVirtArea` so it is safe to unmap.
+                let Some(frag) = (unsafe { cursor.take_next(self.end() - cursor.virt_addr()) })
+                else {
+                    break;
+                };
+                match frag {
+                    PageTableFrag::Mapped { va, item } => {
+                        // SAFETY: The item is kept alive until the flush completes.
+                        let (item, panic_guard) = unsafe { RcuDrop::into_inner(item) };
+                        match item {
+                            MappedItem::Tracked(frame, _) => {
+                                let rcu_frame = RcuDrop::new(frame);
+                                panic_guard.forget();
+                                flusher.issue_tlb_flush_with(TlbFlushOp::for_single(va), rcu_frame);
+                            }
+                            MappedItem::Untracked(..) => {
+                                panic_guard.forget();
+                                flusher.issue_tlb_flush(TlbFlushOp::for_single(va));
+                            }
+                        }
+                    }
+                    PageTableFrag::StrayPageTable { pt, va, len, .. } => {
+                        flusher.issue_tlb_flush_with(
+                            TlbFlushOp::for_range(va..va + len),
+                            Frame::rcu_from_unsized(pt),
+                        );
+                    }
+                }
+            }
         }
 
-        // 2. Free the virtual block.
-        kvirt_area_allocator(&irq_guard).free(range);
+        // 2. Free the range once the flush completes.
+        let keep = KVirtRangeReclaim::new(range.start..range.end);
+        flusher.issue_tlb_flush_with_resource(TlbFlushOp::for_range(range), keep);
+        flusher.dispatch_tlb_flush();
     }
 }

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -2,7 +2,7 @@
 
 //! TLB flush operations.
 
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 use core::{
     mem::MaybeUninit,
     ops::Range,
@@ -76,6 +76,14 @@ impl<'a, G: PinCurrentCpu> TlbFlusher<'a, G> {
         drop_after_flush: RcuDrop<Frame<dyn AnyFrameMeta>>,
     ) {
         self.ops_stack.push(op, Some(drop_after_flush));
+    }
+
+    /// Issues a flush that keeps `keep` alive until it completes.
+    ///
+    /// Like [`Self::issue_tlb_flush_with`], but for an arbitrary resource
+    /// (e.g. a freed virtual address range) instead of a frame.
+    pub fn issue_tlb_flush_with_resource(&mut self, op: TlbFlushOp, keep: Arc<dyn Send + Sync>) {
+        self.ops_stack.push_resource(op, keep);
     }
 
     /// Dispatches all the pending TLB flush requests.
@@ -309,6 +317,8 @@ struct OpsStack {
     /// The elements cannot be modified after being pushed. And they must be
     /// dropped after the RCU grace period and the TLB flushes.
     frame_keeper: Vec<Frame<dyn AnyFrameMeta>>,
+    /// Like `frame_keeper`, but for arbitrary resources.
+    resource_keeper: Vec<Arc<dyn Send + Sync>>,
 }
 
 impl OpsStack {
@@ -318,6 +328,7 @@ impl OpsStack {
             num_ops: 0,
             num_pages_to_flush: 0,
             frame_keeper: Vec::new(),
+            resource_keeper: Vec::new(),
         }
     }
 
@@ -337,7 +348,15 @@ impl OpsStack {
             self.frame_keeper.push(frame);
             panic_guard.forget();
         }
+        self.account_op(op);
+    }
 
+    fn push_resource(&mut self, op: TlbFlushOp, keep: Arc<dyn Send + Sync>) {
+        self.resource_keeper.push(keep);
+        self.account_op(op);
+    }
+
+    fn account_op(&mut self, op: TlbFlushOp) {
         if self.need_flush_all() {
             return;
         }
@@ -357,6 +376,8 @@ impl OpsStack {
 
     fn push_from(&mut self, other: &OpsStack) {
         self.frame_keeper.extend(other.frame_keeper.iter().cloned());
+        self.resource_keeper
+            .extend(other.resource_keeper.iter().cloned());
 
         if self.need_flush_all() {
             return;
@@ -395,6 +416,9 @@ impl OpsStack {
         if !self.frame_keeper.is_empty() {
             let _ = RcuDrop::new(core::mem::take(&mut self.frame_keeper));
         }
+        if !self.resource_keeper.is_empty() {
+            let _ = RcuDrop::new(core::mem::take(&mut self.resource_keeper));
+        }
     }
 
     fn ops_iter(&self) -> impl Iterator<Item = &TlbFlushOp> {
@@ -409,6 +433,9 @@ impl Drop for OpsStack {
     fn drop(&mut self) {
         if !self.frame_keeper.is_empty() {
             let _ = RcuDrop::new(core::mem::take(&mut self.frame_keeper));
+        }
+        if !self.resource_keeper.is_empty() {
+            let _ = RcuDrop::new(core::mem::take(&mut self.resource_keeper));
         }
     }
 }


### PR DESCRIPTION
> Draft: the change compiles and boots cleanly on SMP; broader stress testing is in progress.

## Problem

`KVirtArea::drop` frees the virtual range and drops the unmapped frames without flushing the TLB, so a stale entry on another CPU can alias memory once the range or a frame is recycled. This is the existing `FIXME` in `KVirtArea::drop` ("Need to ensure that the unmapped item outlives the TLB entries").

## Fix

Unmap through a full-CPU `TlbFlusher` and keep both the frames and the virtual range alive until the flush completes:

- Frames use the existing frame keeper (`issue_tlb_flush_with`), the same way `vm_space` already unmaps.
- The range uses a new `TlbFlusher::issue_tlb_flush_with_resource`, which holds an `Arc<dyn Send + Sync>` in the flusher until the flush completes, then drops it, returning the range to the allocator.

The deferred free is structural: the range cannot return to the allocator until the keeper drops it, which only happens after every CPU has flushed (hardware broadcast on aarch64, IPI shootdown on x86). There is no synchronous wait, so it is safe under the IRQ-disabled `Drop`.

## Testing

- `cargo check -p ostd` clean on `x86_64-unknown-none`.
- Boots cleanly under QEMU at `SMP=4` (multiboot2, TCG), no panic/fault, exercising the remote-shootdown path across CPUs.
- Broader regression/stress testing in progress.

## Review notes

- `KVirtRangeReclaim::drop` returns the range to the kvirt allocator from the flush-completion (RCU-deferred) context, the same discipline the frame keeper already relies on; worth confirming the allocator lock is safe there.
