### PR TITLE
Fix missing TLB flushes for the PF CoW into anon case

### DIFF
--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -466,8 +466,6 @@ impl VmMapping {
                         cursor.protect_next(PAGE_SIZE, |flags, _cache| {
                             *flags |= new_flags;
                         });
-                        cursor.flusher().issue_tlb_flush(TlbFlushOp::for_range(va));
-                        cursor.flusher().dispatch_tlb_flush();
                     } else {
                         let new_frame = duplicate_frame(&frame)?;
                         prop.flags |= new_flags;
@@ -479,6 +477,8 @@ impl VmMapping {
                         // We currently do not support this re-classification,
                         // since it will introduce some complexity when unmapping this page.
                     }
+                    cursor.flusher().issue_tlb_flush(TlbFlushOp::for_range(va));
+                    cursor.flusher().dispatch_tlb_flush();
                     cursor.flusher().sync_tlb_flush();
                 }
                 Some(VmQueriedItem::MappedIoMem { .. }) => {


### PR DESCRIPTION
There's a need to flush TLBs on all cores after page faulting on a shared file-backed memory page. Not doing so leads to some unexpected behaviors: If two userspace threads, say, A and B, synchronize on the same lock. A writes to the file and B waits for A's write, then read the file. If the TLB entry is not flushed after A's write, B can still read the original value before A's write.