### PR TITLE
Shrink empty interior nodes on XArray removal

### DIFF
--- a/kernel/libs/xarray/src/cursor.rs
+++ b/kernel/libs/xarray/src/cursor.rs
@@ -466,18 +466,44 @@ impl<'a, P: NonNullPtr + Send + Sync, M> CursorMut<'a, P, M> {
     /// Removes the item at the target index.
     ///
     /// Returns the removed item if it previously exists.
-    //
-    // TODO: Remove the interior node once it becomes empty.
+    ///
+    /// If this operation leaves the current leaf node empty, the leaf and its
+    /// empty ancestors are removed from the `XArray`. The cursor is then reset
+    /// to the inactive state.
     pub fn remove(&mut self) -> Option<P::Ref<'a>> {
         self.traverse_to_target();
-        self.state.as_node().and_then(|(node, off)| {
-            let res = node
-                .deref_target()
-                .entry_with(self.guard, off)
-                .and_then(|entry| entry.right());
-            node.set_entry(self.lock_guard(), off, None);
-            res
-        })
+        let (node, off) = self.state.as_node()?;
+
+        let res = node
+            .deref_target()
+            .entry_with(self.guard, off)
+            .and_then(|entry| entry.right());
+        node.set_entry(self.lock_guard(), off, None);
+
+        if !node.is_empty() {
+            return res;
+        }
+
+        let (mut current, _) = core::mem::take(&mut self.state).into_node().unwrap();
+
+        // Remove the empty leaf node and propagate upwards, removing empty
+        // ancestors until a non-empty node or the root is reached. If the
+        // whole tree becomes empty, the `XArray`'s head is cleared too.
+        loop {
+            let Some(parent) = current.deref_target().parent(self.guard) else {
+                self.xa.head.update(None);
+                break;
+            };
+
+            parent.set_entry(self.lock_guard(), current.offset_in_parent(), None);
+
+            if !parent.is_empty() {
+                break;
+            }
+            current = parent;
+        }
+
+        res
     }
 }
 

--- a/kernel/libs/xarray/src/node.rs
+++ b/kernel/libs/xarray/src/node.rs
@@ -190,6 +190,10 @@ impl<P: NonNullPtr + Send + Sync> XNode<P> {
         self.height == 1
     }
 
+    pub(super) fn is_empty(&self) -> bool {
+        self.is_mark_clear(PRESENT_MARK)
+    }
+
     pub(super) fn next_marked(&self, offset: u8, mark: usize) -> Option<u8> {
         self.marks[mark].next_marked(offset)
     }

--- a/kernel/libs/xarray/src/test.rs
+++ b/kernel/libs/xarray/src/test.rs
@@ -392,6 +392,12 @@ fn load_after_clear() {
 static TEST_LEAKAGE: AtomicBool = AtomicBool::new(false);
 static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
 
+fn finish_grace_period() {
+    let task = || {};
+    let _ = ostd::task::TaskOptions::new(task).data(()).spawn();
+    Task::yield_now();
+}
+
 impl<P: NonNullPtr + Send + Sync> Drop for node::XNode<P> {
     fn drop(&mut self) {
         if TEST_LEAKAGE.load(Ordering::Relaxed) {
@@ -402,14 +408,9 @@ impl<P: NonNullPtr + Send + Sync> Drop for node::XNode<P> {
 
 #[ktest]
 fn no_leakage() {
-    fn finish_grace_period() {
-        let task = || {};
-        let _ = ostd::task::TaskOptions::new(task).data(()).spawn();
-        Task::yield_now();
-    }
-
     // Drop the nodes created by the previous tests.
     finish_grace_period();
+    DROP_COUNT.store(0, Ordering::Relaxed);
     TEST_LEAKAGE.store(true, Ordering::Relaxed);
 
     let xarray_arc: XArray<Arc<u32>> = XArray::new();
@@ -426,4 +427,36 @@ fn no_leakage() {
     // layer 1: 64 + 1
     let expected = 68;
     assert_eq!(count, expected);
+}
+
+#[ktest]
+fn remove_shrinks_empty_nodes() {
+    // Drop the nodes created by the previous tests.
+    finish_grace_period();
+    DROP_COUNT.store(0, Ordering::Relaxed);
+    TEST_LEAKAGE.store(true, Ordering::Relaxed);
+
+    let xarray_arc: XArray<Arc<u32>> = XArray::new();
+    // This index requires a tree of height 3, with exactly one node per
+    // layer (a single chain from the root to the leaf).
+    let index = (SLOT_SIZE * SLOT_SIZE) as u64;
+    xarray_arc.lock().store(index, Arc::new(0));
+
+    assert!(xarray_arc.lock().remove(index).is_some());
+
+    // Drop the nodes detached by the `remove` above.
+    finish_grace_period();
+    TEST_LEAKAGE.store(false, Ordering::Relaxed);
+
+    // All 3 nodes on the chain (root, interior, leaf) should have been
+    // detached and dropped, since removing the only item leaves each of
+    // them empty in turn.
+    let count = DROP_COUNT.load(Ordering::Relaxed);
+    assert_eq!(count, 3);
+
+    // The `XArray` should now behave like a fresh, empty one.
+    assert!(xarray_arc.lock().load(index).is_none());
+    xarray_arc.lock().store(0, Arc::new(1));
+    let guard = disable_preempt();
+    assert_eq!(*xarray_arc.load(&guard, 0).unwrap().as_ref(), 1);
 }


### PR DESCRIPTION
# Summary

  Improve the XArray implementation to remove empty interior nodes when the last item in a subtree is deleted, keeping the tree compact.

  # Changes

  ## Memory management 

  1. Add `CursorMut::shrink_empty_ancestors` in `cursor.rs`. After an item is removed, it prunes empty nodes from the leaf towards the root and clears the XArray head when the entire tree becomes empty.

  2. Add `XNode::is_empty` in `node.rs` to determine whether a node contains any entries. It serves as the predicate for the cleanup logic.

  ## Test

  Add `remove_shrinks_empty_nodes` in `test.rs`. The test creates a three-level XArray, removes its only item, and verifies that all empty nodes are detached and dropped. It also verifies that the XArray behaves as a fresh empty container afterwards.

 Update the existing `no_leakage` test to reset `DROP_COUNT` before enabling drop accounting. Since `remove_shrinks_empty_nodes` also uses the same global counter, resetting it in both tests keeps each expected count independent of execution order.