### PR TITLE
Rewrite safety comments for `KVirtArea::drop`

### DIFF
--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -208,8 +208,10 @@ impl Drop for KVirtArea {
         let range = self.start()..self.end();
         let mut cursor = page_table.cursor_mut(&irq_guard, &range).unwrap();
         loop {
-            // SAFETY: The range is under `KVirtArea` so it is safe to unmap.
-            // FIXME: Need to ensure that the unmapped item outlives the TLB entries.
+            // SAFETY:
+            // 1. The range is under `KVirtArea`, so it is safe to unmap.
+            // 2. The caller of `KVirtArea` will ensure TLB conherence when the range is used again,
+            //    so the unmapped items are safe to be dropped immediately.
             let Some(frag) = (unsafe { cursor.take_next(self.end() - cursor.virt_addr()) }) else {
                 break;
             };

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -490,9 +490,10 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     /// # Safety
     ///
     /// The caller should ensure that:
-    ///  - the range being unmapped does not affect kernel's memory safety.
-    ///  - the items mapped in `PageTableFrag` must outlive any TLB entries
-    ///    that cache the mappings.
+    ///  - the range being unmapped does not affect kernel's memory safety;
+    ///  - there is no memory access to the unmapped range after dropping the
+    ///    items in `PageTableFrag` but before flushing TLB entries that cache
+    ///    the mappings.
     ///
     /// # Panics
     ///

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -467,8 +467,9 @@ impl<'a> CursorMut<'a> {
         let end_va = self.virt_addr() + len;
         let mut num_unmapped: usize = 0;
         loop {
-            // SAFETY: It is safe to un-map memory in the userspace. And the
-            // un-mapped items are dropped after TLB flushes.
+            // SAFETY:
+            // 1. It is safe to unmap memory in the userspace.
+            // 2. We drop the unmapped items only after flushing TLB entries, which is safe.
             let Some(frag) = (unsafe { self.pt_cursor.take_next(end_va - self.virt_addr()) })
             else {
                 break; // No more mappings in the range.


### PR DESCRIPTION
See https://github.com/asterinas/asterinas/pull/3630#issuecomment-5045023099.

The FIXME does not make sense. See https://github.com/asterinas/asterinas/pull/3630#issuecomment-5044860501.
https://github.com/asterinas/asterinas/blob/e0e79a9540b7ae379d758c6c2ed6e15fa59712c4/ostd/src/mm/kspace/kvirt_area.rs#L212