### PR TITLE
Support `ip addr` on Asterinas NixOS and some netlink cleanup

### DIFF
--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -19,7 +19,7 @@ use ostd::sync::{SpinLock, SpinLockGuard};
 use smoltcp::{
     iface::{Context, packet::Packet},
     phy::Device,
-    wire::{IpAddress, IpEndpoint, Ipv4Address, Ipv4Packet, Ipv6Address, Ipv6Packet},
+    wire::{IpAddress, IpEndpoint, Ipv4Cidr, Ipv4Packet, Ipv6Address, Ipv6Cidr, Ipv6Packet},
 };
 
 use super::{
@@ -118,16 +118,12 @@ impl<E: Ext> IfaceCommon<E> {
         self.flags
     }
 
-    pub(super) fn ipv4_addr(&self) -> Option<Ipv4Address> {
-        self.interface.lock().ipv4_addr()
+    pub(super) fn ipv4_cidr(&self) -> Option<Ipv4Cidr> {
+        self.interface.lock().ipv4_cidr()
     }
 
-    pub(super) fn ipv6_addr(&self) -> Option<Ipv6Address> {
-        self.interface.lock().ipv6_addr()
-    }
-
-    pub(super) fn prefix_len(&self) -> Option<u8> {
-        self.interface.lock().prefix_len()
+    pub(super) fn ipv6_cidr(&self) -> Option<Ipv6Cidr> {
+        self.interface.lock().ipv6_cidr()
     }
 
     pub(super) fn sched_poll(&self) -> &E::ScheduleNextPoll {

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -3,7 +3,7 @@
 use alloc::sync::Arc;
 use core::ffi::CStr;
 
-use smoltcp::wire::{Ipv4Address, Ipv4Cidr, Ipv6Cidr};
+use smoltcp::wire::{EthernetAddress, Ipv4Address, Ipv4Cidr, Ipv6Cidr};
 
 use super::{BindPortConfig, BoundTcpPort, BoundUdpPort, InterfaceFlags, InterfaceType};
 use crate::{errors::BindError, ext::Ext};
@@ -15,6 +15,9 @@ use crate::{errors::BindError, ext::Ext};
 /// wireless adapters. They can also be virtual interfaces created by software, such as virtual
 /// private network (VPN) connections.
 pub trait Iface<E>: internal::IfaceInternal<E> + Send + Sync {
+    /// Returns the Ethernet address, if the interface uses Ethernet framing.
+    fn ethernet_addr(&self) -> Option<EthernetAddress>;
+
     /// Transmits or receives packets queued in the iface, and updates socket status accordingly.
     fn poll(&self);
 

--- a/kernel/libs/aster-bigtcp/src/iface/iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/iface.rs
@@ -3,7 +3,7 @@
 use alloc::sync::Arc;
 use core::ffi::CStr;
 
-use smoltcp::wire::{Ipv4Address, Ipv4Cidr, Ipv6Address};
+use smoltcp::wire::{Ipv4Address, Ipv4Cidr, Ipv6Cidr};
 
 use super::{BindPortConfig, BoundTcpPort, BoundUdpPort, InterfaceFlags, InterfaceType};
 use crate::{errors::BindError, ext::Ext};
@@ -73,35 +73,24 @@ impl<E: Ext> dyn Iface<E> {
         self.common().flags()
     }
 
-    /// Gets the IPv4 address of the iface, if any.
-    //
-    // FIXME: One iface may have multiple IPv4 addresses.
-    pub fn ipv4_addr(&self) -> Option<Ipv4Address> {
-        self.common().ipv4_addr()
+    // FIXME: Linux and smoltcp allow multiple IP CIDRs per interface, while the
+    // address-related APIs below only account for the first CIDR of each family.
+
+    /// Gets the IPv4 CIDR of the iface, if any.
+    pub fn ipv4_cidr(&self) -> Option<Ipv4Cidr> {
+        self.common().ipv4_cidr()
     }
 
-    /// Gets the IPv6 address of the iface, if any.
-    pub fn ipv6_addr(&self) -> Option<Ipv6Address> {
-        self.common().ipv6_addr()
+    /// Gets the IPv6 CIDR of the iface, if any.
+    pub fn ipv6_cidr(&self) -> Option<Ipv6Cidr> {
+        self.common().ipv6_cidr()
     }
 
-    /// Retrieves the prefix length of the interface's IPv4 address.
+    /// Gets the IPv4 broadcast address of the iface, if any.
     ///
-    /// Both `Self::ipv4_addr` and this method will either return `Some(_)`
-    /// or both will return `None`.
-    pub fn prefix_len(&self) -> Option<u8> {
-        self.common().prefix_len()
-    }
-
-    /// Gets the broadcast address of the iface, if any.
+    /// IPv6 does not define broadcast addresses and uses multicast instead.
     pub fn broadcast_addr(&self) -> Option<Ipv4Address> {
-        let cidr = {
-            let common = self.common();
-            let ipv4_addr = common.ipv4_addr()?;
-            let prefix_len = common.prefix_len()?;
-            Ipv4Cidr::new(ipv4_addr, prefix_len)
-        };
-        cidr.broadcast()
+        self.common().ipv4_cidr()?.broadcast()
     }
 
     /// Returns a reference to the associated [`ScheduleNextPoll`].

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
@@ -78,6 +78,10 @@ impl<D: WithDevice + 'static, E: Ext> Iface<E> for EtherIface<D, E>
 where
     D::Device: NotifyDevice,
 {
+    fn ethernet_addr(&self) -> Option<EthernetAddress> {
+        Some(self.ether_addr)
+    }
+
     fn poll(&self) {
         self.driver.with(|device| {
             let next_poll = self.common.poll(

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ip.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ip.rs
@@ -5,7 +5,7 @@ use alloc::{ffi::CString, sync::Arc};
 use smoltcp::{
     iface::Config,
     phy::{Device, TxToken},
-    wire::{self, Ipv4Cidr, Ipv4Packet, Ipv6Cidr, Ipv6Packet},
+    wire::{self, EthernetAddress, Ipv4Cidr, Ipv4Packet, Ipv6Cidr, Ipv6Packet},
 };
 
 use crate::{
@@ -63,6 +63,10 @@ impl<D, E: Ext> IfaceInternal<E> for IpIface<D, E> {
 }
 
 impl<D: WithDevice + 'static, E: Ext> Iface<E> for IpIface<D, E> {
+    fn ethernet_addr(&self) -> Option<EthernetAddress> {
+        None
+    }
+
     fn poll(&self) {
         self.driver.with(|device| {
             let next_poll = self.common.poll(

--- a/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
@@ -35,25 +35,24 @@ impl<E: Ext> PollableIface<E> {
         }
     }
 
-    pub(super) fn ipv4_addr(&self) -> Option<smoltcp::wire::Ipv4Address> {
-        self.interface.ipv4_addr()
-    }
-
-    pub(super) fn ipv6_addr(&self) -> Option<smoltcp::wire::Ipv6Address> {
+    pub(super) fn ipv4_cidr(&self) -> Option<smoltcp::wire::Ipv4Cidr> {
         self.interface.ip_addrs().iter().find_map(|cidr| {
-            if let smoltcp::wire::IpCidr::Ipv6(ipv6_cidr) = cidr {
-                Some(ipv6_cidr.address())
+            if let smoltcp::wire::IpCidr::Ipv4(ipv4_cidr) = cidr {
+                Some(*ipv4_cidr)
             } else {
                 None
             }
         })
     }
 
-    pub(super) fn prefix_len(&self) -> Option<u8> {
-        self.interface
-            .ip_addrs()
-            .first()
-            .map(|ip_addr| ip_addr.prefix_len())
+    pub(super) fn ipv6_cidr(&self) -> Option<smoltcp::wire::Ipv6Cidr> {
+        self.interface.ip_addrs().iter().find_map(|cidr| {
+            if let smoltcp::wire::IpCidr::Ipv6(ipv6_cidr) = cidr {
+                Some(*ipv6_cidr)
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the next poll time.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(btree_cursors)]
 #![feature(debug_closure_helpers)]
 #![feature(format_args_nl)]
+#![feature(ip_as_octets)]
 #![feature(linked_list_cursors)]
 #![feature(linked_list_retain)]
 #![feature(panic_can_unwind)]

--- a/kernel/src/net/socket/ip/common.rs
+++ b/kernel/src/net/socket/ip/common.rs
@@ -17,10 +17,18 @@ use crate::{
 fn get_iface_to_bind(ip_addr: &IpAddress) -> Option<Arc<Iface>> {
     match *ip_addr {
         IpAddress::Ipv4(ipv4_addr) => iter_all_ifaces()
-            .find(|iface| iface.ipv4_addr().is_some_and(|addr| addr == ipv4_addr))
+            .find(|iface| {
+                iface
+                    .ipv4_cidr()
+                    .is_some_and(|cidr| cidr.address() == ipv4_addr)
+            })
             .map(Clone::clone),
         IpAddress::Ipv6(ipv6_addr) => iter_all_ifaces()
-            .find(|iface| iface.ipv6_addr().is_some_and(|addr| addr == ipv6_addr))
+            .find(|iface| {
+                iface
+                    .ipv6_cidr()
+                    .is_some_and(|cidr| cidr.address() == ipv6_addr)
+            })
             .map(Clone::clone),
     }
 }
@@ -33,8 +41,8 @@ fn get_ephemeral_iface(remote_ip_addr: &IpAddress) -> Arc<Iface> {
         IpAddress::Ipv4(remote_ipv4_addr) => {
             if let Some(iface) = iter_all_ifaces().find(|iface| {
                 iface
-                    .ipv4_addr()
-                    .is_some_and(|addr| addr == *remote_ipv4_addr)
+                    .ipv4_cidr()
+                    .is_some_and(|cidr| cidr.address() == *remote_ipv4_addr)
             }) {
                 return iface.clone();
             }
@@ -50,8 +58,8 @@ fn get_ephemeral_iface(remote_ip_addr: &IpAddress) -> Arc<Iface> {
         IpAddress::Ipv6(remote_ipv6_addr) => {
             if let Some(iface) = iter_all_ifaces().find(|iface| {
                 iface
-                    .ipv6_addr()
-                    .is_some_and(|addr| addr == *remote_ipv6_addr)
+                    .ipv6_cidr()
+                    .is_some_and(|cidr| cidr.address() == *remote_ipv6_addr)
             }) {
                 return iface.clone();
             }
@@ -59,7 +67,7 @@ fn get_ephemeral_iface(remote_ip_addr: &IpAddress) -> Arc<Iface> {
             // Fall back to an interface with an IPv6 address.
             // Prefer virtio over loopback for external traffic.
             if let Some(virtio_iface) = virtio_iface()
-                && virtio_iface.ipv6_addr().is_some()
+                && virtio_iface.ipv6_cidr().is_some()
             {
                 return virtio_iface.clone();
             }
@@ -107,12 +115,12 @@ pub(super) fn get_ephemeral_endpoint(remote_endpoint: &IpEndpoint) -> Option<IpE
     let iface = get_ephemeral_iface(&remote_endpoint.addr);
     match remote_endpoint.addr {
         IpAddress::Ipv4(_) => {
-            let ip_addr = iface.ipv4_addr()?;
-            Some(IpEndpoint::new(IpAddress::Ipv4(ip_addr), 0))
+            let ipv4_cidr = iface.ipv4_cidr()?;
+            Some(IpEndpoint::new(IpAddress::Ipv4(ipv4_cidr.address()), 0))
         }
         IpAddress::Ipv6(_) => {
-            let ipv6_addr = iface.ipv6_addr()?;
-            Some(IpEndpoint::new(IpAddress::Ipv6(ipv6_addr), 0))
+            let ipv6_cidr = iface.ipv6_cidr()?;
+            Some(IpEndpoint::new(IpAddress::Ipv6(ipv6_cidr.address()), 0))
         }
     }
 }

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -41,7 +41,8 @@ pub(super) fn do_get_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegme
 }
 
 fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<AddrSegment> {
-    let ipv4_addr = iface.ipv4_addr()?;
+    let ipv4_cidr = iface.ipv4_cidr()?;
+    let ipv4_addr = ipv4_cidr.address();
 
     let header = CMsgSegHdr {
         len: 0,
@@ -53,7 +54,7 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<
 
     let addr_message = AddrSegmentBody {
         family: CSocketAddrFamily::AF_INET as _,
-        prefix_len: iface.prefix_len().unwrap(),
+        prefix_len: ipv4_cidr.prefix_len(),
         flags: AddrMessageFlags::PERMANENT,
         scope: RtScope::HOST,
         index: NonZeroU32::new(iface.index()),

--- a/kernel/src/net/socket/netlink/route/kernel/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/addr.rs
@@ -3,7 +3,9 @@
 //! Handle address-related requests.
 
 use alloc::borrow::ToOwned;
-use core::num::NonZeroU32;
+use core::{net::IpAddr, num::NonZeroU32};
+
+use aster_bigtcp::{iface::InterfaceFlags, wire::IpCidr};
 
 use super::util::finish_response;
 use crate::{
@@ -12,7 +14,8 @@ use crate::{
         socket::netlink::{
             message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
             route::message::{
-                AddrAttr, AddrMessageFlags, AddrSegment, AddrSegmentBody, RtScope, RtnlSegment,
+                AddrAttr, AddrMessageFlags, AddrProtocol, AddrSegment, AddrSegmentBody, RtScope,
+                RtnlSegment,
             },
         },
     },
@@ -29,9 +32,17 @@ pub(super) fn do_get_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegme
         return_errno_with_message!(Errno::EOPNOTSUPP, "GETADDR only supports dump requests");
     }
 
-    let mut response_segments: Vec<RtnlSegment> = iter_all_ifaces()
-        // GETADDR only supports dump mode, so we're going to report all addresses.
-        .filter_map(|iface| iface_to_new_addr(request_segment.header(), iface))
+    let requested_family = request_segment.body().family;
+    let mut addr_segments: Vec<AddrSegment> = iter_all_ifaces()
+        .flat_map(|iface| iface_to_new_addrs(request_segment.header(), requested_family, iface))
+        .collect();
+
+    // Linux dumps IPv4 addresses before IPv6 addresses
+    // while preserving interface order within each family.
+    addr_segments.sort_by_key(|segment| segment.body().family);
+
+    let mut response_segments: Vec<RtnlSegment> = addr_segments
+        .into_iter()
         .map(RtnlSegment::NewAddr)
         .collect();
 
@@ -40,9 +51,66 @@ pub(super) fn do_get_addr(request_segment: &AddrSegment) -> Result<Vec<RtnlSegme
     Ok(response_segments)
 }
 
-fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<AddrSegment> {
-    let ipv4_cidr = iface.ipv4_cidr()?;
-    let ipv4_addr = ipv4_cidr.address();
+fn iface_to_new_addrs(
+    request_header: &CMsgSegHdr,
+    requested_family: i32,
+    iface: &Arc<Iface>,
+) -> impl IntoIterator<Item = AddrSegment> {
+    let mut addr_segments = [None, None];
+
+    // Linux dumps addresses for all families
+    // when the requested family is neither AF_INET nor AF_INET6.
+    let dump_ipv4 = requested_family != CSocketAddrFamily::AF_INET6 as i32;
+    let dump_ipv6 = requested_family != CSocketAddrFamily::AF_INET as i32;
+
+    if dump_ipv4 && let Some(cidr) = iface.ipv4_cidr() {
+        addr_segments[0] = Some(iface_to_new_addr(request_header, iface, IpCidr::Ipv4(cidr)));
+    };
+
+    if dump_ipv6 && let Some(cidr) = iface.ipv6_cidr() {
+        addr_segments[1] = Some(iface_to_new_addr(request_header, iface, IpCidr::Ipv6(cidr)));
+    }
+
+    addr_segments.into_iter().flatten()
+}
+
+fn iface_to_new_addr(
+    request_header: &CMsgSegHdr,
+    iface: &Arc<Iface>,
+    ip_cidr: IpCidr,
+) -> AddrSegment {
+    let (family, address, prefix_len, scope) = match ip_cidr {
+        IpCidr::Ipv4(ipv4_cidr) => {
+            let ipv4_addr = ipv4_cidr.address();
+            let scope = if ipv4_addr.is_loopback() {
+                RtScope::HOST
+            } else {
+                RtScope::UNIVERSE
+            };
+            (
+                CSocketAddrFamily::AF_INET,
+                ipv4_addr.into(),
+                ipv4_cidr.prefix_len(),
+                scope,
+            )
+        }
+        IpCidr::Ipv6(ipv6_cidr) => {
+            let ipv6_addr = ipv6_cidr.address();
+            let scope = if ipv6_addr.is_loopback() {
+                RtScope::HOST
+            } else if ipv6_addr.is_unicast_link_local() {
+                RtScope::LINK
+            } else {
+                RtScope::UNIVERSE
+            };
+            (
+                CSocketAddrFamily::AF_INET6,
+                ipv6_addr.into(),
+                ipv6_cidr.prefix_len(),
+                scope,
+            )
+        }
+    };
 
     let header = CMsgSegHdr {
         len: 0,
@@ -53,18 +121,72 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> Option<
     };
 
     let addr_message = AddrSegmentBody {
-        family: CSocketAddrFamily::AF_INET as _,
-        prefix_len: ipv4_cidr.prefix_len(),
+        family: family as _,
+        prefix_len,
         flags: AddrMessageFlags::PERMANENT,
-        scope: RtScope::HOST,
+        scope,
         index: NonZeroU32::new(iface.index()),
     };
 
-    let attrs = vec![
-        AddrAttr::Address(ipv4_addr.octets()),
-        AddrAttr::Label(iface.name().to_owned()),
-        AddrAttr::Local(ipv4_addr.octets()),
-    ];
+    let attrs = match address {
+        IpAddr::V4(_) => {
+            // Linux may report the following IPv4 address attributes, in order:
+            // `IFA_ADDRESS`, `IFA_LOCAL`, `IFA_BROADCAST`, `IFA_LABEL`, `IFA_PROTO`,
+            // `IFA_FLAGS`, `IFA_RT_PRIORITY`, and `IFA_CACHEINFO`.
+            // TODO: Support `IFA_PROTO`, `IFA_RT_PRIORITY`, and `IFA_CACHEINFO`.
+            // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv4/devinet.c#L1759>.
+            let mut attrs = vec![
+                // On a point-to-point link, `IFA_ADDRESS` is the peer address.
+                // Otherwise, it equals `IFA_LOCAL`.
+                // Since `Iface` does not support peer addresses,
+                // report the local address here.
+                // Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/if_addr.h#L16>.
+                AddrAttr::Address(address),
+                AddrAttr::Local(address),
+            ];
+            if iface.flags().contains(InterfaceFlags::BROADCAST)
+                && let Some(broadcast_address) = iface.broadcast_addr()
+            {
+                attrs.push(AddrAttr::Broadcast(broadcast_address));
+            }
+            attrs.extend([
+                // Linux defaults `IFA_LABEL` to the interface name
+                // when no per-address label is configured.
+                // Since `Iface` does not support per-address labels,
+                // report the interface name.
+                // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv4/devinet.c#L1765>.
+                AddrAttr::Label(iface.name().to_owned()),
+                AddrAttr::Flags(addr_message.flags),
+            ]);
+            attrs
+        }
+        IpAddr::V6(_) => {
+            // Linux may report the following IPv6 address attributes, in order:
+            // `IFA_LOCAL`, `IFA_ADDRESS`, `IFA_RT_PRIORITY`, `IFA_CACHEINFO`,
+            // `IFA_FLAGS`, and `IFA_PROTO`.
+            // TODO: Support `IFA_RT_PRIORITY` and `IFA_CACHEINFO`.
+            // TODO: Support `IFA_PROTO` for non-loopback addresses.
+            // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv6/addrconf.c#L5143>.
+            let mut attrs = vec![
+                // When a peer address is configured,
+                // `IFA_ADDRESS` is the peer address,
+                // and `IFA_LOCAL` is the local address.
+                // Otherwise, `IFA_ADDRESS` is the local address,
+                // and `IFA_LOCAL` is omitted.
+                // Since `Iface` does not support peer addresses,
+                // report only `IFA_ADDRESS` with the local address.
+                // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv6/addrconf.c#L5189>.
+                AddrAttr::Address(address),
+                AddrAttr::Flags(addr_message.flags),
+            ];
+            if address.is_loopback() {
+                // Linux marks an IPv6 loopback address with `IFAPROT_KERNEL_LO`.
+                // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv6/addrconf.c#L3289>.
+                attrs.push(AddrAttr::Protocol(AddrProtocol::KernelLoopback));
+            }
+            attrs
+        }
+    };
 
-    Some(AddrSegment::new(header, addr_message, attrs))
+    AddrSegment::new(header, addr_message, attrs)
 }

--- a/kernel/src/net/socket/netlink/route/kernel/link.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/link.rs
@@ -5,7 +5,7 @@
 use alloc::borrow::ToOwned;
 use core::num::NonZero;
 
-use aster_bigtcp::iface::InterfaceType;
+use aster_bigtcp::{iface::InterfaceType, wire::EthernetAddress};
 
 use super::util::finish_response;
 use crate::{
@@ -19,6 +19,18 @@ use crate::{
     prelude::*,
     util::net::CSocketAddrFamily,
 };
+
+/// The unspecified link-layer address.
+const UNSPECIFIED_LINK_ADDR: EthernetAddress = EthernetAddress([0; 6]);
+
+/// The default transmit queue length.
+///
+/// On Linux, this value limits the number of SKBs
+/// that can be queued in a network device's egress qdisc.
+/// This value does not take effect on Asterinas now.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/net/pkt_sched.h#L13>.
+const DEFAULT_TX_QUEUE_LEN: u32 = 1000;
 
 pub(super) fn do_get_link(request_segment: &LinkSegment) -> Result<Vec<RtnlSegment>> {
     let filter_by = FilterBy::from_request(request_segment)?;
@@ -137,10 +149,25 @@ fn iface_to_new_link(request_header: &CMsgSegHdr, iface: &Arc<Iface>) -> LinkSeg
         flags: iface.flags(),
     };
 
-    let attrs = vec![
+    // Linux may report dozens of attributes in a fixed order.
+    // See the reference below for the complete attribute list and ordering.
+    // TODO: Asterinas currently reports only a subset of these attributes.
+    // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/core/rtnetlink.c#L2050>.
+    let mut attrs = Vec::with_capacity(5);
+    attrs.extend([
         LinkAttr::Name(iface.name().to_owned()),
+        LinkAttr::TxqLen(DEFAULT_TX_QUEUE_LEN),
         LinkAttr::Mtu(iface.mtu() as u32),
-    ];
+    ]);
+
+    let (link_addr, link_broadcast_addr) = match iface.ethernet_addr() {
+        Some(ethernet_addr) => (ethernet_addr, EthernetAddress::BROADCAST),
+        None => (UNSPECIFIED_LINK_ADDR, UNSPECIFIED_LINK_ADDR),
+    };
+    attrs.extend([
+        LinkAttr::Address(link_addr),
+        LinkAttr::Broadcast(link_broadcast_addr),
+    ]);
 
     LinkSegment::new(header, link_message, attrs)
 }

--- a/kernel/src/net/socket/netlink/route/kernel/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/mod.rs
@@ -44,8 +44,8 @@ impl NetlinkRouteKernelSocket {
             )),
         };
 
-        let response = match response_segments {
-            Ok(segments) => RtnlMessage::new(segments),
+        let mut response_segments = match response_segments {
+            Ok(segments) => segments,
             Err(error) => {
                 // TODO: Deal with the `NetlinkMessageCommonFlags::ACK` flag.
                 // Should we return `ErrorSegment` if ACK flag does not exist?
@@ -56,9 +56,29 @@ impl NetlinkRouteKernelSocket {
             }
         };
 
-        debug!("netlink route response: {:?}", response);
+        // Modern Linux may place the `NLMSG_DONE` segment
+        // in the same message as the preceding segments,
+        // depending on the message type.
+        // Legacy Linux generally delivered the `NLMSG_DONE` segment
+        // in a separate message.
+        // We follow the legacy Linux behavior here because it is simpler.
+        // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/core/rtnetlink.c#L6870>.
+        let done_segments = if matches!(response_segments.last(), Some(RtnlSegment::Done(_))) {
+            response_segments.split_off(response_segments.len() - 1)
+        } else {
+            Vec::new()
+        };
 
-        NetlinkRouteProtocol::unicast(dst_port, response).unwrap();
+        for segments in [response_segments, done_segments] {
+            if segments.is_empty() {
+                continue;
+            }
+
+            let response = RtnlMessage::new(segments);
+            debug!("netlink route response: {:?}", response);
+
+            NetlinkRouteProtocol::unicast(dst_port, response).unwrap();
+        }
     }
 
     pub(super) fn report_error(&self, err_segment: ErrorSegment, dst_port: PortNum) {

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::net::{IpAddr, Ipv4Addr};
+
+use zerocopy::Immutable;
+
 use crate::{
-    net::socket::netlink::message::{Attribute, CAttrHeader, ContinueRead},
+    net::socket::netlink::{
+        message::{Attribute, CAttrHeader, ContinueRead},
+        route::message::AddrMessageFlags,
+    },
     prelude::*,
     util::MultiRead,
 };
@@ -25,21 +32,47 @@ enum AddrAttrClass {
     FLAGS = 8,
     RT_PRIORITY = 9,
     TARGET_NETNSID = 10,
+    PROTO = 11,
+}
+
+/// The source protocol of an interface address.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/if_addr.h#L73>.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Immutable, IntoBytes)]
+pub enum AddrProtocol {
+    /// An unspecified address source.
+    #[expect(dead_code)]
+    Unspecified = 0,
+    /// A loopback address configured by the kernel.
+    KernelLoopback = 1,
+    /// An address configured by the kernel from a Router Advertisement.
+    #[expect(dead_code)]
+    KernelRouterAdvertisement = 2,
+    /// A link-local address configured by the kernel.
+    #[expect(dead_code)]
+    KernelLinkLocal = 3,
 }
 
 #[derive(Debug)]
 pub enum AddrAttr {
-    Address([u8; 4]),
-    Local([u8; 4]),
+    Address(IpAddr),
+    Broadcast(Ipv4Addr),
+    Flags(AddrMessageFlags),
     Label(CString),
+    Local(IpAddr),
+    Protocol(AddrProtocol),
 }
 
 impl AddrAttr {
     fn class(&self) -> AddrAttrClass {
         match self {
             AddrAttr::Address(_) => AddrAttrClass::ADDRESS,
-            AddrAttr::Local(_) => AddrAttrClass::LOCAL,
+            AddrAttr::Broadcast(_) => AddrAttrClass::BROADCAST,
+            AddrAttr::Flags(_) => AddrAttrClass::FLAGS,
             AddrAttr::Label(_) => AddrAttrClass::LABEL,
+            AddrAttr::Local(_) => AddrAttrClass::LOCAL,
+            AddrAttr::Protocol(_) => AddrAttrClass::PROTO,
         }
     }
 }
@@ -51,9 +84,12 @@ impl Attribute for AddrAttr {
 
     fn payload_as_bytes(&self) -> &[u8] {
         match self {
-            AddrAttr::Address(address) => address,
-            AddrAttr::Local(local) => local,
+            AddrAttr::Address(address) => address.as_octets(),
+            AddrAttr::Broadcast(address) => address.as_octets(),
+            AddrAttr::Flags(flags) => flags.as_bytes(),
             AddrAttr::Label(label) => label.as_bytes_with_nul(),
+            AddrAttr::Local(address) => address.as_octets(),
+            AddrAttr::Protocol(protocol) => protocol.as_bytes(),
         }
     }
 

--- a/kernel/src/net/socket/netlink/route/message/attr/link.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/link.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_bigtcp::wire::EthernetAddress;
+
 use super::IFNAME_SIZE;
 use crate::{
     net::socket::netlink::message::{Attribute, CAttrHeader, ContinueRead},
@@ -84,6 +86,11 @@ enum LinkAttrClass {
 
 #[derive(Debug)]
 pub enum LinkAttr {
+    // FIXME: Linux link-layer addresses have device-specific lengths.
+    // Using `EthernetAddress` may be inappropriate
+    // once Asterinas supports other network device types.
+    Address(EthernetAddress),
+    Broadcast(EthernetAddress),
     Name(CString),
     Mtu(u32),
     TxqLen(u32),
@@ -94,6 +101,8 @@ pub enum LinkAttr {
 impl LinkAttr {
     fn class(&self) -> LinkAttrClass {
         match self {
+            LinkAttr::Address(_) => LinkAttrClass::ADDRESS,
+            LinkAttr::Broadcast(_) => LinkAttrClass::BROADCAST,
             LinkAttr::Name(_) => LinkAttrClass::IFNAME,
             LinkAttr::Mtu(_) => LinkAttrClass::MTU,
             LinkAttr::TxqLen(_) => LinkAttrClass::TXQLEN,
@@ -110,6 +119,8 @@ impl Attribute for LinkAttr {
 
     fn payload_as_bytes(&self) -> &[u8] {
         match self {
+            LinkAttr::Address(address) => &address.0,
+            LinkAttr::Broadcast(address) => &address.0,
             LinkAttr::Name(name) => name.as_bytes_with_nul(),
             LinkAttr::Mtu(mtu) => mtu.as_bytes(),
             LinkAttr::TxqLen(txq_len) => txq_len.as_bytes(),

--- a/kernel/src/net/socket/netlink/route/message/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/mod.rs
@@ -8,7 +8,10 @@
 mod attr;
 mod segment;
 
-pub(super) use attr::{addr::AddrAttr, link::LinkAttr};
+pub(super) use attr::{
+    addr::{AddrAttr, AddrProtocol},
+    link::LinkAttr,
+};
 pub(super) use segment::{
     RtnlSegment,
     addr::{AddrMessageFlags, AddrSegment, AddrSegmentBody, RtScope},

--- a/kernel/src/net/socket/netlink/route/message/segment/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/addr.rs
@@ -84,6 +84,8 @@ bitflags! {
     /// Flags in [`CIfaddrMsg`].
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.13/source/include/uapi/linux/if_addr.h#L45>.
+    #[repr(C)]
+    #[derive(Pod)]
     pub struct AddrMessageFlags: u32 {
         const SECONDARY      = 0x01;
         const NODAD          = 0x02;

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_netlink_route_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_netlink_route_test
@@ -25,7 +25,6 @@ NetlinkRouteTest.NonGetRequestsRequireCapNetAdmin
 NetlinkRouteTest.NoPasscredNoCreds
 NetlinkRouteTest.PasscredCreds
 NetlinkRouteTest.ProcNetDevStableAcrossCalls
-NetlinkRouteTest.RecvmsgTrunc
 NetlinkRouteTest.RemoveLinkByNameNotFound
 NetlinkRouteTest.SpliceFromPipe
 NetlinkRouteTest.VethAdd

--- a/test/initramfs/src/conformance/gvisor/blocklists/socket_netlink_route_test
+++ b/test/initramfs/src/conformance/gvisor/blocklists/socket_netlink_route_test
@@ -2,8 +2,6 @@ NetlinkRouteTest.AddAddr
 NetlinkRouteTest.AddAndRemoveAddr
 NetlinkRouteTest.ChangeNetnsAndOtherAttrsTogether
 NetlinkRouteTest.ControlMessageIgnored
-NetlinkRouteTest.GetLinkByIndex
-NetlinkRouteTest.GetLinkByName
 NetlinkRouteTest.GetRouteDump
 NetlinkRouteTest.GetRouteRequest
 NetlinkRouteTest.GetRuleDump

--- a/test/initramfs/src/regression/network/netlink_route.c
+++ b/test/initramfs/src/regression/network/netlink_route.c
@@ -2,6 +2,8 @@
 
 #include <net/if.h>
 #include <netlink/route/addr.h>
+#include <linux/if_addr.h>
+#include <stdint.h>
 #include <stddef.h>
 #include <unistd.h>
 
@@ -9,8 +11,11 @@
 
 #define ETHER_NAME "eth0"
 #define LOOPBACK_NAME "lo"
+#define BUFFER_SIZE 8192
 
 #define SUCC(expr) ((expr), 0)
+
+char buffer[BUFFER_SIZE];
 
 int find_lo_and_eth0_by_libc(struct if_nameindex *if_ni)
 {
@@ -82,28 +87,40 @@ FN_TEST(get_link_by_libnl)
 }
 END_TEST()
 
-void find_loopback_address(struct nl_object *obj, void *arg)
+struct loopback_addresses {
+	int found_ipv4;
+	int found_ipv6;
+};
+
+void find_loopback_addresses(struct nl_object *obj, void *arg)
 {
-	int *found_loopback = (int *)arg;
+	struct loopback_addresses *found = arg;
 	struct rtnl_addr *addr = (struct rtnl_addr *)obj;
-	struct nl_addr *local;
-	char buf[INET_ADDRSTRLEN];
+	struct nl_addr *address;
+	char buf[INET6_ADDRSTRLEN + sizeof("/128")];
 
 	int family = rtnl_addr_get_family(addr);
-	if (family != AF_INET) {
+	if (family != AF_INET && family != AF_INET6) {
 		return;
 	}
 
-	local = rtnl_addr_get_local(addr);
-	if (local) {
-		nl_addr2str(local, buf, sizeof(buf));
+	address = rtnl_addr_get_local(addr);
+
+	if (family == AF_INET && address) {
+		nl_addr2str(address, buf, sizeof(buf));
 		if (strcmp(buf, "127.0.0.1/8") == 0) {
-			*found_loopback = 1;
+			found->found_ipv4 = 1;
+		}
+	} else if (family == AF_INET6 && address) {
+		nl_addr2str(address, buf, sizeof(buf));
+		if (strcmp(buf, "::1") == 0 &&
+		    rtnl_addr_get_prefixlen(addr) == 128) {
+			found->found_ipv6 = 1;
 		}
 	}
 }
 
-FN_TEST(get_loopback_address)
+FN_TEST(get_loopback_addresses)
 {
 	struct nl_sock *sock;
 	struct nl_cache *addr_cache;
@@ -115,16 +132,182 @@ FN_TEST(get_loopback_address)
 	// 2. Allocate and retrieve address cache
 	TEST_RES(rtnl_addr_alloc_cache(sock, &addr_cache), _ret >= 0);
 
-	// 3. Iterate over all addresses to find loopback address
-	int found_loopback = 0;
-	TEST_RES(SUCC(nl_cache_foreach(addr_cache, find_loopback_address,
-				       &found_loopback)),
-		 found_loopback == 1);
+	// 3. Iterate over all addresses to find IPv4 and IPv6 loopback addresses
+	struct loopback_addresses found = { 0 };
+	TEST_RES(SUCC(nl_cache_foreach(addr_cache, find_loopback_addresses,
+				       &found)),
+		 found.found_ipv4 && found.found_ipv6);
 
 	// 4. Cleanup
 	nl_cache_free(addr_cache);
 	nl_close(sock);
 	nl_socket_free(sock);
+}
+END_TEST()
+
+enum reported_address {
+	REPORTED_ETHERNET_IPV4 = 1 << 0,
+	REPORTED_LOOPBACK_IPV4 = 1 << 1,
+	REPORTED_LOOPBACK_IPV6 = 1 << 2,
+};
+
+static int validate_reported_address_attributes(struct nlmsghdr *nlh)
+{
+	struct ifaddrmsg *ifa = NLMSG_DATA(nlh);
+
+	const unsigned char *address = NULL;
+	size_t address_len = 0;
+	const unsigned char *local = NULL;
+	size_t local_len = 0;
+	const unsigned char *broadcast = NULL;
+	uint32_t flags = 0;
+	const char *label = NULL;
+	uint8_t protocol = IFAPROT_UNSPEC;
+	int attr_len = IFA_PAYLOAD(nlh);
+	struct rtattr *attr;
+
+	for (attr = IFA_RTA(ifa); RTA_OK(attr, attr_len);
+	     attr = RTA_NEXT(attr, attr_len)) {
+		switch (attr->rta_type) {
+		case IFA_ADDRESS:
+			address = RTA_DATA(attr);
+			address_len = RTA_PAYLOAD(attr);
+			break;
+		case IFA_LOCAL:
+			local = RTA_DATA(attr);
+			local_len = RTA_PAYLOAD(attr);
+			break;
+		case IFA_BROADCAST:
+			if (RTA_PAYLOAD(attr) != sizeof(struct in_addr))
+				return -1;
+			broadcast = RTA_DATA(attr);
+			break;
+		case IFA_FLAGS:
+			if (RTA_PAYLOAD(attr) != sizeof(flags))
+				return -1;
+			memcpy(&flags, RTA_DATA(attr), sizeof(flags));
+			break;
+		case IFA_LABEL:
+			if (!memchr(RTA_DATA(attr), '\0', RTA_PAYLOAD(attr)))
+				return -1;
+			label = RTA_DATA(attr);
+			break;
+		case IFA_PROTO:
+			if (RTA_PAYLOAD(attr) != sizeof(protocol))
+				return -1;
+			memcpy(&protocol, RTA_DATA(attr), sizeof(protocol));
+			break;
+		default:
+			break;
+		}
+	}
+	if (attr_len != 0)
+		return -1;
+
+	const unsigned char loopback_ipv4[] = { 127, 0, 0, 1 };
+	const unsigned char ethernet_ipv4[] = { 10, 0, 2, 15 };
+	const unsigned char loopback_ipv6[16] = { [15] = 1 };
+
+	if (ifa->ifa_family == AF_INET &&
+	    address_len == sizeof(loopback_ipv4) &&
+	    memcmp(address, loopback_ipv4, sizeof(loopback_ipv4)) == 0) {
+		if (local_len != sizeof(loopback_ipv4) ||
+		    memcmp(local, loopback_ipv4, sizeof(loopback_ipv4)) != 0 ||
+		    broadcast != NULL || flags != IFA_F_PERMANENT ||
+		    label == NULL || strcmp(label, LOOPBACK_NAME) != 0 ||
+		    ifa->ifa_scope != RT_SCOPE_HOST)
+			return -1;
+		return REPORTED_LOOPBACK_IPV4;
+	}
+
+	if (ifa->ifa_family == AF_INET &&
+	    address_len == sizeof(ethernet_ipv4) &&
+	    memcmp(address, ethernet_ipv4, sizeof(ethernet_ipv4)) == 0) {
+		const unsigned char expected_broadcast[] = { 10, 0, 2, 255 };
+		if (local_len != sizeof(ethernet_ipv4) ||
+		    memcmp(local, ethernet_ipv4, sizeof(ethernet_ipv4)) != 0 ||
+		    broadcast == NULL ||
+		    memcmp(broadcast, expected_broadcast,
+			   sizeof(expected_broadcast)) != 0 ||
+		    flags != IFA_F_PERMANENT || label == NULL ||
+		    strcmp(label, ETHER_NAME) != 0 ||
+		    ifa->ifa_scope != RT_SCOPE_UNIVERSE)
+			return -1;
+		return REPORTED_ETHERNET_IPV4;
+	}
+
+	if (ifa->ifa_family == AF_INET6 &&
+	    address_len == sizeof(loopback_ipv6) &&
+	    memcmp(address, loopback_ipv6, sizeof(loopback_ipv6)) == 0) {
+		if (local != NULL || flags != IFA_F_PERMANENT ||
+		    protocol != IFAPROT_KERNEL_LO ||
+		    ifa->ifa_scope != RT_SCOPE_HOST)
+			return -1;
+		return REPORTED_LOOPBACK_IPV6;
+	}
+
+	return 0;
+}
+
+static int get_reported_addresses(int sock_fd, int family)
+{
+	struct {
+		struct nlmsghdr hdr;
+		struct ifaddrmsg ifa;
+	} req = {
+		.hdr = {
+			.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrmsg)),
+			.nlmsg_type = RTM_GETADDR,
+			.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP,
+			.nlmsg_seq = family + 1,
+		},
+		.ifa = { .ifa_family = family },
+	};
+	if (send(sock_fd, &req, sizeof(req), 0) != (ssize_t)sizeof(req))
+		return -1;
+
+	int found_reports = 0;
+	for (;;) {
+		ssize_t recv_ret = recv(sock_fd, buffer, BUFFER_SIZE, 0);
+		if (recv_ret <= 0)
+			return -1;
+		size_t recv_len = recv_ret;
+
+		struct nlmsghdr *nlh = (struct nlmsghdr *)buffer;
+
+		for (; NLMSG_OK(nlh, recv_len);
+		     nlh = NLMSG_NEXT(nlh, recv_len)) {
+			if (nlh->nlmsg_type == NLMSG_DONE)
+				return found_reports;
+			if (nlh->nlmsg_type != RTM_NEWADDR)
+				return -1;
+			int report = validate_reported_address_attributes(nlh);
+			if (report < 0)
+				return -1;
+			found_reports |= report;
+		}
+	}
+}
+
+FN_TEST(get_address_attributes)
+{
+	int sock_fd = TEST_SUCC(socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE));
+	struct sockaddr_nl sa = { .nl_family = AF_NETLINK };
+	TEST_SUCC(bind(sock_fd, (struct sockaddr *)&sa, sizeof(sa)));
+
+	int expected_ipv4 = REPORTED_LOOPBACK_IPV4;
+#ifdef __asterinas__
+	expected_ipv4 |= REPORTED_ETHERNET_IPV4;
+#endif
+
+	TEST_RES(get_reported_addresses(sock_fd, AF_UNSPEC),
+		 _ret == (expected_ipv4 | REPORTED_LOOPBACK_IPV6));
+	TEST_RES(get_reported_addresses(sock_fd, AF_INET),
+		 _ret == expected_ipv4);
+	TEST_RES(get_reported_addresses(sock_fd, AF_INET6),
+		 _ret == REPORTED_LOOPBACK_IPV6);
+
+	TEST_SUCC(close(sock_fd));
 }
 END_TEST()
 
@@ -146,9 +329,6 @@ int find_new_addr_until_done(char *buffer, size_t len, int *found_new_addr)
 
 	return 0;
 }
-
-#define BUFFER_SIZE 8192
-char buffer[BUFFER_SIZE];
 
 FN_TEST(get_link_error)
 {


### PR DESCRIPTION
This PR primarily adds support for the `ip addr` command. When running `ip addr` on Asterinas NixOS, it should now return correct results, including proper IPv6 address reporting and several previously missing attributes that have been filled in. However, running `ip addr` after `make kernel` may still exhibit some issues — this is because the `ip` command shipped with `busybox` unconditionally uses socket ioctl to retrieve txqlen, which we do not yet support. I will add socket ioctl support in a separate PR. In contrast, iproute2 retrieves this information via the attributes carried in netlink `RTM_GETLINK` messages. In addition, this PR also cleans up several pre-existing issues in the netlink-related code as a preparatory step for #3489.

```bash
[root@asterinas:~]# ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65535 qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
    inet6 ::1/128 scope host proto kernel_lo 
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1514 qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global eth0
```

This PR consists of four commits: 

1. The first commit cleans up some address-related APIs on the iface. Since we have already added IPv6 support, some methods on the iface have become ambiguous — for example, `prefix_len` and `broadcast_addr` no longer clearly indicate whether they refer to IPv4 or IPv6. To address this, I revised these APIs by merging the original IPv4 address and `prefix_len` methods into one that directly returns an `Ipv4Cidr`, which carries both the address and prefix information. `broadcast_addr` now directly returns an `Ipv4Address`, since IPv6 does not have broadcast addresses.
2. The second commit adds support for `RTM_GETADDR` to return IPv6 addresses, and fills in some previously missing attributes. 
3. The third commit fixes the `NetlinkRouteTest.RecvmsgTrunc` gVisor test. In this test, the client issues a `RTM_GETADDR` request and then calls recvmsg twice — the first time with `MSG_TRUNC` and the second time without. The expected behavior is that the second call receives the `DONE` segment.

Under our current implementation, all addresses and the `DONE` segment are returned as a single message: `RtnlMessage [addr1, addr2, addr3, DONE]`. The first `MSG_TRUNC` call consumes the entire message, and the second recvmsg call blocks.

On Linux, however, the first call truncates `RtnlMessage [addr1, addr2, addr3]`, and the second call receives `RtnlMessage [DONE]`.

This behavior stems from internal Linux logic that controls whether the `DONE` segment should be placed in a separate message. The logic itself is somewhat complex — on one hand, there is the `DUMP_SPLIT_NLM_DONE` internal flag, and on the other hand, different message types have their own rules. Below are my test results:

Netlink Operation | `DUMP_SPLIT_NLM_DONE` Present | `DONE` Sent as Separate Segment
-- | -- | --
RTM_GETLINK | Yes | Always sent separately
IPv4 RTM_GETADDR | Yes | Always sent separately
IPv6 RTM_GETADDR | No | May be bundled with the last data message
AF_UNSPEC RTM_GETADDR | No | Codex suggests that certain kernel logic in `rtnl_dump_all` enforces `DONE` to always be sent as a separate message, which is consistent with my observation.

In this PR, rather than fully replicating Linux's logic, I adopted a simpler strategy: if the last segment is `DONE`, it is always sent as a separate message. According to Linux's own comments, this is considered legacy behavior, but it is simpler to implement:

```C
    /* Old dump handlers used to send NLM_DONE as in a separate recvmsg().
	 * Some applications which parse netlink manually depend on this.
	 */
```

https://elixir.bootlin.com/linux/v7.1/source/net/core/rtnetlink.c#L6870

4. The fourth commit adds several previously missing attributes to `RTM_GETLINK`.
