### PR TITLE
Fix Python regression tests on read-only NixOS /nix/store

### DIFF
--- a/test/nixos/tests/development-tools-python/extra_config.nix
+++ b/test/nixos/tests/development-tools-python/extra_config.nix
@@ -4,6 +4,7 @@ in {
   environment.systemPackages = [ py3 ];
   # Make the exact matching source tree available without a download.
   system.activationScripts.testFixtures = ''
+    mkdir -p /tmp
     ln -sfT ${py3.src} /tmp/python3-src.tar.xz
   '';
 }

--- a/test/nixos/tests/development-tools-python/src/main.rs
+++ b/test/nixos/tests/development-tools-python/src/main.rs
@@ -16,7 +16,17 @@ fn python3_regrtest(nixos_shell: &mut Session) -> Result<(), Error> {
     nixos_shell.run_cmd("mkdir /tmp/python3-src")?;
     nixos_shell
         .run_cmd("tar xf /tmp/python3-src.tar.xz --strip-components=1 -C /tmp/python3-src")?;
-    nixos_shell.run_cmd("export PYTHONPATH=/tmp/python3-src/Lib")?;
+    // Regrtest removes legacy .pyc paths under every sys.path entry. Relocate
+    // the installed standard library out of the read-only /nix/store mount.
+    nixos_shell.run_cmd(
+        "python_root=$(dirname $(dirname $(readlink -f $(command -v python3)))); mkdir /tmp/python3-home; cp -a $python_root/lib /tmp/python3-home/lib; ln -s $python_root/include /tmp/python3-home/include",
+    )?;
+    const RUN_REGRTEST: &str = concat!(
+        "import os, runpy, sys; sys.path.insert(0, '/tmp/python3-src/Lib'); ",
+        "os.environ.pop('PYTHONPATH', None); ",
+        "sys.argv = ['test', '-u', 'all', *sys.argv[1:]]; ",
+        "runpy.run_module('test', run_name='__main__')",
+    );
 
     // Printed once by regrtest at the end of every run as `Result: {state}`:
     //   https://github.com/python/cpython/blob/v3.12.12/Lib/test/libregrtest/main.py#L455-L456
@@ -34,7 +44,15 @@ fn python3_regrtest(nixos_shell: &mut Session) -> Result<(), Error> {
         .map(str::trim)
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
     {
-        let cmd = format!("python3 -m test -u all {testcase}");
+        // test_cmd_line validates the behavior of child interpreters with
+        // PYTHONPATH unset, so add the source path to this process only.
+        let cmd = if testcase.split_whitespace().next() == Some("test_cmd_line") {
+            format!("PYTHONHOME=/tmp/python3-home python3 -c \"{RUN_REGRTEST}\" {testcase}")
+        } else {
+            format!(
+                "PYTHONHOME=/tmp/python3-home PYTHONPATH=/tmp/python3-src/Lib python3 -m test -u all {testcase}"
+            )
+        };
         if let Err(err) = nixos_shell.run_cmd_and_expect(&cmd, RESULT_SUCCESS) {
             failed_tests.push((testcase.to_string(), err));
         }


### PR DESCRIPTION
This is part of the groundwork for #3653.

The `development-tools-python` test fails in this [Test AsterNixOS (full) / Test development-tools-python](https://github.com/asterinas/asterinas/actions/runs/30378786574/job/90341173178) CI run.

The failure is reproducible on a normal Linux NixOS host:

```bash
python=$(nix-build '<nixpkgs>' -A python312 --no-out-link)
src_archive=$(nix-build '<nixpkgs>' -A python312.src --no-out-link)
src_dir=$(mktemp -d)
tar xf "$src_archive" --strip-components=1 -C "$src_dir"

PYTHONPATH="$src_dir/Lib" \
  "$python/bin/python3" -m test -u all test_traceback
```

This produces 26 errors. The errors are attempts to remove random `.pyc` paths under `/nix/store`, and Linux returns `EROFS` because NixOS mounts `/nix/store` read-only. CPython `test.support.import_helper.forget()` intentionally tries to unlink possible legacy and PEP 3147/488 bytecode paths even when they do not exist. Linux checks the read-only mount before the final dentry lookup, so a missing path returns `EROFS` instead of `ENOENT`.

The AsterNixOS test combines the test modules from a writable source tree with an installed interpreter whose standard library is under `/nix/store`. This patch makes `/tmp` available before the activation script places the source archive there, copies the interpreter output `lib` directory to `/tmp`, links its read-only `include` directory for `sysconfig` queries, and sets `PYTHONHOME` to the writable copy.

Most regrtest cases run with `PYTHONPATH=/tmp/python3-src/Lib`, so child interpreters can import the source-tree test modules as well. `test_cmd_line` is the exception: it verifies behavior when `PYTHONPATH` is unset, so that case adds the source path to the current process with `sys.path` and removes the environment variable before starting regrtest.

This avoids rebuilding CPython with `configure` and `make`, while preserving the read-only `/nix/store` behavior being tested by NixOS.
