### PR TITLE
Add minimal AppArmor file-open enforcement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ CARGO_OSDK_BUILD_ARGS += --init-args="/opt/run_conformance_test.sh"
 else ifeq ($(AUTO_TEST), regression)
 ENABLE_REGRESSION_TEST := true
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="INTEL_TDX=$(INTEL_TDX)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="lsm=yama,apparmor"
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_regression_test.sh"
 else ifeq ($(AUTO_TEST), boot)
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/boot_hello.sh"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -29,6 +29,7 @@
 * [Advanced Build and Test Instructions](kernel/advanced-instructions.md)
     * [Intel TDX](kernel/intel-tdx.md)
 * [The Framekernel Architecture](kernel/the-framekernel-architecture.md)
+* [AppArmor File-Open Policy](kernel/security/apparmor-file-open.md)
 * [Linux Compatibility](kernel/linux-compatibility/README.md)
     * [Syscall Flag Coverage](kernel/linux-compatibility/syscall-flag-coverage/README.md)
         * [System Call Matching Language (SCML)](kernel/linux-compatibility/syscall-flag-coverage/system-call-matching-language.md)

--- a/book/src/kernel/linux-compatibility/kernel-parameters.md
+++ b/book/src/kernel/linux-compatibility/kernel-parameters.md
@@ -18,6 +18,50 @@ Notes:
 - If omitted, Asterinas will try to execute from the following paths in order:
   `/sbin/init`, `/etc/init`, `/bin/init`, `/bin/sh`.
 
+### `lsm`
+
+Set the optional built-in Linux Security Modules and their order.
+
+Format:
+```text
+lsm=<module>[,<module>...]
+```
+
+Supported optional modules:
+- `yama`
+- `apparmor`
+
+The `capability` module is always enabled.
+Without `lsm=`, Asterinas enables `yama` by default.
+Unknown or duplicate names,
+as well as exclusive modules listed after another exclusive module,
+are ignored with a warning.
+
+Example:
+```text
+lsm=yama,apparmor
+```
+
+### `security`
+
+Select a major Linux Security Module when `lsm=` is not specified.
+This legacy selector currently accepts only `apparmor`.
+
+Format:
+```text
+security=<module>
+```
+
+`security=apparmor` enables AppArmor in addition to
+the default `capability` and `yama` modules.
+If both `lsm=` and `security=` are specified,
+`lsm=` takes precedence and `security=` is ignored with a warning.
+
+Example:
+```text
+security=apparmor
+```
+
 ### `console`
 
 Select console devices for kernel messages.

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
@@ -32,6 +32,10 @@ Partially-supported flags:
 Supported and unsupported functionality of `openat` are the same as `open`.
 The SCML rules are omitted for brevity.
 
+When AppArmor is enabled,
+its [file-open policy](../../../security/apparmor-file-open.md)
+may further restrict regular-file opens.
+
 For more information,
 see [the man page](https://man7.org/linux/man-pages/man2/openat.2.html).
 

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/fully_covered.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/fully_covered.scml
@@ -50,6 +50,7 @@ renameat(olddirfd, oldpath, newdirfd, newpath);
 rmdir(path);
 
 // Create a file
+// If AppArmor is enabled and the task is confined, creat may be denied after leaving the new directory entry in place.
 creat(path, mode);
 
 // Make a new name for a file

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/open_and_openat.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/open_and_openat.scml
@@ -1,3 +1,6 @@
+// If AppArmor is enabled and the task is confined, its file_open policy may additionally deny regular-file opens.
+// With O_CREAT, the check occurs after creation, so a denied open can leave the new directory entry in place.
+
 access_mode =
     O_RDONLY |
     O_WRONLY |

--- a/book/src/kernel/security/apparmor-file-open.md
+++ b/book/src/kernel/security/apparmor-file-open.md
@@ -1,0 +1,117 @@
+# AppArmor File-Open Policy
+
+Asterinas implements an exact-path allowlist for regular-file opens.
+Policy loading and task confinement are manual.
+The policy format described here is specific to Asterinas
+and is not compatible with the Linux AppArmor policy ABI.
+
+## Enable AppArmor
+
+Enable AppArmor with the
+[`lsm=` kernel parameter](../linux-compatibility/kernel-parameters.md#lsm):
+
+```text
+lsm=yama,apparmor
+```
+
+The legacy `security=apparmor` form is also accepted when `lsm=` is absent.
+
+Mount `securityfs` after mounting `sysfs`:
+
+```sh
+mkdir -p /sys/kernel/security
+mount -t securityfs none /sys/kernel/security
+```
+
+When AppArmor is active, its control files are available under `/sys/kernel/security/apparmor`.
+
+## Load policy
+
+One write may contain one version 0 profile.
+A profile consists of a name followed by exact absolute-path rules:
+
+```text
+version 0
+profile example
+/etc/example.conf r
+/var/lib/example/state rw
+```
+
+A policy write may contain at most 4096 bytes,
+and a profile may contain at most 1024 rules.
+A profile name may contain at most 128 bytes.
+Profile names may contain ASCII letters, digits, `_`, `-`, and `.`.
+`unconfined` is reserved and cannot be used as a profile name.
+Rule paths must be canonical absolute paths without ASCII whitespace,
+empty components, `.`, or `..`.
+A rule path may contain at most 4096 bytes
+and is matched against the path resolved by the VFS.
+
+The supported permissions are:
+
+| Permission | Allowed regular-file `file_open` operations |
+| --- | --- |
+| `r` | Open for reading |
+| `w` | Open for writing or truncation |
+| `rw` | Both sets above |
+
+Write a new profile to `.load`,
+or atomically replace an existing profile through `.replace`.
+Writing either file requires `CAP_MAC_ADMIN` in the initial user namespace.
+The `profiles` file lists loaded profiles,
+and `features/policy_version` reports the supported policy version.
+
+## Confine a task
+
+Write a loaded profile name to `/proc/self/attr/current`,
+then replace the task with the intended program:
+
+```sh
+sh -c 'printf %s example > /proc/self/attr/current; exec /path/to/program'
+```
+
+Only an unconfined task can enter a profile.
+After entering a profile,
+the task cannot change or remove it.
+The label is part of the task credentials and is copied by `fork`.
+It is preserved across `execve`.
+Reading the attribute returns either `unconfined`
+or the profile name followed by `(enforce)`.
+
+## Enforcement
+
+The VFS performs its usual checks before AppArmor,
+so an AppArmor rule cannot grant access that the VFS denied.
+A confined task receives `EACCES`
+when it opens a regular file without a matching rule.
+An `O_PATH` open requests no file permission and is allowed.
+
+The `file_open` hook runs after creation.
+If `O_CREAT` creates a file and AppArmor denies opening it,
+the new directory entry remains.
+An unnamed `O_TMPFILE` object is also checked after creation
+and cannot match an exact absolute-path rule.
+
+## Limitations
+
+The hook covers only regular files opened through `open`, `openat`, or `creat`.
+It does not check:
+
+- directories, FIFOs, device nodes, or other non-regular files;
+- file handles created by other system calls or by the kernel;
+- existing file descriptions inherited across `fork` or `execve`;
+- file descriptions received through `SCM_RIGHTS` or duplicated through
+  `pidfd_getfd()`;
+- later reads or writes through any of those existing descriptions.
+
+As a result,
+this implementation is not a complete confinement boundary
+for descriptor-based access.
+It also does not implement a create hook,
+pathname globs,
+profile removal,
+automatic attachment,
+complain mode,
+execute transitions,
+network rules,
+or capability rules.

--- a/kernel/src/fs/file/file_attr/open_args.rs
+++ b/kernel/src/fs/file/file_attr/open_args.rs
@@ -12,6 +12,7 @@ pub struct OpenArgs {
     pub status_flags: StatusFlags,
     pub access_mode: AccessMode,
     pub inode_mode: InodeMode,
+    check_access: bool,
 }
 
 impl OpenArgs {
@@ -53,6 +54,7 @@ impl OpenArgs {
             status_flags,
             access_mode,
             inode_mode,
+            check_access: true,
         })
     }
 
@@ -63,6 +65,7 @@ impl OpenArgs {
             status_flags: StatusFlags::empty(),
             access_mode,
             inode_mode,
+            check_access: true,
         }
     }
 
