### PR TITLE
Fix rename between hard links to the same inode

### DIFF
--- a/kernel/src/fs/vfs/path/dentry.rs
+++ b/kernel/src/fs/vfs/path/dentry.rs
@@ -801,7 +801,12 @@ impl DirDentry<'_> {
 
             let old_dentry = self.resolve_child_for_rename(&mut children, old_name)?;
             let new_dentry = match self.resolve_child_for_rename(&mut children, new_name) {
-                Ok(dentry) => Some(dentry),
+                Ok(new_dentry) => {
+                    if Arc::ptr_eq(old_dentry.inode(), new_dentry.inode()) {
+                        return Ok(());
+                    }
+                    Some(new_dentry)
+                }
                 Err(e) if e.error() == Errno::ENOENT => None,
                 Err(e) => return Err(e),
             };
@@ -847,7 +852,12 @@ impl DirDentry<'_> {
 
             let old_dentry = self.resolve_child_for_rename(&mut old_children, old_name)?;
             let new_dentry = match new_dir.resolve_child_for_rename(&mut new_children, new_name) {
-                Ok(dentry) => Some(dentry),
+                Ok(new_dentry) => {
+                    if Arc::ptr_eq(old_dentry.inode(), new_dentry.inode()) {
+                        return Ok(());
+                    }
+                    Some(new_dentry)
+                }
                 Err(e) if e.error() == Errno::ENOENT => None,
                 Err(e) => return Err(e),
             };

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -10,6 +10,7 @@ SUBDIRS := \
 	overlayfs \
 	procfs \
 	pseudofs \
+	rename \
 	statx \
 	symlink \
 	sync \

