### PR TITLE
Pass `&mut FsCreationCtx` to `FsType`

### DIFF
--- a/kernel/src/fs/file/fs_config_file.rs
+++ b/kernel/src/fs/file/fs_config_file.rs
@@ -164,9 +164,9 @@ impl FsConfigFile {
 
         let result = (|| {
             let args = (!config.extra_options.is_empty()).then_some(config.extra_options.as_str());
-            let fs_creation_ctx =
+            let mut fs_creation_ctx =
                 FsCreationCtx::new(config.source.as_deref(), config.flags, args, ctx);
-            let fs_and_root = self.fs_type.get_or_create(&fs_creation_ctx)?;
+            let fs_and_root = self.fs_type.get_or_create(&mut fs_creation_ctx)?;
             Ok(fs_and_root)
         })();
 

--- a/kernel/src/fs/fs_impls/cgroupfs/fs.rs
+++ b/kernel/src/fs/fs_impls/cgroupfs/fs.rs
@@ -95,7 +95,7 @@ impl FsType for CgroupFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(CgroupFs::singleton().clone())
     }
 

--- a/kernel/src/fs/fs_impls/configfs/fs.rs
+++ b/kernel/src/fs/fs_impls/configfs/fs.rs
@@ -95,7 +95,7 @@ impl FsType for ConfigFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(ConfigFs::singleton().clone())
     }
 

--- a/kernel/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/src/fs/fs_impls/devpts/mod.rs
@@ -137,7 +137,7 @@ impl FsType for DevPtsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(DevPts::new())
     }
 

--- a/kernel/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/src/fs/fs_impls/exfat/fs.rs
@@ -495,14 +495,14 @@ impl FsType for ExfatType {
         FsProperties::NEED_DISK
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         let disk = fs_creation_ctx.resolve_block_device()?.clone();
         Ok(ExfatFs::open(disk, ExfatMountOptions::default())?)
     }
 
     fn obtain_key_and_cache(
         &self,
-        fs_creation_ctx: &FsCreationCtx,
+        fs_creation_ctx: &mut FsCreationCtx,
     ) -> Option<(DeviceId, &FsCache<DeviceId>)> {
         let key = fs_creation_ctx
             .resolve_block_device()

--- a/kernel/src/fs/fs_impls/ext2/fs_type.rs
+++ b/kernel/src/fs/fs_impls/ext2/fs_type.rs
@@ -34,7 +34,7 @@ impl FsType for Ext2Type {
         FsProperties::NEED_DISK
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         let disk = fs_creation_ctx.resolve_block_device()?.clone();
         let flags = fs_creation_ctx.flags();
         let args = fs_creation_ctx.args();
@@ -43,7 +43,7 @@ impl FsType for Ext2Type {
 
     fn obtain_key_and_cache(
         &self,
-        fs_creation_ctx: &FsCreationCtx,
+        fs_creation_ctx: &mut FsCreationCtx,
     ) -> Option<(DeviceId, &FsCache<DeviceId>)> {
         let key = fs_creation_ctx
             .resolve_block_device()

--- a/kernel/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/src/fs/fs_impls/overlayfs/fs.rs
@@ -1184,7 +1184,7 @@ impl FsType for OverlayFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         let mut lower = Vec::new();
         let mut upper = "";
         let mut work = "";

--- a/kernel/src/fs/fs_impls/procfs/mod.rs
+++ b/kernel/src/fs/fs_impls/procfs/mod.rs
@@ -131,7 +131,7 @@ impl FsType for ProcFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(ProcFs::new())
     }
 

--- a/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/pipefs.rs
@@ -62,7 +62,7 @@ impl FsType for PipeFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         return_errno_with_message!(Errno::EINVAL, "pipefs cannot be mounted");
     }
 

--- a/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
+++ b/kernel/src/fs/fs_impls/pseudofs/sockfs.rs
@@ -70,7 +70,7 @@ impl FsType for SockFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         return_errno_with_message!(Errno::EINVAL, "sockfs cannot be mounted");
     }
 

--- a/kernel/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/src/fs/fs_impls/ramfs/fs.rs
@@ -1473,7 +1473,7 @@ impl FsType for RamFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(RamFs::new())
     }
 

--- a/kernel/src/fs/fs_impls/sysfs/fs.rs
+++ b/kernel/src/fs/fs_impls/sysfs/fs.rs
@@ -93,7 +93,7 @@ impl FsType for SysFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(SysFs::singleton().clone())
     }
 

--- a/kernel/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/src/fs/fs_impls/tmpfs/fs.rs
@@ -42,7 +42,7 @@ impl FsType for TmpFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, _fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, _fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         Ok(TmpFs::new_tmpfs())
     }
 

