### PR TITLE
Fix `format_all.sh` silently skipping excluded crates on BSD sed

### DIFF
--- a/tools/format_all.sh
+++ b/tools/format_all.sh
@@ -6,7 +6,18 @@ set -e
 
 WORKSPACE_ROOT="$(dirname "$(readlink -f "$0")")/.."
 
-EXCLUDED_CRATES=$(sed -n -e 's/#.*//; /^\s*$/d' -e '/^\[workspace\]/,/^\[.*\]/{/exclude = \[/,/\]/p}' "$WORKSPACE_ROOT/Cargo.toml" | grep -v "exclude = \[" | tr -d '", \]')
+# Extract the crates excluded from the workspace; they are formatted separately below.
+EXCLUDED_CRATES=$(python3 - "$WORKSPACE_ROOT/Cargo.toml" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as manifest_file:
+    manifest = tomllib.load(manifest_file)
+
+for excluded_crate in manifest.get("workspace", {}).get("exclude", []):
+    print(excluded_crate)
+PY
+)
 
 CHECK_MODE=false
 


### PR DESCRIPTION
`tools/format_all.sh` extracts the workspace `exclude` list by pattern-matching `Cargo.toml`:

```sh
EXCLUDED_CRATES=$(sed -n -e 's/#.*//; /^\s*$/d' -e '/^\[workspace\]/,/^\[.*\]/{/exclude = \[/,/\]/p}' "$WORKSPACE_ROOT/Cargo.toml" | grep -v "exclude = \[" | tr -d '", \]')
```

The nested address range is a GNU extension. Under BSD sed it fails outright:

```
sed: 1: "/^\[workspace\]/,/^\[.* ...": extra characters at the end of p command
```

`set -e` does not catch it, because a pipeline reports the exit status of its *last* command and `tr` succeeds. So `EXCLUDED_CRATES` is silently empty, the `for CRATE in $EXCLUDED_CRATES` loop never executes, and the script exits 0 — reporting success while checking none of the excluded crates.

On macOS that means `make format` and the format half of `make check` quietly skip all six: `osdk`, `tools/sctrace`, `component`, `component-macro`, `controlled`, and `cargo-component`. CI runs GNU sed and is unaffected, so this only misleads contributors working locally on macOS — including into believing formatting is clean when it has not been examined.

Measured before and after, on macOS:

| | crates found | `cargo fmt` violation in `osdk` |
|---|---|---|
| before | 0 | not caught, exit 0 |
| after | 6 | caught, exit 1 |

This reads the list with Python's TOML parser instead, which is also more robust to the manifest being reformatted. It adds no new dependency: `tools/print_workspace_members.sh` already reads the same list the same way, and the Makefile invokes that script in four places, so `python3` and `tomllib` are already required to build.

Verified `./tools/format_all.sh --check` still exits 0 on a clean tree, and exits 1 with an injected formatting error in `osdk`.
