### PR TITLE
Refine aster-code-review skills based on missed benchmark cases

### DIFF
--- a/.agents/skills/aster-code-review/SKILL.md
+++ b/.agents/skills/aster-code-review/SKILL.md
@@ -66,6 +66,8 @@ Run these steps in order.
 Steps 1 and 5 are deterministic scripts;
 steps 6–8 use the model.
 
+Create one fresh temporary directory for the whole run with `mktemp -d`, and put the resolved input, meta file, pass prompts, and fragment directory under it.
+Do not use fixed paths such as `/tmp/aster-review-frags`;
 The helper scripts live in the skill's own `scripts/` directory,
 at `.agents/skills/aster-code-review/scripts/` inside the repository under review.
 **Invoke every script by its absolute path**
@@ -106,6 +108,7 @@ The steps below write `$SKILL/scripts/…` as shorthand for that absolute path.
    Each pass returns a JSON array of comments;
    file each under its persona's `<fragdir>/<persona>.json` (the comment's `persona` field says which),
    so step 5 is unchanged.
+   The `<fragdir>` must be freshly created for this review.
 4. **Collect** the per-persona JSON fragments.
 5. **Assemble.**
    `"$SKILL/scripts/assemble_review.sh" [--overwrite] <meta> <fragdir> <output>` performs the deterministic merge (group by persona in fixed order, sort by file→line, drop exact duplicates *within a persona*, write frontmatter, leave a `<!-- SUMMARY -->` placeholder).