--- a/kernel/src/fs/fs_impls/virtiofs/fs.rs
+++ b/kernel/src/fs/fs_impls/virtiofs/fs.rs
@@ -50,7 +50,7 @@ impl FsType for VirtioFsType {
         FsProperties::empty()
     }
 
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
+    fn create(&self, fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>> {
         let tag = fs_creation_ctx
             .source()
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "virtiofs source(tag) is required"))?
@@ -64,7 +64,7 @@ impl FsType for VirtioFsType {
 
     fn obtain_key_and_cache(
         &self,
-        fs_creation_ctx: &FsCreationCtx,
+        fs_creation_ctx: &mut FsCreationCtx,
     ) -> Option<(String, &FsCache<String>)> {
         let key = fs_creation_ctx.source().map(|tag| tag.to_string())?;
 

--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -34,14 +34,14 @@ pub trait FsType: Send + Sync + 'static {
     fn properties(&self) -> FsProperties;
 
     /// Creates an instance of this FS type.
-    fn create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<Arc<dyn FileSystem>>;
+    fn create(&self, fs_creation_ctx: &mut FsCreationCtx) -> Result<Arc<dyn FileSystem>>;
 
     /// Returns the computed dedup key and the [`FsCache`] for this mount request.
     ///
     /// Return `None` to skip the cache mechanism (every mount is fresh).
     fn obtain_key_and_cache(
         &self,
-        _fs_creation_ctx: &FsCreationCtx,
+        _fs_creation_ctx: &mut FsCreationCtx,
     ) -> Option<(Self::Key, &FsCache<Self::Key>)> {
         None
     }
@@ -68,7 +68,7 @@ pub trait DynFsType: Send + Sync + 'static {
     fn properties(&self) -> FsProperties;
 
     /// Gets or creates a file system instance along with its root dentry.
-    fn get_or_create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<FsAndRoot>;
+    fn get_or_create(&self, fs_creation_ctx: &mut FsCreationCtx) -> Result<FsAndRoot>;
 
     /// Returns a `SysTree` node that represents the FS type.
     fn sysnode(&self) -> Option<Arc<dyn SysNode>>;
@@ -87,7 +87,7 @@ impl<T: FsType> DynFsType for T {
         <T as FsType>::sysnode(self)
     }
 
-    fn get_or_create(&self, fs_creation_ctx: &FsCreationCtx) -> Result<FsAndRoot> {
+    fn get_or_create(&self, fs_creation_ctx: &mut FsCreationCtx) -> Result<FsAndRoot> {
         if let Some((key, cache)) = self.obtain_key_and_cache(fs_creation_ctx) {
             cache.get_or_create(key, fs_creation_ctx.flags(), || {
                 self.create(fs_creation_ctx)
@@ -107,7 +107,7 @@ pub struct FsCreationCtx<'a> {
     flags: FsFlags,
     args: Option<&'a str>,
     task_ctx: &'a Context<'a>,
-    block_device: Once<Arc<dyn BlockDevice>>,
+    block_device: Option<Arc<dyn BlockDevice>>,
 }
 
 impl<'a> FsCreationCtx<'a> {
@@ -123,7 +123,7 @@ impl<'a> FsCreationCtx<'a> {
             flags,
             args,
             task_ctx,
-            block_device: Once::new(),
+            block_device: None,
         }
     }
 
@@ -143,11 +143,15 @@ impl<'a> FsCreationCtx<'a> {
     }
 
     /// Resolves the mount source into a block device.
-    pub(in crate::fs) fn resolve_block_device(&self) -> Result<&Arc<dyn BlockDevice>> {
-        if let Some(block_device) = self.block_device.get() {
-            return Ok(block_device);
+    pub(in crate::fs) fn resolve_block_device(&mut self) -> Result<&Arc<dyn BlockDevice>> {
+        if self.block_device.is_none() {
+            self.do_resolve_block_device()?;
         }
 
+        Ok(self.block_device.as_ref().unwrap())
+    }
+
+    fn do_resolve_block_device(&mut self) -> Result<()> {
         let source = self
             .source()
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "the source is not specified"))?;
@@ -164,11 +168,13 @@ impl<'a> FsCreationCtx<'a> {
             return_errno_with_message!(Errno::ENODEV, "the path is not a device file");
         }
         let id = path.metadata()?.self_dev_id;
+
         let block_device = id
             .and_then(aster_block::lookup)
             .ok_or_else(|| Error::with_message(Errno::ENODEV, "the device is not found"))?;
+        self.block_device = Some(block_device);
 
-        Ok(self.block_device.call_once(|| block_device))
+        Ok(())
     }
 }
 

--- a/kernel/src/syscall/mount.rs
+++ b/kernel/src/syscall/mount.rs
@@ -246,8 +246,8 @@ fn open_fs(
     };
     let data = data.as_deref().map(CStr::to_string_lossy);
 
-    let fs_creation_ctx = FsCreationCtx::new(source, flags.into(), data.as_deref(), ctx);
-    fs_type.get_or_create(&fs_creation_ctx)
+    let mut fs_creation_ctx = FsCreationCtx::new(source, flags.into(), data.as_deref(), ctx);
+    fs_type.get_or_create(&mut fs_creation_ctx)
 }
 
 bitflags! {


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/9388d7d4750ffdb6ff616a3d0c2fff609a071265/kernel/src/fs/vfs/fs_apis/registry.rs#L171

I think this `Once` is not necessary because we can have `&mut FsCreationCtx`, right?