### PR TITLE
Introduce VFS superblocks and sync filesystems on final release

### DIFF
--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -23,7 +23,6 @@ use crate::{
         vfs::{
             inode::MknodType,
             path::{FsPath, Path, PathResolver, PerMountFlags},
-            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -178,7 +177,7 @@ pub fn init_in_first_process(ctx: &Context) -> Result<()> {
     // Mount devtmpfs.
     let dev_path = path_resolver.lookup(&FsPath::try_from("/dev")?)?;
     dev_path.mount(
-        SuperBlock::new(RamFs::new()),
+        RamFs::new().into_super_block(),
         PerMountFlags::default(),
         Some("ramfs".to_string()),
         ctx,

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         vfs::{
             inode::MknodType,
             path::{FsPath, Path, PathResolver, PerMountFlags},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -177,7 +178,7 @@ pub fn init_in_first_process(ctx: &Context) -> Result<()> {
     // Mount devtmpfs.
     let dev_path = path_resolver.lookup(&FsPath::try_from("/dev")?)?;
     dev_path.mount(
-        RamFs::new(),
+        SuperBlock::new(RamFs::new()),
         PerMountFlags::default(),
         Some("ramfs".to_string()),
         ctx,

--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -4,7 +4,10 @@ use crate::{
     fs::{
         devpts::{DevPts, Ptmx},
         file::{InodeType, mkmod},
-        vfs::path::{FsPath, Path, PathResolver, PerMountFlags},
+        vfs::{
+            path::{FsPath, Path, PathResolver, PerMountFlags},
+            super_block::SuperBlock,
+        },
     },
     prelude::*,
 };
@@ -26,7 +29,7 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     // Create the "pts" directory and mount devpts on it.
     let devpts_path = dev.new_fs_child("pts", InodeType::Dir, mkmod!(a+rx, u+w))?;
     let devpts_mount = devpts_path.mount(
-        DevPts::new(),
+        SuperBlock::new(DevPts::new()),
         PerMountFlags::default(),
         Some("devpts".to_string()),
         ctx,

--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -4,10 +4,7 @@ use crate::{
     fs::{
         devpts::{DevPts, Ptmx},
         file::{InodeType, mkmod},
-        vfs::{
-            path::{FsPath, Path, PathResolver, PerMountFlags},
-            super_block::SuperBlock,
-        },
+        vfs::path::{FsPath, Path, PathResolver, PerMountFlags},
     },
     prelude::*,
 };
@@ -29,7 +26,7 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     // Create the "pts" directory and mount devpts on it.
     let devpts_path = dev.new_fs_child("pts", InodeType::Dir, mkmod!(a+rx, u+w))?;
     let devpts_mount = devpts_path.mount(
-        SuperBlock::new(DevPts::new()),
+        DevPts::new().into_super_block(),
         PerMountFlags::default(),
         Some("devpts".to_string()),
         ctx,

--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -4,7 +4,10 @@ use crate::{
     fs::{
         file::{InodeType, chmod},
         ramfs::RamFs,
-        vfs::path::{FsPath, PathResolver, PerMountFlags},
+        vfs::{
+            path::{FsPath, PathResolver, PerMountFlags},
+            super_block::SuperBlock,
+        },
     },
     prelude::*,
 };
@@ -19,7 +22,7 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     let shm_path =
         dev_path.new_fs_child("shm", InodeType::Dir, chmod!(InodeMode::S_ISVTX, a+rwx))?;
     shm_path.mount(
-        RamFs::new_tmpfs(),
+        SuperBlock::new(RamFs::new_tmpfs()),
         PerMountFlags::default(),
         Some("tmpfs".to_string()),
         ctx,

--- a/kernel/src/device/shm.rs
+++ b/kernel/src/device/shm.rs
@@ -4,10 +4,7 @@ use crate::{
     fs::{
         file::{InodeType, chmod},
         ramfs::RamFs,
-        vfs::{
-            path::{FsPath, PathResolver, PerMountFlags},
-            super_block::SuperBlock,
-        },
+        vfs::path::{FsPath, PathResolver, PerMountFlags},
     },
     prelude::*,
 };
@@ -22,7 +19,7 @@ pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Res
     let shm_path =
         dev_path.new_fs_child("shm", InodeType::Dir, chmod!(InodeMode::S_ISVTX, a+rwx))?;
     shm_path.mount(
-        SuperBlock::new(RamFs::new_tmpfs()),
+        RamFs::new_tmpfs().into_super_block(),
         PerMountFlags::default(),
         Some("tmpfs".to_string()),
         ctx,

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -9,9 +9,10 @@ use crate::{
         file::file_table::FdFlags,
         pseudofs::AnonInodeFs,
         vfs::{
-            file_system::{FileSystem, FsFlags},
+            file_system::FsFlags,
             path::{Mount, MountNamespace, Path, PerMountFlags},
             registry::{FsCreationCtx, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -66,8 +67,8 @@ struct FsConfig {
 enum FsConfigState {
     Configuring,
     Failed,
-    AwaitingMount(Arc<dyn FileSystem>),
-    Reconfiguring(Arc<dyn FileSystem>),
+    AwaitingMount(Arc<SuperBlock>),
+    Reconfiguring(Arc<SuperBlock>),
 }
 
 impl FsConfigFile {
@@ -166,9 +167,9 @@ impl FsConfigFile {
             let args = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
             let fs_creation_ctx =
                 FsCreationCtx::new(config.source.as_deref(), config.flags, args, ctx);
-            let fs = self.fs_type.create(&fs_creation_ctx)?;
-            if Arc::strong_count(&fs) > 1 {
-                let extant_readonly = fs.flags().contains(FsFlags::RDONLY);
+            let super_block = self.fs_type.create(&fs_creation_ctx)?;
+            if Arc::strong_count(&super_block) > 1 {
+                let extant_readonly = super_block.fs().flags().contains(FsFlags::RDONLY);
                 let context_readonly = config.flags.contains(FsFlags::RDONLY);
                 if extant_readonly != context_readonly {
                     return_errno_with_message!(
@@ -177,12 +178,12 @@ impl FsConfigFile {
                     );
                 }
             }
-            Ok(fs)
+            Ok(super_block)
         })();
 
         match result {
-            Ok(fs) => {
-                config.state = FsConfigState::AwaitingMount(fs);
+            Ok(super_block) => {
+                config.state = FsConfigState::AwaitingMount(super_block);
                 Ok(())
             }
             Err(err) => {
@@ -203,8 +204,8 @@ impl FsConfigFile {
         mnt_ns: Weak<MountNamespace>,
     ) -> Result<Arc<Mount>> {
         let mut config = self.config.lock();
-        let fs = match &config.state {
-            FsConfigState::AwaitingMount(fs) => fs.clone(),
+        let super_block = match &config.state {
+            FsConfigState::AwaitingMount(super_block) => super_block.clone(),
             FsConfigState::Configuring => {
                 return_errno_with_message!(Errno::EINVAL, "the file system is not created");
             }
@@ -219,11 +220,12 @@ impl FsConfigFile {
             }
         };
 
-        let detached_mount = Mount::new_detached(fs.clone(), flags, mnt_ns, config.source.clone())?;
+        let detached_mount =
+            Mount::new_detached(super_block.clone(), flags, mnt_ns, config.source.clone())?;
         config.source = None;
-        config.flags = fs.flags();
+        config.flags = super_block.fs().flags();
         config.extra_options.clear();
-        config.state = FsConfigState::Reconfiguring(fs);
+        config.state = FsConfigState::Reconfiguring(super_block);
 
         Ok(detached_mount)
     }
@@ -234,10 +236,10 @@ impl FsConfigFile {
     /// context in `Reconfiguring`, while failure transitions to `Failed`.
     pub fn reconfigure_fs(&self, ctx: &Context) -> Result<()> {
         let mut config = self.config.lock();
-        let FsConfigState::Reconfiguring(fs) = &config.state else {
+        let FsConfigState::Reconfiguring(super_block) = &config.state else {
             return_errno_with_message!(Errno::EBUSY, "the file system is not reconfiguring");
         };
-        let fs = fs.clone();
+        let fs = super_block.fs().clone();
 
         let data = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
         let result = fs.set_fs_flags(config.flags, data, ctx);

--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -16,6 +16,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     process::posix_thread::AsThreadLocal,
@@ -93,8 +94,12 @@ impl FsType for CgroupFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(CgroupFs::singleton().clone())
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
+        static SUPER_BLOCK: Once<Arc<SuperBlock>> = Once::new();
+
+        Ok(SUPER_BLOCK
+            .call_once(|| SuperBlock::new(CgroupFs::singleton().clone()))
+            .clone())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -24,8 +24,7 @@ use crate::{
 
 /// A file system for managing cgroups.
 pub(super) struct CgroupFs {
-    _anon_device_id: AnonDeviceId,
-    stats: FsStats,
+    anon_device_id: AnonDeviceId,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
 
@@ -45,13 +44,22 @@ impl CgroupFs {
     fn new() -> Arc<Self> {
         let anon_device_id =
             AnonDeviceId::acquire().expect("no device ID is available for cgroupfs");
-        let stats = FsStats::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
 
         Arc::new(Self {
-            _anon_device_id: anon_device_id,
-            stats,
+            anon_device_id,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
+    }
+
+    fn into_super_block(self: Arc<Self>) -> Arc<SuperBlock> {
+        let container_device_id = self.anon_device_id.id();
+        SuperBlock::new(
+            self,
+            MAGIC_NUMBER,
+            BLOCK_SIZE,
+            NAME_MAX,
+            container_device_id,
+        )
     }
 }
 
@@ -71,11 +79,11 @@ impl FileSystem for CgroupFs {
         let ns_proxy = thread_local.borrow_ns_proxy();
         let cgroup_namespace = ns_proxy.unwrap().cgroup_ns();
 
-        CgroupInode::new_root(cgroup_namespace.root_node(), &self.stats)
+        CgroupInode::new_root(cgroup_namespace.root_node(), self.anon_device_id.id())
     }
 
     fn stats(&self) -> FsStats {
-        self.stats.clone()
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -98,7 +106,7 @@ impl FsType for CgroupFsType {
         static SUPER_BLOCK: Once<Arc<SuperBlock>> = Once::new();
 
         Ok(SUPER_BLOCK
-            .call_once(|| SuperBlock::new(CgroupFs::singleton().clone()))
+            .call_once(|| CgroupFs::singleton().clone().into_super_block())
             .clone())
     }
 

--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -13,7 +13,7 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::systree_inode::SysTreeInodeTy,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
         },
@@ -24,7 +24,7 @@ use crate::{
 /// A file system for managing cgroups.
 pub(super) struct CgroupFs {
     _anon_device_id: AnonDeviceId,
-    sb: SuperBlock,
+    stats: FsStats,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
 
@@ -44,11 +44,11 @@ impl CgroupFs {
     fn new() -> Arc<Self> {
         let anon_device_id =
             AnonDeviceId::acquire().expect("no device ID is available for cgroupfs");
-        let sb = SuperBlock::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let stats = FsStats::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
 
         Arc::new(Self {
             _anon_device_id: anon_device_id,
-            sb,
+            stats,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
     }
@@ -70,11 +70,11 @@ impl FileSystem for CgroupFs {
         let ns_proxy = thread_local.borrow_ns_proxy();
         let cgroup_namespace = ns_proxy.unwrap().cgroup_ns();
 
-        CgroupInode::new_root(cgroup_namespace.root_node(), &self.sb)
+        CgroupInode::new_root(cgroup_namespace.root_node(), &self.stats)
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {

--- a/kernel/src/fs/fs_impls/configfs/fs.rs
+++ b/kernel/src/fs/fs_impls/configfs/fs.rs
@@ -12,7 +12,7 @@ use crate::fs::{
     pseudofs::AnonDeviceId,
     utils::systree_inode::SysTreeInodeTy,
     vfs::{
-        file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+        file_system::{FileSystem, FsEventSubscriberStats, FsStats},
         inode::Inode,
         registry::{FsCreationCtx, FsProperties, FsType},
     },
@@ -26,7 +26,7 @@ use crate::fs::{
 /// `ConfigFs` is designed for dynamic creation and configuration of kernel objects.
 pub struct ConfigFs {
     _anon_device_id: AnonDeviceId,
-    sb: SuperBlock,
+    stats: FsStats,
     root: Arc<dyn Inode>,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
@@ -47,12 +47,12 @@ impl ConfigFs {
     fn new(root_node: Arc<ConfigRootNode>) -> Arc<Self> {
         let anon_device_id =
             AnonDeviceId::acquire().expect("no device ID is available for configfs");
-        let sb = SuperBlock::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
-        let root_inode = ConfigInode::new_root(root_node, &sb);
+        let stats = FsStats::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let root_inode = ConfigInode::new_root(root_node, &stats);
 
         Arc::new(Self {
             _anon_device_id: anon_device_id,
-            sb,
+            stats,
             root: root_inode,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
@@ -73,8 +73,8 @@ impl FileSystem for ConfigFs {
         self.root.clone()
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {

--- a/kernel/src/fs/fs_impls/configfs/fs.rs
+++ b/kernel/src/fs/fs_impls/configfs/fs.rs
@@ -26,8 +26,7 @@ use crate::fs::{
 /// Unlike sysfs which is primarily read-only and represents existing kernel state,
 /// `ConfigFs` is designed for dynamic creation and configuration of kernel objects.
 pub struct ConfigFs {
-    _anon_device_id: AnonDeviceId,
-    stats: FsStats,
+    anon_device_id: AnonDeviceId,
     root: Arc<dyn Inode>,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
@@ -48,15 +47,24 @@ impl ConfigFs {
     fn new(root_node: Arc<ConfigRootNode>) -> Arc<Self> {
         let anon_device_id =
             AnonDeviceId::acquire().expect("no device ID is available for configfs");
-        let stats = FsStats::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
-        let root_inode = ConfigInode::new_root(root_node, &stats);
+        let root_inode = ConfigInode::new_root(root_node, anon_device_id.id());
 
         Arc::new(Self {
-            _anon_device_id: anon_device_id,
-            stats,
+            anon_device_id,
             root: root_inode,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
+    }
+
+    fn into_super_block(self: Arc<Self>) -> Arc<SuperBlock> {
+        let container_device_id = self.anon_device_id.id();
+        SuperBlock::new(
+            self,
+            MAGIC_NUMBER,
+            BLOCK_SIZE,
+            NAME_MAX,
+            container_device_id,
+        )
     }
 }
 
@@ -75,7 +83,7 @@ impl FileSystem for ConfigFs {
     }
 
     fn stats(&self) -> FsStats {
-        self.stats.clone()
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -98,7 +106,7 @@ impl FsType for ConfigFsType {
         static SUPER_BLOCK: Once<Arc<SuperBlock>> = Once::new();
 
         Ok(SUPER_BLOCK
-            .call_once(|| SuperBlock::new(ConfigFs::singleton().clone()))
+            .call_once(|| ConfigFs::singleton().clone().into_super_block())
             .clone())
     }
 

--- a/kernel/src/fs/fs_impls/configfs/fs.rs
+++ b/kernel/src/fs/fs_impls/configfs/fs.rs
@@ -15,6 +15,7 @@ use crate::fs::{
         file_system::{FileSystem, FsEventSubscriberStats, FsStats},
         inode::Inode,
         registry::{FsCreationCtx, FsProperties, FsType},
+        super_block::SuperBlock,
     },
 };
 
@@ -93,8 +94,12 @@ impl FsType for ConfigFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(ConfigFs::singleton().clone())
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
+        static SUPER_BLOCK: Once<Arc<SuperBlock>> = Once::new();
+
+        Ok(SUPER_BLOCK
+            .call_once(|| SuperBlock::new(ConfigFs::singleton().clone()))
+            .clone())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn SysNode>> {

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -5,6 +5,7 @@
 use core::time::Duration;
 
 use aster_util::slot_vec::SlotVec;
+use device_id::DeviceId;
 use id_alloc::IdAlloc;
 
 pub use self::ptmx::Ptmx;
@@ -48,8 +49,7 @@ const MAX_PTY_NUM: usize = 4096;
 ///
 /// Actually, the "/dev/ptmx" is a symlink to the real device at "/dev/pts/ptmx".
 pub struct DevPts {
-    _anon_device_id: AnonDeviceId,
-    stats: FsStats,
+    anon_device_id: AnonDeviceId,
     root: Arc<RootInode>,
     index_alloc: Mutex<IdAlloc>,
     fs_event_subscriber_stats: FsEventSubscriberStats,
@@ -59,11 +59,10 @@ pub struct DevPts {
 impl DevPts {
     pub fn new() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for devpts");
-        let stats = FsStats::new(DEVPTS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let container_device_id = anon_device_id.id();
         Arc::new_cyclic(|weak_self| Self {
-            _anon_device_id: anon_device_id,
-            stats: stats.clone(),
-            root: RootInode::new(weak_self.clone(), &stats),
+            anon_device_id,
+            root: RootInode::new(weak_self.clone(), container_device_id),
             index_alloc: Mutex::new(IdAlloc::with_capacity(MAX_PTY_NUM)),
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
             this: weak_self.clone(),
@@ -101,6 +100,21 @@ impl DevPts {
         self.index_alloc.lock().free(index as usize);
         Some(removed_slave)
     }
+
+    fn container_device_id(&self) -> DeviceId {
+        self.anon_device_id.id()
+    }
+
+    pub fn into_super_block(self: Arc<Self>) -> Arc<VfsSuperBlock> {
+        let container_device_id = self.container_device_id();
+        VfsSuperBlock::new(
+            self,
+            DEVPTS_MAGIC,
+            BLOCK_SIZE,
+            NAME_MAX,
+            container_device_id,
+        )
+    }
 }
 
 impl FileSystem for DevPts {
@@ -117,7 +131,7 @@ impl FileSystem for DevPts {
     }
 
     fn stats(&self) -> FsStats {
-        self.stats.clone()
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -137,7 +151,7 @@ impl FsType for DevPtsType {
     }
 
     fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<VfsSuperBlock>> {
-        Ok(VfsSuperBlock::new(DevPts::new()))
+        Ok(DevPts::new().into_super_block())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
@@ -158,15 +172,15 @@ struct RootInode {
 }
 
 impl RootInode {
-    pub fn new(fs: Weak<DevPts>, stats: &FsStats) -> Arc<Self> {
+    pub fn new(fs: Weak<DevPts>, container_device_id: DeviceId) -> Arc<Self> {
         Arc::new(Self {
-            ptmx: Ptmx::new(fs.clone(), stats),
+            ptmx: Ptmx::new(fs.clone(), container_device_id),
             slaves: RwLock::new(SlotVec::new()),
             metadata: RwLock::new(Metadata::new_dir(
                 ROOT_INO,
                 mkmod!(a+rx, u+w),
                 BLOCK_SIZE,
-                stats.container_dev_id,
+                container_device_id,
             )),
             extension: Extension::new(),
             fs,

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::{DirEntryVecExt, DirentVisitor, NAME_MAX},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::{
                 Extension, FileOps, Inode, Metadata, MknodType, RenameMode, RevalidationPolicy,
             },
@@ -48,7 +48,7 @@ const MAX_PTY_NUM: usize = 4096;
 /// Actually, the "/dev/ptmx" is a symlink to the real device at "/dev/pts/ptmx".
 pub struct DevPts {
     _anon_device_id: AnonDeviceId,
-    sb: SuperBlock,
+    stats: FsStats,
     root: Arc<RootInode>,
     index_alloc: Mutex<IdAlloc>,
     fs_event_subscriber_stats: FsEventSubscriberStats,
@@ -58,11 +58,11 @@ pub struct DevPts {
 impl DevPts {
     pub fn new() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for devpts");
-        let sb = SuperBlock::new(DEVPTS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let stats = FsStats::new(DEVPTS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
         Arc::new_cyclic(|weak_self| Self {
             _anon_device_id: anon_device_id,
-            sb: sb.clone(),
-            root: RootInode::new(weak_self.clone(), &sb),
+            stats: stats.clone(),
+            root: RootInode::new(weak_self.clone(), &stats),
             index_alloc: Mutex::new(IdAlloc::with_capacity(MAX_PTY_NUM)),
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
             this: weak_self.clone(),
@@ -115,8 +115,8 @@ impl FileSystem for DevPts {
         self.root.clone()
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -157,15 +157,15 @@ struct RootInode {
 }
 
 impl RootInode {
-    pub fn new(fs: Weak<DevPts>, sb: &SuperBlock) -> Arc<Self> {
+    pub fn new(fs: Weak<DevPts>, stats: &FsStats) -> Arc<Self> {
         Arc::new(Self {
-            ptmx: Ptmx::new(fs.clone(), sb),
+            ptmx: Ptmx::new(fs.clone(), stats),
             slaves: RwLock::new(SlotVec::new()),
             metadata: RwLock::new(Metadata::new_dir(
                 ROOT_INO,
                 mkmod!(a+rx, u+w),
                 BLOCK_SIZE,
-                sb.container_dev_id,
+                stats.container_dev_id,
             )),
             extension: Extension::new(),
             fs,

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -21,6 +21,7 @@ use crate::{
                 Extension, FileOps, Inode, Metadata, MknodType, RenameMode, RevalidationPolicy,
             },
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock as VfsSuperBlock,
         },
     },
     prelude::*,
@@ -135,8 +136,8 @@ impl FsType for DevPtsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(DevPts::new())
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<VfsSuperBlock>> {
+        Ok(VfsSuperBlock::new(DevPts::new()))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use device_id::{DeviceId, MajorId, MinorId};
+use device_id::{MajorId, MinorId};
 
 use super::*;
 use crate::{
@@ -27,14 +27,14 @@ pub struct Ptmx {
 struct Inner(Weak<DevPts>);
 
 impl Ptmx {
-    pub fn new(fs: Weak<DevPts>, stats: &FsStats) -> Arc<Self> {
+    pub fn new(fs: Weak<DevPts>, container_device_id: DeviceId) -> Arc<Self> {
         let inner = Inner(fs.clone());
         let metadata = Metadata::new_device(
             PTMX_INO,
             mkmod!(a+rw),
             BLOCK_SIZE,
             &inner,
-            stats.container_dev_id,
+            container_device_id,
         );
         Arc::new(Self {
             inner,

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -27,14 +27,14 @@ pub struct Ptmx {
 struct Inner(Weak<DevPts>);
 
 impl Ptmx {
-    pub fn new(fs: Weak<DevPts>, sb: &SuperBlock) -> Arc<Self> {
+    pub fn new(fs: Weak<DevPts>, stats: &FsStats) -> Arc<Self> {
         let inner = Inner(fs.clone());
         let metadata = Metadata::new_device(
             PTMX_INO,
             mkmod!(a+rw),
             BLOCK_SIZE,
             &inner,
-            sb.container_dev_id,
+            stats.container_dev_id,
         );
         Arc::new(Self {
             inner,

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -28,7 +28,7 @@ impl PtySlaveInode {
             mkmod!(u+rw, g+w),
             BLOCK_SIZE,
             device.as_ref(),
-            devpts.sb().container_dev_id,
+            devpts.stats().container_dev_id,
         );
         Arc::new(Self {
             device,

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -28,7 +28,7 @@ impl PtySlaveInode {
             mkmod!(u+rw, g+w),
             BLOCK_SIZE,
             device.as_ref(),
-            devpts.stats().container_dev_id,
+            devpts.container_device_id(),
         );
         Arc::new(Self {
             device,

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -31,7 +31,7 @@ use crate::{
     fs::{
         exfat::{constants::*, inode::Ino},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
         },
@@ -435,8 +435,8 @@ impl FileSystem for ExfatFs {
         self.root_inode()
     }
 
-    fn sb(&self) -> SuperBlock {
-        SuperBlock::new(
+    fn stats(&self) -> FsStats {
+        FsStats::new(
             BOOT_SIGNATURE as u64,
             self.sector_size(),
             MAX_NAME_LENGTH,

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -437,12 +437,7 @@ impl FileSystem for ExfatFs {
     }
 
     fn stats(&self) -> FsStats {
-        FsStats::new(
-            BOOT_SIGNATURE as u64,
-            self.sector_size(),
-            MAX_NAME_LENGTH,
-            self.block_device.id(),
-        )
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -489,10 +484,19 @@ impl FsType for ExfatType {
     }
 
     fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
-        Ok(SuperBlock::new(ExfatFs::open(
+        let fs = ExfatFs::open(
             fs_creation_ctx.resolve_block_device()?,
             ExfatMountOptions::default(),
-        )?))
+        )?;
+        let block_size = fs.sector_size();
+        let container_device_id = fs.block_device.id();
+        Ok(SuperBlock::new(
+            fs,
+            BOOT_SIGNATURE as u64,
+            block_size,
+            MAX_NAME_LENGTH,
+            container_device_id,
+        ))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -34,6 +34,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -487,11 +488,11 @@ impl FsType for ExfatType {
         FsProperties::NEED_DISK
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(ExfatFs::open(
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
+        Ok(SuperBlock::new(ExfatFs::open(
             fs_creation_ctx.resolve_block_device()?,
             ExfatMountOptions::default(),
-        )?)
+        )?))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs.rs
@@ -708,7 +708,7 @@ mod test {
     fn stat_bsddf_subtracts_overhead() {
         let f = Ext2FixtureBuilder::new(3, 512).build().unwrap();
 
-        let stat = FileSystemTrait::sb(f.ext2.as_ref());
+        let stat = FileSystemTrait::stats(f.ext2.as_ref());
         let expected_overhead = expected_overhead_blocks(&f.sb);
 
         assert_eq!(
@@ -723,7 +723,7 @@ mod test {
         let f = Ext2FixtureBuilder::new(3, 512).build().unwrap();
         let ext2 = Ext2::open(f.disk.clone() as Arc<dyn BlockDevice>, Some("minixdf")).unwrap();
 
-        let stat = FileSystemTrait::sb(ext2.as_ref());
+        let stat = FileSystemTrait::stats(ext2.as_ref());
         assert_eq!(stat.blocks, f.sb.total_blocks() as usize);
     }
 

--- a/kernel/src/fs/fs_impls/ext2/fs_type.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs_type.rs
@@ -7,10 +7,13 @@
 
 use aster_systree::SysNode;
 
-use super::{fs::Ext2, prelude::*};
-use crate::fs::vfs::{
-    registry::{FsCreationCtx, FsProperties, FsType},
-    super_block::SuperBlock,
+use super::{fs::Ext2, prelude::*, super_block::MAGIC_NUM};
+use crate::fs::{
+    utils::NAME_MAX,
+    vfs::{
+        registry::{FsCreationCtx, FsProperties, FsType},
+        super_block::SuperBlock,
+    },
 };
 
 /// VFS-visible Ext2 filesystem type.
@@ -28,7 +31,15 @@ impl FsType for Ext2Type {
     fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
         let disk = fs_creation_ctx.resolve_block_device()?;
         let args = fs_creation_ctx.args();
-        Ext2::open(disk, args).map(|fs| SuperBlock::new(fs))
+        let fs = Ext2::open(disk, args)?;
+        let container_device_id = fs.container_device_id();
+        Ok(SuperBlock::new(
+            fs,
+            MAGIC_NUM as u64,
+            BLOCK_SIZE,
+            NAME_MAX,
+            container_device_id,
+        ))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn SysNode>> {

--- a/kernel/src/fs/fs_impls/ext2/fs_type.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs_type.rs
@@ -9,8 +9,8 @@ use aster_systree::SysNode;
 
 use super::{fs::Ext2, prelude::*};
 use crate::fs::vfs::{
-    file_system::FileSystem,
     registry::{FsCreationCtx, FsProperties, FsType},
+    super_block::SuperBlock,
 };
 
 /// VFS-visible Ext2 filesystem type.
@@ -25,10 +25,10 @@ impl FsType for Ext2Type {
         FsProperties::NEED_DISK
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
         let disk = fs_creation_ctx.resolve_block_device()?;
         let args = fs_creation_ctx.args();
-        Ext2::open(disk, args).map(|fs| fs as Arc<dyn FileSystem>)
+        Ext2::open(disk, args).map(|fs| SuperBlock::new(fs))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn SysNode>> {

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
@@ -12,7 +12,7 @@ use crate::{
         fs_impls::ext2::{Ext2, super_block::MAGIC_NUM},
         utils::NAME_MAX,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
         },
     },
@@ -36,14 +36,14 @@ impl FileSystem for Ext2 {
         self.root_inode().unwrap()
     }
 
-    fn sb(&self) -> SuperBlock {
+    fn stats(&self) -> FsStats {
         let sb = self.super_block();
         let blocks = if self.uses_minix_df() {
             sb.total_blocks()
         } else {
             sb.total_blocks().saturating_sub(sb.total_metadata_blocks())
         };
-        SuperBlock {
+        FsStats {
             magic: MAGIC_NUM as u64,
             bsize: BLOCK_SIZE,
             blocks: blocks as usize,

--- a/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ext2/impl_for_vfs/fs.rs
@@ -5,12 +5,11 @@
 //! Translates VFS-level mount, sync, stat, and root-inode requests into
 //! the corresponding ext2-internal operations.
 
-use aster_block::{BLOCK_SIZE, bio::BioStatus};
+use aster_block::bio::BioStatus;
 
 use crate::{
     fs::{
-        fs_impls::ext2::{Ext2, super_block::MAGIC_NUM},
-        utils::NAME_MAX,
+        fs_impls::ext2::Ext2,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
@@ -44,8 +43,6 @@ impl FileSystem for Ext2 {
             sb.total_blocks().saturating_sub(sb.total_metadata_blocks())
         };
         FsStats {
-            magic: MAGIC_NUM as u64,
-            bsize: BLOCK_SIZE,
             blocks: blocks as usize,
             bfree: sb.free_blocks_count() as usize,
             bavail: sb
@@ -54,10 +51,8 @@ impl FileSystem for Ext2 {
             files: sb.total_inodes() as usize,
             ffree: sb.free_inodes_count() as usize,
             fsid: 0,
-            namelen: NAME_MAX,
             frsize: sb.fragment_size(),
             flags: 0,
-            container_dev_id: self.container_device_id(),
         }
     }
 

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -23,7 +23,7 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::{DirentCounter, DirentVisitor, NAME_MAX},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::{
                 Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RenameMode,
                 SymbolicLink,
@@ -201,9 +201,9 @@ impl FileSystem for OverlayFs {
         Ok(())
     }
 
-    fn sb(&self) -> SuperBlock {
+    fn stats(&self) -> FsStats {
         // TODO: Fill the super block with valid field values.
-        SuperBlock::new(
+        FsStats::new(
             OVERLAY_FS_MAGIC,
             BLOCK_SIZE,
             NAME_MAX,
@@ -1302,7 +1302,7 @@ mod tests {
         let work = upper.clone();
 
         let fs = OverlayFs::new(upper, lower, work).unwrap();
-        assert_eq!(fs.sb().magic, OVERLAY_FS_MAGIC);
+        assert_eq!(fs.stats().magic, OVERLAY_FS_MAGIC);
         fs
     }
 

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -203,13 +203,7 @@ impl FileSystem for OverlayFs {
     }
 
     fn stats(&self) -> FsStats {
-        // TODO: Fill the super block with valid field values.
-        FsStats::new(
-            OVERLAY_FS_MAGIC,
-            BLOCK_SIZE,
-            NAME_MAX,
-            self.anon_device_id.id(),
-        )
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -1231,7 +1225,15 @@ impl FsType for OverlayFsType {
             .collect::<Result<Vec<_>>>()?;
         let work = path_resolver.lookup(&FsPath::try_from(work)?)?;
 
-        Ok(SuperBlock::new(OverlayFs::new(upper, lower, work)?))
+        let fs = OverlayFs::new(upper, lower, work)?;
+        let container_device_id = fs.anon_device_id.id();
+        Ok(SuperBlock::new(
+            fs,
+            OVERLAY_FS_MAGIC,
+            BLOCK_SIZE,
+            NAME_MAX,
+            container_device_id,
+        ))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
@@ -1252,7 +1254,7 @@ mod tests {
 
     fn new_dummy_mount() -> Arc<Mount> {
         Mount::new_root(
-            SuperBlock::new(RamFs::new()),
+            RamFs::new().into_super_block(),
             Arc::downgrade(MountNamespace::get_init_singleton()),
         )
         .unwrap()
@@ -1302,9 +1304,7 @@ mod tests {
         };
         let work = upper.clone();
 
-        let fs = OverlayFs::new(upper, lower, work).unwrap();
-        assert_eq!(fs.stats().magic, OVERLAY_FS_MAGIC);
-        fs
+        OverlayFs::new(upper, lower, work).unwrap()
     }
 
     #[ktest]

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -30,6 +30,7 @@ use crate::{
             },
             path::{FsPath, Path},
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
             xattr::{XATTR_VALUE_MAX_LEN, XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -1182,7 +1183,7 @@ impl FsType for OverlayFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
         let mut lower = Vec::new();
         let mut upper = "";
         let mut work = "";
@@ -1230,7 +1231,7 @@ impl FsType for OverlayFsType {
             .collect::<Result<Vec<_>>>()?;
         let work = path_resolver.lookup(&FsPath::try_from(work)?)?;
 
-        Ok(OverlayFs::new(upper, lower, work)?)
+        Ok(SuperBlock::new(OverlayFs::new(upper, lower, work)?))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
@@ -1251,7 +1252,7 @@ mod tests {
 
     fn new_dummy_mount() -> Arc<Mount> {
         Mount::new_root(
-            RamFs::new(),
+            SuperBlock::new(RamFs::new()),
             Arc::downgrade(MountNamespace::get_init_singleton()),
         )
         .unwrap()

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -28,7 +28,7 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::NAME_MAX,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::{Inode, RevalidationPolicy},
             registry::{FsCreationCtx, FsProperties, FsType},
         },
@@ -72,7 +72,7 @@ const BLOCK_SIZE: usize = 1024;
 
 struct ProcFs {
     _anon_device_id: AnonDeviceId,
-    sb: SuperBlock,
+    stats: FsStats,
     root: Arc<dyn Inode>,
     inode_allocator: AtomicU64,
     fs_event_subscriber_stats: FsEventSubscriberStats,
@@ -81,11 +81,11 @@ struct ProcFs {
 impl ProcFs {
     pub(self) fn new() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for procfs");
-        let sb = SuperBlock::new(PROC_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let stats = FsStats::new(PROC_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
         Arc::new_cyclic(|weak_fs| Self {
             _anon_device_id: anon_device_id,
-            sb: sb.clone(),
-            root: RootDirOps::new_inode(weak_fs.clone(), &sb),
+            stats: stats.clone(),
+            root: RootDirOps::new_inode(weak_fs.clone(), &stats),
             inode_allocator: AtomicU64::new(PROC_ROOT_INO + 1),
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
@@ -109,8 +109,8 @@ impl FileSystem for ProcFs {
         self.root.clone()
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -142,10 +142,10 @@ impl FsType for ProcFsType {
 struct RootDirOps;
 
 impl RootDirOps {
-    pub fn new_inode(fs: Weak<ProcFs>, sb: &SuperBlock) -> Arc<dyn Inode> {
+    pub fn new_inode(fs: Weak<ProcFs>, stats: &FsStats) -> Arc<dyn Inode> {
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/root.c#L368>
         let fs: Weak<dyn FileSystem> = fs;
-        ProcDir::new_root(Self, fs, PROC_ROOT_INO, sb, mkmod!(a+rx))
+        ProcDir::new_root(Self, fs, PROC_ROOT_INO, stats, mkmod!(a+rx))
     }
 
     const STATIC_ENTRIES: &'static [StaticEntry] = &[

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -31,6 +31,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::{Inode, RevalidationPolicy},
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -129,8 +130,8 @@ impl FsType for ProcFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(ProcFs::new())
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
+        Ok(SuperBlock::new(ProcFs::new()))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -2,6 +2,7 @@
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
+use device_id::DeviceId;
 use template::{
     ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
     listed_entries_from_table, lookup_child_from_table, sequential_readdir_entries,
@@ -72,8 +73,7 @@ const PROC_ROOT_INO: u64 = 1;
 const BLOCK_SIZE: usize = 1024;
 
 struct ProcFs {
-    _anon_device_id: AnonDeviceId,
-    stats: FsStats,
+    anon_device_id: AnonDeviceId,
     root: Arc<dyn Inode>,
     inode_allocator: AtomicU64,
     fs_event_subscriber_stats: FsEventSubscriberStats,
@@ -82,11 +82,10 @@ struct ProcFs {
 impl ProcFs {
     pub(self) fn new() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for procfs");
-        let stats = FsStats::new(PROC_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let container_device_id = anon_device_id.id();
         Arc::new_cyclic(|weak_fs| Self {
-            _anon_device_id: anon_device_id,
-            stats: stats.clone(),
-            root: RootDirOps::new_inode(weak_fs.clone(), &stats),
+            anon_device_id,
+            root: RootDirOps::new_inode(weak_fs.clone(), container_device_id),
             inode_allocator: AtomicU64::new(PROC_ROOT_INO + 1),
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
@@ -94,6 +93,15 @@ impl ProcFs {
 
     pub(self) fn alloc_id(&self) -> u64 {
         self.inode_allocator.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub(self) fn container_device_id(&self) -> DeviceId {
+        self.anon_device_id.id()
+    }
+
+    fn into_super_block(self: Arc<Self>) -> Arc<SuperBlock> {
+        let container_device_id = self.container_device_id();
+        SuperBlock::new(self, PROC_MAGIC, BLOCK_SIZE, NAME_MAX, container_device_id)
     }
 }
 
@@ -111,7 +119,7 @@ impl FileSystem for ProcFs {
     }
 
     fn stats(&self) -> FsStats {
-        self.stats.clone()
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -131,7 +139,7 @@ impl FsType for ProcFsType {
     }
 
     fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
-        Ok(SuperBlock::new(ProcFs::new()))
+        Ok(ProcFs::new().into_super_block())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
@@ -143,10 +151,10 @@ impl FsType for ProcFsType {
 struct RootDirOps;
 
 impl RootDirOps {
-    pub fn new_inode(fs: Weak<ProcFs>, stats: &FsStats) -> Arc<dyn Inode> {
+    pub fn new_inode(fs: Weak<ProcFs>, container_device_id: DeviceId) -> Arc<dyn Inode> {
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/proc/root.c#L368>
         let fs: Weak<dyn FileSystem> = fs;
-        ProcDir::new_root(Self, fs, PROC_ROOT_INO, stats, mkmod!(a+rx))
+        ProcDir::new_root(Self, fs, PROC_ROOT_INO, container_device_id, mkmod!(a+rx))
     }
 
     const STATIC_ENTRIES: &'static [StaticEntry] = &[

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
@@ -111,7 +111,7 @@ impl MountInfoFileOps {
             let mount_id = mount.id();
             let parent = mount.parent().and_then(|parent| parent.upgrade());
             let parent_id = parent.as_ref().map_or(mount_id, |p| p.id());
-            let container_dev_id = mount.fs().sb().container_dev_id;
+            let container_dev_id = mount.fs().stats().container_dev_id;
             let major = container_dev_id.major().get() as u32;
             let minor = container_dev_id.minor().get();
             let is_resolver_root_mount = Arc::ptr_eq(&mount, path_resolver.root().mount_node());

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mountinfo.rs
@@ -111,7 +111,7 @@ impl MountInfoFileOps {
             let mount_id = mount.id();
             let parent = mount.parent().and_then(|parent| parent.upgrade());
             let parent_id = parent.as_ref().map_or(mount_id, |p| p.id());
-            let container_dev_id = mount.fs().stats().container_dev_id;
+            let container_dev_id = mount.super_block().container_device_id();
             let major = container_dev_id.major().get() as u32;
             let minor = container_dev_id.minor().get();
             let is_resolver_root_mount = Arc::ptr_eq(&mount, path_resolver.root().mount_node());

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -14,7 +14,7 @@ use crate::{
         procfs::{BLOCK_SIZE, ProcFs},
         utils::DirentVisitor,
         vfs::{
-            file_system::{FileSystem, SuperBlock},
+            file_system::{FileSystem, FsStats},
             inode::{
                 Extension, FileOps, Inode, Metadata, MknodType, RenameMode, RevalidationPolicy,
             },
@@ -44,10 +44,10 @@ impl<D: ProcDirOps> ProcDir<D> {
         dir: D,
         fs: Weak<dyn FileSystem>,
         ino: u64,
-        sb: &SuperBlock,
+        stats: &FsStats,
         mode: InodeMode,
     ) -> Arc<Self> {
-        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, sb.container_dev_id);
+        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, stats.container_dev_id);
         let common = Common::new(metadata, fs);
 
         Arc::new_cyclic(|weak_self| Self {
@@ -64,7 +64,8 @@ impl<D: ProcDirOps> ProcDir<D> {
             let fs = parent.upgrade().unwrap().fs();
             let procfs = fs.downcast_ref::<ProcFs>().unwrap();
             let ino = procfs.alloc_id();
-            let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, procfs.sb().container_dev_id);
+            let metadata =
+                Metadata::new_dir(ino, mode, BLOCK_SIZE, procfs.stats().container_dev_id);
             Common::new(metadata, Arc::downgrade(&fs))
         };
         Arc::new_cyclic(|weak_self| Self {

--- a/kernel/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/dir.rs
@@ -5,6 +5,7 @@
 use alloc::borrow::Cow;
 use core::time::Duration;
 
+use device_id::DeviceId;
 use inherit_methods_macro::inherit_methods;
 
 use super::Common;
@@ -14,7 +15,7 @@ use crate::{
         procfs::{BLOCK_SIZE, ProcFs},
         utils::DirentVisitor,
         vfs::{
-            file_system::{FileSystem, FsStats},
+            file_system::FileSystem,
             inode::{
                 Extension, FileOps, Inode, Metadata, MknodType, RenameMode, RevalidationPolicy,
             },
@@ -44,10 +45,10 @@ impl<D: ProcDirOps> ProcDir<D> {
         dir: D,
         fs: Weak<dyn FileSystem>,
         ino: u64,
-        stats: &FsStats,
+        container_device_id: DeviceId,
         mode: InodeMode,
     ) -> Arc<Self> {
-        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, stats.container_dev_id);
+        let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, container_device_id);
         let common = Common::new(metadata, fs);
 
         Arc::new_cyclic(|weak_self| Self {
@@ -64,8 +65,7 @@ impl<D: ProcDirOps> ProcDir<D> {
             let fs = parent.upgrade().unwrap().fs();
             let procfs = fs.downcast_ref::<ProcFs>().unwrap();
             let ino = procfs.alloc_id();
-            let metadata =
-                Metadata::new_dir(ino, mode, BLOCK_SIZE, procfs.stats().container_dev_id);
+            let metadata = Metadata::new_dir(ino, mode, BLOCK_SIZE, procfs.container_device_id());
             Common::new(metadata, Arc::downgrade(&fs))
         };
         Arc::new_cyclic(|weak_self| Self {

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -33,7 +33,7 @@ impl<F: ProcFileOps> ProcFile<F> {
                 procfs.alloc_id(),
                 mode,
                 BLOCK_SIZE,
-                procfs.stats().container_dev_id,
+                procfs.container_device_id(),
             );
             Common::new(metadata, Arc::downgrade(&fs))
         };

--- a/kernel/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/file.rs
@@ -33,7 +33,7 @@ impl<F: ProcFileOps> ProcFile<F> {
                 procfs.alloc_id(),
                 mode,
                 BLOCK_SIZE,
-                procfs.sb().container_dev_id,
+                procfs.stats().container_dev_id,
             );
             Common::new(metadata, Arc::downgrade(&fs))
         };

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -33,7 +33,7 @@ impl<S: ProcSymOps> ProcSym<S> {
                 procfs.alloc_id(),
                 mode,
                 BLOCK_SIZE,
-                procfs.stats().container_dev_id,
+                procfs.container_device_id(),
             );
             Common::new(metadata, Arc::downgrade(&fs))
         };

--- a/kernel/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/src/fs/fs_impls/procfs/template/sym.rs
@@ -33,7 +33,7 @@ impl<S: ProcSymOps> ProcSym<S> {
                 procfs.alloc_id(),
                 mode,
                 BLOCK_SIZE,
-                procfs.sb().container_dev_id,
+                procfs.stats().container_dev_id,
             );
             Common::new(metadata, Arc::downgrade(&fs))
         };

--- a/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
@@ -9,7 +9,6 @@ use crate::{
         vfs::{
             inode::Inode,
             path::{Mount, Path},
-            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -30,7 +29,7 @@ impl AnonInodeFs {
     fn singleton() -> &'static Arc<NaivePseudoFs> {
         static ANON_INODEFS: Once<Arc<NaivePseudoFs>> = Once::new();
 
-        NaivePseudoFs::singleton(&ANON_INODEFS, "anon_inodefs", ANON_INODEFS_MAGIC)
+        NaivePseudoFs::singleton(&ANON_INODEFS, "anon_inodefs")
     }
 
     /// Creates a pseudo `Path` for the shared inode.
@@ -46,8 +45,14 @@ impl AnonInodeFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static ANON_INODEFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        ANON_INODEFS_MOUNT
-            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
+        ANON_INODEFS_MOUNT.call_once(|| {
+            Mount::new_pseudo(
+                Self::singleton()
+                    .clone()
+                    .into_super_block(ANON_INODEFS_MAGIC),
+            )
+            .unwrap()
+        })
     }
 
     /// Returns the shared inode of the anonymous inode file system singleton.

--- a/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/anon_inodefs.rs
@@ -9,6 +9,7 @@ use crate::{
         vfs::{
             inode::Inode,
             path::{Mount, Path},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -45,7 +46,8 @@ impl AnonInodeFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static ANON_INODEFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        ANON_INODEFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
+        ANON_INODEFS_MOUNT
+            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
     }
 
     /// Returns the shared inode of the anonymous inode file system singleton.

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -44,6 +44,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::{Extension, FileOps, Inode, Metadata},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -61,8 +62,7 @@ mod sockfs;
 /// A pseudo file system that manages pseudo inodes, such as pipe inodes and socket inodes.
 pub struct NaivePseudoFs {
     name: &'static str,
-    _anon_device_id: AnonDeviceId,
-    stats: FsStats,
+    anon_device_id: AnonDeviceId,
     root: Arc<dyn Inode>,
     inode_allocator: AtomicU64,
     fs_event_subscriber_stats: FsEventSubscriberStats,
@@ -83,7 +83,7 @@ impl FileSystem for NaivePseudoFs {
     }
 
     fn stats(&self) -> FsStats {
-        self.stats.clone()
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -93,11 +93,7 @@ impl FileSystem for NaivePseudoFs {
 
 impl NaivePseudoFs {
     /// Returns a reference to the singleton pseudo file system.
-    fn singleton(
-        fs: &'static Once<Arc<Self>>,
-        name: &'static str,
-        magic: u64,
-    ) -> &'static Arc<Self> {
+    fn singleton(fs: &'static Once<Arc<Self>>, name: &'static str) -> &'static Arc<Self> {
         // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/fs/libfs.c#L659-L689>
         fs.call_once(|| {
             let anon_device_id =
@@ -105,8 +101,7 @@ impl NaivePseudoFs {
             let container_dev_id = anon_device_id.id();
             Arc::new_cyclic(move |weak_fs: &Weak<Self>| Self {
                 name,
-                _anon_device_id: anon_device_id,
-                stats: FsStats::new(magic, aster_block::BLOCK_SIZE, NAME_MAX, container_dev_id),
+                anon_device_id,
                 root: Arc::new(PseudoInode::new(
                     ROOT_INO,
                     PseudoInodeType::Root,
@@ -136,7 +131,7 @@ impl NaivePseudoFs {
             uid,
             gid,
             Arc::downgrade(self),
-            self.stats.container_dev_id,
+            self.container_dev_id(),
         )
     }
 
@@ -145,7 +140,18 @@ impl NaivePseudoFs {
     }
 
     pub(super) fn container_dev_id(&self) -> DeviceId {
-        self.stats.container_dev_id
+        self.anon_device_id.id()
+    }
+
+    pub(super) fn into_super_block(self: Arc<Self>, magic: u64) -> Arc<SuperBlock> {
+        let container_device_id = self.container_dev_id();
+        SuperBlock::new(
+            self,
+            magic,
+            aster_block::BLOCK_SIZE,
+            NAME_MAX,
+            container_device_id,
+        )
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/mod.rs
@@ -42,7 +42,7 @@ use crate::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         utils::NAME_MAX,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::{Extension, FileOps, Inode, Metadata},
         },
     },
@@ -62,7 +62,7 @@ mod sockfs;
 pub struct NaivePseudoFs {
     name: &'static str,
     _anon_device_id: AnonDeviceId,
-    sb: SuperBlock,
+    stats: FsStats,
     root: Arc<dyn Inode>,
     inode_allocator: AtomicU64,
     fs_event_subscriber_stats: FsEventSubscriberStats,
@@ -82,8 +82,8 @@ impl FileSystem for NaivePseudoFs {
         self.root.clone()
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -106,7 +106,7 @@ impl NaivePseudoFs {
             Arc::new_cyclic(move |weak_fs: &Weak<Self>| Self {
                 name,
                 _anon_device_id: anon_device_id,
-                sb: SuperBlock::new(magic, aster_block::BLOCK_SIZE, NAME_MAX, container_dev_id),
+                stats: FsStats::new(magic, aster_block::BLOCK_SIZE, NAME_MAX, container_dev_id),
                 root: Arc::new(PseudoInode::new(
                     ROOT_INO,
                     PseudoInodeType::Root,
@@ -136,7 +136,7 @@ impl NaivePseudoFs {
             uid,
             gid,
             Arc::downgrade(self),
-            self.sb.container_dev_id,
+            self.stats.container_dev_id,
         )
     }
 
@@ -145,7 +145,7 @@ impl NaivePseudoFs {
     }
 
     pub(super) fn container_dev_id(&self) -> DeviceId {
-        self.sb.container_dev_id
+        self.stats.container_dev_id
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -20,6 +20,7 @@ use crate::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata},
             path::{Dentry, Mount, Path},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -63,7 +64,8 @@ impl NsFs {
     /// Returns the pseudo mount node of the ns file system.
     pub(self) fn mount_node() -> &'static Arc<Mount> {
         static NSFS_MOUNT: Once<Arc<Mount>> = Once::new();
-        NSFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
+        NSFS_MOUNT
+            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -20,7 +20,6 @@ use crate::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata},
             path::{Dentry, Mount, Path},
-            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -45,7 +44,7 @@ impl NsFs {
     /// Returns the singleton instance of the ns file system.
     pub(self) fn singleton() -> &'static Arc<NaivePseudoFs> {
         static NSFS: Once<Arc<NaivePseudoFs>> = Once::new();
-        NaivePseudoFs::singleton(&NSFS, "nsfs", NSFS_MAGIC)
+        NaivePseudoFs::singleton(&NSFS, "nsfs")
     }
 
     /// Creates a pseudo `Path` for a namespace file.
@@ -64,8 +63,9 @@ impl NsFs {
     /// Returns the pseudo mount node of the ns file system.
     pub(self) fn mount_node() -> &'static Arc<Mount> {
         static NSFS_MOUNT: Once<Arc<Mount>> = Once::new();
-        NSFS_MOUNT
-            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
+        NSFS_MOUNT.call_once(|| {
+            Mount::new_pseudo(Self::singleton().clone().into_super_block(NSFS_MAGIC)).unwrap()
+        })
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
@@ -9,7 +9,6 @@ use crate::{
         vfs::{
             inode::Inode,
             path::{Mount, Path},
-            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -30,7 +29,7 @@ impl PidfdFs {
     pub fn singleton() -> &'static Arc<NaivePseudoFs> {
         static PIDFDFS: Once<Arc<NaivePseudoFs>> = Once::new();
 
-        NaivePseudoFs::singleton(&PIDFDFS, "pidfdfs", PIDFDFS_MAGIC)
+        NaivePseudoFs::singleton(&PIDFDFS, "pidfdfs")
     }
 
     /// Creates a pseudo `Path` for a pidfd.
@@ -46,8 +45,9 @@ impl PidfdFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static PIDFDFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        PIDFDFS_MOUNT
-            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
+        PIDFDFS_MOUNT.call_once(|| {
+            Mount::new_pseudo(Self::singleton().clone().into_super_block(PIDFDFS_MAGIC)).unwrap()
+        })
     }
 
     /// Returns the shared inode of the pidfd file system.

--- a/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pidfdfs.rs
@@ -9,6 +9,7 @@ use crate::{
         vfs::{
             inode::Inode,
             path::{Mount, Path},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -45,7 +46,8 @@ impl PidfdFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static PIDFDFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        PIDFDFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
+        PIDFDFS_MOUNT
+            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
     }
 
     /// Returns the shared inode of the pidfd file system.

--- a/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
@@ -9,9 +9,9 @@ use crate::{
         pipe::AnonPipeInode,
         pseudofs::NaivePseudoFs,
         vfs::{
-            file_system::FileSystem,
             path::{Mount, Path},
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -45,7 +45,8 @@ impl PipeFs {
     fn mount_node() -> &'static Arc<Mount> {
         static PIPEFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        PIPEFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
+        PIPEFS_MOUNT
+            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
     }
 }
 
@@ -60,7 +61,7 @@ impl FsType for PipeFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
         return_errno_with_message!(Errno::EINVAL, "pipefs cannot be mounted");
     }
 

--- a/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
@@ -31,7 +31,7 @@ impl PipeFs {
     pub(in crate::fs) fn singleton() -> &'static Arc<NaivePseudoFs> {
         static PIPEFS: Once<Arc<NaivePseudoFs>> = Once::new();
 
-        NaivePseudoFs::singleton(&PIPEFS, "pipefs", PIPEFS_MAGIC)
+        NaivePseudoFs::singleton(&PIPEFS, "pipefs")
     }
 
     /// Creates a pseudo `Path` for an anonymous pipe.
@@ -45,8 +45,9 @@ impl PipeFs {
     fn mount_node() -> &'static Arc<Mount> {
         static PIPEFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        PIPEFS_MOUNT
-            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
+        PIPEFS_MOUNT.call_once(|| {
+            Mount::new_pseudo(Self::singleton().clone().into_super_block(PIPEFS_MAGIC)).unwrap()
+        })
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -9,9 +9,9 @@ use crate::{
         file::mkmod,
         pseudofs::{NaivePseudoFs, PseudoInodeType},
         vfs::{
-            file_system::FileSystem,
             path::{Mount, Path},
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -53,7 +53,8 @@ impl SockFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static SOCKFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        SOCKFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
+        SOCKFS_MOUNT
+            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
     }
 }
 
@@ -68,7 +69,7 @@ impl FsType for SockFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
         return_errno_with_message!(Errno::EINVAL, "sockfs cannot be mounted");
     }
 

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -32,7 +32,7 @@ impl SockFs {
     pub fn singleton() -> &'static Arc<NaivePseudoFs> {
         static SOCKFS: Once<Arc<NaivePseudoFs>> = Once::new();
 
-        NaivePseudoFs::singleton(&SOCKFS, "sockfs", SOCKFS_MAGIC)
+        NaivePseudoFs::singleton(&SOCKFS, "sockfs")
     }
 
     /// Creates a pseudo `Path` for a socket.
@@ -53,8 +53,9 @@ impl SockFs {
     pub fn mount_node() -> &'static Arc<Mount> {
         static SOCKFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        SOCKFS_MOUNT
-            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
+        SOCKFS_MOUNT.call_once(|| {
+            Mount::new_pseudo(Self::singleton().clone().into_super_block(SOCKFS_MAGIC)).unwrap()
+        })
     }
 }
 

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -32,6 +32,7 @@ use crate::{
             },
             path::{is_dot, is_dot_or_dotdot, is_dotdot},
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -1470,8 +1471,8 @@ impl FsType for RamFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(RamFs::new())
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
+        Ok(SuperBlock::new(RamFs::new()))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -25,7 +25,7 @@ use crate::{
         tmpfs::{self, TMPFS_MAGIC},
         utils::{CStr256, DirentVisitor},
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::{
                 Extension, FallocMode, FileOps, HardLinkability, Inode, Metadata, MknodType,
                 RenameMode, SymbolicLink,
@@ -46,8 +46,8 @@ use crate::{
 pub struct RamFs {
     name: &'static str,
     _anon_device_id: AnonDeviceId,
-    /// The super block
-    sb: SuperBlock,
+    /// Filesystem statistics.
+    stats: FsStats,
     /// Root inode
     root: Arc<RamInode>,
     /// An inode allocator
@@ -69,37 +69,36 @@ impl RamFs {
     // aliases `RamFs`.
     pub fn new_tmpfs() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for tmpfs");
-        let sb = {
-            let mut super_block =
-                SuperBlock::new(TMPFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let stats = {
+            let mut stats = FsStats::new(TMPFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
             let max_blocks = tmpfs::default_max_blocks();
             let max_inodes = tmpfs::default_max_inodes();
-            super_block.blocks = max_blocks;
-            super_block.bfree = max_blocks;
-            super_block.bavail = max_blocks;
-            super_block.files = max_inodes;
-            super_block.ffree = max_inodes;
-            super_block
+            stats.blocks = max_blocks;
+            stats.bfree = max_blocks;
+            stats.bavail = max_blocks;
+            stats.files = max_inodes;
+            stats.ffree = max_inodes;
+            stats
         };
-        Self::new_internal_with_sb("tmpfs", anon_device_id, sb)
+        Self::new_internal_with_stats("tmpfs", anon_device_id, stats)
     }
 
     fn new_internal(name: &'static str) -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for ramfs");
-        let sb = SuperBlock::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
-        Self::new_internal_with_sb(name, anon_device_id, sb)
+        let stats = FsStats::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        Self::new_internal_with_stats(name, anon_device_id, stats)
     }
 
-    fn new_internal_with_sb(
+    fn new_internal_with_stats(
         name: &'static str,
         anon_device_id: AnonDeviceId,
-        sb: SuperBlock,
+        stats: FsStats,
     ) -> Arc<Self> {
         let root_dev_id = anon_device_id.id();
         Arc::new_cyclic(move |weak_fs| Self {
             name,
             _anon_device_id: anon_device_id,
-            sb,
+            stats,
             root: Arc::new_cyclic(|weak_root| RamInode {
                 inner: Inner::new_dir(weak_root.clone(), weak_root.clone()),
                 metadata: SpinLock::new(InodeMeta::new_dir(
@@ -140,8 +139,8 @@ impl FileSystem for RamFs {
         self.root.clone()
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -530,7 +529,7 @@ impl RamInode {
             typ: InodeType::Dir,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.sb.container_dev_id,
+            container_dev_id: fs.stats.container_dev_id,
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -545,7 +544,7 @@ impl RamInode {
             typ: InodeType::File,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.sb.container_dev_id,
+            container_dev_id: fs.stats.container_dev_id,
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -566,7 +565,7 @@ impl RamInode {
             typ: InodeType::File,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.sb.container_dev_id,
+            container_dev_id: fs.stats.container_dev_id,
             hard_linkability,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -603,7 +602,7 @@ impl RamInode {
             typ: InodeType::SymLink,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.sb.container_dev_id,
+            container_dev_id: fs.stats.container_dev_id,
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -630,7 +629,7 @@ impl RamInode {
             typ: dev_type.into(),
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.sb.container_dev_id,
+            container_dev_id: fs.stats.container_dev_id,
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -645,7 +644,7 @@ impl RamInode {
             typ: InodeType::Socket,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.sb.container_dev_id,
+            container_dev_id: fs.stats.container_dev_id,
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -660,7 +659,7 @@ impl RamInode {
             typ: InodeType::NamedPipe,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.sb.container_dev_id,
+            container_dev_id: fs.stats.container_dev_id,
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -46,7 +46,7 @@ use crate::{
 /// A volatile file system whose data and metadata exists only in memory.
 pub struct RamFs {
     name: &'static str,
-    _anon_device_id: AnonDeviceId,
+    anon_device_id: AnonDeviceId,
     /// Filesystem statistics.
     stats: FsStats,
     /// Root inode
@@ -71,23 +71,23 @@ impl RamFs {
     pub fn new_tmpfs() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for tmpfs");
         let stats = {
-            let mut stats = FsStats::new(TMPFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
             let max_blocks = tmpfs::default_max_blocks();
             let max_inodes = tmpfs::default_max_inodes();
-            stats.blocks = max_blocks;
-            stats.bfree = max_blocks;
-            stats.bavail = max_blocks;
-            stats.files = max_inodes;
-            stats.ffree = max_inodes;
-            stats
+            FsStats {
+                blocks: max_blocks,
+                bfree: max_blocks,
+                bavail: max_blocks,
+                files: max_inodes,
+                ffree: max_inodes,
+                ..Default::default()
+            }
         };
         Self::new_internal_with_stats("tmpfs", anon_device_id, stats)
     }
 
     fn new_internal(name: &'static str) -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for ramfs");
-        let stats = FsStats::new(RAMFS_MAGIC, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
-        Self::new_internal_with_stats(name, anon_device_id, stats)
+        Self::new_internal_with_stats(name, anon_device_id, FsStats::default())
     }
 
     fn new_internal_with_stats(
@@ -98,7 +98,7 @@ impl RamFs {
         let root_dev_id = anon_device_id.id();
         Arc::new_cyclic(move |weak_fs| Self {
             name,
-            _anon_device_id: anon_device_id,
+            anon_device_id,
             stats,
             root: Arc::new_cyclic(|weak_root| RamInode {
                 inner: Inner::new_dir(weak_root.clone(), weak_root.clone()),
@@ -123,6 +123,20 @@ impl RamFs {
 
     fn alloc_id(&self) -> u64 {
         self.inode_allocator.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub(super) fn container_device_id(&self) -> DeviceId {
+        self.anon_device_id.id()
+    }
+
+    pub fn into_super_block(self: Arc<Self>) -> Arc<SuperBlock> {
+        let magic = if self.name == "tmpfs" {
+            TMPFS_MAGIC
+        } else {
+            RAMFS_MAGIC
+        };
+        let container_device_id = self.container_device_id();
+        SuperBlock::new(self, magic, BLOCK_SIZE, NAME_MAX, container_device_id)
     }
 }
 
@@ -530,7 +544,7 @@ impl RamInode {
             typ: InodeType::Dir,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.stats.container_dev_id,
+            container_dev_id: fs.container_device_id(),
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -545,7 +559,7 @@ impl RamInode {
             typ: InodeType::File,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.stats.container_dev_id,
+            container_dev_id: fs.container_device_id(),
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -566,7 +580,7 @@ impl RamInode {
             typ: InodeType::File,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.stats.container_dev_id,
+            container_dev_id: fs.container_device_id(),
             hard_linkability,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -603,7 +617,7 @@ impl RamInode {
             typ: InodeType::SymLink,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.stats.container_dev_id,
+            container_dev_id: fs.container_device_id(),
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -630,7 +644,7 @@ impl RamInode {
             typ: dev_type.into(),
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.stats.container_dev_id,
+            container_dev_id: fs.container_device_id(),
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -645,7 +659,7 @@ impl RamInode {
             typ: InodeType::Socket,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.stats.container_dev_id,
+            container_dev_id: fs.container_device_id(),
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -660,7 +674,7 @@ impl RamInode {
             typ: InodeType::NamedPipe,
             this: weak_self.clone(),
             fs: Arc::downgrade(fs),
-            container_dev_id: fs.stats.container_dev_id,
+            container_dev_id: fs.container_device_id(),
             hard_linkability: HardLinkability::Linkable,
             extension: Extension::new(),
             xattr: RamXattr::new(),
@@ -1472,7 +1486,7 @@ impl FsType for RamFsType {
     }
 
     fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
-        Ok(SuperBlock::new(RamFs::new()))
+        Ok(RamFs::new().into_super_block())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -19,6 +19,7 @@ use crate::{
             file_system::FileSystem,
             inode::{Extension, FallocMode, FileOps, Inode, Metadata},
             path::{Mount, Path},
+            super_block::SuperBlock,
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -330,7 +331,8 @@ impl MemfdTmpFs {
     fn mount_node() -> &'static Arc<Mount> {
         static MEMFD_TMPFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
-        MEMFD_TMPFS_MOUNT.call_once(|| Mount::new_pseudo(Self::singleton().clone()).unwrap())
+        MEMFD_TMPFS_MOUNT
+            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
     }
 }
 

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -248,7 +248,7 @@ impl MemfdInodeHandle for InodeHandle {
 
             let ram_inode = RamInode::new_file_detached_in_memfd(
                 weak_self,
-                MemfdTmpFs::singleton().sb().container_dev_id,
+                MemfdTmpFs::singleton().stats().container_dev_id,
                 mode,
                 Uid::new_root(),
                 Gid::new_root(),

--- a/kernel/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/src/fs/fs_impls/ramfs/memfd.rs
@@ -19,7 +19,6 @@ use crate::{
             file_system::FileSystem,
             inode::{Extension, FallocMode, FileOps, Inode, Metadata},
             path::{Mount, Path},
-            super_block::SuperBlock,
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -249,7 +248,7 @@ impl MemfdInodeHandle for InodeHandle {
 
             let ram_inode = RamInode::new_file_detached_in_memfd(
                 weak_self,
-                MemfdTmpFs::singleton().stats().container_dev_id,
+                MemfdTmpFs::singleton().container_device_id(),
                 mode,
                 Uid::new_root(),
                 Gid::new_root(),
@@ -332,7 +331,7 @@ impl MemfdTmpFs {
         static MEMFD_TMPFS_MOUNT: Once<Arc<Mount>> = Once::new();
 
         MEMFD_TMPFS_MOUNT
-            .call_once(|| Mount::new_pseudo(SuperBlock::new(Self::singleton().clone())).unwrap())
+            .call_once(|| Mount::new_pseudo(Self::singleton().clone().into_super_block()).unwrap())
     }
 }
 

--- a/kernel/src/fs/fs_impls/sysfs/fs.rs
+++ b/kernel/src/fs/fs_impls/sysfs/fs.rs
@@ -8,7 +8,7 @@ use crate::{
         sysfs::{self, inode::SysFsInode},
         utils::systree_inode::SysTreeInodeTy,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
         },
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Debug)]
 pub(super) struct SysFs {
     _anon_device_id: AnonDeviceId,
-    sb: SuperBlock,
+    stats: FsStats,
     root: Arc<dyn Inode>,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
@@ -44,13 +44,13 @@ impl SysFs {
 
     fn new() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for sysfs");
-        let sb = SuperBlock::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let stats = FsStats::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
         let systree_ref = sysfs::systree_singleton();
-        let root_inode = SysFsInode::new_root(systree_ref.root().clone(), &sb);
+        let root_inode = SysFsInode::new_root(systree_ref.root().clone(), &stats);
 
         Arc::new(Self {
             _anon_device_id: anon_device_id,
-            sb,
+            stats,
             root: root_inode,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
@@ -71,8 +71,8 @@ impl FileSystem for SysFs {
         self.root.clone()
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {

--- a/kernel/src/fs/fs_impls/sysfs/fs.rs
+++ b/kernel/src/fs/fs_impls/sysfs/fs.rs
@@ -20,8 +20,7 @@ use crate::{
 /// A file system for exposing kernel information to the user space.
 #[derive(Debug)]
 pub(super) struct SysFs {
-    _anon_device_id: AnonDeviceId,
-    stats: FsStats,
+    anon_device_id: AnonDeviceId,
     root: Arc<dyn Inode>,
     fs_event_subscriber_stats: FsEventSubscriberStats,
 }
@@ -45,16 +44,25 @@ impl SysFs {
 
     fn new() -> Arc<Self> {
         let anon_device_id = AnonDeviceId::acquire().expect("no device ID is available for sysfs");
-        let stats = FsStats::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
         let systree_ref = sysfs::systree_singleton();
-        let root_inode = SysFsInode::new_root(systree_ref.root().clone(), &stats);
+        let root_inode = SysFsInode::new_root(systree_ref.root().clone(), anon_device_id.id());
 
         Arc::new(Self {
-            _anon_device_id: anon_device_id,
-            stats,
+            anon_device_id,
             root: root_inode,
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
         })
+    }
+
+    fn into_super_block(self: Arc<Self>) -> Arc<SuperBlock> {
+        let container_device_id = self.anon_device_id.id();
+        SuperBlock::new(
+            self,
+            MAGIC_NUMBER,
+            BLOCK_SIZE,
+            NAME_MAX,
+            container_device_id,
+        )
     }
 }
 
@@ -73,7 +81,7 @@ impl FileSystem for SysFs {
     }
 
     fn stats(&self) -> FsStats {
-        self.stats.clone()
+        FsStats::default()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
@@ -96,7 +104,7 @@ impl FsType for SysFsType {
         static SUPER_BLOCK: Once<Arc<SuperBlock>> = Once::new();
 
         Ok(SUPER_BLOCK
-            .call_once(|| SuperBlock::new(SysFs::singleton().clone()))
+            .call_once(|| SysFs::singleton().clone().into_super_block())
             .clone())
     }
 

--- a/kernel/src/fs/fs_impls/sysfs/fs.rs
+++ b/kernel/src/fs/fs_impls/sysfs/fs.rs
@@ -11,6 +11,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -91,8 +92,12 @@ impl FsType for SysFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(SysFs::singleton().clone())
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
+        static SUPER_BLOCK: Once<Arc<SuperBlock>> = Once::new();
+
+        Ok(SUPER_BLOCK
+            .call_once(|| SuperBlock::new(SysFs::singleton().clone()))
+            .clone())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/fs.rs
@@ -4,8 +4,8 @@ use crate::{
     fs::{
         ramfs::RamFs,
         vfs::{
-            file_system::FileSystem,
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -40,8 +40,8 @@ impl FsType for TmpFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
-        Ok(TmpFs::new_tmpfs())
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
+        Ok(SuperBlock::new(TmpFs::new_tmpfs()))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/fs.rs
@@ -41,7 +41,7 @@ impl FsType for TmpFsType {
     }
 
     fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
-        Ok(SuperBlock::new(TmpFs::new_tmpfs()))
+        Ok(TmpFs::new_tmpfs().into_super_block())
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/virtiofs/fs.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/fs.rs
@@ -14,7 +14,6 @@ use super::inode::{InodeCache, VirtioFsInode};
 use crate::{
     fs::{
         pseudofs::AnonDeviceId,
-        utils::NAME_MAX,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
@@ -27,9 +26,6 @@ use crate::{
 
 /// Filesystem magic reported for virtio-fs in `statfs`.
 const VIRTIOFS_MAGIC: u64 = 0x6573_5546;
-
-/// Block size reported to `statfs` for virtio-fs.
-const BLOCK_SIZE: usize = 4096;
 
 /// The `virtiofs` filesystem type.
 pub(super) struct VirtioFsType;
@@ -52,7 +48,7 @@ impl FsType for VirtioFsType {
         let device = device::find_device_by_tag(&tag)
             .ok_or_else(|| Error::with_message(Errno::ENODEV, "virtiofs device is not found"))?;
 
-        Ok(SuperBlock::new(VirtioFs::new(device, tag)?))
+        VirtioFs::new_super_block(device, tag)
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
@@ -62,6 +58,7 @@ impl FsType for VirtioFsType {
 
 /// A mounted virtio-fs filesystem.
 pub(super) struct VirtioFs {
+    anon_device_id: AnonDeviceId,
     stats: FsStats,
     root: Arc<VirtioFsInode>,
     tag: String,
@@ -71,7 +68,7 @@ pub(super) struct VirtioFs {
 }
 
 impl VirtioFs {
-    fn new(device: Arc<FileSystemDevice>, tag: String) -> Result<Arc<Self>> {
+    fn new_super_block(device: Arc<FileSystemDevice>, tag: String) -> Result<Arc<SuperBlock>> {
         let session = FuseSession::new(device)
             .map_err(|_| Error::with_message(Errno::EIO, "virtiofs FUSE_INIT failed"))?;
 
@@ -81,13 +78,13 @@ impl VirtioFs {
         let statfs = session.do_fuse_op(FUSE_ROOT_ID, StatfsOperation)?.st();
 
         // TODO: Update the filesystem statistics based on `statfs` replies.
-        // For now, we set only the fields required by VFS when mounting the filesystem.
-        // No update is made for these fields later.
-        let stats = FsStats::from((container_dev_id, statfs));
+        let block_size = statfs.bsize() as usize;
+        let name_max = statfs.namelen() as usize;
+        let stats = FsStats::from(statfs);
 
         let root_entry = session.do_fuse_op(FUSE_ROOT_ID, LookupOperation::new("."))?;
 
-        Ok(Arc::new_cyclic(|weak_fs| {
+        let fs = Arc::new_cyclic(|weak_fs| {
             let root = VirtioFsInode::new_root(
                 root_entry,
                 weak_fs.clone(),
@@ -97,6 +94,7 @@ impl VirtioFs {
             let inode_cache = InodeCache::new(&root);
 
             Self {
+                anon_device_id,
                 stats,
                 root,
                 tag,
@@ -104,7 +102,15 @@ impl VirtioFs {
                 inode_cache,
                 fs_event_subscriber_stats: FsEventSubscriberStats::new(),
             }
-        }))
+        });
+
+        Ok(SuperBlock::new(
+            fs,
+            VIRTIOFS_MAGIC,
+            block_size,
+            name_max,
+            container_dev_id,
+        ))
     }
 
     pub(super) fn session(&self) -> &Arc<FuseSession> {
@@ -113,7 +119,7 @@ impl VirtioFs {
 
     /// Returns the device ID of this virtio-fs mount.
     pub(super) fn container_device_id(&self) -> DeviceId {
-        self.stats.container_dev_id
+        self.anon_device_id.id()
     }
 
     /// Reads an inode from a FUSE entry reply via the inode cache.
@@ -140,19 +146,17 @@ impl VirtioFs {
     }
 }
 
-impl From<(DeviceId, Kstatfs)> for FsStats {
-    fn from((container_dev_id, statfs): (DeviceId, Kstatfs)) -> Self {
-        let mut stats = FsStats::new(VIRTIOFS_MAGIC, BLOCK_SIZE, NAME_MAX, container_dev_id);
-
-        stats.blocks = statfs.blocks() as usize;
-        stats.bfree = statfs.bfree() as usize;
-        stats.bavail = statfs.bavail() as usize;
-        stats.files = statfs.files() as usize;
-        stats.ffree = statfs.ffree() as usize;
-        stats.bsize = statfs.bsize() as usize;
-        stats.namelen = statfs.namelen() as usize;
-        stats.frsize = statfs.frsize() as usize;
-        stats
+impl From<Kstatfs> for FsStats {
+    fn from(statfs: Kstatfs) -> Self {
+        Self {
+            blocks: statfs.blocks() as usize,
+            bfree: statfs.bfree() as usize,
+            bavail: statfs.bavail() as usize,
+            files: statfs.files() as usize,
+            ffree: statfs.ffree() as usize,
+            frsize: statfs.frsize() as usize,
+            ..Default::default()
+        }
     }
 }
 

--- a/kernel/src/fs/fs_impls/virtiofs/fs.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/fs.rs
@@ -16,7 +16,7 @@ use crate::{
         pseudofs::AnonDeviceId,
         utils::NAME_MAX,
         vfs::{
-            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
         },
@@ -61,7 +61,7 @@ impl FsType for VirtioFsType {
 
 /// A mounted virtio-fs filesystem.
 pub(super) struct VirtioFs {
-    sb: SuperBlock,
+    stats: FsStats,
     root: Arc<VirtioFsInode>,
     tag: String,
     session: Arc<FuseSession>,
@@ -79,10 +79,10 @@ impl VirtioFs {
         let container_dev_id = anon_device_id.id();
         let statfs = session.do_fuse_op(FUSE_ROOT_ID, StatfsOperation)?.st();
 
-        // TODO: Update the super block fields based on `statfs` reply.
+        // TODO: Update the filesystem statistics based on `statfs` replies.
         // For now, we set only the fields required by VFS when mounting the filesystem.
         // No update is made for these fields later.
-        let sb = SuperBlock::from((container_dev_id, statfs));
+        let stats = FsStats::from((container_dev_id, statfs));
 
         let root_entry = session.do_fuse_op(FUSE_ROOT_ID, LookupOperation::new("."))?;
 
@@ -96,7 +96,7 @@ impl VirtioFs {
             let inode_cache = InodeCache::new(&root);
 
             Self {
-                sb,
+                stats,
                 root,
                 tag,
                 session,
@@ -112,7 +112,7 @@ impl VirtioFs {
 
     /// Returns the device ID of this virtio-fs mount.
     pub(super) fn container_device_id(&self) -> DeviceId {
-        self.sb.container_dev_id
+        self.stats.container_dev_id
     }
 
     /// Reads an inode from a FUSE entry reply via the inode cache.
@@ -139,19 +139,19 @@ impl VirtioFs {
     }
 }
 
-impl From<(DeviceId, Kstatfs)> for SuperBlock {
+impl From<(DeviceId, Kstatfs)> for FsStats {
     fn from((container_dev_id, statfs): (DeviceId, Kstatfs)) -> Self {
-        let mut sb = SuperBlock::new(VIRTIOFS_MAGIC, BLOCK_SIZE, NAME_MAX, container_dev_id);
+        let mut stats = FsStats::new(VIRTIOFS_MAGIC, BLOCK_SIZE, NAME_MAX, container_dev_id);
 
-        sb.blocks = statfs.blocks() as usize;
-        sb.bfree = statfs.bfree() as usize;
-        sb.bavail = statfs.bavail() as usize;
-        sb.files = statfs.files() as usize;
-        sb.ffree = statfs.ffree() as usize;
-        sb.bsize = statfs.bsize() as usize;
-        sb.namelen = statfs.namelen() as usize;
-        sb.frsize = statfs.frsize() as usize;
-        sb
+        stats.blocks = statfs.blocks() as usize;
+        stats.bfree = statfs.bfree() as usize;
+        stats.bavail = statfs.bavail() as usize;
+        stats.files = statfs.files() as usize;
+        stats.ffree = statfs.ffree() as usize;
+        stats.bsize = statfs.bsize() as usize;
+        stats.namelen = statfs.namelen() as usize;
+        stats.frsize = statfs.frsize() as usize;
+        stats
     }
 }
 
@@ -173,8 +173,8 @@ impl FileSystem for VirtioFs {
         self.root.clone()
     }
 
-    fn sb(&self) -> SuperBlock {
-        self.sb.clone()
+    fn stats(&self) -> FsStats {
+        self.stats.clone()
     }
 
     fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {

--- a/kernel/src/fs/fs_impls/virtiofs/fs.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/fs.rs
@@ -19,6 +19,7 @@ use crate::{
             file_system::{FileSystem, FsEventSubscriberStats, FsStats},
             inode::Inode,
             registry::{FsCreationCtx, FsProperties, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -42,7 +43,7 @@ impl FsType for VirtioFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>> {
         let tag = fs_creation_ctx
             .source()
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "virtiofs source(tag) is required"))?
@@ -51,7 +52,7 @@ impl FsType for VirtioFsType {
         let device = device::find_device_by_tag(&tag)
             .ok_or_else(|| Error::with_message(Errno::ENODEV, "virtiofs device is not found"))?;
 
-        Ok(VirtioFs::new(device, tag)? as Arc<dyn FileSystem>)
+        Ok(SuperBlock::new(VirtioFs::new(device, tag)?))
     }
 
     fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {

--- a/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
@@ -36,7 +36,7 @@ impl VirtioFsInode {
     ) -> Result<()> {
         let fs = self.fs_ref();
         let now = MonotonicCoarseClock::get().read_time();
-        let metadata = metadata_from_attr(attr_reply.attr(), fs.sb().container_dev_id);
+        let metadata = metadata_from_attr(attr_reply.attr(), fs.stats().container_dev_id);
         let attr_valid_until = valid_until(attr_reply.attr_valid(), attr_reply.attr_valid_nsec());
         let session_flags = fs.session().negotiated_flags();
 

--- a/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/inode/metadata.rs
@@ -12,7 +12,7 @@ use super::{super::valid_until, InodeInner, VirtioFsInode};
 use crate::{
     fs::{
         file::{InodeMode, InodeType},
-        vfs::{file_system::FileSystem, inode::Metadata},
+        vfs::inode::Metadata,
     },
     prelude::*,
     process::{Gid, Uid},
@@ -36,7 +36,7 @@ impl VirtioFsInode {
     ) -> Result<()> {
         let fs = self.fs_ref();
         let now = MonotonicCoarseClock::get().read_time();
-        let metadata = metadata_from_attr(attr_reply.attr(), fs.stats().container_dev_id);
+        let metadata = metadata_from_attr(attr_reply.attr(), fs.container_device_id());
         let attr_valid_until = valid_until(attr_reply.attr_valid(), attr_reply.attr_valid_nsec());
         let session_flags = fs.session().negotiated_flags();
 

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -12,7 +12,7 @@ use crate::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         utils::DirentVisitor,
         vfs::{
-            file_system::{FileSystem, SuperBlock},
+            file_system::{FileSystem, FsStats},
             inode::{
                 Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RenameMode,
                 RevalidationPolicy, SymbolicLink,
@@ -60,16 +60,16 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
     where
         Self: Sized + 'static;
 
-    fn new_root(root_node: Arc<dyn SysBranchNode>, sb: &SuperBlock) -> Arc<Self>
+    fn new_root(root_node: Arc<dyn SysBranchNode>, stats: &FsStats) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let node_kind = SysTreeNodeKind::Branch(root_node);
         let parent = Weak::new();
-        Self::new_branch_dir(node_kind, None, parent, sb)
+        Self::new_branch_dir(node_kind, None, parent, stats)
     }
 
-    fn new_metadata(ino: u64, type_: InodeType, sb: &SuperBlock) -> Metadata {
+    fn new_metadata(ino: u64, type_: InodeType, stats: &FsStats) -> Metadata {
         let now = RealTimeCoarseClock::get().read_time();
         Metadata {
             ino,
@@ -85,7 +85,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             nr_hard_links: 1,
             uid: Uid::new_root(),
             gid: Gid::new_root(),
-            container_dev_id: sb.container_dev_id,
+            container_dev_id: stats.container_dev_id,
             self_dev_id: None,
             birth_at: None,
         }
@@ -95,25 +95,25 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
         attr: SysAttr,
         node: Arc<dyn SysNode>,
         parent: Weak<Self>,
-        sb: &SuperBlock,
+        stats: &FsStats,
     ) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let node_kind = SysTreeNodeKind::Attr(attr.clone(), node);
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::File, sb);
+        let metadata = Self::new_metadata(ino, InodeType::File, stats);
         let mode = attr.perms().into();
         Self::new_arc(node_kind, metadata, mode, parent)
     }
 
-    fn new_symlink(symlink: Arc<dyn SysSymlink>, parent: Weak<Self>, sb: &SuperBlock) -> Arc<Self>
+    fn new_symlink(symlink: Arc<dyn SysSymlink>, parent: Weak<Self>, stats: &FsStats) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let node_kind = SysTreeNodeKind::Symlink(symlink);
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::SymLink, sb);
+        let metadata = Self::new_metadata(ino, InodeType::SymLink, stats);
         let mode = mkmod!(a+rwx);
         Self::new_arc(node_kind, metadata, mode, parent)
     }
@@ -122,13 +122,13 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
         node_kind: SysTreeNodeKind, // Must be SysTreeNodeKind::Branch
         mode: Option<InodeMode>,
         parent: Weak<Self>,
-        sb: &SuperBlock,
+        stats: &FsStats,
     ) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::Dir, sb);
+        let metadata = Self::new_metadata(ino, InodeType::Dir, stats);
         let SysTreeNodeKind::Branch(branch_node) = &node_kind else {
             panic!("new_branch_dir called with non-branch SysTreeNodeKind");
         };
@@ -141,13 +141,13 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
         node_kind: SysTreeNodeKind, // Must be SysTreeNodeKind::Leaf
         mode: Option<InodeMode>,
         parent: Weak<Self>,
-        sb: &SuperBlock,
+        stats: &FsStats,
     ) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::Dir, sb); // Leaf nodes are represented as Dirs
+        let metadata = Self::new_metadata(ino, InodeType::Dir, stats); // Leaf nodes are represented as Dirs
 
         let SysTreeNodeKind::Leaf(leaf_node) = &node_kind else {
             panic!("new_leaf_dir called with non-leaf SysTreeNodeKind");
@@ -161,7 +161,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
     where
         Self: Sized + 'static,
     {
-        let sb = self.fs().sb();
+        let stats = self.fs().stats();
 
         // Try finding a child node (Branch, Leaf, Symlink) first
         if let Some(child_sysnode) = sysnode.child(name) {
@@ -175,7 +175,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                         SysTreeNodeKind::Branch(child_branch),
                         None,
                         Arc::downgrade(&self.this()),
-                        &sb,
+                        &stats,
                     );
                     Ok(inode)
                 }
@@ -186,7 +186,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                         SysTreeNodeKind::Leaf(child_leaf_node),
                         None,
                         Arc::downgrade(&self.this()),
-                        &sb,
+                        &stats,
                     );
                     Ok(inode)
                 }
@@ -194,7 +194,8 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                     let child_symlink = child_sysnode
                         .cast_to_symlink()
                         .ok_or(Error::new(Errno::EIO))?;
-                    let inode = Self::new_symlink(child_symlink, Arc::downgrade(&self.this()), &sb);
+                    let inode =
+                        Self::new_symlink(child_symlink, Arc::downgrade(&self.this()), &stats);
                     Ok(inode)
                 }
             }
@@ -222,7 +223,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                 attr.clone(),
                 parent_node_arc,
                 Arc::downgrade(&self.this()),
-                &sb,
+                &stats,
             );
             Ok(inode)
         }
@@ -248,12 +249,12 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             }
         };
 
-        let sb = self.fs().sb();
+        let stats = self.fs().stats();
         let inode = Self::new_attr(
             attr.clone(),
             leaf_node_arc,
             Arc::downgrade(&self.this()),
-            &sb,
+            &stats,
         );
         Ok(inode)
     }
@@ -503,20 +504,20 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
 
         let new_child = branch_node.create_child(name)?;
 
-        let sb = self.fs().sb();
+        let stats = self.fs().stats();
         let new_inode = if let Some(branch_child) = new_child.cast_to_branch() {
             Self::new_branch_dir(
                 SysTreeNodeKind::Branch(branch_child),
                 Some(mode),
                 self.parent().clone(),
-                &sb,
+                &stats,
             )
         } else {
             Self::new_leaf_dir(
                 SysTreeNodeKind::Leaf(new_child.cast_to_node().unwrap()),
                 Some(mode),
                 self.parent().clone(),
-                &sb,
+                &stats,
             )
         };
 

--- a/kernel/src/fs/utils/systree_inode.rs
+++ b/kernel/src/fs/utils/systree_inode.rs
@@ -6,13 +6,14 @@ use core::time::Duration;
 use aster_systree::{
     SysAttr, SysBranchNode, SysNode, SysNodeId, SysNodeType, SysObj, SysStr, SysSymlink,
 };
+use device_id::DeviceId;
 
 use crate::{
     fs::{
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         utils::DirentVisitor,
         vfs::{
-            file_system::{FileSystem, FsStats},
+            file_system::FileSystem,
             inode::{
                 Extension, FallocMode, FileOps, Inode, Metadata, MknodType, RenameMode,
                 RevalidationPolicy, SymbolicLink,
@@ -60,16 +61,16 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
     where
         Self: Sized + 'static;
 
-    fn new_root(root_node: Arc<dyn SysBranchNode>, stats: &FsStats) -> Arc<Self>
+    fn new_root(root_node: Arc<dyn SysBranchNode>, container_device_id: DeviceId) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let node_kind = SysTreeNodeKind::Branch(root_node);
         let parent = Weak::new();
-        Self::new_branch_dir(node_kind, None, parent, stats)
+        Self::new_branch_dir(node_kind, None, parent, container_device_id)
     }
 
-    fn new_metadata(ino: u64, type_: InodeType, stats: &FsStats) -> Metadata {
+    fn new_metadata(ino: u64, type_: InodeType, container_device_id: DeviceId) -> Metadata {
         let now = RealTimeCoarseClock::get().read_time();
         Metadata {
             ino,
@@ -85,7 +86,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             nr_hard_links: 1,
             uid: Uid::new_root(),
             gid: Gid::new_root(),
-            container_dev_id: stats.container_dev_id,
+            container_dev_id: container_device_id,
             self_dev_id: None,
             birth_at: None,
         }
@@ -95,25 +96,29 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
         attr: SysAttr,
         node: Arc<dyn SysNode>,
         parent: Weak<Self>,
-        stats: &FsStats,
+        container_device_id: DeviceId,
     ) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let node_kind = SysTreeNodeKind::Attr(attr.clone(), node);
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::File, stats);
+        let metadata = Self::new_metadata(ino, InodeType::File, container_device_id);
         let mode = attr.perms().into();
         Self::new_arc(node_kind, metadata, mode, parent)
     }
 
-    fn new_symlink(symlink: Arc<dyn SysSymlink>, parent: Weak<Self>, stats: &FsStats) -> Arc<Self>
+    fn new_symlink(
+        symlink: Arc<dyn SysSymlink>,
+        parent: Weak<Self>,
+        container_device_id: DeviceId,
+    ) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let node_kind = SysTreeNodeKind::Symlink(symlink);
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::SymLink, stats);
+        let metadata = Self::new_metadata(ino, InodeType::SymLink, container_device_id);
         let mode = mkmod!(a+rwx);
         Self::new_arc(node_kind, metadata, mode, parent)
     }
@@ -122,13 +127,13 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
         node_kind: SysTreeNodeKind, // Must be SysTreeNodeKind::Branch
         mode: Option<InodeMode>,
         parent: Weak<Self>,
-        stats: &FsStats,
+        container_device_id: DeviceId,
     ) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::Dir, stats);
+        let metadata = Self::new_metadata(ino, InodeType::Dir, container_device_id);
         let SysTreeNodeKind::Branch(branch_node) = &node_kind else {
             panic!("new_branch_dir called with non-branch SysTreeNodeKind");
         };
@@ -141,13 +146,13 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
         node_kind: SysTreeNodeKind, // Must be SysTreeNodeKind::Leaf
         mode: Option<InodeMode>,
         parent: Weak<Self>,
-        stats: &FsStats,
+        container_device_id: DeviceId,
     ) -> Arc<Self>
     where
         Self: Sized + 'static,
     {
         let ino = ino::from_node_kind(&node_kind);
-        let metadata = Self::new_metadata(ino, InodeType::Dir, stats); // Leaf nodes are represented as Dirs
+        let metadata = Self::new_metadata(ino, InodeType::Dir, container_device_id); // Leaf nodes are represented as Dirs
 
         let SysTreeNodeKind::Leaf(leaf_node) = &node_kind else {
             panic!("new_leaf_dir called with non-leaf SysTreeNodeKind");
@@ -161,7 +166,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
     where
         Self: Sized + 'static,
     {
-        let stats = self.fs().stats();
+        let container_device_id = self.metadata().container_dev_id;
 
         // Try finding a child node (Branch, Leaf, Symlink) first
         if let Some(child_sysnode) = sysnode.child(name) {
@@ -175,7 +180,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                         SysTreeNodeKind::Branch(child_branch),
                         None,
                         Arc::downgrade(&self.this()),
-                        &stats,
+                        container_device_id,
                     );
                     Ok(inode)
                 }
@@ -186,7 +191,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                         SysTreeNodeKind::Leaf(child_leaf_node),
                         None,
                         Arc::downgrade(&self.this()),
-                        &stats,
+                        container_device_id,
                     );
                     Ok(inode)
                 }
@@ -194,8 +199,11 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                     let child_symlink = child_sysnode
                         .cast_to_symlink()
                         .ok_or(Error::new(Errno::EIO))?;
-                    let inode =
-                        Self::new_symlink(child_symlink, Arc::downgrade(&self.this()), &stats);
+                    let inode = Self::new_symlink(
+                        child_symlink,
+                        Arc::downgrade(&self.this()),
+                        container_device_id,
+                    );
                     Ok(inode)
                 }
             }
@@ -223,7 +231,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
                 attr.clone(),
                 parent_node_arc,
                 Arc::downgrade(&self.this()),
-                &stats,
+                container_device_id,
             );
             Ok(inode)
         }
@@ -249,12 +257,12 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
             }
         };
 
-        let stats = self.fs().stats();
+        let container_device_id = self.metadata().container_dev_id;
         let inode = Self::new_attr(
             attr.clone(),
             leaf_node_arc,
             Arc::downgrade(&self.this()),
-            &stats,
+            container_device_id,
         );
         Ok(inode)
     }
@@ -504,20 +512,20 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
 
         let new_child = branch_node.create_child(name)?;
 
-        let stats = self.fs().stats();
+        let container_device_id = self.metadata().container_dev_id;
         let new_inode = if let Some(branch_child) = new_child.cast_to_branch() {
             Self::new_branch_dir(
                 SysTreeNodeKind::Branch(branch_child),
                 Some(mode),
                 self.parent().clone(),
-                &stats,
+                container_device_id,
             )
         } else {
             Self::new_leaf_dir(
                 SysTreeNodeKind::Leaf(new_child.cast_to_node().unwrap()),
                 Some(mode),
                 self.parent().clone(),
-                &stats,
+                container_device_id,
             )
         };
 

--- a/kernel/src/fs/vfs/fs_apis/file_system.rs
+++ b/kernel/src/fs/vfs/fs_apis/file_system.rs
@@ -3,7 +3,6 @@
 use core::sync::atomic::{AtomicI64, AtomicU32, Ordering};
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
-use device_id::DeviceId;
 
 use super::inode::Inode;
 use crate::prelude::*;
@@ -65,39 +64,16 @@ impl Debug for dyn FileSystem {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FsStats {
-    pub magic: u64,
-    pub bsize: usize,
     pub blocks: usize,
     pub bfree: usize,
     pub bavail: usize,
     pub files: usize,
     pub ffree: usize,
     pub fsid: u64,
-    pub namelen: usize,
     pub frsize: usize,
     pub flags: u64,
-    pub container_dev_id: DeviceId,
-}
-
-impl FsStats {
-    pub fn new(magic: u64, block_size: usize, name_max_len: usize, dev_id: DeviceId) -> Self {
-        Self {
-            magic,
-            bsize: block_size,
-            blocks: 0,
-            bfree: 0,
-            bavail: 0,
-            files: 0,
-            ffree: 0,
-            fsid: 0,
-            namelen: name_max_len,
-            frsize: block_size,
-            flags: 0,
-            container_dev_id: dev_id,
-        }
-    }
 }
 
 bitflags! {

--- a/kernel/src/fs/vfs/fs_apis/file_system.rs
+++ b/kernel/src/fs/vfs/fs_apis/file_system.rs
@@ -29,8 +29,8 @@ pub trait FileSystem: Any + Sync + Send {
     /// context that performs the syscall.
     fn root_inode(&self) -> Arc<dyn Inode>;
 
-    /// Returns the super block of this file system.
-    fn sb(&self) -> SuperBlock;
+    /// Returns statistics about this file system.
+    fn stats(&self) -> FsStats;
 
     /// Returns the flags of this file system.
     fn flags(&self) -> FsFlags {
@@ -59,14 +59,14 @@ impl dyn FileSystem {
 impl Debug for dyn FileSystem {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("FileSystem")
-            .field("super_block", &self.sb())
+            .field("stats", &self.stats())
             .field("flags", &self.flags())
             .finish()
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct SuperBlock {
+pub struct FsStats {
     pub magic: u64,
     pub bsize: usize,
     pub blocks: usize,
@@ -81,7 +81,7 @@ pub struct SuperBlock {
     pub container_dev_id: DeviceId,
 }
 
-impl SuperBlock {
+impl FsStats {
     pub fn new(magic: u64, block_size: usize, name_max_len: usize, dev_id: DeviceId) -> Self {
         Self {
             magic,

--- a/kernel/src/fs/vfs/fs_apis/mod.rs
+++ b/kernel/src/fs/vfs/fs_apis/mod.rs
@@ -8,6 +8,7 @@ pub mod file_system;
 pub mod inode;
 pub mod inode_ext;
 pub mod registry;
+pub mod super_block;
 pub mod xattr;
 
 pub(super) fn init() {

--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -10,8 +10,9 @@ use crate::{
     fs::{
         fs_impls::sysfs,
         vfs::{
-            file_system::{FileSystem, FsFlags},
+            file_system::FsFlags,
             path::{AT_FDCWD, EmptyPathStr, FsPath},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -26,7 +27,7 @@ pub trait FsType: Send + Sync + 'static {
     fn properties(&self) -> FsProperties;
 
     /// Creates an instance of this FS type.
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>>;
+    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<SuperBlock>>;
 
     /// Returns a `SysTree` node that represents the FS type.
     ///

--- a/kernel/src/fs/vfs/fs_apis/super_block.rs
+++ b/kernel/src/fs/vfs/fs_apis/super_block.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! VFS superblock objects shared by mounts of the same filesystem instance.
+
+use super::file_system::FileSystem;
+use crate::prelude::*;
+
+/// A live filesystem instance shared by one or more mounts.
+#[derive(Debug)]
+pub struct SuperBlock {
+    fs: Arc<dyn FileSystem>,
+}
+
+impl SuperBlock {
+    /// Creates a superblock for a filesystem implementation.
+    pub fn new(fs: Arc<dyn FileSystem>) -> Arc<Self> {
+        Arc::new(Self { fs })
+    }
+
+    /// Returns the filesystem implementation owned by this superblock.
+    pub fn fs(&self) -> &Arc<dyn FileSystem> {
+        &self.fs
+    }
+}

--- a/kernel/src/fs/vfs/fs_apis/super_block.rs
+++ b/kernel/src/fs/vfs/fs_apis/super_block.rs
@@ -5,7 +5,10 @@
 use device_id::DeviceId;
 
 use super::file_system::{FileSystem, FsStats};
-use crate::prelude::*;
+use crate::{
+    prelude::*,
+    thread::work_queue::{self, WorkPriority},
+};
 
 /// A live filesystem instance shared by one or more mounts.
 #[derive(Debug)]
@@ -59,5 +62,27 @@ impl SuperBlock {
 
     pub fn container_device_id(&self) -> DeviceId {
         self.container_device_id
+    }
+}
+
+impl Drop for SuperBlock {
+    fn drop(&mut self) {
+        let fs = self.fs.clone();
+        let sync_fn = move || {
+            if let Err(err) = fs.sync() {
+                error!(
+                    "failed to sync filesystem {} during final cleanup: {:?}",
+                    fs.name(),
+                    err
+                );
+            }
+        };
+
+        if work_queue::is_initialized() {
+            work_queue::submit_work_func(sync_fn, WorkPriority::Normal);
+        } else {
+            // The initial mount namespace is created before the work queues.
+            sync_fn();
+        }
     }
 }

--- a/kernel/src/fs/vfs/fs_apis/super_block.rs
+++ b/kernel/src/fs/vfs/fs_apis/super_block.rs
@@ -2,23 +2,62 @@
 
 //! VFS superblock objects shared by mounts of the same filesystem instance.
 
-use super::file_system::FileSystem;
+use device_id::DeviceId;
+
+use super::file_system::{FileSystem, FsStats};
 use crate::prelude::*;
 
 /// A live filesystem instance shared by one or more mounts.
 #[derive(Debug)]
 pub struct SuperBlock {
     fs: Arc<dyn FileSystem>,
+    magic: u64,
+    block_size: usize,
+    name_max: usize,
+    container_device_id: DeviceId,
 }
 
 impl SuperBlock {
     /// Creates a superblock for a filesystem implementation.
-    pub fn new(fs: Arc<dyn FileSystem>) -> Arc<Self> {
-        Arc::new(Self { fs })
+    pub fn new(
+        fs: Arc<dyn FileSystem>,
+        magic: u64,
+        block_size: usize,
+        name_max: usize,
+        container_device_id: DeviceId,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            fs,
+            magic,
+            block_size,
+            name_max,
+            container_device_id,
+        })
     }
 
     /// Returns the filesystem implementation owned by this superblock.
     pub fn fs(&self) -> &Arc<dyn FileSystem> {
         &self.fs
+    }
+
+    /// Returns the current filesystem statistics.
+    pub fn stats(&self) -> FsStats {
+        self.fs.stats()
+    }
+
+    pub fn magic(&self) -> u64 {
+        self.magic
+    }
+
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    pub fn name_max(&self) -> usize {
+        self.name_max
+    }
+
+    pub fn container_device_id(&self) -> DeviceId {
+        self.container_device_id
     }
 }

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -11,7 +11,7 @@ pub mod path;
 pub mod range_lock;
 
 // Re-export commonly used abstractions from `fs_apis`
-pub use fs_apis::{file_system, inode, inode_ext, registry, xattr};
+pub use fs_apis::{file_system, inode, inode_ext, registry, super_block, xattr};
 
 pub(super) fn init() {
     fs_apis::init();

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -393,7 +393,7 @@ impl FileLike for InotifyFile {
                         continue;
                     };
                     let mask = subscriber.interesting_events().bits();
-                    let sdev = inode.fs().sb().fsid;
+                    let sdev = inode.fs().stats().fsid;
                     writeln!(
                         f,
                         "inotify wd:{} ino:{:x} sdev:{:x} mask:{:x} ignored_mask:0",

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -781,7 +781,7 @@ impl DirDentry<'_> {
         let old_dir_inode = self.inode();
         let new_dir_inode = new_dir.inode();
 
-        let max_namelen = old_dir_inode.fs().sb().namelen;
+        let max_namelen = old_dir_inode.fs().stats().namelen;
         if old_name.len() > max_namelen || new_name.len() > max_namelen {
             return_errno_with_message!(Errno::ENAMETOOLONG, "old_name or new_name is too long");
         }

--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -16,6 +16,7 @@ use crate::{
         vfs::{
             inode::{Inode, MknodType, RevalidationPolicy},
             inode_ext::InodeExt,
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -131,6 +132,8 @@ use crate::{
 /// since mounts let a single `Dentry`
 /// appear at several locations in the namespace.
 pub(in crate::fs) struct Dentry {
+    /// A weak reference avoids retaining the superblock through the dentry cache cycle.
+    super_block: Weak<SuperBlock>,
     inode: Arc<dyn Inode>,
     type_: InodeType,
     name_and_parent: NameAndParent,
@@ -210,8 +213,8 @@ impl Dentry {
     ///
     /// It is been created during the construction of the `Mount`.
     /// The `Mount` holds an arc reference to this root `Dentry`.
-    pub(super) fn new_root(inode: Arc<dyn Inode>) -> Arc<Self> {
-        Self::new(inode, DentryOptions::Root)
+    pub(super) fn new_root(inode: Arc<dyn Inode>, super_block: &Arc<SuperBlock>) -> Arc<Self> {
+        Self::new(inode, DentryOptions::Root(Arc::downgrade(super_block)))
     }
 
     /// Creates a new anonymous `Dentry` with the given inode and parent.
@@ -230,18 +233,35 @@ impl Dentry {
     pub(super) fn new_pseudo(
         inode: Arc<dyn Inode>,
         name_fn: fn(&dyn Inode) -> String,
+        super_block: &Arc<SuperBlock>,
     ) -> Arc<Self> {
-        Self::new(inode, DentryOptions::Pseudo(name_fn))
+        Self::new(
+            inode,
+            DentryOptions::Pseudo {
+                name_fn,
+                super_block: Arc::downgrade(super_block),
+            },
+        )
     }
 
     fn new(inode: Arc<dyn Inode>, options: DentryOptions) -> Arc<Self> {
-        let name_and_parent = match options {
-            DentryOptions::Root => NameAndParent::Real(None),
+        let (name_and_parent, super_block) = match options {
+            DentryOptions::Root(super_block) => (NameAndParent::Real(None), super_block),
             DentryOptions::Named(name_and_parent) => {
-                NameAndParent::Real(Some(RwLock::new(name_and_parent)))
+                let super_block = name_and_parent.1.super_block.clone();
+                (
+                    NameAndParent::Real(Some(RwLock::new(name_and_parent))),
+                    super_block,
+                )
             }
-            DentryOptions::Anonymous { parent } => NameAndParent::Anonymous(parent),
-            DentryOptions::Pseudo(name_fn) => NameAndParent::Pseudo(name_fn),
+            DentryOptions::Anonymous { parent } => {
+                let super_block = parent.super_block.clone();
+                (NameAndParent::Anonymous(parent), super_block)
+            }
+            DentryOptions::Pseudo {
+                name_fn,
+                super_block,
+            } => (NameAndParent::Pseudo(name_fn), super_block),
         };
 
         let type_ = inode.type_();
@@ -252,6 +272,7 @@ impl Dentry {
         });
 
         Arc::new_cyclic(|weak_self| Self {
+            super_block,
             inode,
             type_,
             name_and_parent,
@@ -781,7 +802,7 @@ impl DirDentry<'_> {
         let old_dir_inode = self.inode();
         let new_dir_inode = new_dir.inode();
 
-        let max_namelen = old_dir_inode.fs().stats().namelen;
+        let max_namelen = self.super_block.upgrade().unwrap().name_max();
         if old_name.len() > max_namelen || new_name.len() > max_namelen {
             return_errno_with_message!(Errno::ENAMETOOLONG, "old_name or new_name is too long");
         }
@@ -1018,7 +1039,7 @@ bitflags! {
 /// See [`Dentry`] for the taxonomy.
 enum DentryOptions {
     /// Root of a mounted filesystem.
-    Root,
+    Root(Weak<SuperBlock>),
     /// A named entry under a parent directory.
     Named((String, Arc<Dentry>)),
     /// A real inode parented to a directory
@@ -1027,7 +1048,10 @@ enum DentryOptions {
     Anonymous { parent: Arc<Dentry> },
     /// An object with no place in any real filesystem tree;
     /// the `fn` synthesizes its display name for `/proc/<pid>/fd/<n>`.
-    Pseudo(fn(&dyn Inode) -> String),
+    Pseudo {
+        name_fn: fn(&dyn Inode) -> String,
+        super_block: Weak<SuperBlock>,
+    },
 }
 
 /// Manages child dentries in the per-directory cache.

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -95,7 +95,7 @@ impl Path {
         inode: Arc<dyn Inode>,
         name_fn: fn(&dyn Inode) -> String,
     ) -> Self {
-        let dentry = Dentry::new_pseudo(inode, name_fn);
+        let dentry = Dentry::new_pseudo(inode, name_fn, mount.super_block());
         Self::new(mount, dentry)
     }
 

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         vfs::{
             file_system::{FileSystem, FsFlags},
             inode::{HardLinkability, Inode, Metadata, MknodType, RenameMode},
+            super_block::SuperBlock,
             xattr::{XattrName, XattrNamespace, XattrSetFlags},
         },
     },
@@ -345,7 +346,7 @@ impl Path {
     /// in the current mount namespace.
     pub fn mount(
         &self,
-        fs: Arc<dyn FileSystem>,
+        super_block: Arc<SuperBlock>,
         flags: PerMountFlags,
         source: Option<String>,
         ctx: &Context,
@@ -368,9 +369,13 @@ impl Path {
         }
 
         let mut topology_guard = MountTopology::write_lock();
-        let child_mount =
-            self.mount
-                .do_mount(fs, flags, &self.dentry, source, &mut topology_guard)?;
+        let child_mount = self.mount.do_mount(
+            super_block,
+            flags,
+            &self.dentry,
+            source,
+            &mut topology_guard,
+        )?;
 
         Ok(child_mount)
     }

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -346,7 +346,7 @@ impl Mount {
 
         let mount = Arc::new_cyclic(|weak_self| Self {
             id,
-            root_dentry: Dentry::new_root(super_block.fs().root_inode()),
+            root_dentry: Dentry::new_root(super_block.fs().root_inode(), &super_block),
             mountpoint: RwLock::new(None),
             super_block,
             source,

--- a/kernel/src/fs/vfs/path/mount.rs
+++ b/kernel/src/fs/vfs/path/mount.rs
@@ -18,6 +18,7 @@ use crate::{
                 dentry::{Dentry, DentryKey},
                 mount_namespace::MountNamespace,
             },
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -248,8 +249,8 @@ pub struct Mount {
     /// Mountpoint dentry. A mount node can be mounted on one dentry of another mount node,
     /// which makes the mount being the child of the mount node.
     mountpoint: RwLock<Option<Arc<Dentry>>>,
-    /// The associated FS.
-    fs: Arc<dyn FileSystem>,
+    /// The associated superblock.
+    super_block: Arc<SuperBlock>,
     /// The mount source (e.g., a device path like "/dev/vda" or a filesystem name like "proc").
     ///
     /// The source is stored in `Mount` instead of requiring each filesystem to provide it.
@@ -282,19 +283,31 @@ impl Mount {
     /// It is allowed to create a mount node even if the fs has been provided to another
     /// mount node. It is the fs's responsibility to ensure the data consistency.
     pub(in crate::fs) fn new_root(
-        fs: Arc<dyn FileSystem>,
+        super_block: Arc<SuperBlock>,
         mnt_ns: Weak<MountNamespace>,
     ) -> Result<Arc<Self>> {
-        let source = fs.name().to_string();
-        Self::new(fs, PerMountFlags::default(), None, mnt_ns, Some(source))
+        let source = super_block.fs().name().to_string();
+        Self::new(
+            super_block,
+            PerMountFlags::default(),
+            None,
+            mnt_ns,
+            Some(source),
+        )
     }
 
     /// Creates a pseudo mount node with an associated FS.
     ///
     /// This pseudo mount is not mounted on other mount nodes, has no parent, and does not
     /// belong to any mount namespace.
-    pub(in crate::fs) fn new_pseudo(fs: Arc<dyn FileSystem>) -> Result<Arc<Self>> {
-        Self::new(fs, PerMountFlags::KERNMOUNT, None, Weak::new(), None)
+    pub(in crate::fs) fn new_pseudo(super_block: Arc<SuperBlock>) -> Result<Arc<Self>> {
+        Self::new(
+            super_block,
+            PerMountFlags::KERNMOUNT,
+            None,
+            Weak::new(),
+            None,
+        )
     }
 
     /// Creates a mount node that is not attached to the mount tree.
@@ -305,12 +318,12 @@ impl Mount {
     // immutable. This should be changed once mount namespaces can be updated
     // during attach.
     pub fn new_detached(
-        fs: Arc<dyn FileSystem>,
+        super_block: Arc<SuperBlock>,
         flags: PerMountFlags,
         mnt_ns: Weak<MountNamespace>,
         source: Option<String>,
     ) -> Result<Arc<Self>> {
-        Self::new(fs, flags, None, mnt_ns, source)
+        Self::new(super_block, flags, None, mnt_ns, source)
     }
 
     /// The internal constructor.
@@ -322,7 +335,7 @@ impl Mount {
     /// exist without a mountpoint, ensuring uniformity and security, while all other
     /// mount nodes must be explicitly assigned a mountpoint to maintain structural integrity.
     fn new(
-        fs: Arc<dyn FileSystem>,
+        super_block: Arc<SuperBlock>,
         flags: PerMountFlags,
         parent_mount: Option<Weak<Mount>>,
         mnt_ns: Weak<MountNamespace>,
@@ -333,9 +346,9 @@ impl Mount {
 
         let mount = Arc::new_cyclic(|weak_self| Self {
             id,
-            root_dentry: Dentry::new_root(fs.root_inode()),
+            root_dentry: Dentry::new_root(super_block.fs().root_inode()),
             mountpoint: RwLock::new(None),
-            fs,
+            super_block,
             source,
             parent: RwLock::new(parent_mount),
             children: RwLock::new(HashMap::new()),
@@ -369,7 +382,7 @@ impl Mount {
 
     /// Returns the mount source.
     pub(in crate::fs) fn source(&self) -> Option<&str> {
-        self.fs.source().or(self.source.as_deref())
+        self.fs().source().or(self.source.as_deref())
     }
 
     /// Mounts a fs on the mountpoint, it will create a new child mount node.
@@ -387,7 +400,7 @@ impl Mount {
     /// Returns the mounted child mount.
     pub(super) fn do_mount(
         self: &Arc<Self>,
-        fs: Arc<dyn FileSystem>,
+        super_block: Arc<SuperBlock>,
         flags: PerMountFlags,
         mountpoint: &Arc<Dentry>,
         source: Option<String>,
@@ -399,7 +412,7 @@ impl Mount {
 
         let key = mountpoint.key();
         let child_mount = Self::new(
-            fs,
+            super_block,
             flags,
             Some(Arc::downgrade(self)),
             self.mnt_ns.clone(),
@@ -448,7 +461,7 @@ impl Mount {
             id,
             root_dentry: root_dentry.clone(),
             mountpoint: RwLock::new(None),
-            fs: self.fs.clone(),
+            super_block: self.super_block.clone(),
             source: self.source.clone(),
             parent: RwLock::new(None),
             children: RwLock::new(HashMap::new()),
@@ -623,7 +636,7 @@ impl Mount {
 
     /// Flushes all pending filesystem metadata and cached file data to the device.
     pub(super) fn sync(&self) -> Result<()> {
-        self.fs.sync()?;
+        self.fs().sync()?;
         Ok(())
     }
 
@@ -636,7 +649,7 @@ impl Mount {
         _topology: &mut MountTopology,
     ) -> Result<()> {
         if let Some(flags) = fs_flags {
-            self.fs.set_fs_flags(flags, data, ctx)?;
+            self.fs().set_fs_flags(flags, data, ctx)?;
         }
 
         // The logics here are consistent with Linux.
@@ -690,9 +703,14 @@ impl Mount {
         &self.mnt_ns
     }
 
+    /// Gets the associated superblock.
+    pub fn super_block(&self) -> &Arc<SuperBlock> {
+        &self.super_block
+    }
+
     /// Gets the associated FS.
     pub fn fs(&self) -> &Arc<dyn FileSystem> {
-        &self.fs
+        self.super_block().fs()
     }
 
     /// Gets the associated mount flags.
@@ -748,7 +766,7 @@ impl Debug for Mount {
         f.debug_struct("Mount")
             .field("root", &self.root_dentry)
             .field("mountpoint", &self.mountpoint)
-            .field("fs", &self.fs)
+            .field("super_block", &self.super_block)
             .finish()
     }
 }

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -12,7 +12,10 @@ use crate::{
     fs::{
         fs_impls::ramfs::RamFs,
         pseudofs::{NsCommonOps, NsType, StashedDentry},
-        vfs::path::{Dentry, Mount, Path, PathResolver},
+        vfs::{
+            path::{Dentry, Mount, Path, PathResolver},
+            super_block::SuperBlock,
+        },
     },
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
@@ -95,7 +98,7 @@ impl MountNamespace {
 
         INIT.call_once(|| {
             let owner = UserNamespace::get_init_singleton().clone();
-            let rootfs = RamFs::new_rootfs();
+            let rootfs = SuperBlock::new(RamFs::new_rootfs());
 
             Self::new_with_root(owner, |weak_ns| Mount::new_root(rootfs, weak_ns.clone()))
                 .expect("failed to allocate mount ID for the root mount")

--- a/kernel/src/fs/vfs/path/mount_namespace.rs
+++ b/kernel/src/fs/vfs/path/mount_namespace.rs
@@ -12,10 +12,7 @@ use crate::{
     fs::{
         fs_impls::ramfs::RamFs,
         pseudofs::{NsCommonOps, NsType, StashedDentry},
-        vfs::{
-            path::{Dentry, Mount, Path, PathResolver},
-            super_block::SuperBlock,
-        },
+        vfs::path::{Dentry, Mount, Path, PathResolver},
     },
     prelude::*,
     process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::PosixThread},
@@ -98,7 +95,7 @@ impl MountNamespace {
 
         INIT.call_once(|| {
             let owner = UserNamespace::get_init_singleton().clone();
-            let rootfs = SuperBlock::new(RamFs::new_rootfs());
+            let rootfs = RamFs::new_rootfs().into_super_block();
 
             Self::new_with_root(owner, |weak_ns| Mount::new_root(rootfs, weak_ns.clone()))
                 .expect("failed to allocate mount ID for the root mount")

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -5,9 +5,10 @@ use crate::{
     fs::{
         file::InodeType,
         vfs::{
-            file_system::{FileSystem, FsFlags},
+            file_system::FsFlags,
             path::{AT_FDCWD, EmptyPathStr, FsPath, MountPropType, Path, PerMountFlags},
             registry::{FsCreationCtx, FsType},
+            super_block::SuperBlock,
         },
     },
     prelude::*,
@@ -223,19 +224,19 @@ fn do_new_mount(
         Some(source)
     };
 
-    let fs = open_fs(source.as_deref(), flags, fs_type, data_addr, ctx)?;
-    target_path.mount(fs, flags.into(), source, ctx)?;
+    let super_block = open_super_block(source.as_deref(), flags, fs_type, data_addr, ctx)?;
+    target_path.mount(super_block, flags.into(), source, ctx)?;
     Ok(())
 }
 
-/// Gets the filesystem by fs_type and source.
-fn open_fs(
+/// Opens a superblock by filesystem type and source.
+fn open_super_block(
     source: Option<&str>,
     flags: MountFlags,
     fs_type: &dyn FsType,
     data_addr: Vaddr,
     ctx: &Context,
-) -> Result<Arc<dyn FileSystem>> {
+) -> Result<Arc<SuperBlock>> {
     let user_space = ctx.user_space();
     let data = if data_addr == 0 {
         None

--- a/kernel/src/syscall/statfs.rs
+++ b/kernel/src/syscall/statfs.rs
@@ -90,7 +90,8 @@ struct Statfs {
 
 impl Statfs {
     fn new(mount: &Mount) -> Self {
-        let stats = mount.fs().stats();
+        let super_block = mount.super_block();
+        let stats = super_block.stats();
         // TODO: Make `SuperBlock` correctly implement and maintain `FsFlags`,
         // so they can be retrieved directly here.
         let statfs_flags = StatfsFlags::new(
@@ -98,16 +99,20 @@ impl Statfs {
             FsFlags::from_bits_truncate(stats.flags as u32),
         );
         Self {
-            f_type: stats.magic,
-            f_bsize: stats.bsize,
+            f_type: super_block.magic(),
+            f_bsize: super_block.block_size(),
             f_blocks: stats.blocks,
             f_bfree: stats.bfree,
             f_bavail: stats.bavail,
             f_files: stats.files,
             f_ffree: stats.ffree,
             f_fsid: stats.fsid,
-            f_namelen: stats.namelen,
-            f_frsize: stats.frsize,
+            f_namelen: super_block.name_max(),
+            f_frsize: if stats.frsize == 0 {
+                super_block.block_size()
+            } else {
+                stats.frsize
+            },
             f_flags: statfs_flags.bits() as u64,
             f_spare: [0u64; 4],
         }

--- a/kernel/src/syscall/statfs.rs
+++ b/kernel/src/syscall/statfs.rs
@@ -90,22 +90,24 @@ struct Statfs {
 
 impl Statfs {
     fn new(mount: &Mount) -> Self {
-        let sb = mount.fs().sb();
+        let stats = mount.fs().stats();
         // TODO: Make `SuperBlock` correctly implement and maintain `FsFlags`,
         // so they can be retrieved directly here.
-        let statfs_flags =
-            StatfsFlags::new(mount.flags(), FsFlags::from_bits_truncate(sb.flags as u32));
+        let statfs_flags = StatfsFlags::new(
+            mount.flags(),
+            FsFlags::from_bits_truncate(stats.flags as u32),
+        );
         Self {
-            f_type: sb.magic,
-            f_bsize: sb.bsize,
-            f_blocks: sb.blocks,
-            f_bfree: sb.bfree,
-            f_bavail: sb.bavail,
-            f_files: sb.files,
-            f_ffree: sb.ffree,
-            f_fsid: sb.fsid,
-            f_namelen: sb.namelen,
-            f_frsize: sb.frsize,
+            f_type: stats.magic,
+            f_bsize: stats.bsize,
+            f_blocks: stats.blocks,
+            f_bfree: stats.bfree,
+            f_bavail: stats.bavail,
+            f_files: stats.files,
+            f_ffree: stats.ffree,
+            f_fsid: stats.fsid,
+            f_namelen: stats.namelen,
+            f_frsize: stats.frsize,
             f_flags: statfs_flags.bits() as u64,
             f_spare: [0u64; 4],
         }

--- a/kernel/src/thread/work_queue/mod.rs
+++ b/kernel/src/thread/work_queue/mod.rs
@@ -82,6 +82,11 @@ static WORKERPOOL_HIGH_PRI: Once<Arc<WorkerPool>> = Once::new();
 static WORKQUEUE_GLOBAL_NORMAL: Once<Arc<WorkQueue>> = Once::new();
 static WORKQUEUE_GLOBAL_HIGH_PRI: Once<Arc<WorkQueue>> = Once::new();
 
+/// Returns whether the global work queues are ready to accept work.
+pub fn is_initialized() -> bool {
+    WORKQUEUE_GLOBAL_NORMAL.get().is_some() && WORKQUEUE_GLOBAL_HIGH_PRI.get().is_some()
+}
+
 /// Submit a function to a global work queue.
 pub fn submit_work_func<F>(work_func: F, work_priority: WorkPriority)
 where


### PR DESCRIPTION
Previously, the VFS type named `SuperBlock` was only a snapshot of filesystem statistics. This differs from Linux, where `struct super_block` represents a live filesystem instance, while `kstatfs` contains the statistics returned by `statfs`.

This PR renames the previous statistics type from `SuperBlock` to `FsStats`. It also introduces a VFS `SuperBlock` that owns the `FileSystem` and records immutable metadata, including the filesystem magic number, block size, maximum filename length, and container device ID.

The filesystem is synchronized when the last `Arc<SuperBlock>` is released. This corresponds to the `sync_filesystem()` step performed by Linux's `generic_shutdown_super()`. Asterinas does not yet implement the remainder of Linux's superblock shutdown and inode eviction procedure.

The exact responsibilities and API boundaries of `SuperBlock` and `FsStats` may warrant further discussion.

References:
1. [Linux `struct super_block`](https://elixir.bootlin.com/linux/v6.17/source/include/linux/fs.h#L1328)
2. [Linux `generic_shutdown_super()`](https://elixir.bootlin.com/linux/v6.17/source/fs/super.c#L622)