### PR TITLE
Support RISC-V Svade in kernel mappings

### DIFF
--- a/ostd/src/arch/riscv/boot/bsp_boot.S
+++ b/ostd/src/arch/riscv/boot/bsp_boot.S
@@ -10,6 +10,8 @@ PTE_V                  = 0x01
 PTE_R                  = 0x02
 PTE_W                  = 0x04
 PTE_X                  = 0x08
+PTE_A                  = 0x40
+PTE_D                  = 0x80
 PTE_PPN_SHIFT          = 10
 PTE_SIZE               = 8
 
@@ -75,39 +77,43 @@ bsp_flush_tlb:
     or     t0, t0, t1
     jr     t0
 
-PTE_VRWX = PTE_V | PTE_R | PTE_W | PTE_X
+# Under Svade, clear A faults on any access and clear D faults on writes.
+# Early boot has no recovery handler, so writable leaves preset A|D; non-leaf
+# A/D bits are reserved and remain zero.
+# Reference: <https://docs.riscv.org/reference/isa/v20260120/priv/supervisor.html#translation>.
+PTE_VRWXAD = PTE_V | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D
 
 .balign 4096
 sv48_boot_l4pt:
-    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWX  # identity 0~512 GiB
+    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWXAD  # identity 0~512 GiB
     .zero 255 * PTE_SIZE
-    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWX  # linear 0~512 GiB
+    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWXAD  # linear 0~512 GiB
     .zero 254 * PTE_SIZE
     .quad 0                                      # TBA (-> boot_l3pt)
 sv48_boot_l3pt:  # 0xffff_ffff_0000_0000 -> 0x0000_0000_0000_0000
     .zero 508 * PTE_SIZE
-    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 0~1 GiB
-    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 1~2 GiB
-    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 2~3 GiB
+    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 0~1 GiB
+    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 1~2 GiB
+    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 2~3 GiB
     .quad 0
 
 .balign 4096
 sv39_boot_l3pt:
     .set i, 0
     .rept 128  # identity 0~128 GiB
-        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWX
+        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWXAD
         .set i, i + 1
     .endr
     .zero 128 * PTE_SIZE
     .set i, 0
     .rept 128  # linear 0~128 GiB
-        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWX
+        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWXAD
         .set i, i + 1
     .endr
     .zero 124 * PTE_SIZE
-    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 0~1 GiB
-    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 1~2 GiB
-    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 2~3 GiB
+    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 0~1 GiB
+    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 1~2 GiB
+    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 2~3 GiB
     .quad 0
 
 .section ".boot.stack", "aw", @nobits

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -54,7 +54,7 @@ use crate::{
         CachePolicy, Infallible, PAGE_SIZE, Paddr, PageFlags, PageProperty, PrivilegedPageFlags,
         Segment, Vaddr, VmReader,
         frame::allocator::{self, EarlyAllocatedFrameMeta},
-        paddr_to_vaddr, page_size,
+        kspace, paddr_to_vaddr, page_size,
         page_table::boot_pt,
     },
     panic::abort,
@@ -466,8 +466,8 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         max_paddr
     );
 
-    // In RISC-V, the boot page table has mapped the 512GB memory,
-    // so we don't need to add temporary linear mapping.
+    // In RISC-V, the boot page table already provides a temporary linear
+    // mapping: 128 GiB with Sv39 or 512 GiB with Sv48.
     // In LoongArch, the DWM0 has mapped the whole memory,
     // so we don't need to add temporary linear mapping.
     #[cfg(target_arch = "x86_64")]
@@ -481,11 +481,11 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         for i in 0..nr_meta_pages {
             let frame_paddr = meta_pages + i * PAGE_SIZE;
             let vaddr = mapping::frame_to_meta::<PagingConsts>(0) + i * PAGE_SIZE;
-            let prop = PageProperty {
+            let prop = kspace::prepare_new_kernel_mapping_prop(PageProperty {
                 flags: PageFlags::RW,
                 cache: CachePolicy::Writeback,
                 priv_flags: PrivilegedPageFlags::GLOBAL,
-            };
+            });
             // SAFETY: we are doing the metadata mappings for the kernel.
             unsafe { boot_pt.map_base_page(vaddr, frame_paddr, prop) };
         }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -92,14 +92,14 @@ impl KVirtArea {
     }
 
     #[cfg(ktest)]
-    pub fn query<'a, G: crate::task::atomic_mode::AsAtomicModeGuard>(
+    pub(in crate::mm) fn query<'a, G: crate::task::atomic_mode::AsAtomicModeGuard>(
         &'a self,
         guard: &'a G,
         addr: Vaddr,
     ) -> Option<super::MappedItemRef<'a>> {
         use align_ext::AlignExt;
 
-        assert!(self.start() <= addr && self.end() >= addr);
+        assert!(self.range.contains(&addr));
 
         let start = addr.align_down(PAGE_SIZE);
         let vaddr = start..start + PAGE_SIZE;
