### PR TITLE
Stop hardcoding the pinned nightly version in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Set `TARGET_ARCH` to `x86_64` (default), `riscv64`, or `loongarch64`.
 
 ## Toolchain
 
-- **Rust nightly** pinned in `rust-toolchain.toml` (nightly-2025-12-06).
+- **Rust nightly** pinned in `rust-toolchain.toml`.
 - **Edition:** 2024.
 - `rustfmt.toml`: imports grouped as Std / External / Crate
   (`imports_granularity = "Crate"`, `group_imports = "StdExternalCrate"`).

--- a/tools/sctrace/README.md
+++ b/tools/sctrace/README.md
@@ -93,7 +93,7 @@ The `sctrace` tool has two prerequisites:
 * [**strace**](https://strace.io/) version 5.15 or higher
     * Install on Debian/Ubuntu: `sudo apt install strace`
     * Install on Fedora/RHEL: `sudo dnf install strace`
-* The Rust toolchain (the version `nightly-2025-12-06` is tested; other versions may be supported as well)
+* The Rust toolchain (the version pinned in [`rust-toolchain.toml`](../../rust-toolchain.toml) is tested; other versions may be supported as well)
     * Install via [Rustup](https://rustup.rs/): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 
 To install the `sctrace` tool, execute the following command:


### PR DESCRIPTION
`AGENTS.md` and `tools/sctrace/README.md` both name `nightly-2025-12-06` as the pinned toolchain, but `rust-toolchain.toml` has pinned `nightly-2026-07-21` since #3588. Anyone following either document — or any agent reading `AGENTS.md`, which is what it exists for — installs the wrong toolchain.

Rather than update the version in two more places, this removes it and points at the manifest. Hardcoding it is what caused the drift: the `osdk` toolchain template stayed in sync because `rust-toolchain.toml` carries a comment reminding you to update it, while these two documents have no such reminder and went stale for seven months.

`kernel/libs/comp-sys/cargo-component/rust-toolchain.toml` also names an old nightly, but that one is deliberate — the crate is pinned to `nightly-2023-02-05` and `tools/format_all.sh` skips it for that reason — so it is left alone.

Documentation only; no code or build changes.