@@ -155,8 +158,19 @@ which is what lets the prompt cache reuse it (see [`execution_model.md`](spec/ex
 each in a CLEAN context with only its own persona block (selective exposure):
 
 - **Claude Code** — spawn a Task sub-agent per persona.
-- **Codex** — run `codex exec "<build_pass_prompt.sh output>"` per persona
-  (pass the built PROMPT TEXT as the argument).
+- **Codex** — write each prompt to a file and run the pass with `--output-last-message`/`-o`, for example:
+  ```sh
+  timeout "${ACR_PASS_TIMEOUT_SECONDS:-600}" \
+    codex exec -C "$repo" --sandbox read-only \
+      -o "$fragdir/$persona.json" \
+      - < "$promptdir/$persona.txt" \
+      > "$logdir/$persona.log" 2>&1
+  ```
+
+  Do **not** redirect `codex exec` stdout to the fragment file;
+  The fragment file must contain only the model's final JSON array.
+  Validate every fragment with `python3 -m json.tool` before assembly.
+  If a pass times out or validation fails, fail closed instead of assembling a review from missing, logged, or stale fragments.
 
 **Never spawn a pass by re-running `aster_code_review.sh` / `run_agent.sh`,
 nor by re-issuing the skill's own arguments** (e.g. `codex exec … diff <base> <out>`).
@@ -186,9 +200,11 @@ and `no` is an explicit, opt-in concession.
 For each comment, isolate the key premise it rests on
 — especially an external-system fact (Linux/POSIX behaviour, the System V ABI, Rust semantics).
 Try to **refute** it:
-re-read the cited code and consult an authoritative source.
-Assign a verdict:
+- re-read the cited code and check the relevant authority.
+- for guideline findings, the authority is the persona template and the inlined/bundled guideline root used to build the pass prompt;
+- do not retract a finding merely because the reviewed worktree's `book/` copy is older or narrower.
 
+When the persona template explicitly instructs the check, assign a verdict:
 - **confirmed** — keep the comment unchanged.
 - **uncertain** — keep it, but prefix `problem` with `(unverified) `.
 - **refuted** — remove the comment,

--- a/.agents/skills/aster-code-review/benchmark/run.sh
+++ b/.agents/skills/aster-code-review/benchmark/run.sh
@@ -160,12 +160,25 @@ default_review() { # <worktree> <out> <skill-args>
     ( cd "$1" && ACR_GUIDELINE_ROOT="$GROOT" "$ACR_CLI" $3 "$2" --overwrite )
 }
 default_grade() { # <defects-file> <review>
-    "$RUN_AGENT" "You are grading a code review. The expected defects are in $1; the \
-produced review is $2. Each expected defect gives a 'defect:' description for context \
-and a 'MATCH IF:' criterion. For each expected defect, decide whether ANY comment in \
-the review satisfies its MATCH IF criterion at the stated code location (wording may \
-differ). Respond with ONLY two space-separated integers, caught then total, and \
-nothing else (for example: 1 2)."
+    local defects_file="$1" review_file="$2" prompt_file status
+    prompt_file="$(mktemp)"
+    {
+        cat <<'EOF'
+You are grading a code review for recall.
+Each expected defect gives a defect description for context and a MATCH IF criterion for grading.
+For each expected defect, decide whether ANY produced review comment semantically satisfies its MATCH IF criterion at the stated code location.
+Wording, grounding label, persona, and severity may differ; judge the underlying defect.
+Respond with ONLY two space-separated integers: caught total. The total must equal the number of expected defects below.
+
+===== EXPECTED DEFECTS =====
+EOF
+        cat "$defects_file"
+        printf '\n===== PRODUCED REVIEW =====\n'
+        cat "$review_file"
+    } > "$prompt_file"
+    "$RUN_AGENT" "$(cat "$prompt_file")"; status=$?
+    rm -f "$prompt_file"
+    return "$status"
 }
 default_neg_grade() { # <negatives-file> <review>
     "$RUN_AGENT" "The items in $1 are false-positive traps that a correct review must \

--- a/.agents/skills/aster-code-review/personas/maintainability.md
+++ b/.agents/skills/aster-code-review/personas/maintainability.md
@@ -18,7 +18,22 @@ and will the next reader understand it without archaeology?
 3. Check naming, comments, and layout,
    including the Rust-Specific items (descriptive/accurate names, explain *why* in comments, one concept per file, small functions, narrow visibility, …).
 
+For files-mode reviews, finish the maintainability pass only after a file-by-file inventory. For each entry point, look for local validation, normalization, dispatch, or special-case branches that may duplicate the contract of a shared parser, resolver, validator, or mutator. Before calling a branch redundant, check the shared helper's implementation and relevant call sites; report each independently confirmed duplicate at its own location.
+
+Maintainability also covers changed internal interfaces, not only names and formatting. Return types and conversions should preserve the value's semantic domain at that layer. Do not let an external ABI representation, such as a signed syscall return convention, weaken an internal nonnegative count or other invariant without a documented reason.
+
 **Always-on:** commit hygiene (Process rules — `imperative-subject`, `atomic-commits`, `focused-prs`, `refactor-then-feature`) applies to every change.
 
-You own readability and structure,
-not runtime correctness (Correctness persona) or doc currency (Documentation persona).
+You own readability and structure, not runtime correctness (Correctness persona) or doc currency (Documentation persona).
+
+When changed code uses a bare literal to express a rule, limit, mask, unit,
+policy, or external contract, check whether the value has a semantic name at
+the point of use. Repeated literals in related code usually indicate duplicated
+policy. Flag this as `no-magic-number` and ask for a named constant, typed value, or shared helper.
+
+When reviewing both rustdoc and ordinary comments. In comments that explain code or
+API behavior, identifiers and code-like terms — types, functions, modules,
+constants, syscalls, flags, paths, and literal values — should be visually
+distinguishable from prose when readability depends on it. For changed
+ordinary comments that leave such terms as plain text, apply `backtick-identifiers`
+and ask for Markdown code formatting or rustdoc links where appropriate.

--- a/.agents/skills/aster-code-review/personas/security.md
+++ b/.agents/skills/aster-code-review/personas/security.md
@@ -20,6 +20,21 @@
    A silent clamp/truncation of a user-supplied length that hides an error the contract requires is a defect.
 3. **Exploitable concurrency** — use-after-free, time-of-check/time-of-use.
 
+For changes touching credentials, capabilities, permissions, or `execve`, audit grant paths and exception paths together.
+For each boolean condition, restate the cited Linux/POSIX rule it implements, then check for broad root, owner,
+or capability shortcuts that bypass file-capability, `no_new_privs`, or DAC exceptions.
+
+For Linux credential or capability transformations, reconstruct the normative rule as a small decision table before judging the code.
+Check each derived result independently: permitted, effective, inheritable, ambient, bounding, saved IDs, and filesystem IDs may follow different rules.
+For every optional metadata source, enabling flag, current credential state, and identity-changing executable attribute, cover the absent present-but-disabled, and present-and-enabled cases.
+Trace every intermediate set and every final set.
+
+Do not stop after finding one bad branch.
+If a metadata-presence or enabling-flag condition gates one derived output, check sibling outputs for nearby broad root, owner, or capability shortcuts that bypass the same exception.
+For Linux `capabilities(7)` exec transformations, distinguish file capability metadata, the file effective flag, and legacy root special handling.
+When file capability metadata is present, do not assume that an effective-UID-root transition may make every permitted capability effective; 
+verify that the effective set is enabled only by the contract's effective-bit rule or by a root shortcut that the same contract explicitly permits in the metadata-present case.
+
 Adversarial mindset: assume inputs are hostile and memory rules are exploitable.
 You own soundness and adversarial reasoning,
 not general correctness (Correctness persona).

--- a/.agents/skills/aster-code-review/personas/security.md
+++ b/.agents/skills/aster-code-review/personas/security.md
@@ -32,7 +32,7 @@ Trace every intermediate set and every final set.
 Do not stop after finding one bad branch.
 If a metadata-presence or enabling-flag condition gates one derived output, check sibling outputs for nearby broad root, owner, or capability shortcuts that bypass the same exception.
 For Linux `capabilities(7)` exec transformations, distinguish file capability metadata, the file effective flag, and legacy root special handling.
-When file capability metadata is present, do not assume that an effective-UID-root transition may make every permitted capability effective; 
+When file capability metadata is present, do not assume that an effective-UID-root transition may make every permitted capability effective;
 verify that the effective set is enabled only by the contract's effective-bit rule or by a root shortcut that the same contract explicitly permits in the metadata-present case.
 
 Adversarial mindset: assume inputs are hostile and memory rules are exploitable.


### PR DESCRIPTION
  ## Motivation

  The current benchmark contains 13 test cases, but aster-code-review still fails to recall all defects
  in four of them:
 |Test Case ID   | Number of Defects |   Recall Result (#pass/#total)|
   |:---|:---:|---:|
   |0001-mprotect-merge-unwrap                          |       1   | 1/1|
   |0002-fair-weight-race                                  |    1   | 1/1|
   |0003-semop-timeout-toctou                  |                1   | 1/1|
   |0004-semop-dead-timer-retain                            |   1  |  1/1|
   |0005-virtio-blk-flush-desc-count  |                         1  |  1/1|
   |0006-trapframe-pad-alignment                              | 1   | 1/1|
   |0007-getcwd-erange                                        | 1   | 1/1|
   |0008-noncompliant-commit-message                          | 1   | 1/1|
   |**0009-tmpfs-statfs**                                     | 3   | 2/3|
   |**0100-cmdline-maintainability-issues**                       | 3   | 1/3|
   |0200-i8042-keyboard-controller-protocol                   | 3    |3/3|
   |**0300-file-cap-setuid-root-effective**                       | 3   | 1/3|
   |**0301-rt-sigprocmask-unblockable-signals**                   | 3    |1/3|
   
  After analysing the execution logs for the missed cases, the main cause appears to be:

  **The guidelines tell the agent which guideline should be checked, but they do not provide concrete review steps (how to check).** In many cases, the agent reaches the defective code, **but subsequent analysis distracts it from the relevant defect, and the agent abandons the relevant candidate before confirming the defect**. As a result, the defect is missed.

## Example
 In 0009-tmpfs-statfs, the test case contains three defects:

 -  A constant literal 2 is not given a semantic capacity-policy name.
 -  A TODO comment does not format identifiers with backticks.
 - The public Path::fs method uses "//" instead of "///", so it is missing rustdoc.

 The simplified execution log for this test case

1. The agent first notices the `Path::fs` method.
  ```
    codex:
       The main maintainability signal so far is the new public `Path::fs` API surface. I’m checking surrounding conventions before deciding whether that is worth a review comment.
    exec:
       rg "fn fs\\(&self\\)" -n kernel/src | head -50
```

2. Because the item is a method, the agent checks whether the exposed accessor matches local API style and visibility patterns.
```
    codex:
        The new method is returning the mounted filesystem instead of the inode’s filesystem, which matches the commit’s intent. I’m also checking whether that exposed accessor matches the local API style and visibility patterns.
    exec:
        nl -ba kernel/src/fs/vfs/path/mount.rs | sed -n '525,565p'
```


  3. While inspecting the code, the agent notices the numeric divisor `2` and its attention shifts to that issue.
```
    codex:
        There’s one maintainability issue in the tmpfs accounting helpers: the new default limit policy is encoded as a bare divisor in two places. I’m verifying the surrounding `SuperBlock` fields before anchoring it.
    exec:
        rg "struct SuperBlock|bsize|PAGE_SIZE" -n 
```

  4. The agent reports only the literal-policy defect and misses the other two.
```
    codex:
        The divisor is indeed a policy value, not just local arithmetic; naming it would make the tmpfs default visible at the point of use. I’m doing a final pass for other maintainability-only concerns before producing the JSON.
    exec:
        nl -ba kernel/src/fs/vfs/fs_apis/file_system.rs | sed -n '55,105p'
```

  This shows that the agent had **already reached suspicious code and comments related to `Path::fs`**, but the literal `2` redirected its attention. Because **there were no concrete review steps for the relevant guidelines**, the agent did not further analyzing the earlier suspicious code and missed the defect.

  ## Solution

  Add review steps for each guideline. 
  When suspicious code triggers a guideline, the agent should follow its coresponding review steps. This should improve review focus on the triggered code and increase defect recall.

  ## Implementation

  This PR does not systematically generate review steps for every guideline. It only adds targeted analysis steps for the guidelines involved in the missed benchmark cases. 

  ## Results

  The refined skills can achieve **100% recall** in the current benchmark.

  ## Discussion

  Currently, for each persona, aster-code-review receives the code to review and a predefined set of guidelines, then directly produces review findings. This creates a very large search space and is not an reasonable review process.

  An expert reviewer would likely first identify which code fragments should be checked against which guidelines, forming pairs such as:  **(code fragment, guideline to check)**

 Then the expert would analyze each pair separately, and **review these code fragment via different steps based on his experience **(with guideline-specific review steps distilled into reusable skill instructions ahead of time)**.
  
For example, the review steps for guideline: `- [`imperative-subject`](process.md#imperative-subject): Write each commit subject in the imperative mood, ≤72 chars, verb-first ("Fix", "Add", "Remove"); backtick identifiers.` can be the follow (generated by LLM):
```
1. Read each reviewed commit subject, i.e. the first line of the commit message.
2. If the subject has a prefix such as fs: or cmdline:, apply the checks to the text after the prefix.
3. Check that the first meaningful word is an imperative verb, e.g. Fix, Add, Remove, Refactor, Document.
4. Flag past tense, gerund, or narrative forms, e.g. Fixed, Added, Adding, This fixes, This commit.
5. Check that the subject is no longer than 72 characters.
6. Check that code identifiers, paths, flags, syscalls, functions, types, commands, and config keys are wrapped in backticks.
7. If any check fails, report the commit message and suggest a concise imperative rewrite.
```
  
 The review process should follow the same structure. There should be trigger modules that identify which code should be checked against which guidelines, and each guideline should provide its own review steps. 

One promising workflow like this:
<img width="1672" height="946" alt="image" src="https://github.com/user-attachments/assets/474b9f0d-85f5-4e28-b1ad-5efcc2dab77c" />

  **This decomposes review into smaller subproblems, reduces the agent’s search space, and improves reasoning efficiency.**