@@ -141,7 +141,7 @@ impl KVirtArea {
         for frame in frames.into_iter() {
             // SAFETY: The constructor of the `KVirtArea` has already ensured
             // that this mapping does not affect kernel's memory safety.
-            unsafe { cursor.map(MappedItem::Tracked(Frame::from_unsized(frame), prop)) };
+            unsafe { cursor.map(MappedItem::tracked(Frame::from_unsized(frame), prop)) };
         }
 
         Self { range }
@@ -191,7 +191,7 @@ impl KVirtArea {
             for (pa, level) in largest_pages::<KernelPtConfig>(va_range.start, pa_range.start, len)
             {
                 // SAFETY: The caller of `map_untracked_frames` has ensured the safety of this mapping.
-                unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+                unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
             }
         }
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -45,20 +45,22 @@ use spin::Once;
 #[cfg(ktest)]
 mod test;
 
+#[cfg(target_arch = "riscv64")]
+use super::page_prop::PageAccess;
 use super::{
-    Frame, HasSize, Paddr, PagingConstsTrait, Vaddr,
+    HasSize, Paddr, PagingConstsTrait, Vaddr,
     frame::{
         Segment,
         meta::{AnyFrameMeta, MetaPageMeta, mapping},
     },
     page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags},
-    page_table::{PageTable, PageTableConfig},
+    page_table::PageTable,
 };
 use crate::{
-    arch::mm::{PageTableEntry, PagingConsts},
+    arch::mm::PagingConsts,
     boot::memory_region::MemoryRegionType,
     const_assert, info,
-    mm::{HasPaddr, PAGE_SIZE, PagingLevel, frame::FrameRef, page_table::largest_pages},
+    mm::{PAGE_SIZE, PagingLevel, frame::FrameRef, page_table::largest_pages},
     task::disable_preempt,
 };
 
@@ -140,77 +142,157 @@ pub(super) static KERNEL_PAGE_TABLE: Once<PageTable<KernelPtConfig>> = Once::new
 #[derive(Clone, Debug)]
 pub(super) struct KernelPtConfig {}
 
-// We use the first available PTE bit to mark the frame as tracked.
-// SAFETY: `item_raw_info`, `item_into_raw`, `item_from_raw`, and
-// `item_ref_from_raw` are correctly implemented with respect to the `Item` and
-// `ItemRef` types.
-unsafe impl PageTableConfig for KernelPtConfig {
-    const TOP_LEVEL_INDEX_RANGE: Range<usize> = 256..512;
-    const TOP_LEVEL_CAN_UNMAP: bool = false;
-
-    type E = PageTableEntry;
-    type C = PagingConsts;
-
-    type Item = MappedItem;
-    type ItemRef<'a> = MappedItemRef<'a>;
-
-    fn item_raw_info(item: &Self::Item) -> (Paddr, PagingLevel, PageProperty) {
-        match *item {
-            MappedItem::Tracked(ref frame, mut prop) => {
-                debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
-                prop.priv_flags |= PrivilegedPageFlags::AVAIL1;
-                let level = frame.map_level();
-                let paddr = frame.paddr();
-                (paddr, level, prop)
-            }
-            MappedItem::Untracked(ref pa, ref level, mut prop) => {
-                debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
-                prop.priv_flags -= PrivilegedPageFlags::AVAIL1;
-                (*pa, *level, prop)
-            }
-        }
-    }
-
-    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item {
-        if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
-            debug_assert_eq!(level, 1);
-            // SAFETY: The caller ensures safety.
-            let frame = unsafe { Frame::<dyn AnyFrameMeta>::from_raw(paddr) };
-            MappedItem::Tracked(frame, prop)
+/// Applies the architecture policy for a newly created kernel mapping.
+///
+/// Under RISC-V Svade, an access with A clear faults, and a write with D clear
+/// faults. Since kernel mappings have no recovery path, new writable mappings
+/// preset both A and D, while non-writable mappings preset only A. See
+/// <https://docs.riscv.org/reference/isa/v20260120/priv/supervisor.html#translation>.
+pub(in crate::mm) fn prepare_new_kernel_mapping_prop(prop: PageProperty) -> PageProperty {
+    #[cfg(target_arch = "riscv64")]
+    {
+        let mut prop = prop;
+        let access = if prop.flags.contains(PageFlags::W) {
+            PageAccess::Write
         } else {
-            MappedItem::Untracked(paddr, level, prop)
-        }
+            PageAccess::Read
+        };
+        prop.flags.record_access(access);
+        prop
     }
 
-    unsafe fn item_ref_from_raw<'a>(
-        paddr: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    ) -> Self::ItemRef<'a> {
-        if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
-            debug_assert_eq!(level, 1);
-            // SAFETY: The caller ensures that the frame outlives `'a` and that
-            // the type matches the frame.
-            let frame = unsafe { FrameRef::<dyn AnyFrameMeta>::borrow_paddr(paddr) };
-            MappedItemRef::Tracked(frame, prop)
-        } else {
-            MappedItemRef::Untracked(paddr, level, prop)
-        }
+    #[cfg(not(target_arch = "riscv64"))]
+    {
+        prop
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) enum MappedItem {
-    Tracked(Frame<dyn AnyFrameMeta>, PageProperty),
-    Untracked(Paddr, PagingLevel, PageProperty),
 }
 
 #[derive(Debug)]
