### PR TITLE
Test RISC-V Svade in CI

### DIFF
--- a/.github/workflows/test_riscv.yml
+++ b/.github/workflows/test_riscv.yml
@@ -51,7 +51,19 @@ jobs:
       matrix:
         include:
           - test_id: 'boot-debug-smp4'
+            release: false
             smp: 4
+
+          - test_id: 'boot-debug-sv48-svade-smp4'
+            release: false
+            smp: 4
+            riscv_qemu_cpu: 'rv64,svpbmt=true,zkr=true,svadu=false,svade=true'
+
+          - test_id: 'boot-debug-sv39-svade-smp4'
+            release: false
+            smp: 4
+            features: 'riscv_sv39_mode'
+            riscv_qemu_cpu: 'rv64,svpbmt=true,zkr=true,sv48=false,svadu=false,svade=true'
 
           - test_id: 'boot-release'
             release: true
@@ -70,8 +82,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run integration tests ${{ (startsWith(matrix.test_id, 'conformance') && 'with LTP') || '' }}
         uses: ./.github/actions/test
+        env:
+          FEATURES: ${{ matrix.features }}
+          RISCV_QEMU_CPU: ${{ matrix.riscv_qemu_cpu }}
         with:
           auto_test: ${{ (startsWith(matrix.test_id, 'boot') && 'boot') || 'conformance' }}
           release: ${{ !contains(matrix.release, 'false') }}
           arch: 'riscv64'
+          smp: ${{ matrix.smp }}
           conformance_test_suite: 'ltp'

--- a/kernel/src/vm/vmar/vm_mapping.rs
+++ b/kernel/src/vm/vmar/vm_mapping.rs
@@ -12,8 +12,11 @@ use aster_util::printer::VmPrinter;
 use ostd::{
     io::IoMem,
     mm::{
-        CachePolicy, Frame, FrameAllocOptions, PageFlags, PageProperty, UFrame, VmSpace,
-        io::util::HasVmReaderWriter, tlb::TlbFlushOp, vm_space::VmQueriedItem,
+        CachePolicy, Frame, FrameAllocOptions, PageAccess, PageFlags, PageProperty, UFrame,
+        VmSpace,
+        io::util::HasVmReaderWriter,
+        tlb::TlbFlushOp,
+        vm_space::{CursorMut, VmQueriedItem},
     },
     task::disable_preempt,
 };
@@ -372,17 +375,15 @@ impl VmMapping {
                 rss_delta,
             );
 
-            // Errors caused by the "around" pages should be ignored, so here we
-            // only return the error if the faulting page is still not mapped.
+            // Errors caused by the "around" pages should be ignored, but the
+            // actual faulting page must still be handled.
             if res.is_err() {
-                let preempt_guard = disable_preempt();
-                let mut cursor = vm_space.cursor(
-                    &preempt_guard,
-                    &(page_aligned_addr..page_aligned_addr + PAGE_SIZE),
-                )?;
-                if let (_, Some(_)) = cursor.query().unwrap() {
-                    return Ok(());
-                }
+                return self.handle_single_page_fault(
+                    vm_space,
+                    page_aligned_addr,
+                    page_fault_info.required_perms,
+                    rss_delta,
+                );
             }
 
             return res;
