### PR TITLE
Unify return error handling and perform some other cleanups

### DIFF
--- a/kernel/src/fs/file/file_table.rs
+++ b/kernel/src/fs/file/file_table.rs
@@ -183,7 +183,7 @@ impl FileTable {
             .table
             .get(fd.into())
             .map(|entry| entry.file.clone())
-            .ok_or(Error::with_message(Errno::EBADF, "the FD does not exist"))?;
+            .ok_or_else(|| Error::with_message(Errno::EBADF, "the FD does not exist"))?;
         Ok(FileTableEntry::new(file, flags))
     }
 
@@ -238,19 +238,19 @@ impl FileTable {
         self.table
             .get(fd.into())
             .map(|entry| entry.file())
-            .ok_or(Error::with_message(Errno::EBADF, "the FD does not exist"))
+            .ok_or_else(|| Error::with_message(Errno::EBADF, "the FD does not exist"))
     }
 
     pub fn get_entry(&self, fd: FileDesc) -> Result<&FileTableEntry> {
         self.table
             .get(fd.into())
-            .ok_or(Error::with_message(Errno::EBADF, "the FD does not exist"))
+            .ok_or_else(|| Error::with_message(Errno::EBADF, "the FD does not exist"))
     }
 
     pub fn get_entry_mut(&mut self, fd: FileDesc) -> Result<&mut FileTableEntry> {
         self.table
             .get_mut(fd.into())
-            .ok_or(Error::with_message(Errno::EBADF, "the FD does not exist"))
+            .ok_or_else(|| Error::with_message(Errno::EBADF, "the FD does not exist"))
     }
 
     pub fn fds_and_files(&self) -> impl Iterator<Item = (FileDesc, &'_ Arc<dyn FileLike>)> {

--- a/kernel/src/fs/fs_impls/ext2/inode/attrs.rs
+++ b/kernel/src/fs/fs_impls/ext2/inode/attrs.rs
@@ -159,10 +159,9 @@ impl Inode {
         name: XattrName,
         value_writer: &mut VmWriter,
     ) -> Result<usize> {
-        let xattr = self.xattr.as_ref().ok_or(Error::with_message(
-            Errno::ENODATA,
-            "xattr not supported on this inode type",
-        ))?;
+        let xattr = self.xattr.as_ref().ok_or_else(|| {
+            Error::with_message(Errno::ENODATA, "xattr not supported on this inode type")
+        })?;
         xattr.get_xattr(name, value_writer)
     }
 
@@ -185,10 +184,9 @@ impl Inode {
         value_reader: &mut VmReader,
         flags: XattrSetFlags,
     ) -> Result<()> {
-        let xattr = self.xattr.as_ref().ok_or(Error::with_message(
-            Errno::EPERM,
-            "xattr not supported on this inode type",
-        ))?;
+        let xattr = self.xattr.as_ref().ok_or_else(|| {
+            Error::with_message(Errno::EPERM, "xattr not supported on this inode type")
+        })?;
         xattr.set_xattr(name, value_reader, flags)?;
         let new_bid = xattr.bid();
 
@@ -200,10 +198,9 @@ impl Inode {
 
     /// Removes one extended attribute.
     pub(in crate::fs::fs_impls::ext2) fn remove_xattr(&self, name: XattrName) -> Result<()> {
-        let xattr = self.xattr.as_ref().ok_or(Error::with_message(
-            Errno::EPERM,
-            "xattr not supported on this inode type",
-        ))?;
+        let xattr = self.xattr.as_ref().ok_or_else(|| {
+            Error::with_message(Errno::EPERM, "xattr not supported on this inode type")
+        })?;
         xattr.remove_xattr(name)?;
         let new_bid = xattr.bid();
 

--- a/kernel/src/fs/fs_impls/ext2/super_block.rs
+++ b/kernel/src/fs/fs_impls/ext2/super_block.rs
@@ -160,7 +160,7 @@ impl TryFrom<RawSuperBlock> for SuperBlock {
         let frag_size = BLOCK_SIZE;
 
         let state = FsState::from_bits(sb.state)
-            .ok_or(Error::with_message(Errno::EINVAL, "invalid fs state"))?;
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid fs state"))?;
 
         let errors_behavior = ErrorsBehavior::try_from(sb.errors)
             .map_err(|_| Error::with_message(Errno::EINVAL, "invalid errors behavior"))?;

--- a/kernel/src/process/process/mod.rs
+++ b/kernel/src/process/process/mod.rs
@@ -474,10 +474,9 @@ impl Process {
         // Lock order: PID table -> group of process -> group inner -> session inner
         let mut pid_table = pid_table::pid_table_mut();
 
-        let process = pid_table.get_process(pid).ok_or(Error::with_message(
-            Errno::ESRCH,
-            "the process to set the PGID does not exist",
-        ))?;
+        let process = pid_table.get_process(pid).ok_or_else(|| {
+            Error::with_message(Errno::ESRCH, "the process to set the PGID does not exist")
+        })?;
 
         let current_session = if self.pid == process.pid() {
             // There is no need to check if the session is the same in this case.

--- a/kernel/src/syscall/clock_gettime.rs
+++ b/kernel/src/syscall/clock_gettime.rs
@@ -63,7 +63,7 @@ pub enum ClockId {
 /// - A clock ID is invalid if bits 2, 1, and 0 are all set.
 ///
 /// Ref: <https://github.com/torvalds/linux/blob/master/include/linux/posix-timers_types.h>.
-pub enum DynamicClockIdInfo {
+pub(super) enum DynamicClockIdInfo {
     Pid(u32, DynamicClockType),
     Tid(u32, DynamicClockType),
     #[cfg_attr(target_arch = "x86_64", expect(dead_code))]
@@ -99,7 +99,7 @@ impl TryFrom<clockid_t> for DynamicClockIdInfo {
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, PartialEq, TryFromInt)]
-pub enum DynamicClockType {
+pub(super) enum DynamicClockType {
     Profiling = 0,
     Virtual = 1,
     Scheduling = 2,
@@ -109,7 +109,7 @@ pub enum DynamicClockType {
 /// Reads the time of a clock specified by the input clock ID.
 ///
 /// If the clock ID does not support, this function will return `Err`.
-pub fn read_clock(clockid: clockid_t, ctx: &Context) -> Result<Duration> {
+pub(super) fn read_clock(clockid: clockid_t, ctx: &Context) -> Result<Duration> {
     if clockid >= 0 {
         let clock_id = ClockId::try_from(clockid)?;
         match clock_id {

--- a/kernel/src/syscall/constants.rs
+++ b/kernel/src/syscall/constants.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! constants used in syscall
+//! Constants used in system calls.
 
-/// LONGEST ALLOWED FILENAME
-pub const MAX_FILENAME_LEN: usize = 4096;
+/// The maximum length of a file name.
+pub(super) const MAX_FILENAME_LEN: usize = 4096;

--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -89,7 +89,7 @@ pub fn sys_epoll_ctl(
 
     let epoll_file = file
         .downcast_ref::<EpollFile>()
-        .ok_or(Error::with_message(Errno::EINVAL, "not epoll file"))?;
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "not epoll file"))?;
     epoll_file.control(ctx.thread_local, &cmd)?;
 
     Ok(SyscallReturn::Return(0 as _))
@@ -124,7 +124,7 @@ fn do_epoll_pwait2(
     let file = get_file_fast!(&mut file_table, epfd.try_into()?);
     let epoll_file = file
         .downcast_ref::<EpollFile>()
-        .ok_or(Error::with_message(Errno::EINVAL, "not epoll file"))?;
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "not epoll file"))?;
 
     let result = epoll_file.wait(max_events, timeout.as_ref());
 

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -61,7 +61,8 @@ fn handle_setfd(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
     let flags = if arg > u64::from(u8::MAX) {
         return_errno_with_message!(Errno::EINVAL, "invalid fd flags");
     } else {
-        FdFlags::from_bits(arg as u8).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?
+        FdFlags::from_bits(arg as u8)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?
     };
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     file_table.read_with(|inner| {
@@ -172,14 +173,9 @@ fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn>
     let owner_process = if pid == 0 {
         None
     } else {
-        Some(
-            pid_table::pid_table_mut()
-                .get_process(pid)
-                .ok_or(Error::with_message(
-                    Errno::ESRCH,
-                    "cannot set_owner with an invalid pid",
-                ))?,
-        )
+        Some(pid_table::pid_table_mut().get_process(pid).ok_or_else(|| {
+            Error::with_message(Errno::ESRCH, "cannot set_owner with an invalid pid")
+        })?)
     };
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
@@ -281,11 +277,11 @@ fn from_c_flock_and_file(lock: &c_flock, file: &dyn FileLike) -> Result<FileRang
             RangeLockWhence::SEEK_SET => lock.l_start,
             RangeLockWhence::SEEK_CUR => (file.as_inode_handle_or_err()?.offset() as off_t)
                 .checked_add(lock.l_start)
-                .ok_or(Error::with_message(Errno::EOVERFLOW, "start overflow"))?,
+                .ok_or_else(|| Error::with_message(Errno::EOVERFLOW, "start overflow"))?,
 
             RangeLockWhence::SEEK_END => (file.path().inode().metadata()?.size as off_t)
                 .checked_add(lock.l_start)
-                .ok_or(Error::with_message(Errno::EOVERFLOW, "start overflow"))?,
+                .ok_or_else(|| Error::with_message(Errno::EOVERFLOW, "start overflow"))?,
         }
     };
 
@@ -297,7 +293,7 @@ fn from_c_flock_and_file(lock: &c_flock, file: &dyn FileLike) -> Result<FileRang
         len if len > 0 => {
             let end = start
                 .checked_add(len)
-                .ok_or(Error::with_message(Errno::EOVERFLOW, "end overflow"))?;
+                .ok_or_else(|| Error::with_message(Errno::EOVERFLOW, "end overflow"))?;
             (start as usize, end as usize)
         }
         0 => (start as usize, OFFSET_MAX),

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -225,12 +225,12 @@ enum FcntlCmd {
 }
 
 #[expect(non_camel_case_types)]
-pub type off_t = i64;
+type off_t = i64;
 
 #[expect(non_camel_case_types)]
 #[repr(u16)]
 #[derive(Clone, Copy, Debug, TryFromInt)]
-pub enum RangeLockWhence {
+enum RangeLockWhence {
     SEEK_SET = 0,
     SEEK_CUR = 1,
     SEEK_END = 2,
@@ -240,7 +240,7 @@ pub enum RangeLockWhence {
 #[padding_struct]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod)]
-pub struct c_flock {
+struct c_flock {
     /// Type of lock: F_RDLCK, F_WRLCK, or F_UNLCK
     pub l_type: u16,
     /// Where `l_start' is relative to

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -41,10 +41,11 @@ pub fn sys_fcntl(raw_fd: RawFileDesc, cmd: i32, arg: u64, ctx: &Context) -> Resu
 }
 
 fn handle_dupfd(fd: FileDesc, arg: u64, flags: FdFlags, ctx: &Context) -> Result<SyscallReturn> {
-    let file_table = ctx.thread_local.borrow_file_table();
     let ceil_fd = (arg as RawFileDesc)
         .try_into()
         .map_err(|_| Error::with_message(Errno::EINVAL, "invalid fd"))?;
+
+    let file_table = ctx.thread_local.borrow_file_table();
     let new_fd = file_table.unwrap().write().dup_ceil(fd, ceil_fd, flags)?;
     Ok(SyscallReturn::Return(new_fd.into()))
 }
@@ -62,8 +63,9 @@ fn handle_setfd(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
         return_errno_with_message!(Errno::EINVAL, "invalid fd flags");
     } else {
         FdFlags::from_bits(arg as u8)
-            .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid fd flags"))?
     };
+
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     file_table.read_with(|inner| {
         inner.get_entry(fd)?.set_flags(flags);
@@ -74,6 +76,7 @@ fn handle_setfd(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
 fn handle_getfl(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
+
     let status_flags = file.status_flags();
     let access_mode = file.access_mode();
     Ok(SyscallReturn::Return(
@@ -84,8 +87,10 @@ fn handle_getfl(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
 fn handle_setfl(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
+
     let new_flags = StatusFlags::from_bits_truncate(arg as _);
     file.update_status_flags(StatusFlagsUpdate::replace(new_flags))?;
+
     Ok(SyscallReturn::Return(0))
 }
 
@@ -93,6 +98,7 @@ fn handle_getlk(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let owner = FileTable::range_lock_owner(file_table.unwrap());
     let file = get_file_fast!(&mut file_table, fd);
+
     let lock_mut_ptr = arg as Vaddr;
     let mut lock_mut_c = ctx.user_space().read_val::<c_flock>(lock_mut_ptr)?;
     let lock_type = RangeLockType::try_from(lock_mut_c.l_type)?;
@@ -105,9 +111,12 @@ fn handle_getlk(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> 
         lock_type,
         from_c_flock_and_file(&lock_mut_c, &**file)?,
     );
+
     let lock = file.as_inode_handle_or_err()?.test_range_lock(lock)?;
+
     lock_mut_c.copy_from_range_lock(&lock);
     ctx.user_space().write_val(lock_mut_ptr, &lock_mut_c)?;
+
     Ok(SyscallReturn::Return(0))
 }
 
@@ -120,6 +129,7 @@ fn handle_setlk(
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let owner = FileTable::range_lock_owner(file_table.unwrap());
     let file = get_file_fast!(&mut file_table, fd).into_owned();
+
     let lock_mut_ptr = arg as Vaddr;
     let lock_mut_c = ctx.user_space().read_val::<c_flock>(lock_mut_ptr)?;
     let lock_type = RangeLockType::try_from(lock_mut_c.l_type)?;
@@ -129,6 +139,7 @@ fn handle_setlk(
         lock_type,
         from_c_flock_and_file(&lock_mut_c, &*file)?,
     );
+
     let inode_file = file.as_inode_handle_or_err()?;
     inode_file.set_range_lock(&lock, is_nonblocking)?;
 
@@ -157,30 +168,34 @@ fn handle_setlk(
 fn handle_getown(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
+
     let pid = file.common().owner().pid().unwrap_or(0);
     Ok(SyscallReturn::Return(pid as _))
 }
 
 fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
     // A process ID is specified as a positive value; a process group ID is specified as a negative value.
-    let abs_arg = (arg as i32).unsigned_abs();
-    if abs_arg > i32::MAX as u32 {
-        return_errno_with_message!(Errno::EINVAL, "process (group) id overflowed");
+    // TODO: Support process groups instead of falling back to processes.
+    let pid = (arg as i32).unsigned_abs();
+    if pid.cast_signed() < 0 {
+        return_errno_with_message!(Errno::EINVAL, "negative PIDs are not valid");
     }
-    let pid = Pid::try_from(abs_arg)
-        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid process (group) id"))?;
 
     let owner_process = if pid == 0 {
         None
     } else {
         Some(pid_table::pid_table_mut().get_process(pid).ok_or_else(|| {
-            Error::with_message(Errno::ESRCH, "cannot set_owner with an invalid pid")
+            Error::with_message(
+                Errno::ESRCH,
+                "the process to be a file owner does not exist",
+            )
         })?)
     };
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
     file.set_owner(owner_process.as_ref());
+
     Ok(SyscallReturn::Return(0))
 }
 
@@ -201,7 +216,6 @@ fn handle_getseal(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     let file = get_file_fast!(&mut file_table, fd);
 
     let file_seals = file.as_inode_handle_or_err()?.get_seals()?;
-
     Ok(SyscallReturn::Return(file_seals.bits() as _))
 }
 

--- a/kernel/src/syscall/fcntl.rs
+++ b/kernel/src/syscall/fcntl.rs
@@ -290,7 +290,7 @@ fn from_c_flock_and_file(lock: &c_flock, file: &dyn FileLike) -> Result<FileRang
     };
 
     if start < 0 {
-        return Err(Error::with_message(Errno::EINVAL, "invalid start"));
+        return_errno_with_message!(Errno::EINVAL, "invalid start");
     }
 
     let (start, end) = match lock.l_len {
@@ -306,7 +306,7 @@ fn from_c_flock_and_file(lock: &c_flock, file: &dyn FileLike) -> Result<FileRang
             // `start + len` won't overflow because `start >= 0` and `len < 0`.
             let new_start = start + len;
             if new_start < 0 {
-                return Err(Error::with_message(Errno::EINVAL, "invalid len"));
+                return_errno_with_message!(Errno::EINVAL, "invalid len");
             }
             (new_start as usize, end as usize)
         }

--- a/kernel/src/syscall/getpgid.rs
+++ b/kernel/src/syscall/getpgid.rs
@@ -18,12 +18,9 @@ pub fn sys_getpgid(pid: Pid, ctx: &Context) -> Result<SyscallReturn> {
         return Ok(SyscallReturn::Return(ctx.process.pgid() as _));
     }
 
-    let process = pid_table::pid_table_mut()
-        .get_process(pid)
-        .ok_or(Error::with_message(
-            Errno::ESRCH,
-            "the process to get the PGID does not exist",
-        ))?;
+    let process = pid_table::pid_table_mut().get_process(pid).ok_or_else(|| {
+        Error::with_message(Errno::ESRCH, "the process to get the PGID does not exist")
+    })?;
 
     // The man pages allow the implementation to return `EPERM` if `process` is in a different
     // session than the current process. Linux does not perform this check by default, but some

--- a/kernel/src/syscall/getrusage.rs
+++ b/kernel/src/syscall/getrusage.rs
@@ -58,7 +58,7 @@ pub fn sys_getrusage(target: i32, rusage_addr: Vaddr, ctx: &Context) -> Result<S
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod)]
-pub struct rusage_t {
+pub(super) struct rusage_t {
     /// user time used
     pub ru_utime: timeval_t,
     /// system time used

--- a/kernel/src/syscall/getsid.rs
+++ b/kernel/src/syscall/getsid.rs
@@ -17,12 +17,9 @@ pub fn sys_getsid(pid: Pid, ctx: &Context) -> Result<SyscallReturn> {
         return Ok(SyscallReturn::Return(ctx.process.sid() as _));
     }
 
-    let process = pid_table::pid_table_mut()
-        .get_process(pid)
-        .ok_or(Error::with_message(
-            Errno::ESRCH,
-            "the process to get the SID does not exist",
-        ))?;
+    let process = pid_table::pid_table_mut().get_process(pid).ok_or_else(|| {
+        Error::with_message(Errno::ESRCH, "the process to get the SID does not exist")
+    })?;
 
     // The man pages allow the implementation to return `EPERM` if `process` is in a different
     // session than the current process. Linux does not perform this check by default, but some

--- a/kernel/src/syscall/inotify.rs
+++ b/kernel/src/syscall/inotify.rs
@@ -27,7 +27,7 @@ pub fn sys_inotify_init1(flags: u32, ctx: &Context) -> Result<SyscallReturn> {
 fn do_inotify_init(flags: u32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("inotify_init flags = {}", flags);
     let flags = InotifyFileFlags::from_bits(flags)
-        .ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     let fd_flags = if flags.contains(InotifyFileFlags::CLOEXEC) {
         FdFlags::CLOEXEC
     } else {

--- a/kernel/src/syscall/link.rs
+++ b/kernel/src/syscall/link.rs
@@ -22,8 +22,8 @@ pub fn sys_linkat(
 
     let old_path_name = user_space.read_cstring(old_path_addr, MAX_FILENAME_LEN)?;
     let new_path_name = user_space.read_cstring(new_path_addr, MAX_FILENAME_LEN)?;
-    let flags: LinkFlags =
-        LinkFlags::from_bits(flags).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;
+    let flags: LinkFlags = LinkFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     debug!(
         "old_dirfd = {}, old_path = {:?}, new_dirfd = {}, new_path = {:?}, flags = {:?}",
         old_dirfd, old_path_name, new_dirfd, new_path_name, flags

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -351,14 +351,14 @@ use dispatch_fn_inner;
 use impl_syscall_nums_and_dispatch_fn;
 use syscall_handler;
 
-pub struct SyscallArgument {
+struct SyscallArgument {
     syscall_number: u64,
     args: [u64; 6],
 }
 
 /// Syscall return
 #[derive(Clone, Copy, Debug)]
-pub enum SyscallReturn {
+enum SyscallReturn {
     /// return isize, this value will be used to set rax
     Return(isize),
     /// does not need to set rax

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -206,10 +206,12 @@ fn do_new_mount(
         let fs_type_str = fs_type_cstr
             .to_str()
             .map_err(|_| Error::with_message(Errno::ENODEV, "invalid file system type"))?;
-        crate::fs::vfs::registry::look_up(fs_type_str).ok_or(Error::with_message(
-            Errno::ENODEV,
-            "the filesystem is not configured in the kernel",
-        ))?
+        crate::fs::vfs::registry::look_up(fs_type_str).ok_or_else(|| {
+            Error::with_message(
+                Errno::ENODEV,
+                "the filesystem is not configured in the kernel",
+            )
+        })?
     };
 
     let source = if src_name_addr == 0 {

--- a/kernel/src/syscall/poll.rs
+++ b/kernel/src/syscall/poll.rs
@@ -235,7 +235,7 @@ struct c_pollfd {
 }
 
 #[derive(Clone, Debug)]
-pub struct PollFd {
+pub(super) struct PollFd {
     fd: Option<FileDesc>,
     events: IoEvents,
     revents: Cell<IoEvents>,

--- a/kernel/src/syscall/rt_sigprocmask.rs
+++ b/kernel/src/syscall/rt_sigprocmask.rs
@@ -61,7 +61,7 @@ fn do_rt_sigprocmask(
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromInt)]
-pub enum MaskOp {
+enum MaskOp {
     Block = 0,
     Unblock = 1,
     SetMask = 2,

--- a/kernel/src/syscall/sched_affinity.rs
+++ b/kernel/src/syscall/sched_affinity.rs
@@ -21,7 +21,7 @@ pub fn sys_sched_getaffinity(
         0 => ctx.thread.atomic_cpu_affinity().load(Ordering::Relaxed),
         _ => match pid_table::pid_table_mut().get_thread(tid) {
             Some(thread) => thread.atomic_cpu_affinity().load(Ordering::Relaxed),
-            None => return Err(Error::with_message(Errno::ESRCH, "thread does not exist")),
+            None => return_errno_with_message!(Errno::ESRCH, "thread does not exist"),
         },
     };
 
@@ -53,7 +53,7 @@ pub fn sys_sched_setaffinity(
                     .atomic_cpu_affinity()
                     .store(&user_cpu_set, Ordering::Relaxed);
             }
-            None => return Err(Error::with_message(Errno::ESRCH, "thread does not exist")),
+            None => return_errno_with_message!(Errno::ESRCH, "thread does not exist"),
         },
     }
 
@@ -72,7 +72,7 @@ fn read_cpu_set_from(
     cpu_set_ptr: Vaddr,
 ) -> Result<CpuSet> {
     if cpuset_size == 0 {
-        return Err(Error::with_message(Errno::EINVAL, "invalid cpuset size"));
+        return_errno_with_message!(Errno::EINVAL, "invalid cpuset size");
     }
 
     let num_cpus = num_cpus();
@@ -94,7 +94,7 @@ fn read_cpu_set_from(
     }
 
     if ret_set.is_empty() {
-        return Err(Error::with_message(Errno::EINVAL, "empty cpuset"));
+        return_errno_with_message!(Errno::EINVAL, "empty cpuset");
     }
 
     Ok(ret_set)
@@ -108,7 +108,7 @@ fn write_cpu_set_to(
     cpu_set_ptr: Vaddr,
 ) -> Result<usize> {
     if cpuset_size == 0 {
-        return Err(Error::with_message(Errno::EINVAL, "invalid cpuset size"));
+        return_errno_with_message!(Errno::EINVAL, "invalid cpuset size");
     }
 
     let num_cpus = num_cpus();

--- a/kernel/src/syscall/sched_affinity.rs
+++ b/kernel/src/syscall/sched_affinity.rs
@@ -21,7 +21,7 @@ pub fn sys_sched_getaffinity(
         0 => ctx.thread.atomic_cpu_affinity().load(Ordering::Relaxed),
         _ => match pid_table::pid_table_mut().get_thread(tid) {
             Some(thread) => thread.atomic_cpu_affinity().load(Ordering::Relaxed),
-            None => return_errno_with_message!(Errno::ESRCH, "thread does not exist"),
+            None => return_errno_with_message!(Errno::ESRCH, "the target thread does not exist"),
         },
     };
 
@@ -53,7 +53,7 @@ pub fn sys_sched_setaffinity(
                     .atomic_cpu_affinity()
                     .store(&user_cpu_set, Ordering::Relaxed);
             }
-            None => return_errno_with_message!(Errno::ESRCH, "thread does not exist"),
+            None => return_errno_with_message!(Errno::ESRCH, "the target thread does not exist"),
         },
     }
 

--- a/kernel/src/syscall/setxattr.rs
+++ b/kernel/src/syscall/setxattr.rs
@@ -106,7 +106,7 @@ fn setxattr(
     ctx: &Context,
 ) -> Result<()> {
     let flags = XattrSetFlags::from_bits(flags as _)
-        .ok_or(Error::with_message(Errno::EINVAL, "invalid xattr flags"))?;
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid xattr flags"))?;
 
     let name_cstr = read_xattr_name_cstr_from_user(name_ptr, user_space)?;
     let name_str = name_cstr.to_string_lossy();
@@ -183,10 +183,8 @@ pub(super) fn parse_xattr_name(name_str: &str) -> Result<XattrName<'_>> {
         return_errno_with_message!(Errno::ERANGE, "xattr name empty or too long");
     }
 
-    let xattr_name = XattrName::try_from_full_name(name_str).ok_or(Error::with_message(
-        Errno::EOPNOTSUPP,
-        "invalid xattr namespace",
-    ))?;
+    let xattr_name = XattrName::try_from_full_name(name_str)
+        .ok_or_else(|| Error::with_message(Errno::EOPNOTSUPP, "invalid xattr namespace"))?;
     Ok(xattr_name)
 }
 

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -57,7 +57,7 @@ pub fn sys_signalfd4(
     );
 
     if sizemask != size_of::<SigMask>() {
-        return Err(Error::with_message(Errno::EINVAL, "invalid mask size"));
+        return_errno_with_message!(Errno::EINVAL, "invalid mask size");
     }
 
     let mut mask = ctx.user_space().read_val::<SigMask>(mask_ptr)?;

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -170,7 +170,7 @@ impl SignalFile {
 
     /// Checks current readable I/O events.
     fn check_io_events(&self, posix_thread: &PosixThread) -> IoEvents {
-        let mask = self.signals_mask.load(Ordering::Relaxed);
+        let mask = self.signal_mask();
         if posix_thread.pending_signals().intersects(mask) {
             IoEvents::IN
         } else {
@@ -181,7 +181,7 @@ impl SignalFile {
     /// Attempts non-blocking read operation.
     fn try_read(&self, writer: &mut VmWriter, thread: &PosixThread) -> Result<usize> {
         // We invert `signal_mask` to get the signals that are not blocked.
-        let mask = !self.signals_mask.load(Ordering::Relaxed);
+        let mask = !self.signal_mask();
         let max_signals = writer.avail() / size_of::<SignalfdSiginfo>();
         let mut count = 0;
 

--- a/kernel/src/syscall/stat.rs
+++ b/kernel/src/syscall/stat.rs
@@ -51,8 +51,8 @@ pub fn sys_fstatat(
 ) -> Result<SyscallReturn> {
     let user_space = ctx.user_space();
     let filename = user_space.read_cstring(filename_ptr, MAX_FILENAME_LEN)?;
-    let flags =
-        StatFlags::from_bits(flags).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;
+    let flags = StatFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     debug!(
         "dirfd = {}, filename = {:?}, stat_buf_ptr = 0x{:x}, flags = {:?}",
         dirfd, filename, stat_buf_ptr, flags

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -27,7 +27,7 @@ pub fn sys_statx(
     let user_space = ctx.user_space();
     let filename = user_space.read_cstring(filename_ptr, MAX_FILENAME_LEN)?;
     let flags = StatxFlags::from_bits(flags)
-        .ok_or(Error::with_message(Errno::EINVAL, "invalid statx flags"))?;
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid statx flags"))?;
     let mask = StatxMask::from_bits_truncate(mask);
     debug!(
         "dirfd = {}, filename = {:?}, flags = {:?}, mask = {:?}, statx_buf_ptr = 0x{:x}",

--- a/kernel/src/syscall/statx.rs
+++ b/kernel/src/syscall/statx.rs
@@ -71,7 +71,7 @@ pub fn sys_statx(
 /// Structures for the extended file attribute retrieval system call statx.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod)]
-pub struct Statx {
+struct Statx {
     /// Indicates which fields in the `statx` structure were successfully filled,
     /// reflecting the state information supported by the filesystem.
     stx_mask: u32,
@@ -199,7 +199,7 @@ impl Statx {
 /// Statx Timestamp (seconds and nanoseconds)
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod)]
-pub struct StatxTimestamp {
+struct StatxTimestamp {
     /// Seconds
     tv_sec: i64,
     /// Nanoseconds

--- a/kernel/src/syscall/timer_create.rs
+++ b/kernel/src/syscall/timer_create.rs
@@ -77,13 +77,13 @@ pub fn sys_timer_create(
                 SigNotify::SIGEV_THREAD_ID => {
                     let tid = sig_event.sigev_un.read_tid() as u32;
                     let thread = pid_table::pid_table_mut().get_thread(tid).ok_or_else(|| {
-                        Error::with_message(Errno::EINVAL, "target thread does not exist")
+                        Error::with_message(Errno::EINVAL, "the target thread does not exist")
                     })?;
                     let posix_thread = thread.as_posix_thread().unwrap();
                     if posix_thread.process().pid() != current_process.pid() {
                         return_errno_with_message!(
                             Errno::EINVAL,
-                            "target thread should belong to current process"
+                            "the target thread does not belong to the current process"
                         );
                     }
                     let signal = KernelSignal::new(SigNum::try_from(signo as u8)?);
@@ -149,7 +149,7 @@ where
             DynamicClockIdInfo::Pid(pid, clock_type) => {
                 let process = pid_table::pid_table_mut()
                     .get_process(pid)
-                    .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock id"))?;
+                    .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock ID"))?;
                 let process_timer_manager = process.timer_manager();
                 match clock_type {
                     DynamicClockType::Profiling => process_timer_manager.create_prof_timer(func),
@@ -161,7 +161,7 @@ where
             DynamicClockIdInfo::Tid(tid, clock_type) => {
                 let thread = pid_table::pid_table_mut()
                     .get_thread(tid)
-                    .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock id"))?;
+                    .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid clock ID"))?;
                 let posix_thread = thread.as_posix_thread().unwrap();
                 match clock_type {
                     DynamicClockType::Profiling => posix_thread.create_prof_timer(func),

--- a/kernel/src/syscall/unlink.rs
+++ b/kernel/src/syscall/unlink.rs
@@ -16,8 +16,8 @@ pub fn sys_unlinkat(
     flags: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let flags =
-        UnlinkFlags::from_bits(flags).ok_or(Error::with_message(Errno::EINVAL, "invalid flags"))?;
+    let flags = UnlinkFlags::from_bits(flags)
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     if flags.contains(UnlinkFlags::AT_REMOVEDIR) {
         return super::rmdir::sys_rmdirat(dirfd, path_addr, ctx);
     }

--- a/kernel/src/syscall/waitid.rs
+++ b/kernel/src/syscall/waitid.rs
@@ -28,7 +28,7 @@ pub fn sys_waitid(
     // FIXME: what does rusage use for?
     let process_filter = ProcessFilter::from_which_and_id(which, upid as _, ctx)?;
     let wait_options = WaitOptions::from_bits(options as u32)
-        .ok_or(Error::with_message(Errno::EINVAL, "invalid options"))?;
+        .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid options"))?;
 
     // Check for waitid options
     if !wait_options


### PR DESCRIPTION
1. The first commit replaces `return Err(Error::with_message(..))` with `return_errno_with_message`.

2. The second commit replaces `ok_or(Error::with_message(..))` with `ok_or_else(|| Error::with_message(..))`.

3. The third commit changes some visibility markers in the syscall module.

The rule is that:
 - We use `pub fn sys_xxx` for system call entries.
 - All other methods and structures should use the most restrictive visibility: `pub(super)` or none.

After the third commit, `grep` shows:
```
> grep -R "^pub [^f]" kernel/src/syscall
kernel/src/syscall/clock_gettime.rs:pub enum ClockId {
kernel/src/syscall/mod.rs:pub use clock_gettime::ClockId;
kernel/src/syscall/mod.rs:pub use timer_create::create_timer;
> grep -R "^pub fn [^s]" kernel/src/syscall
kernel/src/syscall/mod.rs:pub fn handle_syscall(ctx: &Context, user_ctx: &mut UserContext) {
kernel/src/syscall/timer_create.rs:pub fn create_timer<F>(clockid: clockid_t, func: F, ctx: &Context) -> Result<Arc<Timer>>
> grep -R "[^b] fn sys" kernel/src/syscall
kernel/src/syscall/rmdir.rs:pub(super) fn sys_rmdirat(
```
 - `ClockId`, `create_timer`, and `handle_syscall` need to be public because they're used in other modules.
 - `sys_rmdirat` is not a system call. It is a helper. So its visibilty marker is `pub(super)`.

4. The last commit resolves some blank line issues and error messages.

 - Unify "the target thread does not exist" error messages.
 - Add some blank lines in `syscall/fcntl.rs`. Note that I add a blank line before `Ok(SyscallReturn::Return(0))` but remove blank lines before `Ok(SyscallReturn::Return(a_value_that_was_just_computed_above))`.