-pub(crate) enum MappedItemRef<'a> {
+pub(in crate::mm) enum MappedItemRef<'a> {
     #[cfg_attr(not(ktest), expect(dead_code))]
     Tracked(FrameRef<'a, dyn AnyFrameMeta>, PageProperty),
     #[cfg_attr(not(ktest), expect(dead_code))]
     Untracked(Paddr, PagingLevel, PageProperty),
+}
+
+pub(super) use mapped_item::MappedItem;
+
+mod mapped_item {
+    //! Kernel page-table item representation and construction policy.
+    //!
+    //! [`MappedItem`] is the item representation for [`KernelPtConfig`]. New
+    //! mappings go through an architecture policy, while raw restoration
+    //! reconstructs an existing item and preserves all status flags exactly.
+
+    use core::ops::Range;
+
+    use super::{KernelPtConfig, MappedItemRef};
+    use crate::{
+        arch::mm::{PageTableEntry, PagingConsts},
+        mm::{
+            Frame, HasPaddr, Paddr, PagingLevel,
+            frame::{FrameRef, meta::AnyFrameMeta},
+            page_prop::{PageProperty, PrivilegedPageFlags},
+            page_table::PageTableConfig,
+        },
+    };
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(in crate::mm) struct MappedItem(MappedItemKind);
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    enum MappedItemKind {
+        Tracked(Frame<dyn AnyFrameMeta>, PageProperty),
+        Untracked(Paddr, PagingLevel, PageProperty),
+    }
+
+    impl MappedItem {
+        pub(in crate::mm) fn tracked(frame: Frame<dyn AnyFrameMeta>, prop: PageProperty) -> Self {
+            Self(MappedItemKind::Tracked(
+                frame,
+                super::prepare_new_kernel_mapping_prop(prop),
+            ))
+        }
+
+        pub(in crate::mm) fn untracked(
+            paddr: Paddr,
+            level: PagingLevel,
+            prop: PageProperty,
+        ) -> Self {
+            Self(MappedItemKind::Untracked(
+                paddr,
+                level,
+                super::prepare_new_kernel_mapping_prop(prop),
+            ))
+        }
+    }
+
+    // We use the first available PTE bit to mark the frame as tracked.
+    // SAFETY: `item_raw_info`, `item_into_raw`, `item_from_raw`, and
+    // `item_ref_from_raw` are correctly implemented with respect to the `Item`
+    // and `ItemRef` types.
+    unsafe impl PageTableConfig for KernelPtConfig {
+        const TOP_LEVEL_INDEX_RANGE: Range<usize> = 256..512;
+        const TOP_LEVEL_CAN_UNMAP: bool = false;
+
+        type E = PageTableEntry;
+        type C = PagingConsts;
+
+        type Item = MappedItem;
+        type ItemRef<'a> = MappedItemRef<'a>;
+
+        fn item_raw_info(item: &Self::Item) -> (Paddr, PagingLevel, PageProperty) {
+            match &item.0 {
+                MappedItemKind::Tracked(frame, prop) => {
+                    let mut prop = *prop;
+                    debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
+                    prop.priv_flags |= PrivilegedPageFlags::AVAIL1;
+                    let level = frame.map_level();
+                    let paddr = frame.paddr();
+                    (paddr, level, prop)
+                }
+                MappedItemKind::Untracked(pa, level, prop) => {
+                    let mut prop = *prop;
+                    debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
+                    prop.priv_flags -= PrivilegedPageFlags::AVAIL1;
+                    (*pa, *level, prop)
+                }
+            }
+        }
+
+        unsafe fn item_from_raw(
+            paddr: Paddr,
+            level: PagingLevel,
+            prop: PageProperty,
+        ) -> Self::Item {
+            // Raw restoration must preserve the existing status flags exactly,
+            // so it intentionally bypasses the new-mapping policy constructors.
+            if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
+                debug_assert_eq!(level, 1);
+                // SAFETY: The caller ensures safety.
+                let frame = unsafe { Frame::<dyn AnyFrameMeta>::from_raw(paddr) };
+                MappedItem(MappedItemKind::Tracked(frame, prop))
+            } else {
+                MappedItem(MappedItemKind::Untracked(paddr, level, prop))
+            }
+        }
+
+        unsafe fn item_ref_from_raw<'a>(
+            paddr: Paddr,
+            level: PagingLevel,
+            prop: PageProperty,
+        ) -> Self::ItemRef<'a> {
+            if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
+                debug_assert_eq!(level, 1);
+                // SAFETY: The caller ensures that the frame outlives `'a` and that
+                // the type matches the frame.
+                let frame = unsafe { FrameRef::<dyn AnyFrameMeta>::borrow_paddr(paddr) };
+                MappedItemRef::Tracked(frame, prop)
+            } else {
+                MappedItemRef::Untracked(paddr, level, prop)
+            }
+        }
+    }
 }
 
 /// Initializes the kernel page table.
