### PR TITLE
Refactor signal mask getter to preserve encapsulation

### DIFF
--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -112,7 +112,7 @@ fn update_existing_signalfd(
         .downcast_ref::<SignalFile>()
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not a signal file"))?;
 
-    if signal_file.mask().load(Ordering::Relaxed) != new_mask {
+    if signal_file.mask() != new_mask {
         signal_file.update_signal_mask(new_mask)?;
     }
     signal_file.set_non_blocking(non_blocking);
@@ -154,8 +154,8 @@ impl SignalFile {
         }
     }
 
-    fn mask(&self) -> &AtomicSigMask {
-        &self.signals_mask
+    fn mask(&self) -> SigMask {
+        self.signals_mask.load(Ordering::Relaxed)
     }
 
     fn update_signal_mask(&self, new_mask: SigMask) -> Result<()> {
@@ -278,7 +278,7 @@ impl FileLike for SignalFile {
 
         Box::new(FdInfo {
             flags,
-            sigmask: self.mask().load(Ordering::Relaxed).into(),
+            sigmask: self.mask().into(),
         })
     }
 }


### PR DESCRIPTION
## Motivation

`SignalFile::mask()` previously returned `&AtomicSigMask`, exposing atomic mutation operations such as `store` and `swap` to its callers. This allowed callers to bypass `update_signal_mask()`, which is intended to be the controlled interface for updating the signalfd mask.

  ## Changes

  - Changed `SignalFile::mask()` to return a `SigMask` snapshot instead of `&AtomicSigMask`.
  - Moved the atomic load with `Ordering::Relaxed` into the getter.
  - Updated existing callers to consume the returned `SigMask` directly.
  - Kept `update_signal_mask()` as the only interface for modifying the internal mask.

Using `SigMask` instead of `u64` preserves the signal-mask domain type and avoids exposing the underlying atomic implementation.

This is an interface encapsulation improvement and does not change signalfd behavior or atomic ordering semantics.