@@ -442,12 +443,15 @@ impl VmMapping {
 
             let (va, item) = cursor.query().unwrap();
             let is_write = required_perms.contains(VmPerms::WRITE);
+            let access = if is_write {
+                PageAccess::Write
+            } else {
+                PageAccess::Read
+            };
             match item {
                 Some(VmQueriedItem::MappedRam { frame, mut prop }) => {
                     if VmPerms::from(prop.flags).contains(required_perms) {
-                        // The page fault is already handled maybe by other threads.
-                        // Just flush the TLB and return.
-                        TlbFlushOp::for_range(va).perform_on_current();
+                        record_page_access(&mut cursor, va, access);
                         return Ok(());
                     }
                     assert!(is_write);
@@ -463,7 +467,8 @@ impl VmMapping {
                     // frame. We can directly map the frame as writable without copying.
                     let only_reference = frame.reference_count() == 1;
 
-                    let new_flags = PageFlags::W | PageFlags::ACCESSED | PageFlags::DIRTY;
+                    let mut new_flags = PageFlags::W;
+                    new_flags.record_access(PageAccess::Write);
 
                     if self.is_shared || only_reference {
                         cursor.protect_next(PAGE_SIZE, |flags, _cache| {
@@ -515,11 +520,8 @@ impl VmMapping {
                         perms
                     };
 
-                    let mut page_flags = vm_perms.into();
-                    page_flags |= PageFlags::ACCESSED;
-                    if is_write {
-                        page_flags |= PageFlags::DIRTY;
-                    }
+                    let mut page_flags = PageFlags::from(vm_perms);
+                    page_flags.record_access(access);
                     let map_prop = PageProperty::new_user(page_flags, CachePolicy::Writeback);
 
                     cursor.map(frame, map_prop);
@@ -614,19 +616,33 @@ impl VmMapping {
             let rss_delta_ref = &mut rss_delta;
             let operate =
                 move |commit_fn: &mut dyn FnMut() -> Result<(usize, CachePage), VmoCommitError>| {
-                    if let (_, None) = cursor.query().unwrap() {
-                        // We regard all the surrounding pages as accessed, no matter
-                        // if it is really so. Then the hardware won't bother to update
-                        // the accessed bit of the page table on following accesses.
-                        let page_flags = PageFlags::from(vm_perms) | PageFlags::ACCESSED;
-                        let page_prop = PageProperty::new_user(page_flags, CachePolicy::Writeback);
-                        let (_, frame) = commit_fn()?;
-                        cursor.map(frame.into(), page_prop);
-                        rss_delta_ref.add(self.rss_type(), 1);
-                    } else {
-                        let next_addr = cursor.virt_addr() + PAGE_SIZE;
-                        if next_addr < end_addr {
-                            let _ = cursor.jump(next_addr);
+                    let current_addr = cursor.virt_addr();
+                    let (_, item) = cursor.query().unwrap();
+                    match item {
+                        None => {
+                            // We regard all the surrounding pages as accessed, no matter
+                            // if it is really so. Then the hardware won't bother to update
+                            // the accessed bit of the page table on following accesses.
+                            let mut page_flags = PageFlags::from(vm_perms);
+                            page_flags.record_access(PageAccess::Read);
+                            let page_prop =
+                                PageProperty::new_user(page_flags, CachePolicy::Writeback);
+                            let (_, frame) = commit_fn()?;
+                            cursor.map(frame.into(), page_prop);
+                            rss_delta_ref.add(self.rss_type(), 1);
+                        }
+                        Some(VmQueriedItem::MappedRam { prop, .. })
+                            if current_addr == page_aligned_addr
+                                && VmPerms::from(prop.flags).contains(required_perms) =>
+                        {
+                            let va = page_aligned_addr..page_aligned_addr + PAGE_SIZE;
+                            record_page_access(&mut cursor, va, PageAccess::Read);
+                        }
+                        Some(_) => {
+                            let next_addr = current_addr + PAGE_SIZE;
+                            if next_addr < end_addr {
+                                let _ = cursor.jump(next_addr);
+                            }
                         }
                     }
                     Ok(())
@@ -646,6 +662,17 @@ impl VmMapping {
             }
         }
     }
+}
+
+fn record_page_access(cursor: &mut CursorMut<'_>, va: Range<Vaddr>, access: PageAccess) {
+    let protected_range = cursor.protect_next(PAGE_SIZE, |flags, _| {
+        flags.record_access(access);
+    });
+    debug_assert_eq!(protected_range, Some(va.clone()));
+
+    cursor.flusher().issue_tlb_flush(TlbFlushOp::for_range(va));
+    cursor.flusher().dispatch_tlb_flush();
+    cursor.flusher().sync_tlb_flush();
 }
 
 /**************************** Transformations ********************************/
@@ -1028,4 +1055,239 @@ fn duplicate_frame(src: &UFrame) -> Result<Frame<()>> {
     let new_frame = FrameAllocOptions::new().zeroed(false).alloc_frame()?;
     new_frame.writer().write(&mut src.reader());
     Ok(new_frame)
+}
+
+#[cfg(ktest)]
+mod tests {
+    use io_util::batch::IoBatch;
+    use ostd::prelude::ktest;
+
+    use super::*;
+    use crate::vm::page_cache::{LockedCachePage, PageCacheBackend, VmoOptions};
+
+    struct FailingPageCacheBackend;
+
+    impl PageCacheBackend for FailingPageCacheBackend {
+        fn read_page_async(
+            &self,
+            _idx: usize,
+            _locked_page: LockedCachePage,
+            _io_batch: &mut IoBatch,
+        ) -> Result<()> {
+            Err(Error::with_message(
+                Errno::EIO,
+                "intentional fault-around read failure",
+            ))
+        }
+
+        fn write_page_async(
+            &self,
+            _idx: usize,
+            _locked_page: LockedCachePage,
+            _io_batch: &mut IoBatch,
+        ) -> Result<()> {
+            Err(Error::with_message(
+                Errno::EIO,
+                "intentional fault-around write failure",
+            ))
+        }
+    }
+
+    fn assert_mapping_prop(vm_space: &VmSpace, range: &Range<Vaddr>, expected_flags: PageFlags) {
+        let preempt_guard = disable_preempt();
+        let mut cursor = vm_space.cursor(&preempt_guard, range).unwrap();
+        let (_, Some(VmQueriedItem::MappedRam { prop, .. })) = cursor.query().unwrap() else {
+            panic!("query did not return the RAM mapping");
+        };
+        assert_eq!(prop.flags, expected_flags);
+        assert_eq!(prop.cache, CachePolicy::Writeback);
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn page_fault_handler_resolves_ad_bit_fault_for_read() {
+        const EXPECTED_VALUE: u8 = 0x5a;
+
+        let vm_space = Arc::new(VmSpace::new());
+        let map_range = PAGE_SIZE..PAGE_SIZE * 2;
+        let frame = FrameAllocOptions::new().alloc_frame().unwrap();
+        frame.writer().write_val(&EXPECTED_VALUE).unwrap();
+        let preempt_guard = disable_preempt();
+        vm_space
+            .cursor_mut(&preempt_guard, &map_range)
+            .unwrap()
+            .map(
+                frame.into(),
+                PageProperty::new_user(PageFlags::RX | PageFlags::AVAIL2, CachePolicy::Writeback),
+            );
+        vm_space.activate();
+
+        let mapping = VmMapping::new(
+            NonZeroUsize::new(PAGE_SIZE).unwrap(),
+            map_range.start,
+            MappedMemory::Anonymous,
+            None,
+            false,
+            false,
+            VmPerms::READ | VmPerms::EXEC,
+        );
+        mapping
+            .handle_page_fault(
+                &vm_space,
+                &PageFaultInfo::new(map_range.start, VmPerms::READ),
+                &mut RssDelta::new_for_test(),
+            )
+            .unwrap();
+
+        assert_mapping_prop(
+            &vm_space,
+            &map_range,
+            PageFlags::RX | PageFlags::AVAIL2 | PageFlags::ACCESSED,
+        );
+        assert_eq!(
+            vm_space
+                .reader(map_range.start, size_of::<u8>())
+                .unwrap()
+                .read_val::<u8>()
+                .unwrap(),
+            EXPECTED_VALUE
+        );
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn page_fault_handler_resolves_ad_bit_fault_for_write() {
+        const EXPECTED_VALUE: u8 = 0xa5;
+
+        let vm_space = Arc::new(VmSpace::new());
+        let map_range = PAGE_SIZE..PAGE_SIZE * 2;
+        let frame = FrameAllocOptions::new().alloc_frame().unwrap();
+        let preempt_guard = disable_preempt();
+        vm_space
+            .cursor_mut(&preempt_guard, &map_range)
+            .unwrap()
+            .map(
+                frame.clone().into(),
+                PageProperty::new_user(PageFlags::RW | PageFlags::AVAIL2, CachePolicy::Writeback),
+            );
+        vm_space.activate();
+
+        let mapping = VmMapping::new(
+            NonZeroUsize::new(PAGE_SIZE).unwrap(),
+            map_range.start,
+            MappedMemory::Anonymous,
+            None,
+            false,
+            false,
+            VmPerms::READ | VmPerms::WRITE,
+        );
+        mapping
+            .handle_page_fault(
+                &vm_space,
+                &PageFaultInfo::new(map_range.start, VmPerms::WRITE),
+                &mut RssDelta::new_for_test(),
+            )
+            .unwrap();
+
+        assert_mapping_prop(
+            &vm_space,
+            &map_range,
+            PageFlags::RW | PageFlags::AVAIL2 | PageFlags::ACCESSED | PageFlags::DIRTY,
+        );
+        vm_space
+            .writer(map_range.start, size_of::<u8>())
+            .unwrap()
+            .write_val(&EXPECTED_VALUE)
+            .unwrap();
+        assert_eq!(frame.reader().read_val::<u8>().unwrap(), EXPECTED_VALUE);
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn page_fault_handler_resolves_ad_bit_fault_with_fault_around() {
+        let vm_space = Arc::new(VmSpace::new());
+        let map_range = PAGE_SIZE..PAGE_SIZE * 2;
+        let vmo = VmoOptions::new_anon(PAGE_SIZE).alloc().unwrap();
+        let mapped_vmo = MappedVmo::new(vmo, 0, false).unwrap();
+        let frame = mapped_vmo.get_committed_frame(0).unwrap();
+        let preempt_guard = disable_preempt();
+        vm_space
+            .cursor_mut(&preempt_guard, &map_range)
+            .unwrap()
+            .map(
+                frame,
+                PageProperty::new_user(PageFlags::R | PageFlags::AVAIL2, CachePolicy::Writeback),
+            );
+        vm_space.activate();
+
+        let mapping = VmMapping::new(
+            NonZeroUsize::new(PAGE_SIZE).unwrap(),
+            map_range.start,
+            MappedMemory::Vmo(mapped_vmo),
+            None,
+            false,
+            true,
+            VmPerms::READ,
+        );
+        mapping
+            .handle_page_fault(
+                &vm_space,
+                &PageFaultInfo::new(map_range.start, VmPerms::READ),
+                &mut RssDelta::new_for_test(),
+            )
+            .unwrap();
+
+        assert_mapping_prop(
+            &vm_space,
+            &map_range,
+            PageFlags::R | PageFlags::AVAIL2 | PageFlags::ACCESSED,
+        );
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn page_fault_handler_repairs_ad_bit_when_fault_around_io_fails() {
+        let vm_space = Arc::new(VmSpace::new());
+        let mapping_start = PAGE_SIZE;
+        let fault_addr = mapping_start + PAGE_SIZE;
+        let fault_range = fault_addr..fault_addr + PAGE_SIZE;
+        let backend: Arc<dyn PageCacheBackend> = Arc::new(FailingPageCacheBackend);
+        let vmo = VmoOptions::new_page_cache(16 * PAGE_SIZE, Arc::downgrade(&backend))
+            .alloc()
+            .unwrap();
+        let mapped_vmo = MappedVmo::new(vmo, 0, false).unwrap();
+        let frame = FrameAllocOptions::new().alloc_frame().unwrap();
+        let preempt_guard = disable_preempt();
+        vm_space
+            .cursor_mut(&preempt_guard, &fault_range)
+            .unwrap()
+            .map(
+                frame.into(),
+                PageProperty::new_user(PageFlags::R | PageFlags::AVAIL2, CachePolicy::Writeback),
+            );
+        vm_space.activate();
+
+        let mapping = VmMapping::new(
+            NonZeroUsize::new(16 * PAGE_SIZE).unwrap(),
+            mapping_start,
+            MappedMemory::Vmo(mapped_vmo),
+            None,
+            false,
+            true,
+            VmPerms::READ,
+        );
+        mapping
+            .handle_page_fault(
+                &vm_space,
+                &PageFaultInfo::new(fault_addr, VmPerms::READ),
+                &mut RssDelta::new_for_test(),
+            )
+            .unwrap();
+
+        assert_mapping_prop(
+            &vm_space,
+            &fault_range,
+            PageFlags::R | PageFlags::AVAIL2 | PageFlags::ACCESSED,
+        );
+    }
 }

--- a/kernel/src/vm/vmar/vmar_impls/fork.rs
+++ b/kernel/src/vm/vmar/vmar_impls/fork.rs
@@ -125,6 +125,24 @@ mod test {
 
     use super::*;
 
+    fn expected_iomem_flags(flags: PageFlags) -> PageFlags {
+        #[cfg(target_arch = "riscv64")]
+        {
+            let mut flags = flags;
+            flags.record_access(if flags.contains(PageFlags::W) {
+                ostd::mm::PageAccess::Write
+            } else {
+                ostd::mm::PageAccess::Read
+            });
+            flags
+        }
+
+        #[cfg(not(target_arch = "riscv64"))]
+        {
+            flags
+        }
+    }
+
     #[ktest]
     fn cow_copy_pt_basic() {
         let vm_space = VmSpace::new();
@@ -275,7 +293,10 @@ mod test {
         // Confirms the initial mapping.
         assert!(matches!(
             vm_space.cursor(&preempt_guard, &map_range).unwrap().query().unwrap(),
-            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))  if va.start == map_range.start && paddr == IOMEM_PADDR && prop.flags == PageFlags::RW
+            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))
+                if va.start == map_range.start
+                    && paddr == IOMEM_PADDR
+                    && prop.flags == expected_iomem_flags(PageFlags::RW)
         ));
 
         // Creates a child page table with copy-on-write protection.
@@ -324,7 +345,10 @@ mod test {
         // Confirms that the child VA remains mapped.
         assert!(matches!(
             child_space.cursor(&preempt_guard, &map_range).unwrap().query().unwrap(),
-            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))  if va.start == map_range.start && paddr == IOMEM_PADDR && prop.flags == PageFlags::RW
+            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))
+                if va.start == map_range.start
+                    && paddr == IOMEM_PADDR
+                    && prop.flags == expected_iomem_flags(PageFlags::RW)
         ));
 
         // Creates a sibling page table (from the now-modified parent).
@@ -354,7 +378,10 @@ mod test {
         // Confirms that the child VA remains mapped after the parent is dropped.
         assert!(matches!(
             child_space.cursor(&preempt_guard, &map_range).unwrap().query().unwrap(),
-            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))  if va.start == map_range.start && paddr == IOMEM_PADDR && prop.flags == PageFlags::RW
+            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))
+                if va.start == map_range.start
+                    && paddr == IOMEM_PADDR
+                    && prop.flags == expected_iomem_flags(PageFlags::RW)
         ));
 
         // Unmaps the range from the child.
@@ -372,7 +399,10 @@ mod test {
         // Confirms that the sibling mapping points back to the original `IoMem`'s physical address.
         assert!(matches!(
             sibling_space.cursor(&preempt_guard, &map_range).unwrap().query().unwrap(),
-            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))  if va.start == map_range.start && paddr == IOMEM_PADDR && prop.flags == PageFlags::RW
+            (va, Some(VmQueriedItem::MappedIoMem { paddr, prop }))
+                if va.start == map_range.start
+                    && paddr == IOMEM_PADDR
+                    && prop.flags == expected_iomem_flags(PageFlags::RW)
         ));
 
         // Confirms that the child remains unmapped.

--- a/kernel/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/src/vm/vmar/vmar_impls/mod.rs
@@ -137,14 +137,28 @@ const NUM_RSS_COUNTERS: usize = 2;
 
 pub(super) struct RssDelta<'a> {
     delta: [isize; NUM_RSS_COUNTERS],
+    #[cfg(not(ktest))]
     operated_vmar: &'a Vmar,
+    #[cfg(ktest)]
+    operated_vmar: Option<&'a Vmar>,
 }
 
 impl<'a> RssDelta<'a> {
     pub(super) fn new(operated_vmar: &'a Vmar) -> Self {
         Self {
             delta: [0; NUM_RSS_COUNTERS],
+            #[cfg(not(ktest))]
             operated_vmar,
+            #[cfg(ktest)]
+            operated_vmar: Some(operated_vmar),
+        }
+    }
+
+    #[cfg(ktest)]
+    pub(super) fn new_for_test() -> Self {
+        Self {
+            delta: [0; NUM_RSS_COUNTERS],
+            operated_vmar: None,
         }
     }
 
@@ -162,7 +176,12 @@ impl Drop for RssDelta<'_> {
         for i in 0..NUM_RSS_COUNTERS {
             let rss_type = RssType::try_from(i as u32).unwrap();
             let delta = self.get(rss_type);
+            #[cfg(not(ktest))]
             self.operated_vmar.add_rss_counter(rss_type, delta);
+            #[cfg(ktest)]
+            if let Some(operated_vmar) = self.operated_vmar {
+                operated_vmar.add_rss_counter(rss_type, delta);
+            }
         }
     }
 }

--- a/ostd/src/arch/riscv/boot/bsp_boot.S
+++ b/ostd/src/arch/riscv/boot/bsp_boot.S
@@ -10,6 +10,8 @@ PTE_V                  = 0x01
 PTE_R                  = 0x02
 PTE_W                  = 0x04
 PTE_X                  = 0x08
+PTE_A                  = 0x40
+PTE_D                  = 0x80
 PTE_PPN_SHIFT          = 10
 PTE_SIZE               = 8
 
@@ -75,39 +77,43 @@ bsp_flush_tlb:
     or     t0, t0, t1
     jr     t0
 
-PTE_VRWX = PTE_V | PTE_R | PTE_W | PTE_X
+# Under Svade, clear A faults on any access and clear D faults on writes.
+# Early boot has no recovery handler, so writable leaves preset A|D; non-leaf
+# A/D bits are reserved and remain zero.
+# Reference: <https://docs.riscv.org/reference/isa/v20260120/priv/supervisor.html#translation>.
+PTE_VRWXAD = PTE_V | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D
 
 .balign 4096
 sv48_boot_l4pt:
-    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWX  # identity 0~512 GiB
+    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWXAD  # identity 0~512 GiB
     .zero 255 * PTE_SIZE
-    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWX  # linear 0~512 GiB
+    .quad (0x0 << PTE_PPN_SHIFT) | PTE_VRWXAD  # linear 0~512 GiB
     .zero 254 * PTE_SIZE
     .quad 0                                      # TBA (-> boot_l3pt)
 sv48_boot_l3pt:  # 0xffff_ffff_0000_0000 -> 0x0000_0000_0000_0000
     .zero 508 * PTE_SIZE
-    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 0~1 GiB
-    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 1~2 GiB
-    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 2~3 GiB
+    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 0~1 GiB
+    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 1~2 GiB
+    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 2~3 GiB
     .quad 0
 
 .balign 4096
 sv39_boot_l3pt:
     .set i, 0
     .rept 128  # identity 0~128 GiB
-        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWX
+        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWXAD
         .set i, i + 1
     .endr
     .zero 128 * PTE_SIZE
     .set i, 0
     .rept 128  # linear 0~128 GiB
-        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWX
+        .quad ((i * 0x40000) << PTE_PPN_SHIFT) | PTE_VRWXAD
         .set i, i + 1
     .endr
     .zero 124 * PTE_SIZE
-    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 0~1 GiB
-    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 1~2 GiB
-    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWX  # code 2~3 GiB
+    .quad (0x00000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 0~1 GiB
+    .quad (0x40000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 1~2 GiB
+    .quad (0x80000 << PTE_PPN_SHIFT) | PTE_VRWXAD  # code 2~3 GiB
     .quad 0
 
 .section ".boot.stack", "aw", @nobits

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -54,7 +54,7 @@ use crate::{
         CachePolicy, Infallible, PAGE_SIZE, Paddr, PageFlags, PageProperty, PrivilegedPageFlags,
         Segment, Vaddr, VmReader,
         frame::allocator::{self, EarlyAllocatedFrameMeta},
-        paddr_to_vaddr, page_size,
+        kspace, paddr_to_vaddr, page_size,
         page_table::boot_pt,
     },
     panic::abort,
@@ -466,8 +466,8 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         max_paddr
     );
 
-    // In RISC-V, the boot page table has mapped the 512GB memory,
-    // so we don't need to add temporary linear mapping.
+    // In RISC-V, the boot page table already provides a temporary linear
+    // mapping: 128 GiB with Sv39 or 512 GiB with Sv48.
     // In LoongArch, the DWM0 has mapped the whole memory,
     // so we don't need to add temporary linear mapping.
     #[cfg(target_arch = "x86_64")]
@@ -481,11 +481,11 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         for i in 0..nr_meta_pages {
             let frame_paddr = meta_pages + i * PAGE_SIZE;
             let vaddr = mapping::frame_to_meta::<PagingConsts>(0) + i * PAGE_SIZE;
-            let prop = PageProperty {
+            let prop = kspace::prepare_new_kernel_mapping_prop(PageProperty {
                 flags: PageFlags::RW,
                 cache: CachePolicy::Writeback,
                 priv_flags: PrivilegedPageFlags::GLOBAL,
-            };
+            });
             // SAFETY: we are doing the metadata mappings for the kernel.
             unsafe { boot_pt.map_base_page(vaddr, frame_paddr, prop) };
         }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -92,14 +92,14 @@ impl KVirtArea {
     }
 
     #[cfg(ktest)]
-    pub fn query<'a, G: crate::task::atomic_mode::AsAtomicModeGuard>(
+    pub(in crate::mm) fn query<'a, G: crate::task::atomic_mode::AsAtomicModeGuard>(
         &'a self,
         guard: &'a G,
         addr: Vaddr,
     ) -> Option<super::MappedItemRef<'a>> {
         use align_ext::AlignExt;
 
-        assert!(self.start() <= addr && self.end() >= addr);
+        assert!(self.range.contains(&addr));
 
         let start = addr.align_down(PAGE_SIZE);
         let vaddr = start..start + PAGE_SIZE;
@@ -141,7 +141,7 @@ impl KVirtArea {
         for frame in frames.into_iter() {
             // SAFETY: The constructor of the `KVirtArea` has already ensured
             // that this mapping does not affect kernel's memory safety.
-            unsafe { cursor.map(MappedItem::Tracked(Frame::from_unsized(frame), prop)) };
+            unsafe { cursor.map(MappedItem::tracked(Frame::from_unsized(frame), prop)) };
         }
 
         Self { range }
@@ -191,7 +191,7 @@ impl KVirtArea {
             for (pa, level) in largest_pages::<KernelPtConfig>(va_range.start, pa_range.start, len)
             {
                 // SAFETY: The caller of `map_untracked_frames` has ensured the safety of this mapping.
-                unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+                unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
             }
         }
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -45,20 +45,22 @@ use spin::Once;
 #[cfg(ktest)]
 mod test;
 
+#[cfg(target_arch = "riscv64")]
+use super::page_prop::PageAccess;
 use super::{
-    Frame, HasSize, Paddr, PagingConstsTrait, Vaddr,
+    HasSize, Paddr, PagingConstsTrait, Vaddr,
     frame::{
         Segment,
         meta::{AnyFrameMeta, MetaPageMeta, mapping},
     },
     page_prop::{CachePolicy, PageFlags, PageProperty, PrivilegedPageFlags},
-    page_table::{PageTable, PageTableConfig},
+    page_table::PageTable,
 };
 use crate::{
-    arch::mm::{PageTableEntry, PagingConsts},
+    arch::mm::PagingConsts,
     boot::memory_region::MemoryRegionType,
     const_assert, info,
-    mm::{HasPaddr, PAGE_SIZE, PagingLevel, frame::FrameRef, page_table::largest_pages},
+    mm::{PAGE_SIZE, PagingLevel, frame::FrameRef, page_table::largest_pages},
     task::disable_preempt,
 };
 
@@ -140,77 +142,157 @@ pub(super) static KERNEL_PAGE_TABLE: Once<PageTable<KernelPtConfig>> = Once::new
 #[derive(Clone, Debug)]
 pub(super) struct KernelPtConfig {}
 
-// We use the first available PTE bit to mark the frame as tracked.
-// SAFETY: `item_raw_info`, `item_into_raw`, `item_from_raw`, and
-// `item_ref_from_raw` are correctly implemented with respect to the `Item` and
-// `ItemRef` types.
-unsafe impl PageTableConfig for KernelPtConfig {
-    const TOP_LEVEL_INDEX_RANGE: Range<usize> = 256..512;
-    const TOP_LEVEL_CAN_UNMAP: bool = false;
-
-    type E = PageTableEntry;
-    type C = PagingConsts;
-
-    type Item = MappedItem;
-    type ItemRef<'a> = MappedItemRef<'a>;
-
-    fn item_raw_info(item: &Self::Item) -> (Paddr, PagingLevel, PageProperty) {
-        match *item {
-            MappedItem::Tracked(ref frame, mut prop) => {
-                debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
-                prop.priv_flags |= PrivilegedPageFlags::AVAIL1;
-                let level = frame.map_level();
-                let paddr = frame.paddr();
-                (paddr, level, prop)
-            }
-            MappedItem::Untracked(ref pa, ref level, mut prop) => {
-                debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
-                prop.priv_flags -= PrivilegedPageFlags::AVAIL1;
-                (*pa, *level, prop)
-            }
-        }
-    }
-
-    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item {
-        if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
-            debug_assert_eq!(level, 1);
-            // SAFETY: The caller ensures safety.
-            let frame = unsafe { Frame::<dyn AnyFrameMeta>::from_raw(paddr) };
-            MappedItem::Tracked(frame, prop)
+/// Applies the architecture policy for a newly created kernel mapping.
+///
+/// Under RISC-V Svade, an access with A clear faults, and a write with D clear
+/// faults. Since kernel mappings have no recovery path, new writable mappings
+/// preset both A and D, while non-writable mappings preset only A. See
+/// <https://docs.riscv.org/reference/isa/v20260120/priv/supervisor.html#translation>.
+pub(in crate::mm) fn prepare_new_kernel_mapping_prop(prop: PageProperty) -> PageProperty {
+    #[cfg(target_arch = "riscv64")]
+    {
+        let mut prop = prop;
+        let access = if prop.flags.contains(PageFlags::W) {
+            PageAccess::Write
         } else {
-            MappedItem::Untracked(paddr, level, prop)
-        }
+            PageAccess::Read
+        };
+        prop.flags.record_access(access);
+        prop
     }
 
-    unsafe fn item_ref_from_raw<'a>(
-        paddr: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    ) -> Self::ItemRef<'a> {
-        if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
-            debug_assert_eq!(level, 1);
-            // SAFETY: The caller ensures that the frame outlives `'a` and that
-            // the type matches the frame.
-            let frame = unsafe { FrameRef::<dyn AnyFrameMeta>::borrow_paddr(paddr) };
-            MappedItemRef::Tracked(frame, prop)
-        } else {
-            MappedItemRef::Untracked(paddr, level, prop)
-        }
+    #[cfg(not(target_arch = "riscv64"))]
+    {
+        prop
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) enum MappedItem {
-    Tracked(Frame<dyn AnyFrameMeta>, PageProperty),
-    Untracked(Paddr, PagingLevel, PageProperty),
 }
 
 #[derive(Debug)]
-pub(crate) enum MappedItemRef<'a> {
+pub(in crate::mm) enum MappedItemRef<'a> {
     #[cfg_attr(not(ktest), expect(dead_code))]
     Tracked(FrameRef<'a, dyn AnyFrameMeta>, PageProperty),
     #[cfg_attr(not(ktest), expect(dead_code))]
     Untracked(Paddr, PagingLevel, PageProperty),
+}
+
+pub(super) use mapped_item::MappedItem;
+
+mod mapped_item {
+    //! Kernel page-table item representation and construction policy.
+    //!
+    //! [`MappedItem`] is the item representation for [`KernelPtConfig`]. New
+    //! mappings go through an architecture policy, while raw restoration
+    //! reconstructs an existing item and preserves all status flags exactly.
+
+    use core::ops::Range;
+
+    use super::{KernelPtConfig, MappedItemRef};
+    use crate::{
+        arch::mm::{PageTableEntry, PagingConsts},
+        mm::{
+            Frame, HasPaddr, Paddr, PagingLevel,
+            frame::{FrameRef, meta::AnyFrameMeta},
+            page_prop::{PageProperty, PrivilegedPageFlags},
+            page_table::PageTableConfig,
+        },
+    };
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(in crate::mm) struct MappedItem(MappedItemKind);
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    enum MappedItemKind {
+        Tracked(Frame<dyn AnyFrameMeta>, PageProperty),
+        Untracked(Paddr, PagingLevel, PageProperty),
+    }
+
+    impl MappedItem {
+        pub(in crate::mm) fn tracked(frame: Frame<dyn AnyFrameMeta>, prop: PageProperty) -> Self {
+            Self(MappedItemKind::Tracked(
+                frame,
+                super::prepare_new_kernel_mapping_prop(prop),
+            ))
+        }
+
+        pub(in crate::mm) fn untracked(
+            paddr: Paddr,
+            level: PagingLevel,
+            prop: PageProperty,
+        ) -> Self {
+            Self(MappedItemKind::Untracked(
+                paddr,
+                level,
+                super::prepare_new_kernel_mapping_prop(prop),
+            ))
+        }
+    }
+
+    // We use the first available PTE bit to mark the frame as tracked.
+    // SAFETY: `item_raw_info`, `item_into_raw`, `item_from_raw`, and
+    // `item_ref_from_raw` are correctly implemented with respect to the `Item`
+    // and `ItemRef` types.
+    unsafe impl PageTableConfig for KernelPtConfig {
+        const TOP_LEVEL_INDEX_RANGE: Range<usize> = 256..512;
+        const TOP_LEVEL_CAN_UNMAP: bool = false;
+
+        type E = PageTableEntry;
+        type C = PagingConsts;
+
+        type Item = MappedItem;
+        type ItemRef<'a> = MappedItemRef<'a>;
+
+        fn item_raw_info(item: &Self::Item) -> (Paddr, PagingLevel, PageProperty) {
+            match &item.0 {
+                MappedItemKind::Tracked(frame, prop) => {
+                    let mut prop = *prop;
+                    debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
+                    prop.priv_flags |= PrivilegedPageFlags::AVAIL1;
+                    let level = frame.map_level();
+                    let paddr = frame.paddr();
+                    (paddr, level, prop)
+                }
+                MappedItemKind::Untracked(pa, level, prop) => {
+                    let mut prop = *prop;
+                    debug_assert!(!prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1));
+                    prop.priv_flags -= PrivilegedPageFlags::AVAIL1;
+                    (*pa, *level, prop)
+                }
+            }
+        }
+
+        unsafe fn item_from_raw(
+            paddr: Paddr,
+            level: PagingLevel,
+            prop: PageProperty,
+        ) -> Self::Item {
+            // Raw restoration must preserve the existing status flags exactly,
+            // so it intentionally bypasses the new-mapping policy constructors.
+            if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
+                debug_assert_eq!(level, 1);
+                // SAFETY: The caller ensures safety.
+                let frame = unsafe { Frame::<dyn AnyFrameMeta>::from_raw(paddr) };
+                MappedItem(MappedItemKind::Tracked(frame, prop))
+            } else {
+                MappedItem(MappedItemKind::Untracked(paddr, level, prop))
+            }
+        }
+
+        unsafe fn item_ref_from_raw<'a>(
+            paddr: Paddr,
+            level: PagingLevel,
+            prop: PageProperty,
+        ) -> Self::ItemRef<'a> {
+            if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
+                debug_assert_eq!(level, 1);
+                // SAFETY: The caller ensures that the frame outlives `'a` and that
+                // the type matches the frame.
+                let frame = unsafe { FrameRef::<dyn AnyFrameMeta>::borrow_paddr(paddr) };
+                MappedItemRef::Tracked(frame, prop)
+            } else {
+                MappedItemRef::Untracked(paddr, level, prop)
+            }
+        }
+    }
 }
 
 /// Initializes the kernel page table.
