### PR TITLE
Fix RISC-V TLB invalidation after page table activation

### DIFF
--- a/ostd/src/arch/riscv/mm/mod.rs
+++ b/ostd/src/arch/riscv/mm/mod.rs
@@ -84,8 +84,13 @@ bitflags::bitflags! {
     }
 }
 
+const SHARED_ASID: usize = 0;
+
 pub(crate) fn tlb_flush_addr(vaddr: Vaddr) {
-    riscv::asm::sfence_vma(0, vaddr);
+    // Don't specify an ASID here. `vaddr` may be associated with a global entry.
+    //
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { core::arch::riscv64::sfence_vma_vaddr(vaddr) };
 }
 
 pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
@@ -95,12 +100,15 @@ pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
 }
 
 pub(crate) fn tlb_flush_all_excluding_global() {
-    // TODO: excluding global?
-    riscv::asm::sfence_vma_all()
+    // We use `SHARED_ASID` all the time, so all non-global pages are associated with it.
+    //
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { core::arch::riscv64::sfence_vma_asid(SHARED_ASID) };
 }
 
 pub(crate) fn tlb_flush_all_including_global() {
-    riscv::asm::sfence_vma_all()
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { core::arch::riscv64::sfence_vma_all() };
 }
 
 pub(crate) fn can_sync_dma() -> bool {
@@ -169,9 +177,13 @@ pub(crate) unsafe fn activate_page_table(root_paddr: Paddr, _root_pt_cache: Cach
     #[cfg(feature = "riscv_sv39_mode")]
     let mode = riscv::register::satp::Mode::Sv39;
 
-    unsafe {
-        riscv::register::satp::set(mode, 0, ppn);
-    }
+    // SAFETY: The safety is upheld by the caller.
+    unsafe { riscv::register::satp::set(mode, SHARED_ASID, ppn) };
+
+    // We reuse `SHARED_ASID`, so we need to flush the TLB entries.
+    // "[..] if an ASID is reused, it may be necessary to execute an SFENCE.VMA instruction."
+    // Reference: <https://docs.riscv.org/reference/isa/v20260120/priv/supervisor.html#satp>.
+    tlb_flush_all_excluding_global();
 }
 
 pub(crate) fn current_page_table_paddr() -> Paddr {

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(negative_impls)]
 #![feature(ptr_metadata)]
 #![feature(sync_unsafe_cell)]
+#![cfg_attr(target_arch = "riscv64", feature(riscv_ext_intrinsics))]
 #![cfg_attr(target_arch = "x86_64", feature(iter_advance_by, macro_metavar_expr))]
 #![expect(internal_features)]
 #![no_std]


### PR DESCRIPTION
## Summary

- Use one `SHARED_ASID` value for RISC-V page-table activation and TLB invalidation.
- Invalidate all non-global translations for the shared ASID immediately after writing `satp`.
- Document the root-page-table lifetime and global-mapping invariants of page-table activation.

Fixes #3672.

## Motivation

All RISC-V address spaces currently use ASID 0. The RISC-V privileged specification does not
require a `satp` write to invalidate address-translation caches, so translations populated under
the previous root page table may otherwise remain usable after an address-space switch.

The ASID-scoped `SFENCE.VMA` form keeps valid global kernel translations while invalidating stale
non-global translations for the shared ASID.

Specification: <https://docs.riscv.org/reference/isa/priv/supervisor.html>

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p ostd --target riscv64imac-unknown-none-elf` (Sv48)
- `cargo check -p ostd --target riscv64imac-unknown-none-elf --features riscv_sv39_mode` (Sv39)
- `OSDK_TARGET_ARCH=riscv64 ./tools/clippy_check.sh workspace`
- RISC-V SMP=4 full OSTD KTest: 202 passed, 0 failed
- RISC-V SMP=4 boot test: `Successfully booted.`
- Generated-code inspection confirms that `satp::set` is followed by the flush helper and that the
  helper executes `sfence.vma zero, a0` with `a0 = 0`.

### Runtime-test limitation

A same-virtual-address/different-frame KTest was evaluated with the new fence temporarily removed.
It still passed under the project's QEMU 10.2.1 because that QEMU version flushes its software TLB
when a paging-enabled `satp` value changes. Keeping the test would therefore provide a false
behavioral regression guarantee. Issue #3672 records the negative-control result and the relevant
QEMU source location.