--- a/test/initramfs/src/regression/fs/rename/Makefile
+++ b/test/initramfs/src/regression/fs/rename/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/rename/same_inode.c
+++ b/test/initramfs/src/regression/fs/rename/same_inode.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define RAMFS_BASE_DIR "/tmp/rename_same_inode"
+#define RAMFS_CROSS_DIR_BASE_DIR "/tmp/rename_same_inode_cross_dir"
+#define RAMFS_SOURCE_DIR RAMFS_CROSS_DIR_BASE_DIR "/source"
+#define RAMFS_TARGET_DIR RAMFS_CROSS_DIR_BASE_DIR "/target"
+#define EXT2_BASE_DIR "/ext2/rename_same_inode"
+
+static void make_path(char *buffer, size_t size, const char *base,
+		      const char *name)
+{
+	int length = snprintf(buffer, size, "%s/%s", base, name);
+	CHECK_WITH(length, _ret > 0 && (size_t)_ret < size);
+}
+
+static void cleanup_test_files(const char *base)
+{
+	char path[256];
+
+	make_path(path, sizeof(path), base, "a");
+	CHECK_WITH(unlink(path), _ret == 0 || errno == ENOENT);
+	make_path(path, sizeof(path), base, "b");
+	CHECK_WITH(unlink(path), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(rmdir(base), _ret == 0 || errno == ENOENT);
+}
+
+static int verify_two_hardlinks(const char *path_a, const char *path_b)
+{
+	struct stat stat_a;
+	struct stat stat_b;
+	if (stat(path_a, &stat_a) < 0 || stat(path_b, &stat_b) < 0) {
+		return -1;
+	}
+	if (stat_a.st_ino != stat_b.st_ino || stat_a.st_nlink != 2 ||
+	    stat_b.st_nlink != 2) {
+		errno = EIO;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int verify_same_dir_rename(const char *base)
+{
+	char path_a[256];
+	char path_b[256];
+	make_path(path_a, sizeof(path_a), base, "a");
+	make_path(path_b, sizeof(path_b), base, "b");
+
+	if (mkdir(base, 0755) < 0) {
+		return -1;
+	}
+	int fd = open(path_a, O_CREAT | O_EXCL | O_WRONLY, 0644);
+	if (fd < 0) {
+		return -1;
+	}
+	if (close(fd) < 0 || link(path_a, path_b) < 0 ||
+	    rename(path_a, path_b) < 0) {
+		return -1;
+	}
+
+	return verify_two_hardlinks(path_a, path_b);
+}
+
+static void cleanup_cross_dir_test_files(void)
+{
+	char path_a[256];
+	char path_b[256];
+	make_path(path_a, sizeof(path_a), RAMFS_SOURCE_DIR, "a");
+	make_path(path_b, sizeof(path_b), RAMFS_TARGET_DIR, "b");
+
+	CHECK_WITH(unlink(path_a), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(unlink(path_b), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(rmdir(RAMFS_SOURCE_DIR), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(rmdir(RAMFS_TARGET_DIR), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(rmdir(RAMFS_CROSS_DIR_BASE_DIR),
+		   _ret == 0 || errno == ENOENT);
+}
+
+static int verify_cross_dir_rename(void)
+{
+	char path_a[256];
+	char path_b[256];
+	make_path(path_a, sizeof(path_a), RAMFS_SOURCE_DIR, "a");
+	make_path(path_b, sizeof(path_b), RAMFS_TARGET_DIR, "b");
+
+	if (mkdir(RAMFS_CROSS_DIR_BASE_DIR, 0755) < 0 ||
+	    mkdir(RAMFS_SOURCE_DIR, 0755) < 0 ||
+	    mkdir(RAMFS_TARGET_DIR, 0755) < 0) {
+		return -1;
+	}
+	int fd = open(path_a, O_CREAT | O_EXCL | O_WRONLY, 0644);
+	if (fd < 0) {
+		return -1;
+	}
+	if (close(fd) < 0 || link(path_a, path_b) < 0 ||
+	    rename(path_a, path_b) < 0) {
+		return -1;
+	}
+
+	return verify_two_hardlinks(path_a, path_b);
+}
+
+FN_TEST(rename_between_hardlinks_is_noop_on_ramfs)
+{
+	cleanup_test_files(RAMFS_BASE_DIR);
+	TEST_SUCC(verify_same_dir_rename(RAMFS_BASE_DIR));
+	cleanup_test_files(RAMFS_BASE_DIR);
+}
+END_TEST()
+
+FN_TEST(rename_between_cross_dir_hardlinks_is_noop_on_ramfs)
+{
+	cleanup_cross_dir_test_files();
+	TEST_SUCC(verify_cross_dir_rename());
+	cleanup_cross_dir_test_files();
+}
+END_TEST()
+
+FN_TEST(rename_between_hardlinks_is_noop_on_ext2)
+{
+	SKIP_TEST_IF(access("/ext2", F_OK) < 0);
+
+	cleanup_test_files(EXT2_BASE_DIR);
+	TEST_SUCC(verify_same_dir_rename(EXT2_BASE_DIR));
+	cleanup_test_files(EXT2_BASE_DIR);
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -146,6 +146,8 @@ echo "All mount bind file test passed."
 ./pseudofs/pseudo_inode
 ./pseudofs/pseudo_mount
 
+./rename/same_inode
+
 ./statx/btime
 
 ./symlink/symlink


### PR DESCRIPTION
## Problem

When `oldpath` and `newpath` are hard links to the same inode, `rename(2)` must succeed without changing either directory entry.

The issue can be reproduced with:

```c
creat("a", 0644);
link("a", "b");
rename("a", "b");
```

Before this change, Asterinas incorrectly removed a. The resulting state was:

- stat("a") returned ENOENT;
- stat("b") succeeded;
- the inode link count was reduced incorrectly.

The issue affected both ramfs and ext2.

The root cause was that the VFS dentry layer did not check whether the source and destination dentries referred to the same inode. It invoked the filesystem rename operation and then updated the dentry cache as if a real rename had occurred.

## Linux Behavior

Linux handles this case in vfs_rename() before invoking the filesystem rename callback:

```c
struct inode *source = old_dentry->d_inode;
struct inode *target = new_dentry->d_inode;

if (source == target)
    return 0;
```

Therefore, the filesystem backend, directory entries, link count, timestamps, and dentry cache remain unchanged.

This behavior is also specified by rename(2):  https://man7.org/linux/man-pages/man2/rename.2.html
> If oldpath and newpath are existing hard links referring to the same file, then rename() does nothing, and returns a success status.

## Changes

- Add a shared dentry-layer check for source and destination dentries that reference the same inode.

- Compare inode identity with Arc::ptr_eq, avoiding false matches between unrelated filesystems that happen to use the same inode number.

- Return successfully before invoking the filesystem backend or modifying the dentry cache.

- Apply the check to both same-directory and cross-directory rename paths.

- Keep the existing RENAME_NOREPLACE validation before the no-op check, so an existing destination still produces EEXIST.

No filesystem-specific workaround is required because the issue is prevented at the shared VFS layer.

## Regression Tests

Add a standalone regression test covering:

- two hard links in the same ramfs directory;
- two hard links in different ramfs directories;
- two hard links in the same ext2 directory.

Each test verifies that after rename(old, new):

- both pathnames still exist;
- both pathnames report the same inode number;
- both pathnames report st_nlink == 2.

The test can be run inside Asterinas with: `/test/fs/rename/same_inode`