### PR TITLE
Fix the owner model of range locks

### DIFF
--- a/kernel/src/fs/file/file_table.rs
+++ b/kernel/src/fs/file/file_table.rs
@@ -6,9 +6,12 @@ use core::{
 };
 
 use aster_util::{ranged_integer::RangedU32, slot_vec::SlotVec};
+use ostd::sync::RwArc;
 
 use super::file_handle::FileLike;
-use crate::{prelude::*, process::posix_thread::FileTableRefMut};
+use crate::{
+    fs::vfs::range_lock::RangeLockOwner, prelude::*, process::posix_thread::FileTableRefMut,
+};
 
 /// Represents a validated, non-negative file descriptor.
 ///
@@ -94,16 +97,37 @@ impl TryFrom<RawFileDesc> for FileDesc {
     }
 }
 
-#[derive(Clone)]
+/// A file table.
+///
+/// A file table is created within an [`RwArc`] and remains within it (see [`Self::new`] and
+/// [`Self::fork_from`]). The file table's address is used as a [`RangeLockOwner`], so users should
+/// not try to move the file table to a different address.
 pub struct FileTable {
     table: SlotVec<FileTableEntry>,
 }
 
 impl FileTable {
-    pub const fn new() -> Self {
-        Self {
+    /// Creates a new file table.
+    pub fn new() -> RwArc<Self> {
+        RwArc::new(Self {
             table: SlotVec::new(),
-        }
+        })
+    }
+
+    /// Creates a new file table containing clones of all entries in `parent`.
+    pub fn fork_from(parent: &Self) -> RwArc<Self> {
+        RwArc::new(Self {
+            table: parent.table.clone(),
+        })
+    }
+
+    /// Returns the range-lock owner of `file_table`.
+    pub fn range_lock_owner(file_table: &RwArc<Self>) -> RangeLockOwner {
+        RangeLockOwner::from_address(file_table.as_ptr().addr())
+    }
+
+    fn as_range_lock_owner(&self) -> RangeLockOwner {
+        RangeLockOwner::from_address(self as *const Self as usize)
     }
 
     pub fn len(&self) -> usize {
@@ -176,7 +200,7 @@ impl FileTable {
         //
         // Reference: <https://man7.org/linux/man-pages/man2/fcntl_locking.2.html>
         if let Ok(inode_handle) = removed_entry.file.as_inode_handle_or_err() {
-            inode_handle.release_range_locks();
+            inode_handle.release_range_locks(self.as_range_lock_owner());
         }
         Some(removed_entry.file)
     }
@@ -237,9 +261,13 @@ impl FileTable {
     }
 }
 
-impl Default for FileTable {
-    fn default() -> Self {
-        Self::new()
+impl Drop for FileTable {
+    fn drop(&mut self) {
+        for (_, file) in self.fds_and_files() {
+            if let Ok(inode_handle) = file.as_inode_handle_or_err() {
+                inode_handle.release_range_locks(self.as_range_lock_owner());
+            }
+        }
     }
 }
 

--- a/kernel/src/fs/file/file_table.rs
+++ b/kernel/src/fs/file/file_table.rs
@@ -171,7 +171,7 @@ impl FileTable {
         fd: FileDesc,
         new_fd: FileDesc,
         flags: FdFlags,
-    ) -> Result<Option<Arc<dyn FileLike>>> {
+    ) -> Result<Option<ClosedFile>> {
         let entry = self.duplicate_entry(fd, flags)?;
         let closed_file = self.close_file(new_fd);
         self.table.put_at(new_fd.into(), entry);
@@ -193,23 +193,23 @@ impl FileTable {
         (self.table.put(entry) as RawFileDesc).try_into().unwrap()
     }
 
-    pub fn close_file(&mut self, fd: FileDesc) -> Option<Arc<dyn FileLike>> {
+    pub fn close_file(&mut self, fd: FileDesc) -> Option<ClosedFile> {
         let removed_entry = self.table.remove(fd.into())?;
         // POSIX record locks are process-associated and Linux drops them when any fd for the inode is
         // closed by that process, even if duplicated descriptors still exist.
         //
         // Reference: <https://man7.org/linux/man-pages/man2/fcntl_locking.2.html>
-        if let Ok(inode_handle) = removed_entry.file.as_inode_handle_or_err() {
-            inode_handle.release_range_locks(self.as_range_lock_owner());
-        }
-        Some(removed_entry.file)
+        Some(ClosedFile::new(
+            removed_entry.file,
+            self.as_range_lock_owner(),
+        ))
     }
 
-    pub fn close_files_on_exec(&mut self) -> Vec<Arc<dyn FileLike>> {
+    pub fn close_files_on_exec(&mut self) -> Vec<ClosedFile> {
         self.close_files(|entry| entry.flags().contains(FdFlags::CLOEXEC))
     }
 
-    fn close_files<F>(&mut self, should_close: F) -> Vec<Arc<dyn FileLike>>
+    fn close_files<F>(&mut self, should_close: F) -> Vec<ClosedFile>
     where
         F: Fn(&FileTableEntry) -> bool,
     {
@@ -267,6 +267,37 @@ impl Drop for FileTable {
             if let Ok(inode_handle) = file.as_inode_handle_or_err() {
                 inode_handle.release_range_locks(self.as_range_lock_owner());
             }
+        }
+    }
+}
+
+/// A file removed from a [`FileTable`] whose close cleanup is pending.
+///
+/// Dropping this value may block, so it must be dropped after releasing the file-table lock.
+#[must_use = "close cleanup runs when this value is dropped"]
+pub struct ClosedFile {
+    file: Arc<dyn FileLike>,
+    range_lock_owner: RangeLockOwner,
+}
+
+impl ClosedFile {
+    fn new(file: Arc<dyn FileLike>, range_lock_owner: RangeLockOwner) -> Self {
+        Self {
+            file,
+            range_lock_owner,
+        }
+    }
+
+    /// Returns the removed file.
+    pub fn file(&self) -> &Arc<dyn FileLike> {
+        &self.file
+    }
+}
+
+impl Drop for ClosedFile {
+    fn drop(&mut self) {
+        if let Ok(inode_handle) = self.file.as_inode_handle_or_err() {
+            inode_handle.release_range_locks(self.range_lock_owner);
         }
     }
 }

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -18,7 +18,7 @@ use crate::{
             inode::{FallocMode, FileOps},
             inode_ext::InodeExt,
             path::Path,
-            range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
+            range_lock::{RangeLockItem, RangeLockOwner, RangeLockType},
         },
     },
     prelude::*,
@@ -183,12 +183,15 @@ impl InodeHandle {
         range_lock_list.set_lock(lock, is_nonblocking)
     }
 
-    pub fn release_range_locks(&self) {
-        let range_lock = RangeLockItem::new(
-            RangeLockType::Unlock,
-            FileRange::new(0, OFFSET_MAX).unwrap(),
-        );
-        self.unlock_range_lock(&range_lock);
+    pub fn release_range_locks(&self, owner: RangeLockOwner) {
+        if let Some(range_lock_list) = self
+            .path()
+            .inode()
+            .fs_lock_context()
+            .map(|context| context.range_lock_list())
+        {
+            range_lock_list.unlock_all(owner);
+        }
     }
 
     fn unlock_range_lock(&self, lock: &RangeLockItem) {
@@ -493,7 +496,6 @@ impl FileLike for InodeHandle {
 
 impl Drop for InodeHandle {
     fn drop(&mut self) {
-        self.release_range_locks();
         let _ = self.unlock_flock();
     }
 }

--- a/kernel/src/fs/vfs/range_lock/mod.rs
+++ b/kernel/src/fs/vfs/range_lock/mod.rs
@@ -10,14 +10,26 @@ use crate::{prelude::*, process::Pid};
 
 mod range;
 
+/// Identifies the file table that owns a [`RangeLock`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RangeLockOwner(usize);
+
+impl RangeLockOwner {
+    pub(in crate::fs) fn from_address(address: usize) -> Self {
+        Self(address)
+    }
+}
+
 /// The metadata of a POSIX advisory file range lock.
 #[derive(Clone, Debug)]
 struct RangeLock {
-    /// Owner of the lock, representing the process holding the lock
-    owner: Pid,
-    /// Type of lock: can be F_RDLCK (read lock), F_WRLCK (write lock), or F_UNLCK (unlock)
+    /// File-table identity that owns the lock.
+    owner: RangeLockOwner,
+    /// PID associated with this lock.
+    pid: Pid,
+    /// Type of the lock: `F_RDLCK` (read lock), `F_WRLCK` (write lock), or `F_UNLCK` (unlock).
     type_: RangeLockType,
-    /// Range of the lock which specifies the portion of the file being locked
+    /// Range of the lock which specifies the portion of the file being locked.
     range: FileRange,
 }
 
@@ -25,18 +37,20 @@ struct RangeLock {
 /// Contains metadata about the lock and the processes waiting for it.
 /// The lock is associated with a specific range of the file.
 pub struct RangeLockItem {
-    /// The lock data including its properties
+    /// The lock data including its properties.
     lock: RangeLock,
-    /// Waiters that are being blocked by this lock
+    /// Waiters that are being blocked by this lock.
     waitqueue: Arc<WaitQueue>,
 }
 
 impl RangeLockItem {
-    /// Creates a new instance with the given lock type and the file range.
-    /// The new instance will be associated with the current process.
-    pub fn new(type_: RangeLockType, range: FileRange) -> Self {
+    /// Creates a new range lock instance.
+    ///
+    /// The new instance will be associated with the current process and the given lock owner.
+    pub fn new(owner: RangeLockOwner, pid: Pid, type_: RangeLockType, range: FileRange) -> Self {
         let lock = RangeLock {
-            owner: current!().pid(),
+            owner,
+            pid,
             type_,
             range,
         };
@@ -44,6 +58,26 @@ impl RangeLockItem {
             lock,
             waitqueue: Arc::new(WaitQueue::new()),
         }
+    }
+
+    /// Returns the file-table identity that owns the lock.
+    pub fn owner(&self) -> RangeLockOwner {
+        self.lock.owner
+    }
+
+    /// Sets the file-table identity that owns the lock.
+    pub fn set_owner(&mut self, owner: RangeLockOwner) {
+        self.lock.owner = owner;
+    }
+
+    /// Returns the process ID reported for the lock.
+    pub fn pid(&self) -> Pid {
+        self.lock.pid
+    }
+
+    /// Sets the process ID reported for the lock.
+    pub fn set_pid(&mut self, pid: Pid) {
+        self.lock.pid = pid;
     }
 
     /// Returns the type of the lock (READ/WRITE/UNLOCK)
@@ -54,16 +88,6 @@ impl RangeLockItem {
     /// Sets the type of the lock to the specified type
     pub fn set_type(&mut self, type_: RangeLockType) {
         self.lock.type_ = type_;
-    }
-
-    /// Returns the owner (process ID) of the lock
-    pub fn owner(&self) -> Pid {
-        self.lock.owner
-    }
-
-    /// Sets the owner of the lock to the specified process ID
-    pub fn set_owner(&mut self, owner: Pid) {
-        self.lock.owner = owner;
     }
 
     /// Returns the range of the lock
@@ -79,7 +103,7 @@ impl RangeLockItem {
     /// Checks if this lock conflicts with another lock
     /// Returns true if there is a conflict, otherwise false
     pub fn conflict_with(&self, other: &Self) -> bool {
-        // If locks are owned by the same process, they do not conflict
+        // If locks are owned by the same file table, they do not conflict
         if self.owner() == other.owner() {
             return false;
         }
@@ -156,6 +180,7 @@ impl Debug for RangeLockItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RangeLock")
             .field("owner", &self.owner())
+            .field("pid", &self.pid())
             .field("type_", &self.type_())
             .field("range", &self.range())
             .finish()
@@ -176,7 +201,7 @@ impl Clone for RangeLockItem {
 /// List of File POSIX advisory range locks.
 ///
 /// Rule of ordering:
-/// Locks are sorted by owner process, then by the starting offset.
+/// Locks are sorted by file-table owner, then by the starting offset.
 ///
 /// Rule of merging:
 /// Adjacent and overlapping locks with same owner and type will be merged.
@@ -206,6 +231,7 @@ impl RangeLockList {
         for existing_lock in list.iter() {
             if lock.conflict_with(existing_lock) {
                 req_lock.set_owner(existing_lock.owner());
+                req_lock.set_pid(existing_lock.pid());
                 req_lock.set_type(existing_lock.type_());
                 req_lock.set_range(existing_lock.range());
                 return req_lock;
@@ -399,6 +425,12 @@ impl RangeLockList {
                 }
             }
         }
+    }
+
+    /// Removes all locks belonging to `owner`.
+    pub fn unlock_all(&self, owner: RangeLockOwner) {
+        let mut list = self.inner.write();
+        list.retain(|lock| lock.owner() != owner);
     }
 }
 

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -741,7 +741,7 @@ fn clone_files(parent_file_table: &RwArc<FileTable>, clone_flags: CloneFlags) ->
     if clone_flags.contains(CloneFlags::CLONE_FILES) {
         parent_file_table.clone()
     } else {
-        RwArc::new(parent_file_table.read().clone())
+        FileTable::fork_from(&parent_file_table.read())
     }
 }
 

--- a/kernel/src/process/clone.rs
+++ b/kernel/src/process/clone.rs
@@ -787,16 +787,20 @@ fn clone_pidfd(
     };
 
     // Since `write_val` may sleep, we cannot hold the file table lock during its execution.
-    // FIXME: Should we remove the file from the file table if the write operation fails?
     match ctx
         .user_space()
         .write_val(pidfd_addr, &RawFileDesc::from(fd))
     {
         Ok(()) => Ok(()),
         Err(err) => {
-            let file_table = ctx.thread_local.borrow_file_table();
-            let mut file_table_locked = file_table.unwrap().write();
-            file_table_locked.close_file(fd);
+            // FIXME: Introduce reserved FDs to ensure that the file is never visible to user space
+            // before `write_val` succeeds and cleanup closes the exact reserved FD below.
+            let closed_file = {
+                let file_table = ctx.thread_local.borrow_file_table();
+                let mut file_table_locked = file_table.unwrap().write();
+                file_table_locked.close_file(fd)
+            };
+            drop(closed_file);
             Err(err.into())
         }
     }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -378,11 +378,12 @@ fn reset_vfork_child(process: &Process) {
 fn unshare_and_close_files(ctx: &Context) {
     ctx.unshare_files();
 
-    ctx.thread_local
-        .borrow_file_table()
-        .unwrap()
-        .write()
-        .close_files_on_exec();
+    let closed_files = {
+        let file_table = ctx.thread_local.borrow_file_table();
+        let mut file_table_locked = file_table.unwrap().write();
+        file_table_locked.close_files_on_exec()
+    };
+    drop(closed_files);
 }
 
 fn unshare_and_reset_sigdispositions(process: &Process) {

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::sync::RwArc;
-
-use crate::{prelude::*, process::CloneFlags};
+use crate::{fs::file::file_table::FileTable, prelude::*, process::CloneFlags};
 
 /// Provides administrative APIs for disassociating execution contexts.
 pub trait ContextUnshareAdminApi {
@@ -23,7 +21,7 @@ impl ContextUnshareAdminApi for Context<'_> {
         let mut thread_local_file_table_ref = self.thread_local.borrow_file_table_mut();
         let thread_local_file_table = thread_local_file_table_ref.unwrap();
 
-        let new_file_table = RwArc::new(thread_local_file_table.read().clone());
+        let new_file_table = FileTable::fork_from(&thread_local_file_table.read());
 
         *pthread_file_table = Some(new_file_table.clone_ro());
         *thread_local_file_table = new_file_table;

--- a/kernel/src/process/posix_thread/builder.rs
+++ b/kernel/src/process/posix_thread/builder.rs
@@ -169,7 +169,7 @@ impl PosixThreadBuilder {
             default_timer_slack_ns,
         } = self;
 
-        let file_table = file_table.unwrap_or_else(|| RwArc::new(FileTable::new()));
+        let file_table = file_table.unwrap_or_else(FileTable::new);
 
         assert_eq!(user_ns.is_none(), ns_proxy.is_none());
         let user_ns = user_ns.unwrap_or_else(|| UserNamespace::get_init_singleton().clone());

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -22,7 +22,7 @@ bitflags! {
 pub fn sys_close(raw_fd: RawFileDesc, ctx: &Context) -> Result<SyscallReturn> {
     debug!("raw_fd = {}", raw_fd);
 
-    let file = {
+    let closed_file = {
         let fd = raw_fd.try_into()?;
         let file_table = ctx.thread_local.borrow_file_table();
         let mut file_table_locked = file_table.unwrap().write();
@@ -30,14 +30,14 @@ pub fn sys_close(raw_fd: RawFileDesc, ctx: &Context) -> Result<SyscallReturn> {
         file_table_locked.close_file(fd).unwrap()
     };
 
-    fs::vfs::notify::on_close(&file);
+    fs::vfs::notify::on_close(closed_file.file());
 
     // Cleanup work needs to be done in the `Drop` impl.
     //
     // We don't mind the races between closing the file descriptor and using the file descriptor,
     // because such races are explicitly allowed in the man pages. See the "Multithreaded processes
     // and close()" section in <https://man7.org/linux/man-pages/man2/close.2.html>.
-    drop(file);
+    drop(closed_file);
 
     // Linux has error codes for the close() system call for diagnostic and remedial purposes, but
     // only for a small subset of file systems such as NFS. We currently have no support for such
@@ -58,10 +58,11 @@ pub fn sys_close_range(
     debug!("first = {}, last = {}, flags = {}", first, last, raw_flags);
 
     if last < first {
-        return_errno!(Errno::EINVAL);
+        return_errno_with_message!(Errno::EINVAL, "the range to close is invalid");
     }
 
-    let flags = CloseRangeFlags::from_bits(raw_flags).ok_or_else(|| Error::new(Errno::EINVAL))?;
+    let flags = CloseRangeFlags::from_bits(raw_flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid close_range flags"))?;
 
     if flags.contains(CloseRangeFlags::UNSHARE) {
         // FIXME: While directly invoking `unshare_files` is logically correct,

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -7,7 +7,7 @@ use crate::{
     fs::{
         file::{
             FileLike, StatusFlags, StatusFlagsUpdate,
-            file_table::{FdFlags, FileDesc, RawFileDesc, WithFileTable, get_file_fast},
+            file_table::{FdFlags, FileDesc, FileTable, RawFileDesc, WithFileTable, get_file_fast},
         },
         ramfs::memfd::{FileSeals, MemfdInodeHandle},
         vfs::range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
@@ -90,6 +90,7 @@ fn handle_setfl(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
 
 fn handle_getlk(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
+    let owner = FileTable::range_lock_owner(file_table.unwrap());
     let file = get_file_fast!(&mut file_table, fd);
     let lock_mut_ptr = arg as Vaddr;
     let mut lock_mut_c = ctx.user_space().read_val::<c_flock>(lock_mut_ptr)?;
@@ -97,9 +98,13 @@ fn handle_getlk(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
     if lock_type == RangeLockType::Unlock {
         return_errno_with_message!(Errno::EINVAL, "invalid flock type for getlk");
     }
-    let mut lock = RangeLockItem::new(lock_type, from_c_flock_and_file(&lock_mut_c, &**file)?);
-    let inode_file = file.as_inode_handle_or_err()?;
-    lock = inode_file.test_range_lock(lock)?;
+    let lock = RangeLockItem::new(
+        owner,
+        ctx.process.pid(),
+        lock_type,
+        from_c_flock_and_file(&lock_mut_c, &**file)?,
+    );
+    let lock = file.as_inode_handle_or_err()?.test_range_lock(lock)?;
     lock_mut_c.copy_from_range_lock(&lock);
     ctx.user_space().write_val(lock_mut_ptr, &lock_mut_c)?;
     Ok(SyscallReturn::Return(0))
@@ -112,13 +117,39 @@ fn handle_setlk(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
-    let file = get_file_fast!(&mut file_table, fd);
+    let owner = FileTable::range_lock_owner(file_table.unwrap());
+    let file = get_file_fast!(&mut file_table, fd).into_owned();
     let lock_mut_ptr = arg as Vaddr;
     let lock_mut_c = ctx.user_space().read_val::<c_flock>(lock_mut_ptr)?;
     let lock_type = RangeLockType::try_from(lock_mut_c.l_type)?;
-    let lock = RangeLockItem::new(lock_type, from_c_flock_and_file(&lock_mut_c, &**file)?);
+    let lock = RangeLockItem::new(
+        owner,
+        ctx.process.pid(),
+        lock_type,
+        from_c_flock_and_file(&lock_mut_c, &*file)?,
+    );
     let inode_file = file.as_inode_handle_or_err()?;
     inode_file.set_range_lock(&lock, is_nonblocking)?;
+
+    if lock.type_() == RangeLockType::Unlock {
+        return Ok(SyscallReturn::Return(0));
+    }
+    // A concurrent close will release the range locks for this owner and inode
+    // but may miss the new one. If it happens, release the new lock to prevent
+    // it from leaking forever.
+    let file_is_still_open = file_table.read_with(|table| {
+        table
+            .get_file(fd)
+            .is_ok_and(|current_file| Arc::ptr_eq(current_file, &file))
+    });
+    if !file_is_still_open {
+        inode_file.release_range_locks(owner);
+        return_errno_with_message!(
+            Errno::EBADF,
+            "the file descriptor was closed while setting a range lock"
+        );
+    }
+
     Ok(SyscallReturn::Return(0))
 }
 
@@ -237,7 +268,7 @@ impl c_flock {
             } else {
                 lock.range().len() as off_t
             };
-            self.l_pid = lock.owner();
+            self.l_pid = lock.pid();
         }
     }
 }

--- a/kernel/src/syscall/pipe.rs
+++ b/kernel/src/syscall/pipe.rs
@@ -45,9 +45,20 @@ pub fn sys_pipe2(fds: Vaddr, flags: u32, ctx: &Context) -> Result<SyscallReturn>
     };
     debug!("pipe_fds: {:?}", pipe_fds);
 
+    // Since `write_val` may sleep, we cannot hold the file table lock during its execution.
+    drop(file_table_locked);
+
     if let Err(err) = ctx.user_space().write_val(fds, &pipe_fds) {
-        file_table_locked.close_file(reader_fd).unwrap();
-        file_table_locked.close_file(writer_fd).unwrap();
+        // FIXME: Introduce reserved FDs to ensure that the files are never visible to user space
+        // before `write_val` succeeds and cleanup closes the exact reserved FDs below.
+        let closed_files = {
+            let mut file_table_locked = file_table.unwrap().write();
+            [
+                file_table_locked.close_file(reader_fd),
+                file_table_locked.close_file(writer_fd),
+            ]
+        };
+        drop(closed_files);
         return Err(err.into());
     }
 

--- a/ostd/src/sync/rwarc.rs
+++ b/ostd/src/sync/rwarc.rs
@@ -50,6 +50,11 @@ impl<T> RwArc<T> {
         self.0.data.write()
     }
 
+    /// Returns a raw pointer to the contained value.
+    pub fn as_ptr(&self) -> *const T {
+        self.0.data.as_ptr()
+    }
+
     /// Returns an immutable reference if no other `RwArc` points to the same allocation.
     ///
     /// This method is cheap because it does not acquire a lock.

--- a/test/initramfs/src/regression/io/file_io/fcntl_lock.c
+++ b/test/initramfs/src/regression/io/file_io/fcntl_lock.c
@@ -4,12 +4,17 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sched.h>
+#include <stdint.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include "../../common/test.h"
 
 #define TEST_FILE "/tmp/fcntl_lock_regression"
+#define CLONE_STACK_SIZE 4096
+
+static char clone_stack[CLONE_STACK_SIZE];
 
 static int open_test_file(void)
 {
@@ -64,6 +69,18 @@ static int child_try_write_lock(off_t start, off_t len)
 	return WEXITSTATUS(status);
 }
 
+static int clone_child_exit(void *arg)
+{
+	(void)arg;
+	return 0;
+}
+
+static int clone_child_close(void *arg)
+{
+	CHECK(close((int)(intptr_t)arg));
+	return 0;
+}
+
 FN_SETUP(create)
 {
 	int fd = CHECK(open_test_file());
@@ -95,3 +112,95 @@ FN_TEST(close_dup_fd_releases_locks)
 	TEST_SUCC(close(fd));
 }
 END_TEST()
+
+FN_TEST(process_exit_releases_locks)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		CHECK(try_write_lock(fd, 0, 100));
+		_exit(0);
+	}
+
+	/* Exiting the sole owner closes its file table and releases its locks. */
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_SUCC(try_write_lock(fd, 0, 100));
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(forked_process_close_keeps_parent_locks)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+
+	TEST_SUCC(try_write_lock(fd, 0, 100));
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		/* fork() gives the child a distinct file table and lock owner. */
+		CHECK(close(fd));
+		_exit(0);
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_RES(child_try_write_lock(0, 100), _ret == EAGAIN);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(shared_file_table_exit_keeps_locks)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+
+	TEST_SUCC(try_write_lock(fd, 0, 100));
+	/* CLONE_FILES makes the child share the parent's file table. */
+	pid_t child = TEST_SUCC(clone(clone_child_exit,
+				      clone_stack + sizeof(clone_stack),
+				      CLONE_FILES | SIGCHLD, NULL));
+
+	/* One sharer exiting must not release locks owned by the shared table. */
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_RES(child_try_write_lock(0, 100), _ret == EAGAIN);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(shared_file_table_close_releases_locks)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+	int duplicated_fd = TEST_SUCC(dup(fd));
+
+	TEST_SUCC(try_write_lock(fd, 0, 100));
+	/* The child closes the duplicate in the file table shared with its parent. */
+	pid_t child = TEST_SUCC(
+		clone(clone_child_close, clone_stack + sizeof(clone_stack),
+		      CLONE_FILES | SIGCHLD, (void *)(intptr_t)duplicated_fd));
+
+	/* Closing any fd for the file releases this table owner's POSIX locks. */
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0), _ret == child &&
+						     WIFEXITED(status) &&
+						     WEXITSTATUS(status) == 0);
+	TEST_RES(child_try_write_lock(0, 100), _ret == 0);
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(unlink(TEST_FILE));
+}
+END_SETUP()


### PR DESCRIPTION
Previously, the owner of a `RangeLock` in our implementation was the process that created it. However, this behavior is inconsistent with Linux. In Linux, `RangeLock`s created by processes sharing the same `FileTable` have the same owner.

This PR fixes that inconsistency by making the lock owner associated with the `FileTable` rather than the creating process. It also moves lock release to `FileTable::drop`, aligning the behavior with Linux.

Serves for #3399 .