### PR TITLE
Fix OSDK panic trace and coverage utils

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -10,6 +10,7 @@ boot_protocol = "multiboot2"
 
 [qemu]
 args = "$(./tools/qemu_args.sh normal)"
+log_file = "qemu-serial.log"
 
 # Special options for running
 [run.boot]

--- a/book/src/osdk/reference/manifest.md
+++ b/book/src/osdk/reference/manifest.md
@@ -49,16 +49,17 @@ display_grub_menu = false                   # <16>
 [qemu]                                      # <17>
 path = "path/to/it"                         # <18>
 args = "-machine q35 -m 2G"                 # <19>
+log_file = "qemu.log"                       # <20>
 
 # Special options for run subcommand
-[run]                                       # <20>
+[run]                                       # <21>
 [run.build]                                 # <3>
 [run.boot]                                  # <8>
 [run.grub]                                  # <13>
 [run.qemu]                                  # <17>
 
 # Special options for test subcommand
-[test]                                      # <21>
+[test]                                      # <22>
 [test.build]                                # <3>
 [test.boot]                                 # <8>
 [test.grub]                                 # <13>
@@ -66,10 +67,10 @@ args = "-machine q35 -m 2G"                 # <19>
 # ----------------------- end of the default scheme settings ----------------------------
 
 # A customized scheme settings
-[scheme."custom"]                           # <22>
+[scheme."custom"]                           # <23>
 [scheme."custom".build]                     # <3>