@@ -242,7 +324,7 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
         let mut cursor = kpt.cursor_mut(&preempt_guard, &from).unwrap();
         for (pa, level) in largest_pages::<KernelPtConfig>(from.start, 0, max_paddr) {
             // SAFETY: we are doing the linear mapping for the kernel.
-            unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+            unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
         }
     }
 
@@ -264,7 +346,7 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
             largest_pages::<KernelPtConfig>(from.start, pa_range.start, pa_range.len())
         {
             // SAFETY: We are doing the metadata mappings for the kernel.
-            unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+            unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
         }
     }
 
@@ -288,7 +370,7 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
         let mut cursor = kpt.cursor_mut(&preempt_guard, &from).unwrap();
         for (pa, level) in largest_pages::<KernelPtConfig>(from.start, region.base(), from.len()) {
             // SAFETY: we are doing the kernel code mapping.
-            unsafe { cursor.map(MappedItem::Untracked(pa, level, prop)) };
+            unsafe { cursor.map(MappedItem::untracked(pa, level, prop)) };
         }
     }
 

--- a/ostd/src/mm/kspace/test.rs
+++ b/ostd/src/mm/kspace/test.rs
@@ -5,10 +5,11 @@ use crate::{
         Frame, FrameAllocOptions, PAGE_SIZE,
         frame::max_paddr,
         kspace::{
-            LINEAR_MAPPING_BASE_VADDR, MappedItemRef, VMALLOC_VADDR_RANGE, kvirt_area::KVirtArea,
-            paddr_to_vaddr,
+            KernelPtConfig, LINEAR_MAPPING_BASE_VADDR, MappedItemRef, VMALLOC_VADDR_RANGE,
+            kvirt_area::KVirtArea, paddr_to_vaddr,
         },
-        page_prop::{CachePolicy, PageFlags, PageProperty},
+        page_prop::{CachePolicy, PageAccess, PageFlags, PageProperty},
+        page_table::PageTableConfig,
     },
     prelude::*,
     task::disable_preempt,