@@ -77,5 +80,27 @@ impl OpenArgs {
     pub fn is_tmpfile(&self) -> bool {
         self.creation_flags.contains(CreationFlags::O_TMPFILE)
             && !self.status_flags.contains(StatusFlags::O_PATH)
+    }
+
+    /// Converts the arguments for opening a file that this request has just created.
+    ///
+    /// Creation-only flags have already served their purpose by this point.
+    /// `O_TRUNC` is also cleared
+    /// because a newly created file must not be truncated again during open completion.
+    pub(crate) fn into_created_file_open(mut self) -> Self {
+        self.creation_flags.remove(
+            CreationFlags::O_CREAT
+                | CreationFlags::O_EXCL
+                | CreationFlags::O_TRUNC
+                | CreationFlags::O_DIRECTORY
+                | CreationFlags::O_TMPFILE,
+        );
+        self.check_access = false;
+        self
+    }
+
+    /// Returns whether ordinary inode access checks are required.
+    pub(in crate::fs) const fn should_check_access(&self) -> bool {
+        self.check_access
     }
 }

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -37,19 +37,7 @@ pub struct InodeHandle {
 }
 
 impl InodeHandle {
-    pub fn new(path: Path, access_mode: AccessMode, status_flags: StatusFlags) -> Result<Self> {
-        let inode = path.inode();
-        if !status_flags.contains(StatusFlags::O_PATH) {
-            // "Opening a file or directory with the O_PATH flag requires no permissions on the
-            // object itself".
-            // Reference: <https://man7.org/linux/man-pages/man2/openat.2.html>
-            inode.check_permission(access_mode.into())?;
-        }
-
-        Self::new_unchecked_access(path, access_mode, status_flags)
-    }
-
-    pub fn new_unchecked_access(
+    pub(in crate::fs) fn new_unchecked_access(
         path: Path,
         access_mode: AccessMode,
         status_flags: StatusFlags,

--- a/kernel/src/fs/fs_impls/mod.rs
+++ b/kernel/src/fs/fs_impls/mod.rs
@@ -13,6 +13,7 @@ pub mod overlayfs;
 pub mod procfs;
 pub mod pseudofs;
 pub mod ramfs;
+pub mod securityfs;
 pub mod sysfs;
 pub mod tmpfs;
 pub mod virtiofs;
@@ -20,6 +21,7 @@ pub mod virtiofs;
 pub(super) fn init() {
     sysfs::init();
     procfs::init();
+    securityfs::init();
     cgroupfs::init();
     configfs::init();
     ramfs::init();

--- a/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/attr.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! LSM attributes under `/proc/<pid>/attr`.
+
+use super::TidDirOps;
+use crate::{
+    fs::{
+        file::{InodeType, mkmod},
+        procfs::template::{
+            ListedEntry, ProcDir, ProcDirOps, ProcFile, ProcFileOps, ReaddirEntry,
+            visit_listed_entries,
+        },
+        vfs::inode::Inode,
+    },
+    prelude::*,
+    process::posix_thread::AsPosixThread,
+    security::lsm,
+    thread::Thread,
+};
+
+/// Represents `/proc/<pid>/attr`.
+pub struct AttrDirOps(TidDirOps);
+
+impl AttrDirOps {
+    pub fn new_inode(dir: &TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcDir::new(Self(dir.clone()), parent, mkmod!(a+rx))
+    }
+}
+
+impl ProcDirOps for AttrDirOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn lookup_child(&self, this_dir: &ProcDir<Self>, name: &str) -> Result<Arc<dyn Inode>> {
+        if name != "current" {
+            return_errno_with_message!(Errno::ENOENT, "the LSM attribute does not exist");
+        }
+
+        Ok(CurrentFileOps::new_inode(
+            self.0.clone(),
+            this_dir.this_weak().clone(),
+        ))
+    }
+
+    fn visit_entries_from_offset<'a, F>(&'a self, offset: usize, visit_fn: F) -> Result<()>
+    where
+        F: FnMut(ReaddirEntry<'a>) -> Result<()>,
+    {
+        visit_listed_entries(
+            offset,
+            [ListedEntry::new("current", InodeType::File)],
+            visit_fn,
+        )
+    }
+}
+
+/// Represents `/proc/<pid>/attr/current`.
+struct CurrentFileOps(TidDirOps);
+
+impl CurrentFileOps {
+    fn new_inode(dir: TidDirOps, parent: Weak<dyn Inode>) -> Arc<dyn Inode> {
+        ProcFile::new(Self(dir), parent, mkmod!(a+r, u+w))
+    }
+}
+
+impl ProcFileOps for CurrentFileOps {
+    fn owner_thread(&self) -> Option<Arc<Thread>> {
+        self.0.thread()
+    }
+
+    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        let thread = self
+            .0
+            .thread()
+            .ok_or_else(|| Error::with_message(Errno::ESRCH, "the thread does not exist"))?;
+        let posix_thread = thread.as_posix_thread().unwrap();
+        let mut value = lsm::task_attr_current(posix_thread)?;
+        value.push('\n');
+
+        let bytes = value.as_bytes();
+        let mut reader = VmReader::from(&bytes[offset.min(bytes.len())..]);
+        Ok(writer.write_fallible(&mut reader)?)
+    }
+
+    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+        if offset != 0 {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "an LSM task attribute must be written at offset zero"
+            );
+        }
+
+        let target = self
+            .0
+            .thread()
+            .ok_or_else(|| Error::with_message(Errno::ESRCH, "the thread does not exist"))?;
+        let current = Thread::current()
+            .ok_or_else(|| Error::with_message(Errno::ESRCH, "there is no current thread"))?;
+        if !Arc::ptr_eq(&target, &current) {
+            return_errno_with_message!(
+                Errno::EPERM,
+                "an LSM task attribute can only be changed by the current thread"
+            );
+        }
+
+        let input_len = reader.remain();
+        // Keep the generic procfs buffer bounded. Each LSM validates the
+        // syntax and semantic length of its own task attribute.
+        if input_len == 0 || input_len > PAGE_SIZE {
+            return_errno_with_message!(Errno::EINVAL, "the LSM task attribute has an invalid size");
+        }
+
+        let (value, bytes_read) = reader.read_cstring_until_end(input_len)?;
+        if bytes_read != input_len || value.as_bytes().len() != input_len {
+            return_errno_with_message!(Errno::EINVAL, "the LSM task attribute contains a NUL byte");
+        }
+        let value = value.to_str().map_err(|_| {
+            Error::with_message(Errno::EINVAL, "the LSM task attribute is not UTF-8")
+        })?;
+        lsm::set_task_attr_current(target.as_posix_thread().unwrap(), value)?;
+
+        Ok(bytes_read)
+    }
+}

--- a/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -7,12 +7,12 @@ use crate::{
         procfs::{
             StaticEntryWithOps,
             pid::task::{
-                auxv::AuxvFileOps, cgroup::CgroupFileOps, cmdline::CmdlineFileOps,
-                comm::CommFileOps, environ::EnvironFileOps, exe::ExeSymOps, fd::FdDirOps,
-                gid_map::GidMapFileOps, maps::MapsFileOps, mem::MemFileOps,
-                mountinfo::MountInfoFileOps, mounts::MountsFileOps, mountstats::MountStatsFileOps,
-                ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps, stat::StatFileOps,
-                status::StatusFileOps, uid_map::UidMapFileOps,
+                attr::AttrDirOps, auxv::AuxvFileOps, cgroup::CgroupFileOps,
+                cmdline::CmdlineFileOps, comm::CommFileOps, environ::EnvironFileOps,
+                exe::ExeSymOps, fd::FdDirOps, gid_map::GidMapFileOps, maps::MapsFileOps,
+                mem::MemFileOps, mountinfo::MountInfoFileOps, mounts::MountsFileOps,
+                mountstats::MountStatsFileOps, ns::NsDirOps, oom_score_adj::OomScoreAdjFileOps,
+                stat::StatFileOps, status::StatusFileOps, uid_map::UidMapFileOps,
             },
             template::{
                 ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, keyed_readdir_entries,
@@ -24,9 +24,11 @@ use crate::{
     },
     prelude::*,
     process::{Process, pid_table, pid_table::PidEntry, posix_thread::AsPosixThread},
+    security::lsm,
     thread::{Thread, Tid},
 };
 
+mod attr;
 mod auxv;
 mod cgroup;
 mod cmdline;
@@ -169,6 +171,10 @@ impl TidDirOps {
         this_ptr: Weak<dyn Inode>,
         name: &str,
     ) -> Result<Arc<dyn Inode>> {
+        if name == "attr" && lsm::task_attrs_enabled() {
+            return Ok(AttrDirOps::new_inode(self, this_ptr));
+        }
+
         if let Some(child) =
             lookup_child_from_table(name, Self::STATIC_ENTRIES, |f| (f)(self, this_ptr))
         {
@@ -179,7 +185,10 @@ impl TidDirOps {
     }
 
     pub(super) fn static_listed_entries(&self) -> impl Iterator<Item = ListedEntry<'_>> + '_ {
-        listed_entries_from_table(Self::STATIC_ENTRIES)
+        lsm::task_attrs_enabled()
+            .then_some(ListedEntry::new("attr", InodeType::Dir))
+            .into_iter()
+            .chain(listed_entries_from_table(Self::STATIC_ENTRIES))
     }
 }
 

--- a/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -11,7 +11,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, InodeHandle, InodeMode, InodeType, PerOpenFileOps, StatusFlags,
+            AccessMode, InodeMode, InodeType, OpenArgs, PerOpenFileOps, StatusFlags,
             file_table::{FdFlags, FileDesc},
             mkmod,
         },
@@ -275,10 +275,11 @@ impl<T: NsCommonOps> FileOps for NsFile<T> {
 /// Opens a namespace as a file and returns the file descriptor.
 fn open_ns_as_file<T: NsCommonOps>(ns: &Arc<T>) -> Result<FileDesc> {
     let path = ns.get_path();
-    let inode_handle = InodeHandle::new(path.clone(), AccessMode::O_RDONLY, StatusFlags::empty())?;
-
     let current_task = Task::current().unwrap();
     let thread_local = current_task.as_thread_local().unwrap();
+    let open_args = OpenArgs::from_modes(AccessMode::O_RDONLY, mkmod!(u+r));
+    let inode_handle = path.open(open_args)?;
+
     let mut file_table_ref = thread_local.borrow_file_table_mut();
     let mut file_table = file_table_ref.unwrap().write();
     let fd = file_table.insert(Arc::new(inode_handle), FdFlags::CLOEXEC);

--- a/kernel/src/fs/fs_impls/securityfs/fs.rs
+++ b/kernel/src/fs/fs_impls/securityfs/fs.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use spin::Once;
+
+use super::{inode::SecurityFsInode, systree_node::SecurityRootNode};
+use crate::{
+    fs::{
+        pseudofs::AnonDeviceId,
+        utils::systree_inode::SysTreeInodeTy,
+        vfs::{
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            inode::Inode,
+            registry::{FsCreationCtx, FsProperties, FsType},
+        },
+    },
+    prelude::*,
+};
+
+/// A pseudo filesystem that exposes kernel security interfaces.
+pub struct SecurityFs {
+    _anon_device_id: AnonDeviceId,
+    sb: SuperBlock,
+    root: Arc<dyn Inode>,
+    fs_event_subscriber_stats: FsEventSubscriberStats,
+}
+
+// Reference: <https://elixir.bootlin.com/linux/v6.18.6/source/include/uapi/linux/magic.h>.
+const MAGIC_NUMBER: u64 = 0x7363_6673;
+const BLOCK_SIZE: usize = 4096;
+const NAME_MAX: usize = 255;
+
+impl SecurityFs {
+    pub(super) fn singleton() -> &'static Arc<Self> {
+        static SINGLETON: Once<Arc<SecurityFs>> = Once::new();
+
+        SINGLETON.call_once(Self::new)
+    }
+
+    fn new() -> Arc<Self> {
+        let anon_device_id =
+            AnonDeviceId::acquire().expect("no device ID is available for securityfs");
+        let sb = SuperBlock::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let root_inode = SecurityFsInode::new_root(SecurityRootNode::new(), &sb);
+
+        Arc::new(Self {
+            _anon_device_id: anon_device_id,
+            sb,
+            root: root_inode,
+            fs_event_subscriber_stats: FsEventSubscriberStats::new(),
+        })
+    }
+}
+
+impl FileSystem for SecurityFs {
+    fn name(&self) -> &'static str {
+        "securityfs"
+    }
+
+    fn sync(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.root.clone()
+    }
+
+    fn sb(&self) -> SuperBlock {
+        self.sb.clone()
+    }
+
+    fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+        &self.fs_event_subscriber_stats
+    }
+}
+
+pub(super) struct SecurityFsType;
+
+impl FsType for SecurityFsType {
+    fn name(&self) -> &'static str {
+        "securityfs"
+    }
+
+    fn properties(&self) -> FsProperties {
+        FsProperties::empty()
+    }
+
+    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(SecurityFs::singleton().clone())
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
+        None
+    }
+}