-[scheme."custom".run]                       # <20>
-[scheme."custom".test]                      # <21>
+[scheme."custom".run]                       # <21>
+[scheme."custom".test]                      # <22>
 ```
 
 Here are some additional notes for the fields:
@@ -191,17 +192,37 @@ can include any POSIX shell compliant separators.
     even use this mechanism to read from files by using command replacement
     `$(cat path/to/your/custom/args/file)`.
 
-20. Special settings for running. Only take effect when running `cargo osdk run`.
+20. The path to the file where QEMU writes the guest output.
+
+    Optional.
+    If this field is absent,
+    OSDK does not inspect QEMU output for kernel panics or coverage data.
+
+    This field only tells OSDK where to read the log;
+    it does not cause QEMU to create the file.
+    QEMU must be configured through `args` to write guest output to the same path.
+    For example:
+
+    ```toml
+    [qemu]
+    args = "-serial file:qemu-serial.log"
+    log_file = "qemu-serial.log"
+    ```
+
+    If the path is relative,
+    it is relative to the manifest's enclosing directory.
+
+21. Special settings for running. Only take effect when running `cargo osdk run`.
 
     By default, it inherits common options.
 
     Values set here are used to override common options.
 
-21. Special settings for testing.
+22. Special settings for testing.
 
-    Similar to `20`, but only take effect when running `cargo osdk test`.
+    Similar to `21`, but only take effect when running `cargo osdk test`.
 
-22. The definition of customized scheme.
+23. The definition of customized scheme.
 
     A customized scheme has the same fields as the default scheme.
     By default, a customized scheme will inherit all options from the default scheme,

--- a/osdk/src/bundle/mod.rs
+++ b/osdk/src/bundle/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     arch::Arch,
     config::{
         Config,
-        scheme::{ActionChoice, BootMethod, BootProtocol},
+        scheme::{Action, ActionChoice, BootMethod, BootProtocol},
     },
     error::Errno,
     error_msg,
@@ -321,7 +321,10 @@ impl Bundle {
             }
         }
 
-        let exit_status = if action.qemu.with_monitor {
+        let exit_status = if action.qemu.with_monitor
+            && let Some(qemu_log_file) = &action.qemu.log_file
+        {
+            let qemu_log_path = config.work_dir.join(qemu_log_file);
             let qemu_monitor_socket_path = NamedTempFile::new().unwrap().into_temp_path();
             qemu_cmd.arg("-monitor").arg(format!(
                 "unix:{},server,nowait",
@@ -332,23 +335,25 @@ impl Bundle {
             let mut qemu_child = qemu_cmd.spawn().unwrap();
             std::thread::sleep(Duration::from_secs(1)); // Wait for QEMU to start
             let mut qemu_monitor_stream = UnixStream::connect(&qemu_monitor_socket_path).unwrap();
-            wait_until_guest_kernel_shutdown(config, &mut qemu_monitor_stream);
+            wait_until_guest_kernel_shutdown(config, &qemu_log_path, &mut qemu_monitor_stream);
             info!("VM is paused (shutdown)");
 
-            self.post_run_action(config, Some(&mut qemu_monitor_stream));
+            self.post_run_action(config, action, Some(&mut qemu_monitor_stream));
 
             let _ = qemu_monitor_stream.write_all(b"quit\n");
             qemu_child.wait().unwrap()
         } else {
             info!("Running QEMU: {qemu_cmd:#?}");
             let exit_status = qemu_cmd.status().unwrap();
-            self.post_run_action(config, None);
+            self.post_run_action(config, action, None);
             exit_status
         };
 
-        fn wait_until_guest_kernel_shutdown(config: &Config, qemu_monitor_stream: &mut UnixStream) {
-            let log_file = std::fs::File::open(config.work_dir.join("qemu.log")).unwrap();
-
+        fn wait_until_guest_kernel_shutdown(
+            config: &Config,
+            qemu_log_path: &Path,
+            qemu_monitor_stream: &mut UnixStream,
+        ) {
             // Check VM status every 0.1 seconds and break the loop if the VM is stopped or hanging.
             while qemu_monitor_stream.write_all(b"info status\n").is_ok() {
                 let status = BufReader::new(&mut *qemu_monitor_stream)
@@ -358,7 +363,9 @@ impl Bundle {
                     break;
                 }
 
-                if config.target_arch == Arch::RiscV64 {
+                if config.target_arch == Arch::RiscV64
+                    && let Ok(log_file) = std::fs::File::open(qemu_log_path)
+                {
                     let log = rev_buf_reader::RevBufReader::new(&log_file);
                     if log.lines().next().is_some_and(|line| {
                         line.as_ref().is_ok_and(|s| {
@@ -399,18 +406,27 @@ impl Bundle {
         std::fs::write(manifest_file_path, manifest_file_content).unwrap();
     }
 
-    fn post_run_action(&self, config: &Config, qemu_monitor_stream: Option<&mut UnixStream>) {
-        // Find the QEMU output in "qemu.log", read it and check if it failed with a panic.
+    fn post_run_action(
+        &self,
+        config: &Config,
+        action: &Action,
+        qemu_monitor_stream: Option<&mut UnixStream>,
+    ) {
+        let Some(qemu_log_file) = &action.qemu.log_file else {
+            return;
+        };
+
+        // Read the configured QEMU output and check if it failed with a panic.
         // Setting a QEMU log is required for source line stack trace because piping the output
         // is less desirable when running QEMU with serial redirected to standard I/O.
-        let qemu_log_path = config.work_dir.join("qemu.log");
+        let qemu_log_path = config.work_dir.join(qemu_log_file);
         if let Ok(file) = std::fs::File::open(&qemu_log_path)
             && let Some(aster_bin) = &self.manifest.aster_bin
         {
             crate::util::trace_panic_from_log(file, self.path.join(aster_bin.path()));
         }
 
-        // Find the coverage data information in "qemu.log", and dump it if found.
+        // Find the coverage data information in the QEMU log, and dump it if found.
         if let Some(qemu_monitor_stream) = qemu_monitor_stream
             && let Ok(file) = std::fs::File::open(&qemu_log_path)
         {

--- a/osdk/src/config/mod.rs
+++ b/osdk/src/config/mod.rs
@@ -180,7 +180,7 @@ fn apply_args_after_finalize(action: &mut Action, args: &CommonArgs) {
     if args.display_grub_menu {
         action.grub.display_grub_menu = true;
     }
-    if args.coverage {
+    if args.coverage && action.qemu.log_file.is_some() {
         action.qemu.args += " --no-shutdown";
         action.qemu.with_monitor = true;
     }

--- a/osdk/src/config/scheme/mod.rs
+++ b/osdk/src/config/scheme/mod.rs
@@ -96,6 +96,9 @@ impl Scheme {
                     qemu.path.clone_from(&from_qemu.path);
                     self.work_dir.clone_from(&from.work_dir);
                 }
+                if qemu.log_file.is_none() {
+                    qemu.log_file.clone_from(&from_qemu.log_file);
+                }
             }
         } else {
             self.qemu.clone_from(&from.qemu);

--- a/osdk/src/config/scheme/qemu.rs
+++ b/osdk/src/config/scheme/qemu.rs
@@ -34,6 +34,9 @@ pub struct QemuScheme {
     pub path: Option<PathBuf>,
     /// Whether to run QEMU as daemon and connect to it in monitor mode.
     pub with_monitor: Option<bool>,
+    /// The QEMU output log used for panic translation and coverage collection.
+    /// Relative paths are resolved from the OSDK working directory.
+    pub log_file: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Serialize)]
@@ -47,6 +50,8 @@ pub struct Qemu {
     pub path: PathBuf,
     /// Whether to run QEMU as daemon and connect to it in monitor mode.
     pub with_monitor: bool,
+    /// The QEMU output log used for panic translation and coverage collection.
+    pub log_file: Option<PathBuf>,
 }
 
 impl Default for Qemu {
@@ -56,6 +61,7 @@ impl Default for Qemu {
             bootdev_append_options: None,
             path: PathBuf::from(get_default_arch().system_qemu()),
             with_monitor: false,
+            log_file: None,
         }
     }
 }
@@ -72,6 +78,7 @@ impl PartialEq for Qemu {
             && self.bootdev_append_options == other.bootdev_append_options
             && self.path == other.path
             && self.with_monitor == other.with_monitor
+            && self.log_file == other.log_file
     }
 }
 
@@ -101,6 +108,9 @@ impl QemuScheme {
         if self.with_monitor.is_none() {
             self.with_monitor.clone_from(&from.with_monitor);
         }
+        if self.log_file.is_none() {
+            self.log_file.clone_from(&from.log_file);
+        }
     }
 
     pub fn finalize(self, arch: Arch) -> Qemu {
@@ -109,6 +119,7 @@ impl QemuScheme {
             bootdev_append_options: self.bootdev_append_options,
             path: self.path.unwrap_or(PathBuf::from(arch.system_qemu())),
             with_monitor: self.with_monitor.unwrap_or(false),
+            log_file: self.log_file,
         }
     }
 }

--- a/osdk/src/config/test/OSDK.toml.full
+++ b/osdk/src/config/test/OSDK.toml.full
@@ -25,6 +25,7 @@ boot_protocol = "multiboot2"
 display_grub_menu = true
 
 [qemu]
+log_file = "qemu-serial.log"
 args = """\
     -machine q35 \
     -smp $SMP \

--- a/osdk/src/config/test/mod.rs
+++ b/osdk/src/config/test/mod.rs
@@ -34,9 +34,14 @@ fn conditional_manifest() {
             .unwrap()
             .contains(&String::from("-machine q35",))
     );
+    assert_eq!(
+        scheme.qemu.as_ref().unwrap().log_file.as_deref(),
+        Some(Path::new("qemu-serial.log"))
+    );
 
     // Iommu
-    let scheme = toml_manifest.get_scheme(Some("iommu".to_owned()));
+    let mut scheme = toml_manifest.get_scheme(Some("iommu".to_owned())).clone();
+    scheme.inherit(&toml_manifest.default_scheme);
     assert!(
         scheme
             .qemu
@@ -46,6 +51,10 @@ fn conditional_manifest() {
             .as_ref()
             .unwrap()
             .contains(&String::from("-device ioh3420,id=pcie.0,chassis=1",))
+    );
+    assert_eq!(
+        scheme.qemu.as_ref().unwrap().log_file.as_deref(),
+        Some(Path::new("qemu-serial.log"))
     );
 
     // Tdx

--- a/osdk/tests/util/mod.rs
+++ b/osdk/tests/util/mod.rs
@@ -159,14 +159,23 @@ pub(crate) fn depends_on_coverage(manifest_path: impl AsRef<Path>, osdk_path: im
 
     fs::write(manifest_path, manifest.to_string().as_bytes()).unwrap();
 
-    // Modify OSDK.toml to add logfile=qemu.log to chardev line
+    // Configure QEMU to write the log and OSDK to inspect it.
     if osdk_path.as_ref().exists() {
         let osdk_content = fs::read_to_string(&osdk_path).unwrap();
         let modified_content = osdk_content.replace(
             "-chardev stdio,id=mux,mux=on,signal=off \\",
             "-chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \\",
         );
-        fs::write(osdk_path, modified_content).unwrap();
+        let mut osdk_manifest: Table = toml::from_str(&modified_content).unwrap();
+        osdk_manifest
+            .get_mut("qemu")
+            .and_then(Value::as_table_mut)
+            .unwrap()
+            .insert(
+                "log_file".to_string(),
+                Value::String("qemu.log".to_string()),
+            );
+        fs::write(osdk_path, osdk_manifest.to_string()).unwrap();
     }
 }
 


### PR DESCRIPTION
We seems to have lost such formatted panic traces for quite a while now:

```
[     6.829] ERROR : Uncaught panic:
        test
        at /root/asterinas/kernel/src/init.rs:103
        on CPU 0 by thread Some(Thread { task: (Weak), data: Any { .. }, is_exited: false, cpu_affinity: AtomicIdSet { bits: [1], phantom: PhantomData<ostd::cpu::id::CpuId> }, sched_attr: SchedAttr { policy: SchedPolicyState { kind: AtomicSchedPolicyKind(3), policy: UnsafeCell { .. } }, last_cpu: AtomicCpuId(0), real_time: RealTimeAttr { prio: 99, time_slice: 32915920 }, fair: FairAttr { weight: 1024, pending_weight: UnsafeCell { .. }, vruntime: 0 } } })
[OSDK] The kernel seems panicked. Parsing stack trace for source lines:
(  1) ostd::panic::print_stack_trace
          at /root/asterinas/ostd/src/panic.rs:144
(  2) aster_kernel::thread::oops::panic_handler
          at /root/asterinas/kernel/src/thread/oops.rs:118
(  3) __ostd_panic_handler
          at ??:?
(  4) __rustc::rust_begin_unwind
          at aqzlik0mhblc97mkd1367ex6p:?
(  5) core::panicking::panic_fmt
          at ??:?
(  6) aster_kernel::init::bsp_idle_loop
          at /root/asterinas/kernel/src/init.rs:100
(  7) <aster_kernel::init::bsp_idle_loop as core::ops::function::FnOnce<()>>::call_once
          at /root/.rustup/toolchains/nightly-2026-07-21-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250
(  8) <aster_kernel::init::bsp_idle_loop as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
          at /root/.rustup/toolchains/nightly-2026-07-21-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250
          ...
```

It is because we redirected serial output to `qemu-serial.log`, while OSDK only checks hardcoded `qemu.log`, and the panic trace only prints to the serial. I added a configuration in OSDK to allow users to specify the log to inspect, so the functionality can be restored.