@@ -242,7 +324,7 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
         let mut cursor = kpt.cursor_mut(&preempt_guard, &from).unwrap();
         for (pa, level) in largest_pages::<KernelPtConfig>(from.start, 0, max_paddr) {
             // SAFETY: we are doing the linear mapping for the kernel.
-            unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+            unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
         }
     }
 
@@ -264,7 +346,7 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
             largest_pages::<KernelPtConfig>(from.start, pa_range.start, pa_range.len())
         {
             // SAFETY: We are doing the metadata mappings for the kernel.
-            unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+            unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
         }
     }
 
@@ -288,7 +370,7 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
         let mut cursor = kpt.cursor_mut(&preempt_guard, &from).unwrap();
         for (pa, level) in largest_pages::<KernelPtConfig>(from.start, region.base(), from.len()) {
             // SAFETY: we are doing the kernel code mapping.
-            unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+            unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
         }
     }
 

--- a/ostd/src/mm/kspace/test.rs
+++ b/ostd/src/mm/kspace/test.rs
@@ -5,10 +5,11 @@ use crate::{
         Frame, FrameAllocOptions, PAGE_SIZE,
         frame::max_paddr,
         kspace::{
-            LINEAR_MAPPING_BASE_VADDR, MappedItemRef, VMALLOC_VADDR_RANGE, kvirt_area::KVirtArea,
-            paddr_to_vaddr,
+            KernelPtConfig, LINEAR_MAPPING_BASE_VADDR, MappedItemRef, VMALLOC_VADDR_RANGE,
+            kvirt_area::KVirtArea, paddr_to_vaddr,
         },
-        page_prop::{CachePolicy, PageFlags, PageProperty},
+        page_prop::{CachePolicy, PageAccess, PageFlags, PageProperty},
+        page_table::PageTableConfig,
     },
     prelude::*,
     task::disable_preempt,
@@ -16,6 +17,22 @@ use crate::{
 
 fn default_prop() -> PageProperty {
     PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback)
+}
+
+fn non_writable_prop() -> PageProperty {
+    PageProperty::new_user(PageFlags::RX, CachePolicy::Writeback)
+}
+
+#[cfg(target_arch = "riscv64")]
+fn expected_mapped_prop(mut prop: PageProperty, access: PageAccess) -> PageProperty {
+    prop.flags.record_access(access);
+    prop
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+fn expected_mapped_prop(prop: PageProperty, access: PageAccess) -> PageProperty {
+    let _ = access;
+    prop
 }
 
 #[ktest]
@@ -37,10 +54,13 @@ fn kvirt_area_tracked_map_pages() {
     for i in 0..2 {
         let addr = kvirt_area.start() + i * PAGE_SIZE;
         let MappedItemRef::Tracked(page, prop) = kvirt_area.query(&guard, addr).unwrap() else {
-            panic!("Expected a tracked page");
+            panic!("expected a tracked page");
         };
         assert_eq!(page.paddr(), paddr + (i * PAGE_SIZE));
-        assert_eq!(prop.flags, default_prop().flags);
+        assert_eq!(
+            prop.flags,
+            expected_mapped_prop(default_prop(), PageAccess::Write).flags
+        );
         assert_eq!(prop.cache, default_prop().cache);
     }
 }
@@ -52,6 +72,8 @@ fn kvirt_area_untracked_map_pages() {
     let size = 2 * PAGE_SIZE;
     let pa_range = max_paddr..max_paddr + 2 * PAGE_SIZE as Paddr;
 
+    // SAFETY: The range starts beyond all tracked physical memory and the test
+    // only queries the mapping without dereferencing or taking ownership of it.
     let kvirt_area =
         unsafe { KVirtArea::map_untracked_frames(size, 0, pa_range.clone(), default_prop()) };
 
@@ -66,11 +88,67 @@ fn kvirt_area_untracked_map_pages() {
 
         let MappedItemRef::Untracked(pa, level, prop) = kvirt_area.query(&guard, addr).unwrap()
         else {
-            panic!("Expected a untracked page");
+            panic!("expected an untracked page");
         };
         assert_eq!(pa, pa_range.start + (i * PAGE_SIZE) as Paddr);
         assert_eq!(level, 1);
-        assert_eq!(prop, default_prop());
+        assert_eq!(
+            prop,
+            expected_mapped_prop(default_prop(), PageAccess::Write)
+        );
+        assert_eq!(prop.cache, default_prop().cache);
+    }
+}
+
+// Regression test for Asterinas issue #3589.
+#[ktest]
+fn kvirt_area_untracked_read_only_map_page() {
+    let max_paddr = max_paddr();
+    let pa_range = max_paddr..max_paddr + PAGE_SIZE as Paddr;
+
+    // SAFETY: The range starts beyond all tracked physical memory and the test
+    // only queries the mapping without dereferencing it.
+    let kvirt_area =
+        unsafe { KVirtArea::map_untracked_frames(PAGE_SIZE, 0, pa_range, non_writable_prop()) };
+    let guard = disable_preempt();
+
+    let MappedItemRef::Untracked(pa, level, prop) =
+        kvirt_area.query(&guard, kvirt_area.start()).unwrap()
+    else {
+        panic!("expected an untracked page");
+    };
+    assert_eq!(pa, max_paddr);
+    assert_eq!(level, 1);
+    assert_eq!(
+        prop,
+        expected_mapped_prop(non_writable_prop(), PageAccess::Read)
+    );
+    assert_eq!(prop.cache, non_writable_prop().cache);
+    assert!(!prop.flags.contains(PageFlags::DIRTY));
+}
+
+// Regression test for Asterinas issue #3589.
+#[ktest]
+fn kernel_pt_raw_info_preserves_status_flags() {
+    let test_paddr = max_paddr() + PAGE_SIZE as Paddr;
+
+    for status_flags in [
+        PageFlags::empty(),
+        PageFlags::ACCESSED,
+        PageFlags::ACCESSED | PageFlags::DIRTY,
+    ] {
+        let mut prop = default_prop();
+        prop.flags |= status_flags;
+
+        // SAFETY: `test_paddr` is aligned and beyond all tracked physical
+        // memory. `AVAIL1` is clear, so this restores an untracked mapping and
+        // reconstructs no frame ownership.
+        let item = unsafe { KernelPtConfig::item_from_raw(test_paddr, 1, prop) };
+        let (raw_paddr, raw_level, raw_prop) = KernelPtConfig::item_raw_info(&item);
+
+        assert_eq!(raw_paddr, test_paddr);
+        assert_eq!(raw_level, 1);
+        assert_eq!(raw_prop, prop);
     }
 }
 

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
     },
     kspace::{KERNEL_VADDR_RANGE, MAX_USERSPACE_VADDR},
     mem_obj::{HasDaddr, HasPaddr, HasPaddrRange, HasSize, Split},
