### PR TITLE
Invalidate OSDK base crates when linker scripts change

### DIFF
--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -14,7 +14,7 @@ use crate::util::get_cargo_metadata;
 
 /// Compares two files byte-by-byte to check if they are identical.
 /// Returns `Ok(true)` if files are identical, `Ok(false)` if they are different, or `Err` if any I/O operation fails.
-fn are_files_identical(file1: &PathBuf, file2: &PathBuf) -> Result<bool> {
+fn are_files_identical(file1: &Path, file2: &Path) -> Result<bool> {
     // Check file size first
     let metadata1 = fs::metadata(file1)?;
     let metadata2 = fs::metadata(file2)?;
@@ -42,6 +42,31 @@ fn are_files_identical(file1: &PathBuf, file2: &PathBuf) -> Result<bool> {
             return Ok(true); // End of both files, identical
         }
     }
+}
+
+const GENERATED_BASE_FILES: &[&str] = &["Cargo.toml", "src/main.rs"];
+const GENERATED_LINKER_SCRIPTS: &[(&str, &str)] = &[
+    ("x86_64.ld", include_str!("x86_64.ld.template")),
+    ("riscv64.ld", include_str!("riscv64.ld.template")),
+    ("loongarch64.ld", include_str!("loongarch64.ld.template")),
+];
+
+fn generated_base_files_are_identical(existing: &Path, regenerated: &Path) -> bool {
+    GENERATED_BASE_FILES
+        .iter()
+        .copied()
+        .chain(
+            GENERATED_LINKER_SCRIPTS
+                .iter()
+                .map(|(relative_path, _)| *relative_path),
+        )
+        .all(|relative_path| {
+            are_files_identical(
+                &existing.join(relative_path),
+                &regenerated.join(relative_path),
+            )
+            .is_ok_and(|identical| identical)
+        })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -88,16 +113,9 @@ pub fn new_base_crate(
             &dep_crate_path,
             link_unit_test_kernel,
         );
-        let cargo_result = are_files_identical(
-            &base_crate_path.join("Cargo.toml"),
-            &base_crate_tmp_path.join("Cargo.toml"),
-        );
-        let main_rs_result = are_files_identical(
-            &base_crate_path.join("src").join("main.rs"),
-            &base_crate_tmp_path.join("src").join("main.rs"),
-        );
+        let can_reuse = generated_base_files_are_identical(&base_crate_path, &base_crate_tmp_path);
         std::fs::remove_dir_all(&base_crate_tmp_path).unwrap();
-        if cargo_result.is_ok_and(|res| res) && main_rs_result.is_ok_and(|res| res) {
+        if can_reuse {
             info!("Reusing existing base crate");
             return base_crate_path;
         }
@@ -164,18 +182,9 @@ fn do_new_base_crate(
     let original_dir = std::env::current_dir().unwrap();
     std::env::set_current_dir(&base_crate_path).unwrap();
 
-    // Add linker script files
-    macro_rules! include_linker_script {
-        ([$($linker_script:literal),+]) => {$(
-            fs::write(
-                base_crate_path.as_ref().join($linker_script),
-                include_str!(concat!($linker_script, ".template"))
-            ).unwrap();
-        )+};
+    for (relative_path, contents) in GENERATED_LINKER_SCRIPTS {
+        fs::write(base_crate_path.as_ref().join(relative_path), contents).unwrap();
     }
-    // TODO: currently just x86_64 works; add support for other architectures
-    // here when OSTD is ready
-    include_linker_script!(["x86_64.ld", "riscv64.ld", "loongarch64.ld"]);
 
     // Overwrite the main.rs file
     let main_rs = include_str!("main.rs.template");
@@ -341,4 +350,69 @@ fn add_feature_entries(
 
     let content = toml::to_string(&manifest).unwrap();
     fs::write(manifest_path, content).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    const GENERATED_FILE_FIXTURES: &[(&str, &str)] = &[
+        ("Cargo.toml", "[package]\nname = \"base\"\n"),
+        ("src/main.rs", "fn main() {}\n"),
+        ("x86_64.ld", "x86_64 linker script\n"),
+        ("riscv64.ld", "riscv64 linker script\n"),
+        ("loongarch64.ld", "loongarch64 linker script\n"),
+    ];
+
+    fn write_generated_base_crate(path: &Path) {
+        fs::create_dir_all(path.join("src")).unwrap();
+        for (relative_path, contents) in GENERATED_FILE_FIXTURES {
+            fs::write(path.join(relative_path), contents).unwrap();
+        }
+    }
+
+    #[test]
+    fn changed_linker_script_prevents_base_crate_reuse() {
+        // Regression test for https://github.com/asterinas/asterinas/issues/3649.
+        let temp_dir = tempdir().unwrap();
+        let existing = temp_dir.path().join("existing");
+        let regenerated = temp_dir.path().join("regenerated");
+        write_generated_base_crate(&existing);
+        write_generated_base_crate(&regenerated);
+
+        assert!(
+            super::generated_base_files_are_identical(&existing, &regenerated),
+            "identical generated base crates must remain reusable"
+        );
+
+        for linker_script in ["x86_64.ld", "riscv64.ld", "loongarch64.ld"] {
+            fs::write(regenerated.join(linker_script), "changed linker script\n").unwrap();
+            assert!(
+                !super::generated_base_files_are_identical(&existing, &regenerated),
+                "a change to {linker_script} must invalidate the generated base crate"
+            );
+            fs::copy(
+                existing.join(linker_script),
+                regenerated.join(linker_script),
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn missing_linker_script_prevents_base_crate_reuse() {
+        let temp_dir = tempdir().unwrap();
+        let existing = temp_dir.path().join("existing");
+        let regenerated = temp_dir.path().join("regenerated");
+        write_generated_base_crate(&existing);
+        write_generated_base_crate(&regenerated);
+        fs::remove_file(regenerated.join("riscv64.ld")).unwrap();
+
+        assert!(
+            !super::generated_base_files_are_identical(&existing, &regenerated),
+            "a missing linker script must invalidate the generated base crate"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

OSDK copies architecture linker scripts into generated run base crates, but
the reuse check compares only `Cargo.toml` and `src/main.rs`.

After a linker-script template changes, an incremental build can therefore
reuse a stale generated script even though the running OSDK binary contains
the new template.

Fixes #3649.

## Root Cause

The base-crate writer and reuse check have separate notions of the generated
inputs. The writer emits three linker scripts, while the reuse check knows only
about the generated manifest and Rust entry point.

## Fix

- Define the generated linker-script filenames and embedded contents once.
- Use that list both to write linker scripts and to compare generated run base
  crates.
- Treat a missing, unreadable, or different generated file as a cache miss.
- Add issue-linked regression coverage for all three linker scripts and a
  missing linker script.

## Scope

This is an architecture-neutral OSDK cache correctness fix. It does not change
any linker-script template, boot protocol, kernel artifact, QEMU path, or
architecture behavior.

The standard RISC-V kernel `Image` feature will be submitted separately after
this prerequisite.

## Testing

- `cargo fmt --manifest-path osdk/Cargo.toml -- --check`
- `make check_osdk`
- `make test_osdk` — 9 unit tests and 21 integration tests passed
- `git diff --check upstream/main...HEAD`