--- a/kernel/src/fs/fs_impls/securityfs/fs.rs
+++ b/kernel/src/fs/fs_impls/securityfs/fs.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use spin::Once;
+
+use super::{inode::SecurityFsInode, systree_node::SecurityRootNode};
+use crate::{
+    fs::{
+        pseudofs::AnonDeviceId,
+        utils::systree_inode::SysTreeInodeTy,
+        vfs::{
+            file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+            inode::Inode,
+            registry::{FsCreationCtx, FsProperties, FsType},
+        },
+    },
+    prelude::*,
+};
+
+/// A pseudo filesystem that exposes kernel security interfaces.
+pub struct SecurityFs {
+    _anon_device_id: AnonDeviceId,
+    sb: SuperBlock,
+    root: Arc<dyn Inode>,
+    fs_event_subscriber_stats: FsEventSubscriberStats,
+}
+
+// Reference: <https://elixir.bootlin.com/linux/v6.18.6/source/include/uapi/linux/magic.h>.
+const MAGIC_NUMBER: u64 = 0x7363_6673;
+const BLOCK_SIZE: usize = 4096;
+const NAME_MAX: usize = 255;
+
+impl SecurityFs {
+    pub(super) fn singleton() -> &'static Arc<Self> {
+        static SINGLETON: Once<Arc<SecurityFs>> = Once::new();
+
+        SINGLETON.call_once(Self::new)
+    }
+
+    fn new() -> Arc<Self> {
+        let anon_device_id =
+            AnonDeviceId::acquire().expect("no device ID is available for securityfs");
+        let sb = SuperBlock::new(MAGIC_NUMBER, BLOCK_SIZE, NAME_MAX, anon_device_id.id());
+        let root_inode = SecurityFsInode::new_root(SecurityRootNode::new(), &sb);
+
+        Arc::new(Self {
+            _anon_device_id: anon_device_id,
+            sb,
+            root: root_inode,
+            fs_event_subscriber_stats: FsEventSubscriberStats::new(),
+        })
+    }
+}
+
+impl FileSystem for SecurityFs {
+    fn name(&self) -> &'static str {
+        "securityfs"
+    }
+
+    fn sync(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn root_inode(&self) -> Arc<dyn Inode> {
+        self.root.clone()
+    }
+
+    fn sb(&self) -> SuperBlock {
+        self.sb.clone()
+    }
+
+    fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+        &self.fs_event_subscriber_stats
+    }
+}
+
+pub(super) struct SecurityFsType;
+
+impl FsType for SecurityFsType {
+    type Key = ();
+
+    fn name(&self) -> &'static str {
+        "securityfs"
+    }
+
+    fn properties(&self) -> FsProperties {
+        FsProperties::empty()
+    }
+
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+        Ok(SecurityFs::singleton().clone())
+    }
+
+    fn sysnode(&self) -> Option<Arc<dyn aster_systree::SysNode>> {
+        None
+    }
+}

--- a/kernel/src/fs/fs_impls/securityfs/inode.rs
+++ b/kernel/src/fs/fs_impls/securityfs/inode.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::fs::SecurityFs;
+use crate::{
+    fs::{
+        file::InodeMode,
+        utils::systree_inode::{SysTreeInodeTy, SysTreeNodeKind},
+        vfs::{
+            file_system::FileSystem,
+            inode::{Extension, Inode, Metadata},
+        },
+    },
+    prelude::*,
+};
+
+/// An inode backed by a node in the securityfs system tree.
+pub struct SecurityFsInode {
+    node_kind: SysTreeNodeKind,
+    metadata: Metadata,
+    extension: Extension,
+    mode: RwLock<InodeMode>,
+    parent: Weak<Self>,
+    this: Weak<Self>,
+}
+
+impl SysTreeInodeTy for SecurityFsInode {
+    fn new_arc(
+        node_kind: SysTreeNodeKind,
+        metadata: Metadata,
+        mode: InodeMode,
+        parent: Weak<Self>,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|this| Self {
+            node_kind,
+            metadata,
+            extension: Extension::new(),
+            mode: RwLock::new(mode),
+            parent,
+            this: this.clone(),
+        })
+    }
+
+    fn node_kind(&self) -> &SysTreeNodeKind {
+        &self.node_kind
+    }
+
+    fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    fn mode(&self) -> Result<InodeMode> {
+        Ok(*self.mode.read())
+    }
+
+    fn set_mode(&self, mode: InodeMode) -> Result<()> {
+        *self.mode.write() = mode;
+        Ok(())
+    }
+
+    fn extension(&self) -> &Extension {
+        &self.extension
+    }
+
+    fn parent(&self) -> &Weak<Self> {
+        &self.parent
+    }
+
+    fn this(&self) -> Arc<Self> {
+        self.this.upgrade().expect("securityfs inode is alive")
+    }
+}
+
+impl Inode for SecurityFsInode {
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        SecurityFs::singleton().clone()
+    }
+}

--- a/kernel/src/fs/fs_impls/securityfs/mod.rs
+++ b/kernel/src/fs/fs_impls/securityfs/mod.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The securityfs pseudo filesystem.
+//!
+//! [`fs::SecurityFs`] is the singleton VFS filesystem.
+//! [`systree_node::SecurityRootNode`] collects top-level [`aster_systree`] nodes from active LSM modules.
+//! [`inode::SecurityFsInode`] adapts that system tree to VFS inodes.
+
+use aster_systree::EmptyNode;
+
+use crate::fs::securityfs::fs::SecurityFsType;
+
+mod fs;
+mod inode;
+mod systree_node;
+
+pub(super) fn init() {
+    let security_kernel_sysnode = EmptyNode::new("security".into());
+    super::sysfs::register_kernel_sysnode(security_kernel_sysnode).unwrap();
+
+    crate::fs::vfs::registry::register(&SecurityFsType).unwrap();
+}

--- a/kernel/src/fs/fs_impls/securityfs/systree_node.rs
+++ b/kernel/src/fs/fs_impls/securityfs/systree_node.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_systree::{
+    BranchNodeFields, SysBranchNode, SysObj, SysPerms, SysStr, inherit_sys_branch_node,
+};
+
+use crate::{prelude::*, security::lsm};
+
+pub(super) struct SecurityRootNode {
+    fields: BranchNodeFields<dyn SysObj, Self>,
+}
+
+impl SecurityRootNode {
+    pub(super) fn new() -> Arc<Self> {
+        let root = Arc::new_cyclic(|weak_self| Self {
+            fields: BranchNodeFields::new(SysStr::from(""), Default::default(), weak_self.clone()),
+        });
+
+        for node in lsm::securityfs_nodes() {
+            root.fields
+                .add_child(node)
+                .expect("LSM securityfs node names must be unique");
+        }
+
+        root
+    }
+}
+
+impl Debug for SecurityRootNode {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("SecurityRootNode")
+            .finish_non_exhaustive()
+    }
+}
+
+inherit_sys_branch_node!(SecurityRootNode, fields, {
+    fn is_root(&self) -> bool {
+        true
+    }
+
+    fn init_parent(&self, _parent: Weak<dyn SysBranchNode>) {}
+
+    fn perms(&self) -> SysPerms {
+        SysPerms::DEFAULT_RO_PERMS
+    }
+});

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -9,7 +9,7 @@ pub mod utils;
 pub mod vfs;
 
 pub use fs_impls::{
-    cgroupfs, configfs, devpts, exfat, ext2, procfs, pseudofs, ramfs, sysfs, tmpfs,
+    cgroupfs, configfs, devpts, exfat, ext2, procfs, pseudofs, ramfs, securityfs, sysfs, tmpfs,
 };
 
 use crate::{

--- a/kernel/src/fs/vfs/path/mod.rs
+++ b/kernel/src/fs/vfs/path/mod.rs
@@ -28,7 +28,9 @@ use crate::{
     },
     prelude::*,
     process::{
-        Gid, Uid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
+        Gid, Uid, UserNamespace,
+        credentials::capabilities::CapSet,
+        posix_thread::{AsPosixThread, PosixThread},
     },
     security::lsm::hooks as lsm_hooks,
 };
@@ -118,9 +120,55 @@ impl Path {
     }
 
     /// Opens the `Path` with the given `OpenArgs`.
-    ///
-    /// Returns an `InodeHandle` on success.
     pub fn open(&self, open_args: OpenArgs) -> Result<InodeHandle> {
+        self.open_internal(open_args, None)
+    }
+
+    /// Opens the `Path` for an open-family system call.
+    pub(crate) fn open_from_syscall(
+        &self,
+        open_args: OpenArgs,
+        path_resolver: &PathResolver,
+        posix_thread: &PosixThread,
+    ) -> Result<InodeHandle> {
+        let context = lsm_hooks::FileOpenContext::new(
+            self,
+            path_resolver,
+            posix_thread,
+            open_args.access_mode,
+            open_args.creation_flags,
+            open_args.status_flags,
+        );
+        self.open_internal(open_args, Some(&context))
+    }
+
+    fn open_internal(
+        &self,
+        open_args: OpenArgs,
+        file_open_context: Option<&lsm_hooks::FileOpenContext<'_>>,
+    ) -> Result<InodeHandle> {
+        self.check_open(&open_args)?;
+
+        if let Some(context) = file_open_context {
+            lsm_hooks::on_file_open(context)?;
+        }
+
+        let inode = self.inode().as_ref();
+        let inode_type = inode.type_();
+        let creation_flags = &open_args.creation_flags;
+        let status_flags = &open_args.status_flags;
+
+        if inode_type.is_regular_file()
+            && creation_flags.contains(CreationFlags::O_TRUNC)
+            && !status_flags.contains(StatusFlags::O_PATH)
+        {
+            self.resize(0)?;
+        }
+
+        InodeHandle::new_unchecked_access(self.clone(), open_args.access_mode, *status_flags)
+    }
+
+    fn check_open(&self, open_args: &OpenArgs) -> Result<()> {
         let inode = self.inode().as_ref();
         let inode_type = inode.type_();
         let creation_flags = &open_args.creation_flags;
@@ -151,14 +199,20 @@ impl Path {
             );
         }
 
-        if inode_type.is_regular_file()
-            && creation_flags.contains(CreationFlags::O_TRUNC)
-            && !status_flags.contains(StatusFlags::O_PATH)
+        if open_args.should_check_access() && !status_flags.contains(StatusFlags::O_PATH) {
+            // "Opening a file or directory with the O_PATH flag requires no permissions on the
+            // object itself".
+            // Reference: <https://man7.org/linux/man-pages/man2/openat.2.html>
+            inode.check_permission(open_args.access_mode.into())?;
+        }
+        if !status_flags.contains(StatusFlags::O_PATH)
+            && inode_type == InodeType::Dir
+            && open_args.access_mode.is_writable()
         {
-            self.resize(0)?;
+            return_errno_with_message!(Errno::EISDIR, "a directory cannot be opened writable");
         }
 