@@ -16,6 +17,22 @@ use crate::{
 
 fn default_prop() -> PageProperty {
     PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback)
+}
+
+fn non_writable_prop() -> PageProperty {
+    PageProperty::new_user(PageFlags::RX, CachePolicy::Writeback)
+}
+
+#[cfg(target_arch = "riscv64")]
+fn expected_mapped_prop(mut prop: PageProperty, access: PageAccess) -> PageProperty {
+    prop.flags.record_access(access);
+    prop
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+fn expected_mapped_prop(prop: PageProperty, access: PageAccess) -> PageProperty {
+    let _ = access;
+    prop
 }
 
 #[ktest]
@@ -37,10 +54,13 @@ fn kvirt_area_tracked_map_pages() {
     for i in 0..2 {
         let addr = kvirt_area.start() + i * PAGE_SIZE;
         let MappedItemRef::Tracked(page, prop) = kvirt_area.query(&guard, addr).unwrap() else {
-            panic!("Expected a tracked page");
+            panic!("expected a tracked page");
         };
         assert_eq!(page.paddr(), paddr + (i * PAGE_SIZE));
-        assert_eq!(prop.flags, default_prop().flags);
+        assert_eq!(
+            prop.flags,
+            expected_mapped_prop(default_prop(), PageAccess::Write).flags
+        );
         assert_eq!(prop.cache, default_prop().cache);
     }
 }
@@ -52,6 +72,8 @@ fn kvirt_area_untracked_map_pages() {
     let size = 2 * PAGE_SIZE;
     let pa_range = max_paddr..max_paddr + 2 * PAGE_SIZE as Paddr;
 
+    // SAFETY: The range starts beyond all tracked physical memory and the test
+    // only queries the mapping without dereferencing or taking ownership of it.
     let kvirt_area =
         unsafe { KVirtArea::map_untracked_frames(size, 0, pa_range.clone(), default_prop()) };
 
@@ -66,11 +88,67 @@ fn kvirt_area_untracked_map_pages() {
 
         let MappedItemRef::Untracked(pa, level, prop) = kvirt_area.query(&guard, addr).unwrap()
         else {
-            panic!("Expected a untracked page");
+            panic!("expected an untracked page");
         };
         assert_eq!(pa, pa_range.start + (i * PAGE_SIZE) as Paddr);
         assert_eq!(level, 1);
-        assert_eq!(prop, default_prop());
+        assert_eq!(
+            prop,
+            expected_mapped_prop(default_prop(), PageAccess::Write)
+        );
+        assert_eq!(prop.cache, default_prop().cache);
+    }
+}
+
+// Regression test for Asterinas issue #3589.
+#[ktest]
+fn kvirt_area_untracked_read_only_map_page() {
+    let max_paddr = max_paddr();
+    let pa_range = max_paddr..max_paddr + PAGE_SIZE as Paddr;
+
+    // SAFETY: The range starts beyond all tracked physical memory and the test
+    // only queries the mapping without dereferencing it.
+    let kvirt_area =
+        unsafe { KVirtArea::map_untracked_frames(PAGE_SIZE, 0, pa_range, non_writable_prop()) };
+    let guard = disable_preempt();
+
+    let MappedItemRef::Untracked(pa, level, prop) =
+        kvirt_area.query(&guard, kvirt_area.start()).unwrap()
+    else {
+        panic!("expected an untracked page");
+    };
+    assert_eq!(pa, max_paddr);
+    assert_eq!(level, 1);
+    assert_eq!(
+        prop,
+        expected_mapped_prop(non_writable_prop(), PageAccess::Read)
+    );
+    assert_eq!(prop.cache, non_writable_prop().cache);
+    assert!(!prop.flags.contains(PageFlags::DIRTY));
+}
+
+// Regression test for Asterinas issue #3589.
+#[ktest]
+fn kernel_pt_raw_info_preserves_status_flags() {
+    let test_paddr = max_paddr() + PAGE_SIZE as Paddr;
+
+    for status_flags in [
+        PageFlags::empty(),
+        PageFlags::ACCESSED,
+        PageFlags::ACCESSED | PageFlags::DIRTY,
+    ] {
+        let mut prop = default_prop();
+        prop.flags |= status_flags;
+
+        // SAFETY: `test_paddr` is aligned and beyond all tracked physical
+        // memory. `AVAIL1` is clear, so this restores an untracked mapping and
+        // reconstructs no frame ownership.
+        let item = unsafe { KernelPtConfig::item_from_raw(test_paddr, 1, prop) };
+        let (raw_paddr, raw_level, raw_prop) = KernelPtConfig::item_raw_info(&item);
+
+        assert_eq!(raw_paddr, test_paddr);
+        assert_eq!(raw_level, 1);
+        assert_eq!(raw_prop, prop);
     }
 }
 

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
     },
     kspace::{KERNEL_VADDR_RANGE, MAX_USERSPACE_VADDR},
     mem_obj::{HasDaddr, HasPaddr, HasPaddrRange, HasSize, Split},
