### PR TITLE
Open PTY peers through the correct devpts mount

### DIFF
--- a/kernel/src/device/evdev/file.rs
+++ b/kernel/src/device/evdev/file.rs
@@ -17,7 +17,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
@@ -414,7 +414,7 @@ impl PerOpenFileOps for EvdevFile {
         false
     }
 
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {

--- a/kernel/src/device/fb.rs
+++ b/kernel/src/device/fb.rs
@@ -13,7 +13,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{Mappable, PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -503,7 +503,7 @@ impl PerOpenFileOps for FbHandle {
         Ok(Mappable::IoMem(iomem.clone()))
     }
 
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {

--- a/kernel/src/device/misc/tdxguest.rs
+++ b/kernel/src/device/misc/tdxguest.rs
@@ -58,7 +58,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -183,7 +183,7 @@ impl PerOpenFileOps for TdxGuestFile {
         false
     }
 
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {

--- a/kernel/src/device/pty/file.rs
+++ b/kernel/src/device/pty/file.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -80,16 +80,17 @@ impl FileOps for PtySlaveFile {
     }
 }
 
-#[inherit_methods(from = "self.0")]
 impl PerOpenFileOps for PtySlaveFile {
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32>;
-
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "the inode is a TTY");
     }
 
     fn is_offset_aware(&self) -> bool {
         false
+    }
+
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
+        self.0.ioctl(raw_ioctl)
     }
 
     fn settable_status_flags(&self) -> SettableStatusFlags {

--- a/kernel/src/device/pty/ioctl_defs.rs
+++ b/kernel/src/device/pty/ioctl_defs.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::util::ioctl::{InData, NoData, OutData, ioc};
+use crate::util::ioctl::{InData, OutData, PassByVal, ioc};
 
 // Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/asm-generic/ioctls.h>
 
 pub(super) type SetPtyLock   = ioc!(TIOCSPTLCK,  b'T', 0x31, InData<i32>);
 pub(super) type GetPtyLock   = ioc!(TIOCGPTLCK,  b'T', 0x39, OutData<i32>);
 
-pub(super) type OpenPtySlave = ioc!(TIOCGPTPEER, b'T', 0x41, NoData);
+pub(super) type OpenPtySlave = ioc!(TIOCGPTPEER, 0x5441,     InData<u32, PassByVal>);
 
 pub(super) type SetPktMode   = ioc!(TIOCPKT,     0x5420,     InData<i32>);
 pub(super) type GetPktMode   = ioc!(TIOCGPKT,    b'T', 0x38, OutData<i32>);

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::format;
-
 use ostd::task::Task;
 
 use super::{PtySlave, driver::PtyDriver};
@@ -14,10 +12,7 @@ use crate::{
             AccessMode, OpenArgs, PerOpenFileOps, SettableStatusFlags, StatusFlags,
             file_table::FdFlags, mkmod,
         },
-        vfs::{
-            inode::FileOps,
-            path::{FsPath, Path},
-        },
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::{
@@ -153,7 +148,7 @@ impl PerOpenFileOps for PtyMaster {
         false
     }
 
-    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use super::ioctl_defs::*;
         use crate::{device::tty::ioctl_defs::*, util::ioctl::common_defs::GetNumBytesToRead};
 
@@ -189,23 +184,10 @@ impl PerOpenFileOps for PtyMaster {
 
                 // TODO: Deal with `open()` flags.
                 let slave = {
-                    let fs_ref = thread_local.borrow_fs();
-                    let path_resolver = fs_ref.resolver().read();
-
-                    let slave_name = {
-                        let devpts_path = path_resolver
-                            .make_abs_path(super::DEV_PTS.get().unwrap())
-                            .into_string();
-                        format!("{}/{}", devpts_path, self.slave.index())
-                    };
-
-                    let fs_path = FsPath::try_from(slave_name.as_str())?;
-
-                    let inode_handle = {
-                        let open_args = OpenArgs::from_modes(AccessMode::O_RDWR, mkmod!(u+rw));
-                        path_resolver.lookup(&fs_path)?.open(open_args)?
-                    };
-                    Arc::new(inode_handle)
+                    let devpts_root = Path::new_fs_root(path.mount_node().clone());
+                    let slave_path = devpts_root.lookup_child(&self.slave.index().to_string())?;
+                    let open_args = OpenArgs::from_modes(AccessMode::O_RDWR, mkmod!(u+rw));
+                    Arc::new(slave_path.open(open_args)?)
                 };
 
                 let fd = {

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -9,8 +9,8 @@ use crate::{
     fs::{
         devpts::Ptmx,
         file::{
-            AccessMode, OpenArgs, PerOpenFileOps, SettableStatusFlags, StatusFlags,
-            file_table::FdFlags, mkmod,
+            CreationFlags, InodeMode, OpenArgs, PerOpenFileOps, SettableStatusFlags, StatusFlags,
+            file_table::FdFlags,
         },
         vfs::{inode::FileOps, path::Path},
     },
@@ -178,23 +178,29 @@ impl PerOpenFileOps for PtyMaster {
 
                 cmd.write(&is_locked)?;
             }
-            _cmd @ OpenPtySlave => {
-                let current_task = Task::current().unwrap();
-                let thread_local = current_task.as_thread_local().unwrap();
+            cmd @ OpenPtySlave => {
+                let flags = cmd.get();
+                let open_args = OpenArgs::from_flags_and_mode(flags, InodeMode::empty())?;
+                let fd_flags = if CreationFlags::from_bits_truncate(flags)
+                    .contains(CreationFlags::O_CLOEXEC)
+                {
+                    FdFlags::CLOEXEC
+                } else {
+                    FdFlags::empty()
+                };
 
-                // TODO: Deal with `open()` flags.
                 let slave = {
                     let devpts_root = Path::new_fs_root(path.mount_node().clone());
                     let slave_path = devpts_root.lookup_child(&self.slave.index().to_string())?;
-                    let open_args = OpenArgs::from_modes(AccessMode::O_RDWR, mkmod!(u+rw));
                     Arc::new(slave_path.open(open_args)?)
                 };
 
                 let fd = {
+                    let current_task = Task::current().unwrap();
+                    let thread_local = current_task.as_thread_local().unwrap();
                     let file_table = thread_local.borrow_file_table();
                     let mut file_table_locked = file_table.unwrap().write();
-                    // TODO: Deal with the `O_CLOEXEC` flag.
-                    file_table_locked.insert(slave, FdFlags::empty())
+                    file_table_locked.insert(slave, fd_flags)
                 };
                 return Ok(fd.into());
             }

--- a/kernel/src/device/pty/master.rs
+++ b/kernel/src/device/pty/master.rs
@@ -14,7 +14,10 @@ use crate::{
             AccessMode, OpenArgs, PerOpenFileOps, SettableStatusFlags, StatusFlags,
             file_table::FdFlags, mkmod,
         },
-        vfs::{inode::FileOps, path::FsPath},
+        vfs::{
+            inode::FileOps,
+            path::{FsPath, Path},
+        },
     },
     prelude::*,
     process::{
@@ -150,7 +153,7 @@ impl PerOpenFileOps for PtyMaster {
         false
     }
 
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use super::ioctl_defs::*;
         use crate::{device::tty::ioctl_defs::*, util::ioctl::common_defs::GetNumBytesToRead};
 

--- a/kernel/src/device/pty/mod.rs
+++ b/kernel/src/device/pty/mod.rs
@@ -5,7 +5,7 @@ use crate::{
         devpts::{DevPts, Ptmx},
         file::{InodeType, mkmod},
         vfs::{
-            path::{FsPath, Path, PathResolver, PerMountFlags},
+            path::{FsPath, PathResolver, PerMountFlags},
             registry::FsAndRoot,
         },
     },
@@ -20,26 +20,23 @@ mod packet;
 
 pub use driver::PtySlave;
 pub use master::PtyMaster;
-use spin::Once;
-
-static DEV_PTS: Once<Path> = Once::new();
 
 pub fn init_in_first_process(path_resolver: &PathResolver, ctx: &Context) -> Result<()> {
     let dev = path_resolver.lookup(&FsPath::try_from("/dev")?)?;
+
     // Create the "pts" directory and mount devpts on it.
     let devpts_path = dev.new_fs_child("pts", InodeType::Dir, mkmod!(a+rx, u+w))?;
-    let devpts_mount = devpts_path.mount(
+    devpts_path.mount(
         FsAndRoot::new(DevPts::new()),
         PerMountFlags::default(),
         Some("devpts".to_string()),
         ctx,
     )?;
 
-    DEV_PTS.call_once(|| Path::new_fs_root(devpts_mount));
-
     // Create the "ptmx" symlink.
     let ptmx = dev.new_fs_child("ptmx", InodeType::SymLink, mkmod!(a+rwx))?;
     ptmx.inode().write_link("pts/ptmx")?;
+
     Ok(())
 }
 

--- a/kernel/src/device/registry/block.rs
+++ b/kernel/src/device/registry/block.rs
@@ -12,7 +12,10 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::{inode::FileOps, path::PathResolver},
+        vfs::{
+            inode::FileOps,
+            path::{Path, PathResolver},
+        },
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -209,7 +212,7 @@ impl PerOpenFileOps for OpenBlockFile {
         Ok(Some(self.0.metadata().nr_sectors * SECTOR_SIZE))
     }
 
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {

--- a/kernel/src/device/tty/file.rs
+++ b/kernel/src/device/tty/file.rs
@@ -7,7 +7,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -47,16 +47,17 @@ impl<D: TtyDriver> FileOps for TtyFile<D> {
     }
 }
 
-#[inherit_methods(from = "self.0")]
 impl<D: TtyDriver> PerOpenFileOps for TtyFile<D> {
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32>;
-
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "the inode is a TTY");
     }
 
     fn is_offset_aware(&self) -> bool {
         false
+    }
+
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
+        self.0.ioctl(raw_ioctl)
     }
 
     fn settable_status_flags(&self) -> SettableStatusFlags {

--- a/kernel/src/device/tty/vt/file.rs
+++ b/kernel/src/device/tty/vt/file.rs
@@ -15,7 +15,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
-        vfs::inode::FileOps,
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -104,16 +104,17 @@ impl FileOps for VtFile {
     }
 }
 
-#[inherit_methods(from = "self.0")]
 impl PerOpenFileOps for VtFile {
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32>;
-
     fn check_seekable(&self) -> Result<()> {
         return_errno_with_message!(Errno::ESPIPE, "the inode is a TTY");
     }
 
     fn is_offset_aware(&self) -> bool {
         false
+    }
+
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
+        self.0.ioctl(raw_ioctl)
     }
 
     fn settable_status_flags(&self) -> SettableStatusFlags {

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -347,7 +347,7 @@ impl FileLike for InodeHandle {
         }
 
         if let Some(ref open_file) = self.open_file {
-            return open_file.ioctl(raw_ioctl);
+            return open_file.ioctl(self.common.path(), raw_ioctl);
         }
 
         return_errno_with_message!(Errno::ENOTTY, "ioctl is not supported");
@@ -565,7 +565,7 @@ pub trait PerOpenFileOps: Pollable + FileOps + Any + Send + Sync + 'static {
         return_errno_with_message!(Errno::EINVAL, "the file is not mappable");
     }
 
-    fn ioctl(&self, _raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, _raw_ioctl: RawIoctl) -> Result<i32> {
         return_errno_with_message!(Errno::ENOTTY, "ioctl is not supported");
     }
 

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -10,7 +10,7 @@ use id_alloc::IdAlloc;
 pub use self::ptmx::Ptmx;
 use self::slave::PtySlaveInode;
 use crate::{
-    device::{Device, DeviceType, PtyMaster},
+    device::PtyMaster,
     fs::{
         file::{InodeMode, InodeType, StatusFlags, mkmod},
         pseudofs::AnonDeviceId,

--- a/kernel/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/src/fs/fs_impls/devpts/ptmx.rs
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::time::Duration;
+
 use device_id::{DeviceId, MajorId, MinorId};
 
-use super::*;
+use super::{BLOCK_SIZE, DevPts, PTMX_INO};
 use crate::{
-    device::DevtmpfsInodeMeta,
-    fs::file::{AccessMode, PerOpenFileOps},
+    device::{Device, DeviceType, DevtmpfsInodeMeta},
+    fs::{
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        vfs::{
+            file_system::{FileSystem, SuperBlock},
+            inode::{Extension, FileOps, Inode, Metadata},
+        },
+    },
+    prelude::*,
+    process::{Gid, Uid},
 };
 
 /// Same major number with Linux.

--- a/kernel/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/src/fs/fs_impls/devpts/slave.rs
@@ -3,10 +3,20 @@
 #![expect(dead_code)]
 #![expect(unused_variables)]
 
-use super::*;
+use core::time::Duration;
+
+use super::{BLOCK_SIZE, DevPts, FIRST_SLAVE_INO};
 use crate::{
-    device::PtySlave,
-    fs::file::{AccessMode, PerOpenFileOps},
+    device::{Device, PtySlave},
+    fs::{
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        vfs::{
+            file_system::FileSystem,
+            inode::{Extension, FileOps, Inode, Metadata},
+        },
+    },
+    prelude::*,
+    process::{Gid, Uid},
 };
 
 /// Same major number with Linux, the minor number is the index of slave.

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -191,7 +191,7 @@ impl<T: NsCommonOps> PerOpenFileOps for NsFile<T> {
         Ok(())
     }
 
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use ioctl_defs::*;
 
         dispatch_ioctl!(match raw_ioctl {

--- a/kernel/src/fs/pipe/common.rs
+++ b/kernel/src/fs/pipe/common.rs
@@ -12,7 +12,7 @@ use crate::{
     fs::{
         file::{AccessMode, PerOpenFileOps, SettableStatusFlags, StatusFlags},
         utils::{Endpoint, EndpointState},
-        vfs::inode::FileOps,
+        vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
     process::{
@@ -145,7 +145,7 @@ impl PerOpenFileOps for PipeHandle {
         false
     }
 
-    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+    fn ioctl(&self, _path: &Path, raw_ioctl: RawIoctl) -> Result<i32> {
         use crate::util::ioctl::common_defs::GetNumBytesToRead;
 
         dispatch_ioctl!(match raw_ioctl {

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -72,6 +72,15 @@ impl Path {
         Ok(Self::new(self.mount.clone(), new_child_dentry))
     }
 
+    /// Looks up a direct child within the current mount.
+    ///
+    /// This does not interpret special names, check search permissions, or traverse mount points.
+    pub fn lookup_child(&self, name: &str) -> Result<Self> {
+        let dir_dentry = self.dentry.as_dir_dentry_or_err()?;
+        let child_dentry = dir_dentry.lookup_child(name)?;
+        Ok(Self::new(self.mount.clone(), child_dentry))
+    }
+
     /// Creates a new `Path` to represent an unnamed temporary file.
     ///
     /// The returned inode has no directory entry and is invisible to `readdir`.

--- a/kernel/src/util/ioctl/mod.rs
+++ b/kernel/src/util/ioctl/mod.rs
@@ -309,8 +309,8 @@ macro_rules! impl_get_by_val_for {
     };
 }
 
-// We can add more types as needed, e.g., `u32`, `i8`.
-impl_get_by_val_for! { i32 }
+// We can add more types as needed, e.g., `i8`.
+impl_get_by_val_for! { i32 u32 }
 
 impl DataSpec for InData<[u8]> {
     const SIZE: Option<u16> = None;

--- a/test/initramfs/src/regression/device/pty/open_ptmx.c
+++ b/test/initramfs/src/regression/device/pty/open_ptmx.c
@@ -57,6 +57,15 @@ FN_TEST(clear_lock_and_open_slave)
 }
 END_TEST()
 
+FN_TEST(open_slave_with_flags)
+{
+	int peer = TEST_SUCC(ioctl(master, TIOCGPTPEER, O_WRONLY | O_CLOEXEC));
+	TEST_RES(fcntl(peer, F_GETFL), (_ret & O_ACCMODE) == O_WRONLY);
+	TEST_RES(fcntl(peer, F_GETFD), (_ret & FD_CLOEXEC) != 0);
+	TEST_SUCC(close(peer));
+}
+END_TEST()
+
 FN_TEST(read_write)
 {
 	// Set master blocking mode

--- a/test/initramfs/src/regression/device/pty/open_pty_peer.c
+++ b/test/initramfs/src/regression/device/pty/open_pty_peer.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+#include "../../common/test.h"
+
+#define DEVPTS_MOUNT "/tmp/devpts-peer"
+#define PTMX_PATH DEVPTS_MOUNT "/ptmx"
+
+static int master;
+static char slave_path[128];
+
+FN_SETUP(mount_devpts)
+{
+	CHECK(mkdir(DEVPTS_MOUNT, 0755));
+	CHECK(mount("devpts", DEVPTS_MOUNT, "devpts", 0, NULL));
+	master = CHECK(open(PTMX_PATH, O_RDWR));
+
+	int index;
+	CHECK(ioctl(master, TIOCGPTN, &index));
+	memset(slave_path, 0, sizeof(slave_path));
+	sprintf(slave_path, DEVPTS_MOUNT "/%d", index);
+
+	int lock = 0;
+	CHECK(ioctl(master, TIOCSPTLCK, &lock));
+}
+END_SETUP()
+
+FN_TEST(open_peer_from_master_mount)
+{
+	int peer = TEST_SUCC(ioctl(master, TIOCGPTPEER, O_RDWR));
+	struct stat peer_stat;
+	struct stat path_stat;
+	TEST_SUCC(fstat(peer, &peer_stat));
+	TEST_RES(stat(slave_path, &path_stat),
+		 peer_stat.st_dev == path_stat.st_dev &&
+			 peer_stat.st_ino == path_stat.st_ino);
+	TEST_SUCC(close(peer));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(master));
+	CHECK(umount(DEVPTS_MOUNT));
+	CHECK(rmdir(DEVPTS_MOUNT));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/device/run_test.sh
+++ b/test/initramfs/src/regression/device/run_test.sh
@@ -7,6 +7,7 @@ set -e
 ./pty/close_pty
 ./pty/open_ptmx
 ./pty/open_pty
+./pty/open_pty_peer
 ./pty/pty_blocking
 ./pty/pty_packet_mode
 ./pty/termios2


### PR DESCRIPTION
This PR makes `TIOCGPTPEER` open the PTY slave through the `devpts` mount associated with the master FD instead of the hard-coded `/dev/pts`. It passes the opened path to per-open ioctl handlers, honors the supplied open flags including `O_CLOEXEC`, and adds regression coverage for non-default `devpts` mounts and peer open flags.

See #3645 for the full background and design discussion.