### PR TITLE
Remove `FileLike::status_flags` (and use `FileCommon::status_flags` instead)

### DIFF
--- a/kernel/src/events/epoll/file.rs
+++ b/kernel/src/events/epoll/file.rs
@@ -281,7 +281,8 @@ impl FileLike for EpollFile {
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
+                let mut flags =
+                    self.inner.common.status_flags().bits() | self.inner.access_mode() as u32;
                 if self.fd_flags.contains(FdFlags::CLOEXEC) {
                     flags |= CreationFlags::O_CLOEXEC.bits();
                 }

--- a/kernel/src/fs/file/file_handle.rs
+++ b/kernel/src/fs/file/file_handle.rs
@@ -110,10 +110,6 @@ pub trait FileLike: Pollable + Send + Sync + Any {
         return_errno_with_message!(Errno::EINVAL, "resize is not supported");
     }
 
-    fn status_flags(&self) -> StatusFlags {
-        self.common().status_flags()
-    }
-
     /// Returns the status flags that can be set for this file.
     fn settable_status_flags(&self) -> SettableStatusFlags {
         // `O_ASYNC` and `O_DIRECT` can only be set on file descriptions that explicitly
@@ -179,6 +175,11 @@ impl dyn FileLike {
     /// Returns the path associated with the file description.
     pub fn path(&self) -> &Path {
         self.common().path()
+    }
+
+    /// Returns the status flags of the file description.
+    pub fn status_flags(&self) -> StatusFlags {
+        self.common().status_flags()
     }
 
     /// Updates file status flags atomically.

--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -294,7 +294,7 @@ impl FileLike for FsConfigFile {
 
         Box::new(FdInfo {
             access_mode: self.access_mode(),
-            status_flags: self.status_flags(),
+            status_flags: self.common.status_flags(),
             fd_flags,
         })
     }
@@ -361,7 +361,7 @@ impl FileLike for DetachedMountFile {
 
         Box::new(FdInfo {
             access_mode: self.access_mode(),
-            status_flags: self.status_flags(),
+            status_flags: self.common.status_flags(),
             fd_flags,
         })
     }

--- a/kernel/src/fs/file/inode_handle.rs
+++ b/kernel/src/fs/file/inode_handle.rs
@@ -77,6 +77,10 @@ impl InodeHandle {
         self.common.path()
     }
 
+    pub fn status_flags(&self) -> StatusFlags {
+        self.common.status_flags()
+    }
+
     pub fn offset(&self) -> usize {
         let offset = self.offset.lock();
         *offset

--- a/kernel/src/fs/vfs/notify/inotify.rs
+++ b/kernel/src/fs/vfs/notify/inotify.rs
@@ -375,7 +375,8 @@ impl FileLike for InotifyFile {
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
+                let mut flags =
+                    self.inner.common.status_flags().bits() | self.inner.access_mode() as u32;
                 if self.fd_flags.contains(FdFlags::CLOEXEC) {
                     flags |= CreationFlags::O_CLOEXEC.bits();
                 }

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -193,7 +193,7 @@ impl<T: Socket + 'static> FileLike for T {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
+        let mut flags = self.common().status_flags().bits() | self.access_mode() as u32;
         if fd_flags.contains(FdFlags::CLOEXEC) {
             flags |= CreationFlags::O_CLOEXEC.bits();
         }

--- a/kernel/src/process/pid_file.rs
+++ b/kernel/src/process/pid_file.rs
@@ -112,7 +112,7 @@ impl FileLike for PidFile {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
+        let mut flags = self.common.status_flags().bits() | self.access_mode() as u32;
         if fd_flags.contains(FdFlags::CLOEXEC) {
             flags |= CreationFlags::O_CLOEXEC.bits();
         }

--- a/kernel/src/syscall/eventfd.rs
+++ b/kernel/src/syscall/eventfd.rs
@@ -230,7 +230,8 @@ impl FileLike for EventFile {
 
         impl Display for FdInfo {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags = self.inner.status_flags().bits() | self.inner.access_mode() as u32;
+                let mut flags =
+                    self.inner.common.status_flags().bits() | self.inner.access_mode() as u32;
                 if self.fd_flags.contains(FdFlags::CLOEXEC) {
                     flags |= CreationFlags::O_CLOEXEC.bits();
                 }

--- a/kernel/src/syscall/signalfd.rs
+++ b/kernel/src/syscall/signalfd.rs
@@ -268,7 +268,7 @@ impl FileLike for SignalFile {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
+        let mut flags = self.common.status_flags().bits() | self.access_mode() as u32;
         if fd_flags.contains(FdFlags::CLOEXEC) {
             flags |= CreationFlags::O_CLOEXEC.bits();
         }

--- a/kernel/src/time/timerfd.rs
+++ b/kernel/src/time/timerfd.rs
@@ -264,7 +264,7 @@ impl FileLike for TimerfdFile {
             }
         }
 
-        let mut flags = self.status_flags().bits() | self.access_mode() as u32;
+        let mut flags = self.common.status_flags().bits() | self.access_mode() as u32;
         if fd_flags.contains(FdFlags::CLOEXEC) {
             flags |= CreationFlags::O_CLOEXEC.bits();
         }


### PR DESCRIPTION
I'm surprised that I didn't notice this when reviewing https://github.com/asterinas/asterinas/pull/3577.

However, `FileLike::status_flags` should no longer exist because it should be provided via `FileCommon::status_flags`. It should never be overridden by individual implementations.

Add `fn status_flags` for `dyn FileLike`. It will go through `FileLike::common` and `FileCommon::status_flags`.

Add `InodeHandle::status_flags` because it is accessed quite often. It is public because it will also be accessed in the system call module.

https://github.com/asterinas/asterinas/blob/07ae890cef4380273464e0748e9fa17b6e831f28/kernel/src/fs/file/inode_handle.rs#L289
https://github.com/asterinas/asterinas/blob/07ae890cef4380273464e0748e9fa17b6e831f28/kernel/src/syscall/setxattr.rs#L157-L159