-    page_prop::{CachePolicy, PageFlags, PageProperty},
+    page_prop::{CachePolicy, PageAccess, PageFlags, PageProperty},
     vm_space::VmSpace,
 };
 pub(crate) use self::{

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -87,6 +87,15 @@ pub enum CachePolicy {
     Writeback,
 }
 
+/// The kind of access made to a page.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PageAccess {
+    /// A read or instruction fetch.
+    Read,
+    /// A write.
+    Write,
+}
+
 bitflags! {
     /// Page protection permissions and access status.
     pub struct PageFlags: u8 {
@@ -110,6 +119,19 @@ bitflags! {
 
         /// The second bit available for software use.
         const AVAIL2    = 0b10000000;
+    }
+}
+
+impl PageFlags {
+    /// Records an access in the page status flags.
+    ///
+    /// Every access sets [`PageFlags::ACCESSED`]. A [`PageAccess::Write`] also
+    /// sets [`PageFlags::DIRTY`]. All other flags are preserved.
+    pub fn record_access(&mut self, access: PageAccess) {
+        self.insert(Self::ACCESSED);
+        if access == PageAccess::Write {
+            self.insert(Self::DIRTY);
+        }
     }
 }
 
@@ -140,5 +162,44 @@ bitflags! {
         const AVAIL1    = 0b01000000;
         /// The second bit available for software use.
         const AVAIL2    = 0b10000000;
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use super::{PageAccess, PageFlags};
+    use crate::prelude::ktest;
+
+    #[ktest]
+    fn record_access_for_read_preserves_flags_and_sets_accessed() {
+        let mut flags = PageFlags::RX | PageFlags::AVAIL2;
+
+        flags.record_access(PageAccess::Read);
+
+        assert_eq!(
+            flags,
+            PageFlags::RX | PageFlags::AVAIL2 | PageFlags::ACCESSED
+        );
+
+        let mut dirty_flags = PageFlags::RX | PageFlags::AVAIL2 | PageFlags::DIRTY;
+
+        dirty_flags.record_access(PageAccess::Read);
+
+        assert_eq!(
+            dirty_flags,
+            PageFlags::RX | PageFlags::AVAIL2 | PageFlags::ACCESSED | PageFlags::DIRTY
+        );
+    }
+
+    #[ktest]
+    fn record_access_for_write_preserves_flags_and_sets_accessed_and_dirty() {
+        let mut flags = PageFlags::RW | PageFlags::AVAIL2;
+
+        flags.record_access(PageAccess::Write);
+
+        assert_eq!(
+            flags,
+            PageFlags::RW | PageFlags::AVAIL2 | PageFlags::ACCESSED | PageFlags::DIRTY
+        );
     }
 }

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -585,7 +585,7 @@ pub(crate) unsafe trait PteTrait:
 ///
 /// # Safety
 ///
-/// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
+/// The safety preconditions are the same as those of [`AtomicUsize::from_ptr`].
 pub unsafe fn load_pte<E: PteTrait>(ptr: *mut E, ordering: Ordering) -> E {
     // SAFETY: The safety is upheld by the caller.
     let atomic = unsafe { AtomicUsize::from_ptr(ptr.cast()) };
@@ -597,10 +597,31 @@ pub unsafe fn load_pte<E: PteTrait>(ptr: *mut E, ordering: Ordering) -> E {
 ///
 /// # Safety
 ///
-/// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
+/// The safety preconditions are the same as those of [`AtomicUsize::from_ptr`].
 pub unsafe fn store_pte<E: PteTrait>(ptr: *mut E, new_val: E, ordering: Ordering) {
     let new_raw = new_val.as_usize();
     // SAFETY: The safety is upheld by the caller.
     let atomic = unsafe { AtomicUsize::from_ptr(ptr.cast()) };
     atomic.store(new_raw, ordering)
+}
+
+/// Atomically replaces a page table entry if it still matches `current`.
+///
+/// # Safety
+///
+/// The safety preconditions are the same as those of
+/// [`AtomicUsize::from_ptr`].
+pub(in crate::mm::page_table) unsafe fn compare_exchange_pte<E: PteTrait>(
+    ptr: *mut E,
+    current: E,
+    new: E,
+    success: Ordering,
+    failure: Ordering,
+) -> Result<E, E> {
+    // SAFETY: The caller upholds `AtomicUsize::from_ptr`'s requirements.
+    let atomic = unsafe { AtomicUsize::from_ptr(ptr.cast()) };
+    atomic
+        .compare_exchange(current.as_usize(), new.as_usize(), success, failure)
+        .map(E::from_usize)
+        .map_err(E::from_usize)
 }

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -6,7 +6,7 @@ use super::{PageTableGuard, PageTableNode, PteState, PteStateRef, PteTrait};
 use crate::{
     mm::{
         HasPaddr, nr_subpage_per_huge,
-        page_prop::PageProperty,
+        page_prop::{PageFlags, PageProperty},
         page_size,
         page_table::{PageTableConfig, PageTableNodeRef, PteScalar},
     },
@@ -63,14 +63,37 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             return;
         }
 
-        self.pte = C::E::from_repr(&PteScalar::Mapped(pa, new_prop), level);
-
-        // SAFETY:
-        //  1. The index is within the bounds.
-        //  2. We replace the PTE with a new one, which differs only in
-        //     `PageProperty`, so it's in `C` and at the correct paging level.
-        //  3. The child is still owned by the page table node.
-        unsafe { self.node.write_pte(self.idx, self.pte) };
+        loop {
+            let PteScalar::Mapped(_, expected_prop) = self.pte.to_repr(level) else {
+                unreachable!("the protected PTE must keep mapping the same page");
+            };
+            let new_pte = C::E::from_repr(&PteScalar::Mapped(pa, new_prop), level);
+            // SAFETY:
+            //  1. The index is within the bounds.
+            //  2. `self.pte` is a non-owning snapshot of the installed PTE.
+            //  3. The replacement keeps the same mapping and paging level and
+            //     differs only in `PageProperty`.
+            //  4. The node retains ownership of the mapped child regardless of
+            //     whether the comparison succeeds.
+            match unsafe { self.node.compare_exchange_pte(self.idx, self.pte, new_pte) } {
+                Ok(_) => {
+                    self.pte = new_pte;
+                    return;
+                }
+                Err(actual_pte) => {
+                    let PteScalar::Mapped(actual_pa, actual_prop) = actual_pte.to_repr(level)
+                    else {
+                        unreachable!("hardware status updates cannot change the PTE kind");
+                    };
+                    debug_assert_eq!(actual_pa, pa);
+                    let new_hardware_status = actual_prop.flags
+                        & !expected_prop.flags
+                        & (PageFlags::ACCESSED | PageFlags::DIRTY);
+                    new_prop.flags |= new_hardware_status;
+                    self.pte = actual_pte;
+                }
+            }
+        }
     }
 
     /// Replaces the entry with a new child.

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         FrameAllocOptions, HasPaddr, Infallible, PagingConstsTrait, PagingLevel, VmReader,
         frame::{Frame, FrameRef, meta::AnyFrameMeta},
         paddr_to_vaddr,
-        page_table::{PteScalar, load_pte, store_pte},
+        page_table::{self, PteScalar},
     },
     task::atomic_mode::InAtomicMode,
 };