-    page_prop::{CachePolicy, PageFlags, PageProperty},
+    page_prop::{CachePolicy, PageAccess, PageFlags, PageProperty},
     vm_space::VmSpace,
 };
 pub(crate) use self::{

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -87,6 +87,15 @@ pub enum CachePolicy {
     Writeback,
 }
 
+/// The kind of access made to a page.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PageAccess {
+    /// A read or instruction fetch.
+    Read,
+    /// A write.
+    Write,
+}
+
 bitflags! {
     /// Page protection permissions and access status.
     pub struct PageFlags: u8 {
@@ -110,6 +119,19 @@ bitflags! {
 
         /// The second bit available for software use.
         const AVAIL2    = 0b10000000;
+    }
+}
+
+impl PageFlags {
+    /// Records an access in the page status flags.
+    ///
+    /// Every access sets [`PageFlags::ACCESSED`]. A [`PageAccess::Write`] also
+    /// sets [`PageFlags::DIRTY`]. All other flags are preserved.
+    pub fn record_access(&mut self, access: PageAccess) {
+        self.insert(Self::ACCESSED);
+        if access == PageAccess::Write {
+            self.insert(Self::DIRTY);
+        }
     }
 }
 
@@ -140,5 +162,44 @@ bitflags! {
         const AVAIL1    = 0b01000000;
         /// The second bit available for software use.
         const AVAIL2    = 0b10000000;
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use super::{PageAccess, PageFlags};
+    use crate::prelude::ktest;
+
+    #[ktest]
+    fn record_access_for_read_preserves_flags_and_sets_accessed() {
+        let mut flags = PageFlags::RX | PageFlags::AVAIL2;
+
+        flags.record_access(PageAccess::Read);
+
+        assert_eq!(
+            flags,
+            PageFlags::RX | PageFlags::AVAIL2 | PageFlags::ACCESSED
+        );
+
+        let mut dirty_flags = PageFlags::RX | PageFlags::AVAIL2 | PageFlags::DIRTY;
+
+        dirty_flags.record_access(PageAccess::Read);
+
+        assert_eq!(
+            dirty_flags,
+            PageFlags::RX | PageFlags::AVAIL2 | PageFlags::ACCESSED | PageFlags::DIRTY
+        );
+    }
+
+    #[ktest]
+    fn record_access_for_write_preserves_flags_and_sets_accessed_and_dirty() {
+        let mut flags = PageFlags::RW | PageFlags::AVAIL2;
+
+        flags.record_access(PageAccess::Write);
+
+        assert_eq!(
+            flags,
+            PageFlags::RW | PageFlags::AVAIL2 | PageFlags::ACCESSED | PageFlags::DIRTY
+        );
     }
 }

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -585,7 +585,7 @@ pub(crate) unsafe trait PteTrait:
 ///
 /// # Safety
 ///
-/// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
+/// The safety preconditions are the same as those of [`AtomicUsize::from_ptr`].
 pub unsafe fn load_pte<E: PteTrait>(ptr: *mut E, ordering: Ordering) -> E {
     // SAFETY: The safety is upheld by the caller.
     let atomic = unsafe { AtomicUsize::from_ptr(ptr.cast()) };
@@ -597,10 +597,31 @@ pub unsafe fn load_pte<E: PteTrait>(ptr: *mut E, ordering: Ordering) -> E {
 ///
 /// # Safety
 ///
-/// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
+/// The safety preconditions are the same as those of [`AtomicUsize::from_ptr`].
 pub unsafe fn store_pte<E: PteTrait>(ptr: *mut E, new_val: E, ordering: Ordering) {
     let new_raw = new_val.as_usize();
     // SAFETY: The safety is upheld by the caller.
     let atomic = unsafe { AtomicUsize::from_ptr(ptr.cast()) };
     atomic.store(new_raw, ordering)
+}
+
+/// Atomically replaces a page table entry if it still matches `current`.
+///
+/// # Safety
+///
+/// The safety preconditions are the same as those of
+/// [`AtomicUsize::from_ptr`].
+pub(in crate::mm::page_table) unsafe fn compare_exchange_pte<E: PteTrait>(
+    ptr: *mut E,
+    current: E,
+    new: E,
+    success: Ordering,
+    failure: Ordering,
+) -> Result<E, E> {
+    // SAFETY: The caller upholds `AtomicUsize::from_ptr`'s requirements.
+    let atomic = unsafe { AtomicUsize::from_ptr(ptr.cast()) };
+    atomic
+        .compare_exchange(current.as_usize(), new.as_usize(), success, failure)
+        .map(E::from_usize)
+        .map_err(E::from_usize)
 }

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -6,7 +6,7 @@ use super::{PageTableGuard, PageTableNode, PteState, PteStateRef, PteTrait};
 use crate::{
     mm::{
         HasPaddr, nr_subpage_per_huge,
-        page_prop::PageProperty,
+        page_prop::{PageFlags, PageProperty},
         page_size,
         page_table::{PageTableConfig, PageTableNodeRef, PteScalar},
     },
@@ -63,14 +63,37 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             return;
         }
 
-        self.pte = C::E::from_repr(&PteScalar::Mapped(pa, new_prop), level);
-
-        // SAFETY:
-        //  1. The index is within the bounds.
-        //  2. We replace the PTE with a new one, which differs only in
-        //     `PageProperty`, so it's in `C` and at the correct paging level.
-        //  3. The child is still owned by the page table node.
-        unsafe { self.node.write_pte(self.idx, self.pte) };
+        loop {
+            let PteScalar::Mapped(_, expected_prop) = self.pte.to_repr(level) else {
+                unreachable!("the protected PTE must keep mapping the same page");
+            };
+            let new_pte = C::E::from_repr(&PteScalar::Mapped(pa, new_prop), level);
+            // SAFETY:
+            //  1. The index is within the bounds.
+            //  2. `self.pte` is a non-owning snapshot of the installed PTE.
+            //  3. The replacement keeps the same mapping and paging level and
+            //     differs only in `PageProperty`.
+            //  4. The node retains ownership of the mapped child regardless of
+            //     whether the comparison succeeds.
+            match unsafe { self.node.compare_exchange_pte(self.idx, self.pte, new_pte) } {
+                Ok(_) => {
+                    self.pte = new_pte;
+                    return;
+                }
+                Err(actual_pte) => {
+                    let PteScalar::Mapped(actual_pa, actual_prop) = actual_pte.to_repr(level)
+                    else {
+                        unreachable!("hardware status updates cannot change the PTE kind");
+                    };
+                    debug_assert_eq!(actual_pa, pa);
+                    let new_hardware_status = actual_prop.flags
+                        & !expected_prop.flags
+                        & (PageFlags::ACCESSED | PageFlags::DIRTY);
+                    new_prop.flags |= new_hardware_status;
+                    self.pte = actual_pte;
+                }
+            }
+        }
     }
 
     /// Replaces the entry with a new child.

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         FrameAllocOptions, HasPaddr, Infallible, PagingConstsTrait, PagingLevel, VmReader,
         frame::{Frame, FrameRef, meta::AnyFrameMeta},
         paddr_to_vaddr,
-        page_table::{PteScalar, load_pte, store_pte},
+        page_table::{self, PteScalar},
     },
     task::atomic_mode::InAtomicMode,
 };
