### PR TITLE
Synchronize network regression test

### DIFF
--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -4,17 +4,60 @@
 
 set -e
 
-./tcp_server &
-sleep 0.2
-./tcp_client
+server_pid=
+ready_file=
 
-./udp_server &
-sleep 0.2
-./udp_client
+cleanup_server() {
+    if [ -n "$server_pid" ]; then
+        kill "$server_pid" 2>/dev/null || true
+        wait "$server_pid" 2>/dev/null || true
+        server_pid=
+    fi
 
-./unix_server &
-sleep 0.2
-./unix_client
+    rm -f "$ready_file" /tmp/test.sock
+}
+
+wait_for_server() {
+    attempts=0
+    while [ ! -e "$ready_file" ]; do
+        if [ "$attempts" -eq 100 ]; then
+            echo "Timed out waiting for $1 to become ready." >&2
+            return 1
+        fi
+
+        if ! kill -0 "$server_pid" 2>/dev/null; then
+            echo "$1 exited before becoming ready." >&2
+            wait "$server_pid"
+            return 1
+        fi
+
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+}
+
+run_server_client_pair() {
+    server=$1
+    client=$2
+    ready_file="/tmp/$(basename "$server")-ready-$$"
+
+    rm -f "$ready_file"
+    "$server" "$ready_file" &
+    server_pid=$!
+
+    trap cleanup_server EXIT HUP INT TERM
+    wait_for_server "$server"
+    "$client"
+    wait "$server_pid"
+    server_pid=
+    trap - EXIT HUP INT TERM
+    rm -f "$ready_file"
+}
+
+rm -f /tmp/test.sock
+run_server_client_pair ./tcp_server ./tcp_client
+run_server_client_pair ./udp_server ./udp_client
+run_server_client_pair ./unix_server ./unix_client
 
 ./listen_backlog
 ./msg_peek

--- a/test/initramfs/src/regression/network/tcp_server.c
+++ b/test/initramfs/src/regression/network/tcp_server.c
@@ -4,11 +4,26 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <arpa/inet.h>
 
 #define PORT 8080
 
-int main()
+static void notify_ready(const char *ready_file)
+{
+	if (ready_file == NULL) {
+		return;
+	}
+
+	int ready_fd = open(ready_file, O_WRONLY | O_CREAT | O_EXCL, 0600);
+	if (ready_fd < 0) {
+		perror("create ready file");
+		exit(EXIT_FAILURE);
+	}
+	close(ready_fd);
+}
+
+int main(int argc, char *argv[])
 {
 	int server_fd, new_socket;
 	struct sockaddr_in address;
@@ -51,6 +66,7 @@ int main()
 		perror("listen failed");
 		exit(EXIT_FAILURE);
 	}
+	notify_ready(argc > 1 ? argv[1] : NULL);
 
 	// Accept the connection
 	if ((new_socket = accept(server_fd, (struct sockaddr *)&address,

--- a/test/initramfs/src/regression/network/udp_server.c
+++ b/test/initramfs/src/regression/network/udp_server.c
@@ -7,12 +7,27 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #define SERVER_IP "127.0.0.1"
 #define SERVER_PORT 1234
 #define BUFFER_SIZE 1024
 
-int main()
+static void notify_ready(const char *ready_file)
+{
+	if (ready_file == NULL) {
+		return;
+	}
+
+	int ready_fd = open(ready_file, O_WRONLY | O_CREAT | O_EXCL, 0600);
+	if (ready_fd < 0) {
+		perror("create ready file");
+		exit(EXIT_FAILURE);
+	}
+	close(ready_fd);
+}
+
+int main(int argc, char *argv[])
 {
 	int sock_fd;
 	char buffer[BUFFER_SIZE];
@@ -39,6 +54,7 @@ int main()
 		perror("bind failed");
 		exit(EXIT_FAILURE);
 	}
+	notify_ready(argc > 1 ? argv[1] : NULL);
 
 	// Receive message from client
 	struct sockaddr_in sender_addr;

--- a/test/initramfs/src/regression/network/unix_server.c
+++ b/test/initramfs/src/regression/network/unix_server.c
@@ -7,11 +7,26 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <fcntl.h>
 
 #define SOCKET_NAME "/tmp/test.sock"
 #define BUFFER_SIZE 128
 
-int main()
+static void notify_ready(const char *ready_file)
+{
+	if (ready_file == NULL) {
+		return;
+	}
+
+	int ready_fd = open(ready_file, O_WRONLY | O_CREAT | O_EXCL, 0600);
+	if (ready_fd < 0) {
+		perror("create ready file");
+		exit(EXIT_FAILURE);
+	}
+	close(ready_fd);
+}
+
+int main(int argc, char *argv[])
 {
 	int server_fd, accepted_fd;
 	struct sockaddr_un server_addr, client_addr;
@@ -41,6 +56,7 @@ int main()
 		perror("listen");
 		exit(EXIT_FAILURE);
 	}
+	notify_ready(argc > 1 ? argv[1] : NULL);
 
 	printf("Server is listening...\n");
 


### PR DESCRIPTION
## Summary

  Replace the fixed `sleep 0.2` delays in the network regression runner with an
  explicit server-readiness handshake.

  Previously, `run_test.sh` started each server in the background, waited for
  0.2 seconds, and then started its client. On a slow or contended CI/QEMU
  guest, the client may run before the server has completed `bind()` or
  `listen()`, causing an unrelated PR to fail in the network regression suite.
  For example, this was observed in PR #3603.

  Instead of relying on timing, each server now creates a ready file after it is
  ready to serve requests. The test runner waits for that file before starting
  the corresponding client.

  ## Changes

  - Refactor `test/initramfs/src/regression/network/run_test.sh` to:
    - create a unique ready-file path for each server/client pair;
    - wait for readiness with a bounded retry loop;
    - wait for the server after the client exits, so server-side failures are
      reported;
    - terminate and reap a running server, and remove temporary files, when the
      test exits early.

  - Update `tcp_server`, `udp_server`, and `unix_server` to accept an optional
    ready-file argument:
    - TCP and Unix-domain servers create the file after `listen()`;
    - the UDP server creates it after `bind()`.

  ## Why a ready file?

  Linux kselftest network helpers can often detect readiness by inspecting
  `/proc/net/tcp`, `/proc/net/udp`, or `/proc/net/unix`.

  Asterinas does not currently implement `/proc/net/`, so this test cannot use
  that mechanism. The ready file is a local synchronization protocol for these
  three regression-test server/client pairs. It avoids coupling this regression
  test to an unrelated procfs feature while providing a bounded, observable
  readiness condition.

  ## Scope and follow-up

  During the investigation, I found other regression tests that also use fixed
  `sleep` intervals for process synchronization. I have drafted fixes for some
  of them, but have intentionally kept them out of this PR.

  After expanding the scope, I am unsure whether the same ready-file approach is
  the preferred pattern for all such tests, especially where a more
  subsystem-specific synchronization mechanism may be available. Feedback from
  maintainers on the preferred direction would be greatly appreciated before I
  submit follow-up changes.