-        InodeHandle::new(self.clone(), open_args.access_mode, *status_flags)
+        Ok(())
     }
 
     /// Gets the parent `Path` within the same mount.

--- a/kernel/src/process/credentials/credentials_.rs
+++ b/kernel/src/process/credentials/credentials_.rs
@@ -10,6 +10,7 @@ use super::{
 use crate::{
     prelude::*,
     process::credentials::capabilities::{AtomicCapSet, CapSet},
+    security::lsm::CredentialSecurity,
 };
 
 #[derive(Debug)]
@@ -78,6 +79,9 @@ pub(super) struct Credentials_ {
 
     /// Whether `execve()` is forbidden from granting new privileges.
     no_new_privs: AtomicBool,
+
+    /// Security state managed by Linux Security Modules.
+    security: CredentialSecurity,
 }
 
 impl Credentials_ {
@@ -105,7 +109,12 @@ impl Credentials_ {
             ambient_capset: AtomicCapSet::new(CapSet::empty()),
             securebits: AtomicSecureBits::new(SecureBits::new_empty()),
             no_new_privs: AtomicBool::new(false),
+            security: CredentialSecurity::new(),
         }
+    }
+
+    pub(super) fn security(&self) -> &CredentialSecurity {
+        &self.security
     }
 
     //  ******* UID methods *******
@@ -669,6 +678,7 @@ impl Clone for Credentials_ {
             ambient_capset: self.ambient_capset.clone(),
             securebits: self.securebits.clone(),
             no_new_privs: AtomicBool::new(self.no_new_privs()),
+            security: self.security.clone(),
         }
     }
 }

--- a/kernel/src/process/credentials/mod.rs
+++ b/kernel/src/process/credentials/mod.rs
@@ -27,3 +27,10 @@ use crate::prelude::*;
 /// - Linux capabilities;
 /// - secure bits.
 pub struct Credentials<R = FullOp>(Arc<Credentials_>, R);
+
+impl<R> Credentials<R> {
+    /// Returns the security state associated with these credentials.
+    pub(crate) fn security(&self) -> &crate::security::lsm::CredentialSecurity {
+        self.0.security()
+    }
+}