@@ -214,7 +214,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY:
         // - The page table node is alive. The index is inside the bound, so the page table entry is valid.
         // - All page table entries are aligned and accessed with atomic operations only.
-        unsafe { load_pte(ptr.add(idx), Ordering::Relaxed) }
+        unsafe { page_table::load_pte(ptr.add(idx), Ordering::Relaxed) }
     }
 
     /// Writes a page table entry at a given index.
@@ -235,7 +235,43 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY:
         // - The page table node is alive. The index is inside the bound, so the page table entry is valid.
         // - All page table entries are aligned and accessed with atomic operations only.
-        unsafe { store_pte(ptr.add(idx), pte, Ordering::Release) }
+        unsafe { page_table::store_pte(ptr.add(idx), pte, Ordering::Release) }
+    }
+
+    /// Replaces a page table entry if it has not changed since it was read.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///  1. `idx` is within the node's bounds;
+    ///  2. `current` is a non-owning snapshot of the installed, node-owned PTE;
+    ///  3. `new_pte` identifies the same child or mapping at the same paging
+    ///     level and differs only in non-ownership fields such as mapping
+    ///     properties.
+    ///
+    /// This method does not transfer ownership through either return variant.
+    /// On success, the node retains ownership of the same child. On failure,
+    /// `new_pte` is not installed and the `Err` value is a non-owning snapshot
+    /// of the still-installed PTE.
+    unsafe fn compare_exchange_pte(
+        &mut self,
+        idx: usize,
+        current: C::E,
+        new_pte: C::E,
+    ) -> Result<C::E, C::E> {
+        debug_assert!(idx < nr_subpage_per_huge::<C>());
+        let ptr = paddr_to_vaddr(self.paddr()) as *mut C::E;
+        // SAFETY: The node is alive, the index is in bounds, and all accesses
+        // are atomic. The caller validates the replacement PTE.
+        unsafe {
+            page_table::compare_exchange_pte(
+                ptr.add(idx),
+                current,
+                new_pte,
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+        }
     }
 
     /// Gets the mutable reference to the number of valid PTEs in the node.

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -5,7 +5,7 @@ use ostd_pod::FromZeros;
 use super::*;
 use crate::{
     mm::{
-        FrameAllocOptions, MAX_USERSPACE_VADDR, PAGE_SIZE,
+        self, FrameAllocOptions, MAX_USERSPACE_VADDR, PAGE_SIZE,
         kspace::{KernelPtConfig, LINEAR_MAPPING_BASE_VADDR},
         page_prop::{CachePolicy, PageFlags},
         vm_space::VmItem,
@@ -610,8 +610,11 @@ mod navigation {
 
         // Map a page near the address space end.
         assert_eq!(cursor.virt_addr(), 0usize.wrapping_sub(HUGE_PAGE_SIZE));
+        // SAFETY: The cursor targets an empty test page table, and the
+        // untracked synthetic frame is used only to validate page-table
+        // navigation; it is never dereferenced or given ownership.
         unsafe {
-            cursor.map(MappedItem::Untracked(
+            cursor.map(MappedItem::untracked(
                 0,
                 1,
                 PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback),
@@ -944,6 +947,132 @@ mod mapping {
 
 mod protection_and_query {
     use super::{test_utils::*, *};
+
+    /// Returns the leaf PTE pointer for a mapped virtual address.
+    ///
+    /// # Safety
+    ///
+    /// `root_paddr` must identify a live `C` page table whose traversed nodes
+    /// remain valid and atomically accessed. The returned pointer must not
+    /// outlive or be used after removing its leaf page-table node.
+    unsafe fn mapped_pte_ptr<C: PageTableConfig>(
+        root_paddr: Paddr,
+        vaddr: Vaddr,
+    ) -> (*mut C::E, PagingLevel) {
+        let mut node_vaddr = mm::paddr_to_vaddr(root_paddr);
+        for level in (1..=C::NR_LEVELS).rev() {
+            // SAFETY: The caller guarantees that `root_paddr` owns a live page
+            // table and that the calculated index is in bounds.
+            let pte_ptr = unsafe { (node_vaddr as *mut C::E).add(pte_index::<C>(vaddr, level)) };
+            // SAFETY: The page-table node is alive and all PTE accesses are atomic.
+            let pte = unsafe { load_pte(pte_ptr, Ordering::Acquire) };
+            match pte.to_repr(level) {
+                PteScalar::PageTable(child_paddr, _) => {
+                    node_vaddr = mm::paddr_to_vaddr(child_paddr);
+                }
+                PteScalar::Mapped(_, _) => return (pte_ptr, level),
+                PteScalar::Absent => panic!("mapping is absent"),
+            }
+        }
+
+        panic!("mapping has no leaf PTE");
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn protect_preserves_concurrent_hardware_status_update() {
+        let page_table = PageTable::<TestPtConfig>::empty();
+        let range = PAGE_SIZE..PAGE_SIZE * 2;
+        let prop = PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback);
+        map_untracked(&page_table, range.clone(), 0, prop);
+
+        // SAFETY: The local page table owns a live mapping covering
+        // `range.start`, no operation removes it before the pointer's last use,
+        // the cursor locks the range while the pointer is used, and every
+        // pointer access uses the page-table atomic helpers.
+        let (pte_ptr, level) =
+            unsafe { mapped_pte_ptr::<TestPtConfig>(page_table.root_paddr(), range.start) };
+
+        let preempt_guard = disable_preempt();
+        let mut cursor = page_table.cursor_mut(&preempt_guard, &range).unwrap();
+        let mut simulate_hardware_update_fn = |prop: &mut PageProperty| {
+            // Simulate the MMU setting DIRTY after the cursor's initial PTE load.
+            // SAFETY: The pointer remains a live, aligned leaf PTE and all
+            // accesses use the page-table atomic helpers.
+            let hardware_pte = unsafe { load_pte(pte_ptr, Ordering::Acquire) };
+            let PteScalar::Mapped(paddr, mut hardware_prop) = hardware_pte.to_repr(level) else {
+                panic!("leaf PTE stopped mapping a page");
+            };
+            hardware_prop.flags |= PageFlags::DIRTY;
+            let hardware_pte = <TestPtConfig as PageTableConfig>::E::from_repr(
+                &PteScalar::Mapped(paddr, hardware_prop),
+                level,
+            );
+            // SAFETY: The replacement changes only the hardware-managed DIRTY bit.
+            unsafe { store_pte(pte_ptr, hardware_pte, Ordering::Release) };
+
+            prop.flags |= PageFlags::ACCESSED;
+        };
+        // SAFETY: The operation changes only public status flags and does not
+        // alter the mapping identity or its software-reserved ownership bit.
+        let protected =
+            unsafe { cursor.protect_next(range.len(), &mut simulate_hardware_update_fn) };
+        assert_eq!(protected, Some(range.clone()));
+        drop(cursor);
+
+        let (_, protected_prop) = page_table.page_walk(range.start).unwrap();
+        assert_eq!(
+            protected_prop.flags,
+            PageFlags::RW | PageFlags::ACCESSED | PageFlags::DIRTY
+        );
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn protect_merges_only_new_hardware_status_update() {
+        let page_table = PageTable::<TestPtConfig>::empty();
+        let range = PAGE_SIZE..PAGE_SIZE * 2;
+        let prop =
+            PageProperty::new_user(PageFlags::RW | PageFlags::ACCESSED, CachePolicy::Writeback);
+        map_untracked(&page_table, range.clone(), 0, prop);
+
+        // SAFETY: The local page table owns a live mapping covering
+        // `range.start`, no operation removes it before the pointer's last use,
+        // the cursor locks the range while the pointer is used, and every
+        // pointer access uses the page-table atomic helpers.
+        let (pte_ptr, level) =
+            unsafe { mapped_pte_ptr::<TestPtConfig>(page_table.root_paddr(), range.start) };
+
+        let preempt_guard = disable_preempt();
+        let mut cursor = page_table.cursor_mut(&preempt_guard, &range).unwrap();
+        let mut simulate_hardware_update_fn = |prop: &mut PageProperty| {
+            // Simulate the MMU setting DIRTY after the cursor's initial PTE load.
+            // SAFETY: The pointer remains a live, aligned leaf PTE and all
+            // accesses use the page-table atomic helpers.
+            let hardware_pte = unsafe { load_pte(pte_ptr, Ordering::Acquire) };
+            let PteScalar::Mapped(paddr, mut hardware_prop) = hardware_pte.to_repr(level) else {
+                panic!("leaf PTE stopped mapping a page");
+            };
+            hardware_prop.flags |= PageFlags::DIRTY;
+            let hardware_pte = <TestPtConfig as PageTableConfig>::E::from_repr(
+                &PteScalar::Mapped(paddr, hardware_prop),
+                level,
+            );
+            // SAFETY: The replacement changes only the hardware-managed DIRTY bit.
+            unsafe { store_pte(pte_ptr, hardware_pte, Ordering::Release) };
+
+            prop.flags = PageFlags::R;
+        };
+        // SAFETY: The operation changes only public status and permission flags
+        // and does not alter the mapping identity or software-reserved ownership bit.
+        let protected =
+            unsafe { cursor.protect_next(range.len(), &mut simulate_hardware_update_fn) };
+        assert_eq!(protected, Some(range.clone()));
+        drop(cursor);
+
+        let (_, protected_prop) = page_table.page_walk(range.start).unwrap();
+        assert_eq!(protected_prop.flags, PageFlags::R | PageFlags::DIRTY);
+    }
 
     #[ktest]
     fn base_protect_query() {


### PR DESCRIPTION
## Summary

- Initialize the Accessed/Dirty bits of early RISC-V leaf PTEs and newly
  created kernel mappings so they work when hardware A/D updates are disabled.
- Keep the RISC-V policy at the kernel-mapping construction boundary while
  preserving exact PTE encoding and raw item restoration.
- Atomically preserve newly observed hardware A/D updates when page-table
  protection changes race with hardware accesses.
- Add focused regression coverage for access recording, kernel mapping
  construction, exact raw restoration, and concurrent PTE updates.

## Design

- Read and executable RISC-V kernel mappings preset `A`; writable mappings
  preset both `A` and `D`.
- Early boot leaf entries preset `A/D`, while non-leaf entries remain `V`-only.
- Non-RISC-V mapping properties remain unchanged.
- `PageAccess` provides the typed A/D update operation needed by follow-up
  software-managed user mapping faults.

This is the first scoped part of #3589. It intentionally does not close the
issue: user mapping A/D fault handling and a persistent forced-Svade CI lane
remain follow-up work.

## Testing

- `make check`
- `cargo fmt --all -- --check`
- `git diff upstream/main...HEAD --check`
- OSTD `cfg(ktest)` cross-compilation:
  - `riscv64imac-unknown-none-elf`
  - `x86_64-unknown-none`
  - `loongarch64-unknown-none-softfloat`
- Full RISC-V OSTD ktest matrix with `SMP=4`:

| Paging mode | A/D model | Result |
| --- | --- | --- |
| Sv48 | Hardware update | 208 passed, 0 failed |
| Sv39 (`sv48=false`) | Hardware update | 208 passed, 0 failed |
| Sv48 | Forced Svade (`svadu=false,svade=true`) | 208 passed, 0 failed |
| Sv39 (`sv48=false`) | Forced Svade (`svadu=false,svade=true`) | 208 passed, 0 failed |