@@ -214,7 +214,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY:
         // - The page table node is alive. The index is inside the bound, so the page table entry is valid.
         // - All page table entries are aligned and accessed with atomic operations only.
-        unsafe { load_pte(ptr.add(idx), Ordering::Relaxed) }
+        unsafe { page_table::load_pte(ptr.add(idx), Ordering::Relaxed) }
     }
 
     /// Writes a page table entry at a given index.
@@ -235,7 +235,43 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY:
         // - The page table node is alive. The index is inside the bound, so the page table entry is valid.
         // - All page table entries are aligned and accessed with atomic operations only.
-        unsafe { store_pte(ptr.add(idx), pte, Ordering::Release) }
+        unsafe { page_table::store_pte(ptr.add(idx), pte, Ordering::Release) }
+    }
+
+    /// Replaces a page table entry if it has not changed since it was read.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///  1. `idx` is within the node's bounds;
+    ///  2. `current` is a non-owning snapshot of the installed, node-owned PTE;
+    ///  3. `new_pte` identifies the same child or mapping at the same paging
+    ///     level and differs only in non-ownership fields such as mapping
+    ///     properties.
+    ///
+    /// This method does not transfer ownership through either return variant.
+    /// On success, the node retains ownership of the same child. On failure,
+    /// `new_pte` is not installed and the `Err` value is a non-owning snapshot
+    /// of the still-installed PTE.
+    unsafe fn compare_exchange_pte(
+        &mut self,
+        idx: usize,
+        current: C::E,
+        new_pte: C::E,
+    ) -> Result<C::E, C::E> {
+        debug_assert!(idx < nr_subpage_per_huge::<C>());
+        let ptr = paddr_to_vaddr(self.paddr()) as *mut C::E;
+        // SAFETY: The node is alive, the index is in bounds, and all accesses
+        // are atomic. The caller validates the replacement PTE.
+        unsafe {
+            page_table::compare_exchange_pte(
+                ptr.add(idx),
+                current,
+                new_pte,
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+        }
     }
 
     /// Gets the mutable reference to the number of valid PTEs in the node.

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -5,7 +5,7 @@ use ostd_pod::FromZeros;
 use super::*;
 use crate::{
     mm::{
-        FrameAllocOptions, MAX_USERSPACE_VADDR, PAGE_SIZE,
+        self, FrameAllocOptions, MAX_USERSPACE_VADDR, PAGE_SIZE,
         kspace::{KernelPtConfig, LINEAR_MAPPING_BASE_VADDR},
         page_prop::{CachePolicy, PageFlags},
         vm_space::VmItem,
@@ -610,8 +610,11 @@ mod navigation {
 
         // Map a page near the address space end.
         assert_eq!(cursor.virt_addr(), 0usize.wrapping_sub(HUGE_PAGE_SIZE));
+        // SAFETY: The cursor targets an empty test page table, and the
+        // untracked synthetic frame is used only to validate page-table
+        // navigation; it is never dereferenced or given ownership.
         unsafe {
-            cursor.map(MappedItem::Untracked(
+            cursor.map(MappedItem::untracked(
                 0,
                 1,
                 PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback),
@@ -944,6 +947,132 @@ mod mapping {
 
 mod protection_and_query {
     use super::{test_utils::*, *};
+
+    /// Returns the leaf PTE pointer for a mapped virtual address.
+    ///
+    /// # Safety
+    ///
+    /// `root_paddr` must identify a live `C` page table whose traversed nodes
+    /// remain valid and atomically accessed. The returned pointer must not
+    /// outlive or be used after removing its leaf page-table node.
+    unsafe fn mapped_pte_ptr<C: PageTableConfig>(
+        root_paddr: Paddr,
+        vaddr: Vaddr,
+    ) -> (*mut C::E, PagingLevel) {
+        let mut node_vaddr = mm::paddr_to_vaddr(root_paddr);
+        for level in (1..=C::NR_LEVELS).rev() {
+            // SAFETY: The caller guarantees that `root_paddr` owns a live page
+            // table and that the calculated index is in bounds.
+            let pte_ptr = unsafe { (node_vaddr as *mut C::E).add(pte_index::<C>(vaddr, level)) };
+            // SAFETY: The page-table node is alive and all PTE accesses are atomic.
+            let pte = unsafe { load_pte(pte_ptr, Ordering::Acquire) };
+            match pte.to_repr(level) {
+                PteScalar::PageTable(child_paddr, _) => {
+                    node_vaddr = mm::paddr_to_vaddr(child_paddr);
+                }
+                PteScalar::Mapped(_, _) => return (pte_ptr, level),
+                PteScalar::Absent => panic!("mapping is absent"),
+            }
+        }
+
+        panic!("mapping has no leaf PTE");
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn protect_preserves_concurrent_hardware_status_update() {
+        let page_table = PageTable::<TestPtConfig>::empty();
+        let range = PAGE_SIZE..PAGE_SIZE * 2;
+        let prop = PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback);
+        map_untracked(&page_table, range.clone(), 0, prop);
+
+        // SAFETY: The local page table owns a live mapping covering
+        // `range.start`, no operation removes it before the pointer's last use,
+        // the cursor locks the range while the pointer is used, and every
+        // pointer access uses the page-table atomic helpers.
+        let (pte_ptr, level) =
+            unsafe { mapped_pte_ptr::<TestPtConfig>(page_table.root_paddr(), range.start) };
+
+        let preempt_guard = disable_preempt();
+        let mut cursor = page_table.cursor_mut(&preempt_guard, &range).unwrap();
+        let mut simulate_hardware_update_fn = |prop: &mut PageProperty| {
+            // Simulate the MMU setting DIRTY after the cursor's initial PTE load.
+            // SAFETY: The pointer remains a live, aligned leaf PTE and all
+            // accesses use the page-table atomic helpers.
+            let hardware_pte = unsafe { load_pte(pte_ptr, Ordering::Acquire) };
+            let PteScalar::Mapped(paddr, mut hardware_prop) = hardware_pte.to_repr(level) else {
+                panic!("leaf PTE stopped mapping a page");
+            };
+            hardware_prop.flags |= PageFlags::DIRTY;
+            let hardware_pte = <TestPtConfig as PageTableConfig>::E::from_repr(
+                &PteScalar::Mapped(paddr, hardware_prop),
+                level,
+            );
+            // SAFETY: The replacement changes only the hardware-managed DIRTY bit.
+            unsafe { store_pte(pte_ptr, hardware_pte, Ordering::Release) };
+
+            prop.flags |= PageFlags::ACCESSED;
+        };
+        // SAFETY: The operation changes only public status flags and does not
+        // alter the mapping identity or its software-reserved ownership bit.
+        let protected =
+            unsafe { cursor.protect_next(range.len(), &mut simulate_hardware_update_fn) };
+        assert_eq!(protected, Some(range.clone()));
+        drop(cursor);
+
+        let (_, protected_prop) = page_table.page_walk(range.start).unwrap();
+        assert_eq!(
+            protected_prop.flags,
+            PageFlags::RW | PageFlags::ACCESSED | PageFlags::DIRTY
+        );
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn protect_merges_only_new_hardware_status_update() {
+        let page_table = PageTable::<TestPtConfig>::empty();
+        let range = PAGE_SIZE..PAGE_SIZE * 2;
+        let prop =
+            PageProperty::new_user(PageFlags::RW | PageFlags::ACCESSED, CachePolicy::Writeback);
+        map_untracked(&page_table, range.clone(), 0, prop);
+
+        // SAFETY: The local page table owns a live mapping covering
+        // `range.start`, no operation removes it before the pointer's last use,
+        // the cursor locks the range while the pointer is used, and every
+        // pointer access uses the page-table atomic helpers.
+        let (pte_ptr, level) =
+            unsafe { mapped_pte_ptr::<TestPtConfig>(page_table.root_paddr(), range.start) };
+
+        let preempt_guard = disable_preempt();
+        let mut cursor = page_table.cursor_mut(&preempt_guard, &range).unwrap();
+        let mut simulate_hardware_update_fn = |prop: &mut PageProperty| {
+            // Simulate the MMU setting DIRTY after the cursor's initial PTE load.
+            // SAFETY: The pointer remains a live, aligned leaf PTE and all
+            // accesses use the page-table atomic helpers.
+            let hardware_pte = unsafe { load_pte(pte_ptr, Ordering::Acquire) };
+            let PteScalar::Mapped(paddr, mut hardware_prop) = hardware_pte.to_repr(level) else {
+                panic!("leaf PTE stopped mapping a page");
+            };
+            hardware_prop.flags |= PageFlags::DIRTY;
+            let hardware_pte = <TestPtConfig as PageTableConfig>::E::from_repr(
+                &PteScalar::Mapped(paddr, hardware_prop),
+                level,
+            );
+            // SAFETY: The replacement changes only the hardware-managed DIRTY bit.
+            unsafe { store_pte(pte_ptr, hardware_pte, Ordering::Release) };
+
+            prop.flags = PageFlags::R;
+        };
+        // SAFETY: The operation changes only public status and permission flags
+        // and does not alter the mapping identity or software-reserved ownership bit.
+        let protected =
+            unsafe { cursor.protect_next(range.len(), &mut simulate_hardware_update_fn) };
+        assert_eq!(protected, Some(range.clone()));
+        drop(cursor);
+
+        let (_, protected_prop) = page_table.page_walk(range.start).unwrap();
+        assert_eq!(protected_prop.flags, PageFlags::R | PageFlags::DIRTY);
+    }
 
     #[ktest]
     fn base_protect_query() {

--- a/ostd/src/mm/test.rs
+++ b/ostd/src/mm/test.rs
@@ -6,8 +6,8 @@ use crate::{
     Error,
     io::IoMem,
     mm::{
-        CachePolicy, FallibleVmRead, FallibleVmWrite, FrameAllocOptions, PageFlags, PageProperty,
-        UFrame, VmSpace,
+        CachePolicy, FallibleVmRead, FallibleVmWrite, FrameAllocOptions, PAGE_SIZE, PageFlags,
+        PageProperty, UFrame, VmSpace,
         io::{VmIo, VmIoFill, VmReader, VmWriter, util::HasVmReaderWriter},
         tlb::TlbFlushOp,
         vm_space::{VmQueriedItem, get_activated_vm_space},
@@ -830,6 +830,24 @@ mod vmspace {
     /// A very large address (16 TiB) beyond typical physical memory for testing.
     const IOMEM_PADDR: usize = 0x100_000_000_000;
 
+    fn expected_iomem_flags(flags: PageFlags) -> PageFlags {
+        #[cfg(target_arch = "riscv64")]
+        {
+            let mut flags = flags;
+            flags.record_access(if flags.contains(PageFlags::W) {
+                crate::mm::PageAccess::Write
+            } else {
+                crate::mm::PageAccess::Read
+            });
+            flags
+        }
+
+        #[cfg(not(target_arch = "riscv64"))]
+        {
+            flags
+        }
+    }
+
     /// Maps and queries an `IoMem` using `CursorMut`.
     #[ktest]
     fn vmspace_map_query_iomem() {
@@ -865,7 +883,9 @@ mod vmspace {
             assert!(matches!(
                 query_item,
                 Some(VmQueriedItem::MappedIoMem { paddr, prop: query_prop })
-                if paddr == IOMEM_PADDR && query_prop.flags == prop.flags && query_prop.cache == prop.cache
+                if paddr == IOMEM_PADDR
+                    && query_prop.flags == expected_iomem_flags(prop.flags)
+                    && query_prop.cache == prop.cache
             ));
         }
 
@@ -892,6 +912,56 @@ mod vmspace {
                     .is_none()
             );
         }
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn vmspace_map_query_read_only_iomem() {
+        let vmspace = VmSpace::new();
+        let range = 0x4000..0x5000;
+        let iomem = IoMem::acquire(IOMEM_PADDR + 0x4000..IOMEM_PADDR + 0x5000).unwrap();
+        let prop = PageProperty::new_user(PageFlags::R, CachePolicy::Uncacheable);
+        let preempt_guard = disable_preempt();
+
+        vmspace
+            .cursor_mut(&preempt_guard, &range)
+            .unwrap()
+            .map_iomem(iomem, prop, PAGE_SIZE, 0);
+
+        let mut cursor = vmspace.cursor(&preempt_guard, &range).unwrap();
+        let (_, Some(VmQueriedItem::MappedIoMem { prop, .. })) = cursor.query().unwrap() else {
+            panic!("query did not return the I/O mapping");
+        };
+        assert_eq!(prop.flags, expected_iomem_flags(PageFlags::R));
+        assert!(!prop.flags.contains(PageFlags::DIRTY));
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn vmspace_protect_iomem_preserves_riscv_status() {
+        let vmspace = VmSpace::new();
+        let range = 0x5000..0x6000;
+        let iomem = IoMem::acquire(IOMEM_PADDR + 0x5000..IOMEM_PADDR + 0x6000).unwrap();
+        let prop = PageProperty::new_user(PageFlags::RW, CachePolicy::Uncacheable);
+        let preempt_guard = disable_preempt();
+
+        vmspace
+            .cursor_mut(&preempt_guard, &range)
+            .unwrap()
+            .map_iomem(iomem, prop, PAGE_SIZE, 0);
+        let mut cursor = vmspace.cursor_mut(&preempt_guard, &range).unwrap();
+        assert_eq!(
+            cursor.protect_next(PAGE_SIZE, |flags, _| *flags = PageFlags::R),
+            Some(range.clone())
+        );
+        drop(cursor);
+
+        let mut cursor = vmspace.cursor(&preempt_guard, &range).unwrap();
+        let (_, Some(VmQueriedItem::MappedIoMem { prop, .. })) = cursor.query().unwrap() else {
+            panic!("query did not return the protected I/O mapping");
+        };
+        assert_eq!(prop.flags, expected_iomem_flags(PageFlags::R));
+        assert!(!prop.flags.contains(PageFlags::DIRTY));
     }
 
     /// Maps and queries an `IoMem` with an offset using `CursorMut`.
@@ -923,7 +993,9 @@ mod vmspace {
             assert!(matches!(
                 query_item,
                 Some(VmQueriedItem::MappedIoMem { paddr, prop: query_prop })
-                if paddr == IOMEM_PADDR + 0x2000 && query_prop.flags == prop.flags && query_prop.cache == prop.cache
+                if paddr == IOMEM_PADDR + 0x2000
+                    && query_prop.flags == expected_iomem_flags(prop.flags)
+                    && query_prop.cache == prop.cache
             ));
         }
 

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -561,6 +561,10 @@ impl<'a> CursorMut<'a> {
         unsafe {
             self.pt_cursor.protect_next(len, &mut |prop| {
                 op(&mut prop.flags, &mut prop.cache);
+                #[cfg(target_arch = "riscv64")]
+                if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
+                    *prop = prepare_user_io_mapping_prop(*prop);
+                }
             })
         }
     }
@@ -640,6 +644,31 @@ enum MappedItemRef<'a> {
     UntrackedIoMem { paddr: Paddr, level: PagingLevel },
 }
 
+/// Applies the architecture policy for a user I/O mapping.
+///
+/// Under RISC-V Svade, accesses fault when A is clear or, for writes, when D
+/// is clear. Device mappings cannot recover these faults, so the required
+/// status bits are preset. See
+/// <https://docs.riscv.org/reference/isa/v20260120/priv/supervisor.html#translation>.
+fn prepare_user_io_mapping_prop(prop: PageProperty) -> PageProperty {
+    #[cfg(target_arch = "riscv64")]
+    {
+        let mut prop = prop;
+        let access = if prop.flags.contains(PageFlags::W) {
+            crate::mm::PageAccess::Write
+        } else {
+            crate::mm::PageAccess::Read
+        };
+        prop.flags.record_access(access);
+        prop
+    }
+
+    #[cfg(not(target_arch = "riscv64"))]
+    {
+        prop
+    }
+}
+
 impl VmItem {
     /// Creates a new `VmItem` that maps a tracked frame.
     pub(super) fn new_tracked(frame: UFrame, prop: PageProperty) -> Self {
@@ -651,9 +680,13 @@ impl VmItem {
 
     /// Creates a new `VmItem` that maps an untracked I/O memory.
     fn new_untracked_io(paddr: Paddr, prop: PageProperty) -> Self {
+        Self::from_untracked_io_raw_parts(paddr, 1, prepare_user_io_mapping_prop(prop))
+    }
+
+    fn from_untracked_io_raw_parts(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self {
         Self {
             prop,
-            mapped_item: MappedItem::UntrackedIoMem { paddr, level: 1 },
+            mapped_item: MappedItem::UntrackedIoMem { paddr, level },
         }
     }
 }
@@ -712,7 +745,7 @@ unsafe impl PageTableConfig for UserPtConfig {
         debug_assert_eq!(level, 1);
         if prop.priv_flags.contains(PrivilegedPageFlags::AVAIL1) {
             // `AVAIL1` is set, this is I/O memory.
-            VmItem::new_untracked_io(paddr, prop)
+            VmItem::from_untracked_io_raw_parts(paddr, level, prop)
         } else {
             // `AVAIL1` is clear, this is tracked memory.
             // SAFETY: The caller ensures safety.
@@ -743,5 +776,36 @@ unsafe impl PageTableConfig for UserPtConfig {
                 mapped_item: MappedItemRef::TrackedFrame(frame_ref),
             }
         }
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use super::*;
+    use crate::prelude::ktest;
+
+    // Regression test for Asterinas issue #3589.
+    #[ktest]
+    fn user_io_raw_info_preserves_status_flags() {
+        let prop = PageProperty::new_user(PageFlags::RW, CachePolicy::Uncacheable);
+        let item = VmItem::new_untracked_io(PAGE_SIZE, prop);
+
+        let (_, _, raw_prop) = UserPtConfig::item_raw_info(&item);
+
+        assert_eq!(raw_prop.flags, item.prop.flags);
+    }
+
+    // Regression test for Asterinas issue #3589.
+    #[cfg(target_arch = "riscv64")]
+    #[ktest]
+    fn user_io_raw_restoration_preserves_exact_property() {
+        let mut prop =
+            PageProperty::new_user(PageFlags::RW | PageFlags::AVAIL2, CachePolicy::Uncacheable);
+        prop.priv_flags |= PrivilegedPageFlags::AVAIL1;
+
+        // SAFETY: The aligned address and level describe an untracked I/O item.
+        let restored = unsafe { UserPtConfig::item_from_raw(PAGE_SIZE, 1, prop) };
+
+        assert_eq!(restored.prop, prop);
     }
 }

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -19,6 +19,7 @@
 #  - SMP: number of CPUs;
 #  - MEM: amount of memory, e.g. "8G";
 #  - VNC_PORT: VNC port, default is "42";
+#  - RISCV_QEMU_CPU: RISC-V QEMU CPU model and extensions;
 #  - ATTACH_XFSTESTS_IMAGES: "true" or "false", whether to attach xfstests images (xfstests_test.img and xfstests_scratch.img) to the VM. Defaults to auto-detection from ENABLE_CONFORMANCE_TEST + CONFORMANCE_TEST_SUITE.
 
 OVMF=${OVMF:-"on"}
@@ -27,6 +28,7 @@ VSOCK=${VSOCK:-"off"}
 VIRTIOFS=${VIRTIOFS:-"off"}
 NETDEV=${NETDEV:-"user"}
 CONSOLE=${CONSOLE:-"hvc0"}
+RISCV_QEMU_CPU=${RISCV_QEMU_CPU:-"rv64,svpbmt=true,zkr=true"}
 
 ATTACH_XFSTESTS_IMAGES=${ATTACH_XFSTESTS_IMAGES:-false}
 if [ "${ENABLE_CONFORMANCE_TEST:-"false"}" = "true" ] && \
@@ -76,7 +78,7 @@ if [ "$1" = "riscv" ]; then
     # in the reverse of the desired device-node order.
     # TODO: Once UUID-based mounting is implemented, this strict ordering will no longer be required.
     QEMU_ARGS="\
-        -cpu rv64,svpbmt=true,zkr=true \
+        -cpu $RISCV_QEMU_CPU \
         -machine virt \
         -m ${MEM:-8G} \
         -smp ${SMP:-1} \


### PR DESCRIPTION
## Summary

- make the RISC-V QEMU CPU model configurable while preserving the existing
  default
- add persistent Sv48 and Sv39 debug boot lanes with forced Svade and four
  harts
- make the existing RISC-V debug and SMP matrix settings effective

## Dependency

Depends on #3660. Until that PR lands, this stacked PR also includes #3657 and
#3660; the PR3-only commit is `b424ea4ab`.

Part of #3589.

## Testing

- `make check TARGET_ARCH=riscv64`
- workflow configuration contract and shell syntax checks
- Sv48 + forced Svade (`svadu=false,svade=true`) + `SMP=4`:
  `Successfully booted.`
- Sv39 + forced Svade (`sv48=false,svadu=false,svade=true`) +
  `riscv_sv39_mode` + `SMP=4`: `Successfully booted.`

## Review note

Please review `b86f120a3..b424ea4ab` for the PR3-only diff.