--- a/kernel/src/security/lsm/credential.rs
+++ b/kernel/src/security/lsm/credential.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Security state carried by process credentials.
+
+use super::modules::apparmor::Label;
+use crate::prelude::*;
+
+/// LSM state associated with one set of process credentials.
+#[derive(Debug)]
+pub struct CredentialSecurity {
+    apparmor_label: RwLock<Label>,
+}
+
+impl CredentialSecurity {
+    /// Creates security state for unconfined credentials.
+    pub const fn new() -> Self {
+        Self {
+            apparmor_label: RwLock::new(Label::Unconfined),
+        }
+    }
+
+    pub(in crate::security::lsm) const fn apparmor_label(&self) -> &RwLock<Label> {
+        &self.apparmor_label
+    }
+}
+
+impl Clone for CredentialSecurity {
+    fn clone(&self) -> Self {
+        Self {
+            apparmor_label: RwLock::new(self.apparmor_label.read().clone()),
+        }
+    }
+}
+
+impl Default for CredentialSecurity {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/kernel/src/security/lsm/hooks/alien_access.rs
+++ b/kernel/src/security/lsm/hooks/alien_access.rs
@@ -14,8 +14,11 @@ use crate::{
 
 /// Runs alien access hooks in module order.
 pub fn on_alien_access(context: AlienAccessContext) -> Result<()> {
-    for module in modules::active_modules() {
-        module.on_alien_access(&context)?;
+    for hook in modules::active_modules()
+        .iter()
+        .filter_map(|module| module.alien_access_hook())
+    {
+        hook.on_alien_access(&context)?;
     }
 
     Ok(())

--- a/kernel/src/security/lsm/hooks/capability.rs
+++ b/kernel/src/security/lsm/hooks/capability.rs
@@ -8,8 +8,11 @@ use crate::{
 
 /// Runs capability hooks in module order.
 pub fn on_capable(context: CapableContext) -> Result<()> {
-    for module in modules::active_modules() {
-        module.on_capable(&context)?;
+    for hook in modules::active_modules()
+        .iter()
+        .filter_map(|module| module.capability_hook())
+    {
+        hook.on_capable(&context)?;
     }
 
     Ok(())

--- a/kernel/src/security/lsm/hooks/file_open.rs
+++ b/kernel/src/security/lsm/hooks/file_open.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! LSM hook inputs for opening files.
+
+use super::super::modules;
+use crate::{
+    fs::{
+        file::{AccessMode, CreationFlags, StatusFlags},
+        vfs::path::{AbsPathResult, Path, PathResolver},
+    },
+    prelude::*,
+    process::posix_thread::PosixThread,
+};
+
+bitflags! {
+    /// Semantic permissions requested by a file-open operation.
+    pub struct FileOpenAccess: u8 {
+        /// Opens the file for reading.
+        const READ = 1 << 0;
+        /// Opens the file for writing.
+        const WRITE = 1 << 1;
+        /// Truncates an existing regular file.
+        const TRUNCATE = 1 << 2;
+    }
+}
+
+/// Runs file-open hooks in module order.
+pub fn on_file_open(context: &FileOpenContext<'_>) -> Result<()> {
+    for hook in modules::active_modules()
+        .iter()
+        .filter_map(|module| module.file_open_hook())
+    {
+        hook.on_file_open(context)?;
+    }
+
+    Ok(())
+}
+
+/// The inputs for checking a file-open operation.
+pub struct FileOpenContext<'a> {
+    path: &'a Path,
+    path_resolver: &'a PathResolver,
+    posix_thread: &'a PosixThread,
+    is_regular_file: bool,
+    requested_access: FileOpenAccess,
+}
+
+impl<'a> FileOpenContext<'a> {
+    /// Creates a context for opening a path.
+    pub(crate) fn new(
+        path: &'a Path,
+        path_resolver: &'a PathResolver,
+        posix_thread: &'a PosixThread,
+        access_mode: AccessMode,
+        creation_flags: CreationFlags,
+        status_flags: StatusFlags,
+    ) -> Self {
+        let is_regular_file = path.inode().type_().is_regular_file();
+        Self {
+            path,
+            path_resolver,
+            posix_thread,
+            is_regular_file,
+            requested_access: requested_access(
+                access_mode,
+                creation_flags,
+                status_flags,
+                is_regular_file,
+            ),
+        }
+    }
+
+    /// Returns the thread requesting the file handle.
+    pub const fn posix_thread(&self) -> &PosixThread {
+        self.posix_thread
+    }
+
+    /// Returns whether the target is a regular file.
+    pub const fn is_regular_file(&self) -> bool {
+        self.is_regular_file
+    }
+
+    /// Returns the semantic permissions requested by the operation.
+    pub const fn requested_access(&self) -> FileOpenAccess {
+        self.requested_access
+    }
+
+    /// Resolves the target pathname from the requesting thread's root.
+    pub fn resolve_path_name(&self) -> AbsPathResult {
+        self.path_resolver.make_abs_path(self.path)
+    }
+}
+
+fn requested_access(
+    access_mode: AccessMode,
+    creation_flags: CreationFlags,
+    status_flags: StatusFlags,
+    is_regular_file: bool,
+) -> FileOpenAccess {
+    if status_flags.contains(StatusFlags::O_PATH) {
+        return FileOpenAccess::empty();
+    }
+
+    let mut requested = FileOpenAccess::empty();
+    if access_mode.is_readable() {
+        requested.insert(FileOpenAccess::READ);
+    }
+    if access_mode.is_writable() {
+        requested.insert(FileOpenAccess::WRITE);
+    }
+    if is_regular_file && creation_flags.contains(CreationFlags::O_TRUNC) {
+        requested.insert(FileOpenAccess::TRUNCATE);
+    }
+
+    requested
+}

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -4,10 +4,12 @@
 
 mod alien_access;
 mod capability;
+mod file_open;
 
 pub use self::{
     alien_access::{AlienAccessContext, on_alien_access},
     capability::{CapableContext, on_capable},
+    file_open::{FileOpenAccess, FileOpenContext, on_file_open},
 };
 use crate::prelude::*;
 
@@ -19,4 +21,9 @@ pub(super) trait LsmAlienAccessHook: Sync {
 pub(super) trait LsmCapabilityHook: Sync {
     /// Checks whether a thread holds a capability in a user namespace.
     fn on_capable(&self, context: &CapableContext) -> Result<()>;
+}
+
+pub(super) trait LsmFileOpenHook: Sync {
+    /// Checks whether a new file handle may be opened.
+    fn on_file_open(&self, context: &FileOpenContext<'_>) -> Result<()>;
 }

--- a/kernel/src/security/lsm/hooks/mod.rs
+++ b/kernel/src/security/lsm/hooks/mod.rs
@@ -13,14 +13,10 @@ use crate::prelude::*;
 
 pub(super) trait LsmAlienAccessHook: Sync {
     /// Handles an alien access attempt.
-    fn on_alien_access(&self, _context: &AlienAccessContext) -> Result<()> {
-        Ok(())
-    }
+    fn on_alien_access(&self, context: &AlienAccessContext) -> Result<()>;
 }
 
 pub(super) trait LsmCapabilityHook: Sync {
     /// Checks whether a thread holds a capability in a user namespace.
-    fn on_capable(&self, _context: &CapableContext) -> Result<()> {
-        Ok(())
-    }
+    fn on_capable(&self, context: &CapableContext) -> Result<()>;
 }

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -20,7 +20,7 @@ pub mod yama {
 use aster_systree::SysObj;
 
 use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmFileOpenHook};
-use crate::prelude::*;
+use crate::{prelude::*, process::posix_thread::PosixThread};
 
 bitflags! {
     /// LSM module flags.
@@ -55,10 +55,24 @@ trait LsmModule: Sync {
         None
     }
 
+    /// Returns the module's task-attribute interface, if it has one.
+    fn task_attrs(&self) -> Option<&dyn LsmTaskAttrs> {
+        None
+    }
+
     /// Returns the module's top-level securityfs node, if it has one.
     fn securityfs_node(&self) -> Option<Arc<dyn SysObj>> {
         None
     }
+}
+
+/// An LSM interface exposed through `/proc/<pid>/attr`.
+trait LsmTaskAttrs: Sync {
+    /// Returns the module's `current` task attribute.
+    fn current(&self, posix_thread: &PosixThread) -> Result<String>;
+
+    /// Updates the module's `current` task attribute.
+    fn set_current(&self, posix_thread: &PosixThread, value: &str) -> Result<()>;
 }
 
 /// Returns whether the Yama LSM is enabled.
@@ -67,6 +81,8 @@ pub fn is_yama_enabled() -> bool {
         .iter()
         .any(|module| module.name() == "yama")
 }
+
+pub(crate) use self::task::{set_task_attr_current, task_attr_current, task_attrs_enabled};
 
 pub(crate) fn securityfs_nodes() -> Vec<Arc<dyn SysObj>> {
     modules::active_modules()
@@ -80,3 +96,5 @@ pub(super) fn init() {
         info!("[kernel] LSM module enabled: {}", module.name());
     }
 }
+
+mod task;

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -17,6 +17,8 @@ pub mod yama {
     pub use super::modules::yama::{YamaScope, get_scope, set_scope};
 }
 
+use aster_systree::SysObj;
+
 use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmFileOpenHook};
 use crate::prelude::*;
 
@@ -52,6 +54,11 @@ trait LsmModule: Sync {
     fn file_open_hook(&self) -> Option<&dyn LsmFileOpenHook> {
         None
     }
+
+    /// Returns the module's top-level securityfs node, if it has one.
+    fn securityfs_node(&self) -> Option<Arc<dyn SysObj>> {
+        None
+    }
 }
 
 /// Returns whether the Yama LSM is enabled.
@@ -59,6 +66,13 @@ pub fn is_yama_enabled() -> bool {
     modules::active_modules()
         .iter()
         .any(|module| module.name() == "yama")
+}
+
+pub(crate) fn securityfs_nodes() -> Vec<Arc<dyn SysObj>> {
+    modules::active_modules()
+        .iter()
+        .filter_map(|module| module.securityfs_node())
+        .collect()
 }
 
 pub(super) fn init() {

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -97,4 +97,7 @@ pub(super) fn init() {
     }
 }
 
+mod credential;
 mod task;
+
+pub(crate) use credential::CredentialSecurity;

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -17,7 +17,7 @@ pub mod yama {
     pub use super::modules::yama::{YamaScope, get_scope, set_scope};
 }
 
-use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook};
+use self::hooks::{LsmAlienAccessHook, LsmCapabilityHook, LsmFileOpenHook};
 use crate::prelude::*;
 
 bitflags! {
@@ -45,6 +45,11 @@ trait LsmModule: Sync {
 
     /// Returns the module's capability hook, if it implements one.
     fn capability_hook(&self) -> Option<&dyn LsmCapabilityHook> {
+        None
+    }
+
+    /// Returns the module's file-open hook, if it implements one.
+    fn file_open_hook(&self) -> Option<&dyn LsmFileOpenHook> {
         None
     }
 }

--- a/kernel/src/security/lsm/mod.rs
+++ b/kernel/src/security/lsm/mod.rs
@@ -31,12 +31,22 @@ bitflags! {
 }
 
 /// The common interface for built-in LSM modules.
-trait LsmModule: LsmAlienAccessHook + LsmCapabilityHook + Sync {
+trait LsmModule: Sync {
     /// Returns the module name.
     fn name(&self) -> &'static str;
 
     /// Returns the module flags.
     fn flags(&self) -> LsmFlags;
+
+    /// Returns the module's alien-access hook, if it implements one.
+    fn alien_access_hook(&self) -> Option<&dyn LsmAlienAccessHook> {
+        None
+    }
+
+    /// Returns the module's capability hook, if it implements one.
+    fn capability_hook(&self) -> Option<&dyn LsmCapabilityHook> {
+        None
+    }
 }
 
 /// Returns whether the Yama LSM is enabled.

--- a/kernel/src/security/lsm/modules/apparmor.rs
+++ b/kernel/src/security/lsm/modules/apparmor.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Minimal task-centered AppArmor integration.
+//!
+//! [`AppArmorLsm`] participates in the common LSM interfaces for regular-file open checks, task attributes, and securityfs controls.
+//! The `label`, `policy`, `file`, and `securityfs` submodules own those AppArmor-specific concerns.
+
+mod file;
+mod label;
+mod policy;
+mod securityfs;
+
+use alloc::format;
+
+use aster_systree::SysObj;
+
+pub(in crate::security::lsm) use self::label::Label;
+use super::super::{
+    LsmFlags, LsmModule, LsmTaskAttrs,
+    hooks::{FileOpenContext, LsmFileOpenHook},
+};
+use crate::{prelude::*, process::posix_thread::PosixThread};
+
+pub(super) static APPARMOR_LSM: AppArmorLsm = AppArmorLsm;
+pub(super) const UNCONFINED_PROFILE_NAME: &str = "unconfined";
+
+/// The AppArmor major LSM.
+pub(super) struct AppArmorLsm;
+
+impl LsmModule for AppArmorLsm {
+    fn name(&self) -> &'static str {
+        "apparmor"
+    }
+
+    fn flags(&self) -> LsmFlags {
+        LsmFlags::LEGACY_MAJOR | LsmFlags::EXCLUSIVE
+    }
+
+    fn file_open_hook(&self) -> Option<&dyn LsmFileOpenHook> {
+        Some(self)
+    }
+
+    fn task_attrs(&self) -> Option<&dyn LsmTaskAttrs> {
+        Some(self)
+    }
+
+    fn securityfs_node(&self) -> Option<Arc<dyn SysObj>> {
+        Some(securityfs::new_node())
+    }
+}
+
+impl LsmTaskAttrs for AppArmorLsm {
+    fn current(&self, posix_thread: &PosixThread) -> Result<String> {
+        let value = label::task_profile_name(posix_thread)
+            .map(|profile_name| format!("{} (enforce)", profile_name))
+            .unwrap_or_else(|| UNCONFINED_PROFILE_NAME.to_string());
+        Ok(value)
+    }
+
+    fn set_current(&self, posix_thread: &PosixThread, value: &str) -> Result<()> {
+        label::confine_task(posix_thread, value)
+    }
+}
+
+impl LsmFileOpenHook for AppArmorLsm {
+    fn on_file_open(&self, context: &FileOpenContext<'_>) -> Result<()> {
+        file::open(context)
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/file.rs
+++ b/kernel/src/security/lsm/modules/apparmor/file.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! AppArmor file-open mediation.
+
+use super::{label, policy};
+use crate::{
+    fs::vfs::path::AbsPathResult,
+    prelude::*,
+    security::lsm::hooks::{FileOpenAccess, FileOpenContext},
+};
+
+pub(super) fn open(context: &FileOpenContext<'_>) -> Result<()> {
+    if !context.is_regular_file() {
+        return Ok(());
+    }
+
+    let Some(profile_name) = label::task_profile_name(context.posix_thread()) else {
+        return Ok(());
+    };
+    let requested = context.requested_access();
+    if requested.is_empty() {
+        return Ok(());
+    }
+
+    let path_name = match context.resolve_path_name() {
+        AbsPathResult::Reachable(path_name) => path_name,
+        AbsPathResult::Unreachable(path_name) => {
+            return deny(&profile_name, &path_name, requested);
+        }
+    };
+
+    if !policy::allows_file(&profile_name, &path_name, requested) {
+        return deny(&profile_name, &path_name, requested);
+    }
+
+    Ok(())
+}
+
+fn deny(profile_name: &str, path_name: &str, requested: FileOpenAccess) -> Result<()> {
+    warn!(
+        "apparmor=\"DENIED\" operation=\"file_open\" profile=\"{}\" path={:?} requested={:?}",
+        profile_name, path_name, requested
+    );
+    Err(Error::with_message(
+        Errno::EACCES,
+        "AppArmor denied file open",
+    ))
+}

--- a/kernel/src/security/lsm/modules/apparmor/label.rs
+++ b/kernel/src/security/lsm/modules/apparmor/label.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! AppArmor labels carried by process credentials.
+
+use super::{UNCONFINED_PROFILE_NAME, policy};
+use crate::{prelude::*, process::posix_thread::PosixThread};
+
+/// An AppArmor label attached to process credentials.
+#[derive(Clone, Debug)]
+pub(in crate::security::lsm) enum Label {
+    /// The task is not confined by AppArmor.
+    Unconfined,
+    /// The task is confined by the named profile.
+    Confined(Arc<str>),
+}
+
+pub(super) fn task_profile_name(posix_thread: &PosixThread) -> Option<Arc<str>> {
+    match &*posix_thread
+        .credentials()
+        .security()
+        .apparmor_label()
+        .read()
+    {
+        Label::Unconfined => None,
+        Label::Confined(profile_name) => Some(profile_name.clone()),
+    }
+}
+
+pub(super) fn confine_task(posix_thread: &PosixThread, value: &str) -> Result<()> {
+    let profile_name = value.trim();
+    if profile_name == UNCONFINED_PROFILE_NAME || !policy::is_valid_profile_name(profile_name) {
+        return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is invalid");
+    }
+
+    let Some(stored_name) = policy::stored_profile_name(profile_name) else {
+        return_errno_with_message!(Errno::ENOENT, "the AppArmor profile is not loaded");
+    };
+
+    let credentials = posix_thread.credentials();
+    let mut label = credentials.security().apparmor_label().write();
+    if !matches!(*label, Label::Unconfined) {
+        return_errno_with_message!(
+            Errno::EPERM,
+            "a confined task cannot change its AppArmor profile"
+        );
+    }
+
+    *label = Label::Confined(stored_name);
+    Ok(())
+}

--- a/kernel/src/security/lsm/modules/apparmor/policy.rs
+++ b/kernel/src/security/lsm/modules/apparmor/policy.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! AppArmor policy parsing, representation, and storage.
+
+use spin::Once;
+
+use super::UNCONFINED_PROFILE_NAME;
+use crate::{prelude::*, security::lsm::hooks::FileOpenAccess};
+
+pub(super) const POLICY_VERSION: &str = "0";
+const MAX_PROFILE_NAME_LEN_BYTES: usize = 128;
+const MAX_RULE_PATH_LEN_BYTES: usize = 4096;
+const MAX_RULES_PER_PROFILE: usize = 1024;
+
+#[derive(Debug)]
+struct Profile {
+    name: String,
+    file_rules: BTreeMap<String, FileOpenAccess>,
+}
+
+impl Profile {
+    fn parse(policy: &str) -> Result<Self> {
+        let mut lines = policy
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'));
+
+        let Some(version_line) = lines.next() else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor policy is empty");
+        };
+        let mut version_fields = version_line.split_ascii_whitespace();
+        if version_fields.next() != Some("version")
+            || version_fields.next() != Some(POLICY_VERSION)
+            || version_fields.next().is_some()
+        {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor policy version is invalid");
+        }
+
+        let Some(profile_line) = lines.next() else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile header is missing");
+        };
+        let mut profile_fields = profile_line.split_ascii_whitespace();
+        if profile_fields.next() != Some("profile") {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the AppArmor policy must contain a profile header"
+            );
+        }
+        let Some(name) = profile_fields.next() else {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is missing");
+        };
+        if profile_fields.next().is_some()
+            || name == UNCONFINED_PROFILE_NAME
+            || !is_valid_profile_name(name)
+        {
+            return_errno_with_message!(Errno::EINVAL, "the AppArmor profile name is invalid");
+        }
+
+        let mut file_rules = BTreeMap::<String, FileOpenAccess>::new();
+        for (rule_index, line) in lines.enumerate() {
+            if rule_index >= MAX_RULES_PER_PROFILE {
+                return_errno_with_message!(
+                    Errno::E2BIG,
+                    "the AppArmor profile has too many file rules"
+                );
+            }
+
+            let mut fields = line.split_ascii_whitespace();
+            let Some(path) = fields.next() else {
+                continue;
+            };
+            let Some(permissions) = fields.next() else {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "an AppArmor file rule is missing permissions"
+                );
+            };
+            if fields.next().is_some() || !is_canonical_absolute_path(path) {
+                return_errno_with_message!(Errno::EINVAL, "an AppArmor file rule is invalid");
+            }
+
+            let permissions = parse_file_permissions(permissions)?;
+            file_rules
+                .entry(path.to_string())
+                .and_modify(|current| current.insert(permissions))
+                .or_insert(permissions);
+        }
+
+        Ok(Self {
+            name: name.to_string(),
+            file_rules,
+        })
+    }
+
+    fn allows(&self, path: &str, requested: FileOpenAccess) -> bool {
+        self.file_rules
+            .get(path)
+            .is_some_and(|allowed| allowed.contains(requested))
+    }
+}
+
+#[derive(Default)]
+struct PolicySnapshot {
+    profiles: BTreeMap<String, Arc<Profile>>,
+}
+
+fn policy_store() -> &'static RwLock<Arc<PolicySnapshot>> {
+    static POLICY_STORE: Once<RwLock<Arc<PolicySnapshot>>> = Once::new();
+
+    POLICY_STORE.call_once(|| RwLock::new(Arc::new(PolicySnapshot::default())))
+}
+
+pub(super) fn load_profile(policy: &str) -> Result<()> {
+    update_profile(ProfileUpdate::Load, Profile::parse(policy)?)
+}
+
+pub(super) fn replace_profile(policy: &str) -> Result<()> {
+    update_profile(ProfileUpdate::Replace, Profile::parse(policy)?)
+}
+
+pub(super) fn loaded_profile_names() -> Vec<String> {
+    policy_store().read().profiles.keys().cloned().collect()
+}
+
+pub(super) fn stored_profile_name(name: &str) -> Option<Arc<str>> {
+    let snapshot = policy_store().read();
+    let (stored_name, _) = snapshot.profiles.get_key_value(name)?;
+    Some(Arc::from(stored_name.as_str()))
+}
+
+pub(super) fn allows_file(profile_name: &str, path: &str, requested: FileOpenAccess) -> bool {
+    let snapshot = policy_store().read().clone();
+    snapshot
+        .profiles
+        .get(profile_name)
+        .is_some_and(|profile| profile.allows(path, requested))
+}
+
+pub(super) fn is_valid_profile_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_PROFILE_NAME_LEN_BYTES
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+}
+
+enum ProfileUpdate {
+    Load,
+    Replace,
+}
+
+fn update_profile(update: ProfileUpdate, profile: Profile) -> Result<()> {
+    let mut current = policy_store().write();
+    let profile_exists = current.profiles.contains_key(&profile.name);
+    match update {
+        ProfileUpdate::Load if profile_exists => {
+            return_errno_with_message!(Errno::EEXIST, "the AppArmor profile is already loaded");
+        }
+        ProfileUpdate::Replace if !profile_exists => {
+            return_errno_with_message!(Errno::ENOENT, "the AppArmor profile is not loaded");
+        }
+        ProfileUpdate::Load | ProfileUpdate::Replace => {}
+    }
+
+    let mut profiles = current.profiles.clone();
+    profiles.insert(profile.name.clone(), Arc::new(profile));
+    *current = Arc::new(PolicySnapshot { profiles });
+
+    Ok(())
+}
+
+fn is_canonical_absolute_path(path: &str) -> bool {
+    if path.is_empty() || path.len() > MAX_RULE_PATH_LEN_BYTES || !path.starts_with('/') {
+        return false;
+    }
+    if path == "/" {
+        return true;
+    }
+    if path.ends_with('/') {
+        return false;
+    }
+
+    path.split('/')
+        .skip(1)
+        .all(|component| !component.is_empty() && component != "." && component != "..")
+}
+
+fn parse_file_permissions(permissions: &str) -> Result<FileOpenAccess> {
+    if permissions.is_empty() {
+        return_errno_with_message!(Errno::EINVAL, "AppArmor file permissions are empty");
+    }
+
+    let mut parsed = FileOpenAccess::empty();
+    for permission in permissions.bytes() {
+        match permission {
+            b'r' => parsed.insert(FileOpenAccess::READ),
+            b'w' => parsed.insert(FileOpenAccess::WRITE | FileOpenAccess::TRUNCATE),
+            _ => {
+                return_errno_with_message!(
+                    Errno::EINVAL,
+                    "AppArmor file permissions contain an unsupported value"
+                );
+            }
+        }
+    }
+
+    Ok(parsed)
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::Profile;
+    use crate::security::lsm::hooks::FileOpenAccess;
+
+    #[ktest]
+    fn parses_exact_path_permissions() {
+        let profile = Profile::parse(
+            "version 0\n\
+             profile test-profile\n\
+             /read-only r\n\
+             /state rw\n",
+        )
+        .unwrap();
+
+        assert!(profile.allows("/read-only", FileOpenAccess::READ));
+        assert!(!profile.allows("/read-only", FileOpenAccess::WRITE));
+        assert!(profile.allows(
+            "/state",
+            FileOpenAccess::READ | FileOpenAccess::WRITE | FileOpenAccess::TRUNCATE
+        ));
+        assert!(!profile.allows("/missing", FileOpenAccess::READ));
+    }
+
+    #[ktest]
+    fn rejects_noncanonical_paths_and_unknown_permissions() {
+        assert!(Profile::parse("version 0\nprofile test\n/tmp/../secret r\n").is_err());
+        assert!(Profile::parse("version 0\nprofile test\n/tmp/file x\n").is_err());
+    }
+}

--- a/kernel/src/security/lsm/modules/apparmor/securityfs.rs
+++ b/kernel/src/security/lsm/modules/apparmor/securityfs.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! AppArmor policy management through securityfs.
+
+use aster_systree::{
+    BranchNodeFields, Error as SysTreeError, MAX_ATTR_SIZE, NormalNodeFields,
+    Result as SysTreeResult, SysAttrSetBuilder, SysObj, SysPerms, SysStr, inherit_sys_branch_node,
+    inherit_sys_leaf_node,
+};
+use aster_util::printer::VmPrinter;
+
+use crate::{
+    prelude::*,
+    process::{UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread},
+    security::lsm::hooks as lsm_hooks,
+    thread::Thread,
+};
+
+#[derive(Debug)]
+struct AppArmorNode {
+    fields: BranchNodeFields<dyn SysObj, Self>,
+}
+
+pub(super) fn new_node() -> Arc<dyn SysObj> {
+    let mut attrs = SysAttrSetBuilder::new();
+    attrs.add(SysStr::from(".load"), SysPerms::from_bits_retain(0o0200));
+    attrs.add(SysStr::from(".replace"), SysPerms::from_bits_retain(0o0200));
+    attrs.add(SysStr::from("profiles"), SysPerms::DEFAULT_RO_ATTR_PERMS);
+    let attrs = attrs.build().expect("the AppArmor attribute set is small");
+
+    let node = Arc::new_cyclic(|weak_self| AppArmorNode {
+        fields: BranchNodeFields::new(SysStr::from("apparmor"), attrs, weak_self.clone()),
+    });
+    node.fields
+        .add_child(FeaturesNode::new())
+        .expect("the AppArmor features node name is unique");
+    node
+}
+
+inherit_sys_branch_node!(AppArmorNode, fields, {
+    fn read_attr_at(
+        &self,
+        name: &str,
+        offset: usize,
+        writer: &mut VmWriter,
+    ) -> SysTreeResult<usize> {
+        if name != "profiles" {
+            return Err(SysTreeError::PermissionDenied);
+        }
+
+        let profile_names = super::policy::loaded_profile_names();
+        let mut printer = VmPrinter::new_skip(writer, offset);
+        for profile_name in profile_names {
+            writeln!(printer, "{} (enforce)", profile_name)?;
+        }
+
+        Ok(printer.bytes_written())
+    }
+
+    fn write_attr(&self, name: &str, reader: &mut VmReader) -> SysTreeResult<usize> {
+        let update_fn = match name {
+            ".load" => super::policy::load_profile,
+            ".replace" => super::policy::replace_profile,
+            _ => return Err(SysTreeError::PermissionDenied),
+        };
+
+        ensure_current_task_can_manage_policy()?;
+        let (policy_text, read_len) = read_text(reader)?;
+        update_fn(&policy_text).map_err(map_kernel_error)?;
+
+        Ok(read_len)
+    }
+
+    fn perms(&self) -> SysPerms {
+        SysPerms::DEFAULT_RO_PERMS
+    }
+});
+
+#[derive(Debug)]
+struct FeaturesNode {
+    fields: NormalNodeFields<Self>,
+}
+
+impl FeaturesNode {
+    fn new() -> Arc<Self> {
+        let mut attrs = SysAttrSetBuilder::new();
+        attrs.add(
+            SysStr::from("policy_version"),
+            SysPerms::DEFAULT_RO_ATTR_PERMS,
+        );
+        let attrs = attrs.build().expect("the AppArmor feature set is small");
+
+        Arc::new_cyclic(|weak_self| Self {
+            fields: NormalNodeFields::new(SysStr::from("features"), attrs, weak_self.clone()),
+        })
+    }
+}
+
+inherit_sys_leaf_node!(FeaturesNode, fields, {
+    fn read_attr_at(
+        &self,
+        name: &str,
+        offset: usize,
+        writer: &mut VmWriter,
+    ) -> SysTreeResult<usize> {
+        if name != "policy_version" {
+            return Err(SysTreeError::NotFound);
+        }
+
+        let mut printer = VmPrinter::new_skip(writer, offset);
+        writeln!(printer, "{}", super::policy::POLICY_VERSION)?;
+        Ok(printer.bytes_written())
+    }
+
+    fn perms(&self) -> SysPerms {
+        SysPerms::DEFAULT_RO_PERMS
+    }
+});
+
+fn ensure_current_task_can_manage_policy() -> SysTreeResult<()> {
+    let thread = Thread::current().ok_or(SysTreeError::PermissionDenied)?;
+    let posix_thread = thread
+        .as_posix_thread()
+        .ok_or(SysTreeError::PermissionDenied)?;
+
+    lsm_hooks::on_capable(lsm_hooks::CapableContext::new(
+        UserNamespace::get_init_singleton().as_ref(),
+        posix_thread,
+        CapSet::MAC_ADMIN,
+    ))
+    .map_err(|_| SysTreeError::PermissionDenied)
+}
+
+fn read_text(reader: &mut VmReader) -> SysTreeResult<(String, usize)> {
+    let read_len = reader.remain();
+    if read_len == 0 || read_len > MAX_ATTR_SIZE {
+        return Err(SysTreeError::InvalidOperation);
+    }
+
+    let mut bytes = vec![0u8; read_len];
+    let mut writer = VmWriter::from(bytes.as_mut_slice());
+    let copied = reader
+        .read_fallible(&mut writer)
+        .map_err(|_| SysTreeError::PageFault)?;
+    if copied != read_len || bytes.contains(&0) {
+        return Err(SysTreeError::InvalidOperation);
+    }
+
+    let text = core::str::from_utf8(&bytes).map_err(|_| SysTreeError::InvalidOperation)?;
+    Ok((text.to_string(), read_len))
+}
+
+fn map_kernel_error(error: Error) -> SysTreeError {
+    match error.error() {
+        Errno::ENOENT => SysTreeError::NotFound,
+        Errno::EEXIST => SysTreeError::AlreadyExists,
+        Errno::EACCES | Errno::EPERM => SysTreeError::PermissionDenied,
+        Errno::EFAULT => SysTreeError::PageFault,
+        _ => SysTreeError::InvalidOperation,
+    }
+}

--- a/kernel/src/security/lsm/modules/capability.rs
+++ b/kernel/src/security/lsm/modules/capability.rs
@@ -22,6 +22,14 @@ impl LsmModule for CapabilityLsm {
     fn flags(&self) -> LsmFlags {
         LsmFlags::empty()
     }
+
+    fn alien_access_hook(&self) -> Option<&dyn LsmAlienAccessHook> {
+        Some(self)
+    }
+
+    fn capability_hook(&self) -> Option<&dyn LsmCapabilityHook> {
+        Some(self)
+    }
 }
 
 impl LsmCapabilityHook for CapabilityLsm {

--- a/kernel/src/security/lsm/modules/mod.rs
+++ b/kernel/src/security/lsm/modules/mod.rs
@@ -28,6 +28,7 @@
 //! describes the optional enabled stack. If neither parameter is specified, the
 //! mandatory modules plus the default optional stack are used.
 
+pub(super) mod apparmor;
 mod capability;
 pub mod yama;
 
@@ -46,7 +47,11 @@ aster_cmdline::define_kv_param!("security", LEGACY_SECURITY_PARAM);
 static MANDATORY_MODULES: [&'static dyn LsmModule; 1] = [&capability::CAPABILITY_LSM];
 
 /// All LSM modules compiled into the kernel.
-static ALL_MODULES: [&'static dyn LsmModule; 2] = [&capability::CAPABILITY_LSM, &yama::YAMA_LSM];
+static ALL_MODULES: [&'static dyn LsmModule; 3] = [
+    &capability::CAPABILITY_LSM,
+    &yama::YAMA_LSM,
+    &apparmor::APPARMOR_LSM,
+];
 
 /// The fallback optional LSM stack used when no boot-time selector is specified.
 pub(super) static DEFAULT_OPTIONAL_MODULES: [&'static dyn LsmModule; 1] = [&yama::YAMA_LSM];

--- a/kernel/src/security/lsm/modules/yama.rs
+++ b/kernel/src/security/lsm/modules/yama.rs
@@ -6,7 +6,7 @@ use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
 use super::super::{
     LsmFlags, LsmModule,
-    hooks::{AlienAccessContext, LsmAlienAccessHook, LsmCapabilityHook},
+    hooks::{AlienAccessContext, LsmAlienAccessHook},
 };
 use crate::{
     prelude::*,
@@ -68,9 +68,11 @@ impl LsmModule for YamaLsm {
     fn flags(&self) -> LsmFlags {
         LsmFlags::empty()
     }
-}
 
-impl LsmCapabilityHook for YamaLsm {}
+    fn alien_access_hook(&self) -> Option<&dyn LsmAlienAccessHook> {
+        Some(self)
+    }
+}
 
 /// Returns the current Yama scope for alien access.
 pub fn get_scope() -> YamaScope {

--- a/kernel/src/security/lsm/task.rs
+++ b/kernel/src/security/lsm/task.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Process attributes supplied by active LSM modules.
+
+use super::modules;
+use crate::{prelude::*, process::posix_thread::PosixThread};
+
+pub(crate) fn task_attrs_enabled() -> bool {
+    modules::active_modules()
+        .iter()
+        .any(|module| module.task_attrs().is_some())
+}
+
+pub(crate) fn task_attr_current(posix_thread: &PosixThread) -> Result<String> {
+    modules::active_modules()
+        .iter()
+        .find_map(|module| module.task_attrs())
+        .ok_or_else(|| Error::with_message(Errno::ENOENT, "no LSM task attribute is available"))?
+        .current(posix_thread)
+}
+
+pub(crate) fn set_task_attr_current(posix_thread: &PosixThread, value: &str) -> Result<()> {
+    modules::active_modules()
+        .iter()
+        .find_map(|module| module.task_attrs())
+        .ok_or_else(|| Error::with_message(Errno::ENOENT, "no LSM task attribute is available"))?
+        .set_current(posix_thread, value)
+}

--- a/kernel/src/syscall/open.rs
+++ b/kernel/src/syscall/open.rs
@@ -5,8 +5,7 @@ use crate::{
     fs,
     fs::{
         file::{
-            AccessMode, CreationFlags, FileLike, InodeHandle, InodeMode, InodeType, OpenArgs,
-            StatusFlags,
+            AccessMode, CreationFlags, FileLike, InodeMode, InodeType, OpenArgs, StatusFlags,
             file_table::{FdFlags, RawFileDesc},
         },
         vfs::{
@@ -15,6 +14,7 @@ use crate::{
         },
     },
     prelude::*,
+    process::posix_thread::PosixThread,
     syscall::constants::MAX_FILENAME_LEN,
 };
 
@@ -42,6 +42,7 @@ pub fn sys_openat(
         do_open(
             &path_resolver,
             &fs_path,
+            ctx.posix_thread,
             flags,
             InodeMode::from_bits_truncate(mask_mode),
         )
@@ -80,13 +81,14 @@ pub fn sys_creat(path_addr: Vaddr, mode: u16, ctx: &Context) -> Result<SyscallRe
 fn do_open(
     path_resolver: &PathResolver,
     fs_path: &FsPath,
+    posix_thread: &PosixThread,
     flags: u32,
     mode: InodeMode,
 ) -> Result<Arc<dyn FileLike>> {
     let open_args = OpenArgs::from_flags_and_mode(flags, mode)?;
 
     if open_args.is_tmpfile() {
-        return do_open_tmpfile(path_resolver, fs_path, &open_args);
+        return do_open_tmpfile(path_resolver, fs_path, posix_thread, open_args);
     }
 
     let lookup_res = if open_args.follow_tail_link() {
@@ -96,7 +98,9 @@ fn do_open(
     };
 
     let file_handle: Arc<dyn FileLike> = match lookup_res {
-        LookupResult::Resolved(path) => Arc::new(path.open(open_args)?),
+        LookupResult::Resolved(path) => {
+            Arc::new(path.open_from_syscall(open_args, path_resolver, posix_thread)?)
+        }
         LookupResult::AtParent(result) => {
             if !open_args.creation_flags.contains(CreationFlags::O_CREAT)
                 || open_args.status_flags.contains(StatusFlags::O_PATH)
@@ -115,11 +119,10 @@ fn do_open(
                 parent.new_fs_child(&tail_name, InodeType::File, open_args.inode_mode)?;
             fs::vfs::notify::on_create(&parent, || tail_name.clone());
 
-            // Don't check access mode for newly created file.
-            Arc::new(InodeHandle::new_unchecked_access(
-                new_path,
-                open_args.access_mode,
-                open_args.status_flags,
+            Arc::new(new_path.open_from_syscall(
+                open_args.into_created_file_open(),
+                path_resolver,
+                posix_thread,
             )?)
         }
     };
@@ -130,7 +133,8 @@ fn do_open(
 fn do_open_tmpfile(
     path_resolver: &PathResolver,
     fs_path: &FsPath,
-    open_args: &OpenArgs,
+    posix_thread: &PosixThread,
+    open_args: OpenArgs,
 ) -> Result<Arc<dyn FileLike>> {
     let dir_path = if open_args.follow_tail_link() {
         path_resolver.lookup(fs_path)?
@@ -148,9 +152,9 @@ fn do_open_tmpfile(
     };
     let tmpfile_path = dir_path.create_tmpfile(open_args.inode_mode, hard_linkability)?;
 
-    Ok(Arc::new(InodeHandle::new_unchecked_access(
-        tmpfile_path,
-        open_args.access_mode,
-        open_args.status_flags,
+    Ok(Arc::new(tmpfile_path.open_from_syscall(
+        open_args.into_created_file_open(),
+        path_resolver,
+        posix_thread,
     )?))
 }

--- a/test/initramfs/src/init
+++ b/test/initramfs/src/init
@@ -23,6 +23,8 @@ mount -t sysfs none /sys
 mount -t proc none /proc
 mount -t cgroup2 none /sys/fs/cgroup
 mount -t configfs none /sys/kernel/config
+mkdir -p /sys/kernel/security
+mount -t securityfs none /sys/kernel/security
 mount -t ext2 /dev/vda /ext2
 mount -t exfat /dev/vdb /exfat
 

--- a/test/initramfs/src/regression/security/lsm/Makefile
+++ b/test/initramfs/src/regression/security/lsm/Makefile
@@ -1,3 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 include ../../common/Makefile
+
+# The helper must not open a dynamic loader or shared libraries after its
+# AppArmor label survives execve.
+$(OBJ_OUTPUT_DIR)/apparmor_exec_helper: EXTRA_C_FLAGS += -static

--- a/test/initramfs/src/regression/security/lsm/apparmor_exec_helper.c
+++ b/test/initramfs/src/regression/security/lsm/apparmor_exec_helper.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *ALLOWED_PATH = "/tmp/apparmor-file-open-allowed";
+static const char *DENIED_PATH = "/tmp/apparmor-file-open-denied";
+static const char *DENIED_CREATE_PATH = "/tmp/apparmor-file-open-denied-create";
+static const char *UNMEDIATED_FIFO_PATH =
+	"/tmp/apparmor-file-open-unmediated-fifo";
+static const char *ALLOWED_CONTENT = "allowed\n";
+
+FN_SETUP(check_confined_file_open)
+{
+	char buffer[32] = { 0 };
+	int fd = CHECK(open(ALLOWED_PATH, O_RDONLY));
+	CHECK_WITH(read(fd, buffer, sizeof(buffer)),
+		   _ret == (ssize_t)strlen(ALLOWED_CONTENT) &&
+			   memcmp(buffer, ALLOWED_CONTENT, _ret) == 0);
+	CHECK(close(fd));
+
+	CHECK_WITH(open(DENIED_PATH, O_RDONLY), _ret == -1 && errno == EACCES);
+
+	CHECK_WITH(open(DENIED_PATH, O_WRONLY | O_TRUNC),
+		   _ret == -1 && errno == EACCES);
+
+	CHECK_WITH(open(DENIED_CREATE_PATH, O_WRONLY | O_CREAT, 0600),
+		   _ret == -1 && errno == EACCES);
+
+	fd = CHECK(open(DENIED_PATH, O_PATH));
+	CHECK(close(fd));
+
+	fd = CHECK(open(UNMEDIATED_FIFO_PATH, O_RDONLY | O_NONBLOCK | O_TRUNC));
+	CHECK(close(fd));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/security/lsm/apparmor_file_open.c
+++ b/test/initramfs/src/regression/security/lsm/apparmor_file_open.c
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include "../../common/test.h"
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static const char *POLICY_VERSION_PATH =
+	"/sys/kernel/security/apparmor/features/policy_version";
+static const char *POLICY_LOAD_PATH = "/sys/kernel/security/apparmor/.load";
+static const char *PROFILES_PATH = "/sys/kernel/security/apparmor/profiles";
+static const char *CURRENT_ATTR_PATH = "/proc/self/attr/current";
+static const char *HELPER_PATH = "/test/security/lsm/apparmor_exec_helper";
+static const char *ALLOWED_PATH = "/tmp/apparmor-file-open-allowed";
+static const char *DENIED_PATH = "/tmp/apparmor-file-open-denied";
+static const char *DENIED_CREATE_PATH = "/tmp/apparmor-file-open-denied-create";
+static const char *UNMEDIATED_FIFO_PATH =
+	"/tmp/apparmor-file-open-unmediated-fifo";
+static const char *ALLOWED_CONTENT = "allowed\n";
+static const char *DENIED_CONTENT = "must survive truncation\n";
+
+enum { PROFILE_NAME_LEN = 128 };
+static char profile_name[PROFILE_NAME_LEN + 1];
+
+static void write_whole_file(const char *path, const char *content)
+{
+	int fd = CHECK(open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600));
+	size_t length = strlen(content);
+
+	CHECK_WITH(write(fd, content, length), _ret == (ssize_t)length);
+	CHECK(close(fd));
+}
+
+static void read_whole_file(const char *path, char *buffer, size_t buffer_size)
+{
+	int fd = CHECK(open(path, O_RDONLY));
+	ssize_t length = CHECK(read(fd, buffer, buffer_size - 1));
+
+	buffer[length] = '\0';
+	CHECK(close(fd));
+}
+
+static void write_profile(const char *control_path)
+{
+	char policy[512];
+	int length = CHECK(snprintf(policy, sizeof(policy),
+				    "version 0\n"
+				    "profile %s\n"
+				    "%s r\n",
+				    profile_name, ALLOWED_PATH));
+	int fd = CHECK(open(control_path, O_WRONLY));
+
+	CHECK_WITH(write(fd, policy, length), _ret == (ssize_t)length);
+	CHECK(close(fd));
+}
+
+static void run_confined_helper(void)
+{
+	char current_value[PROFILE_NAME_LEN + 2];
+	int fd = CHECK(open(CURRENT_ATTR_PATH, O_WRONLY));
+	int length = CHECK(snprintf(current_value, sizeof(current_value),
+				    "%s\n", profile_name));
+
+	CHECK_WITH(write(fd, current_value, length), _ret == (ssize_t)length);
+	CHECK(close(fd));
+	execl(HELPER_PATH, HELPER_PATH, NULL);
+	_exit(120);
+}
+
+static void reject_too_long_profile_name(void)
+{
+	char too_long_name[PROFILE_NAME_LEN + 1];
+	int fd = CHECK(open(CURRENT_ATTR_PATH, O_WRONLY));
+
+	memset(too_long_name, 'b', sizeof(too_long_name));
+	CHECK_WITH(write(fd, too_long_name, sizeof(too_long_name)),
+		   _ret == -1 && errno == EINVAL);
+	CHECK(close(fd));
+}
+
+FN_TEST(enforces_file_open_across_exec)
+{
+	char buffer[256] = { 0 };
+	struct stat statbuf;
+
+	TEST_SUCC(access(POLICY_VERSION_PATH, F_OK));
+	memset(profile_name, 'a', PROFILE_NAME_LEN);
+	profile_name[PROFILE_NAME_LEN] = '\0';
+
+	CHECK_WITH(unlink(DENIED_CREATE_PATH), _ret == 0 || errno == ENOENT);
+	CHECK_WITH(unlink(UNMEDIATED_FIFO_PATH), _ret == 0 || errno == ENOENT);
+	TEST_SUCC(mkfifo(UNMEDIATED_FIFO_PATH, 0600));
+	write_whole_file(ALLOWED_PATH, ALLOWED_CONTENT);
+	write_whole_file(DENIED_PATH, DENIED_CONTENT);
+	write_profile(POLICY_LOAD_PATH);
+	reject_too_long_profile_name();
+
+	read_whole_file(CURRENT_ATTR_PATH, buffer, sizeof(buffer));
+	TEST_RES(strcmp(buffer, "unconfined\n"), _ret == 0);
+	memset(buffer, 0, sizeof(buffer));
+	read_whole_file(PROFILES_PATH, buffer, sizeof(buffer));
+	TEST_RES(strstr(buffer, profile_name), _ret != NULL);
+
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		run_confined_helper();
+	}
+
+	int status = 0;
+	TEST_RES(waitpid(child, &status, 0),
+		 WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+	memset(buffer, 0, sizeof(buffer));
+	read_whole_file(CURRENT_ATTR_PATH, buffer, sizeof(buffer));
+	TEST_RES(strcmp(buffer, "unconfined\n"), _ret == 0);
+	memset(buffer, 0, sizeof(buffer));
+	read_whole_file(DENIED_PATH, buffer, sizeof(buffer));
+	TEST_RES(strcmp(buffer, DENIED_CONTENT), _ret == 0);
+	TEST_RES(stat(DENIED_CREATE_PATH, &statbuf), S_ISREG(statbuf.st_mode));
+
+	TEST_SUCC(unlink(ALLOWED_PATH));
+	TEST_SUCC(unlink(DENIED_PATH));
+	TEST_SUCC(unlink(DENIED_CREATE_PATH));
+	TEST_SUCC(unlink(UNMEDIATED_FIFO_PATH));
+}
+END_TEST()

--- a/test/initramfs/src/regression/security/run_test.sh
+++ b/test/initramfs/src/regression/security/run_test.sh
@@ -14,6 +14,7 @@ set -e
 ./capability/trusted_xattr
 
 ./lsm/module_selection
+./lsm/apparmor_file_open
 ./lsm/yama
 
 ./namespace/cgroup_ns


### PR DESCRIPTION
## Summary

This PR adds an initial AppArmor enforcement path to Asterinas. When AppArmor is enabled, a task can manually enter a loaded profile through `/proc/self/attr/current`. Subsequent regular-file opens through `open`, `openat`, or `creat` are checked against that profile.

Version 0 policies are exact-path allowlists with `r`, `w`, and `rw` permissions. The policy format is specific to Asterinas and is not compatible with the Linux AppArmor policy ABI.

This is intentionally a limited first increment. It is not a complete AppArmor implementation or a complete confinement boundary.

## Design

The patch adds the LSM and VFS infrastructure required by this enforcement path:

- LSM modules expose only the hooks they implement, so adding `file_open` does not require empty implementations in Capability or Yama.
- `FileOpenContext` converts open flags into `READ`, `WRITE`, and `TRUNCATE` permissions. `O_PATH` requests no file permission, and `TRUNCATE` is requested only for regular files.
- The open path performs normal VFS validation first, invokes the LSM hook next, and truncates the file only after the hook succeeds.
- A generic `securityfs` implementation collects control nodes exposed by active LSMs.
- The generic procfs task-attribute layer enforces transport-level constraints, including offset, size, UTF-8, and embedded-NUL validation. The selected LSM validates attribute syntax and semantic limits.

AppArmor stores the active label in task credentials. The label is copied during `fork` and preserved across `execve`. Once confined, a task cannot change or clear its own label. An authorized administrator may still replace the policy associated with that profile name.

Profiles are loaded through `/sys/kernel/security/apparmor/.load` and existing profiles are replaced through `.replace`. Both operations require `CAP_MAC_ADMIN` in the initial user namespace. The `profiles` file lists loaded profiles, and `features/policy_version` reports the supported policy version.

## Scope and limitations

This PR mediates only regular files opened through `open`, `openat`, or `creat`.

It does not mediate:

- directories, FIFOs, device nodes, or other non-regular files;
- internal kernel opens or file handles created by other system calls;
- existing file descriptions inherited across `fork` or `execve`;
- file descriptions received through `SCM_RIGHTS` or duplicated through `pidfd_getfd()`;
- later reads, writes, memory mappings, or other operations on an existing file description.

There is no creation-time hook in this patch. If an `O_CREAT` request creates a new file and AppArmor subsequently rejects the open, the new directory entry remains.

An unnamed `O_TMPFILE` object has no reachable absolute pathname. It therefore cannot match an exact-path rule and its open is denied for a confined task.

Pathname patterns, profile removal, automatic attachment, complain mode, auditing, execute transitions, capability rules, network rules, and Linux policy ABI compatibility remain outside this PR.
