### PR TITLE
Add block device test utility and remove duplicated test code

### DIFF
--- a/kernel/src/fs/vfs/fs_apis/registry.rs
+++ b/kernel/src/fs/vfs/fs_apis/registry.rs
@@ -158,7 +158,7 @@ impl<'a> FsCreationCtx<'a> {
             .borrow_fs()
             .resolver()
             .read()
-            .lookup_no_follow(&fs_path)?;
+            .lookup(&fs_path)?;
 
         if !path.type_().is_device() {
             return_errno_with_message!(Errno::ENODEV, "the path is not a device file");

--- a/test/initramfs/src/regression/common/block_device.h
+++ b/test/initramfs/src/regression/common/block_device.h
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#ifndef BLOCK_DEVICE_H
+#define BLOCK_DEVICE_H
+
+/*
+ * Utilities to operate block devices, which work in both guest Asterinas and
+ * host Linux.
+ *
+ * By opening a block device via open_block_device(), the device will be opened
+ * in guest Asterinas via /dev/vda (or similar) and in host Linux via
+ * /dev/loop0 (or similar). These correspond to the same device image, where
+ * the underlying file system is prepared as part of the build process.
+ *
+ * The device can be mounted using mount_block_device(). After use, the mount
+ * can be cleaned up and the device can be closed via umount_block_device() and
+ * close_block_device(), respectively.
+ */
+
+#include <sys/mount.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+enum block_device {
+	BLOCK_VDA_EXT2,
+	BLOCK_VDB_EXFAT,
+	BLOCK_VDC_EXT2,
+};
+
+#ifdef __asterinas__
+
+static int open_block_device(enum block_device dev)
+{
+	switch (dev) {
+	case BLOCK_VDA_EXT2:
+		return open("/dev/vda", O_RDWR);
+	case BLOCK_VDB_EXFAT:
+		return open("/dev/vdb", O_RDWR);
+	case BLOCK_VDC_EXT2:
+		return open("/dev/vdc", O_RDWR);
+	}
+
+	errno = ENODEV;
+	return -1;
+}
+
+static int close_block_device(int fd)
+{
+	return close(fd);
+}
+
+#else /* __asterinas__ */
+
+#include <sys/ioctl.h>
+#include <linux/loop.h>
+
+#include "test.h"
+
+static int open_block_device(enum block_device dev)
+{
+	int img_fd, ctrl_fd, loop_fd;
+	int id;
+	char loop_path[20];
+
+	img_fd = -1;
+	switch (dev) {
+	case BLOCK_VDA_EXT2:
+		img_fd = CHECK(open("./test/initramfs/build/ext2.img", O_RDWR));
+		break;
+	case BLOCK_VDB_EXFAT:
+		img_fd =
+			CHECK(open("./test/initramfs/build/exfat.img", O_RDWR));
+		break;
+	case BLOCK_VDC_EXT2:
+		img_fd = CHECK(
+			open("./test/initramfs/build/ltp_dev.img", O_RDWR));
+		break;
+	}
+
+	ctrl_fd = CHECK(open("/dev/loop-control", O_RDWR));
+	id = CHECK(ioctl(ctrl_fd, LOOP_CTL_GET_FREE));
+	CHECK(close(ctrl_fd));
+
+	snprintf(loop_path, sizeof(loop_path), "/dev/loop%d", id);
+	loop_fd = CHECK(open(loop_path, O_RDWR));
+	CHECK(ioctl(loop_fd, LOOP_SET_FD, img_fd));
+	CHECK(close(img_fd));
+
+	return loop_fd;
+}
+
+static int close_block_device(int fd)
+{
+	CHECK(ioctl(fd, LOOP_CLR_FD));
+	CHECK(close(fd));
+
+	return 0;
+}
+
+#endif /* __asterinas__ */
+
+static int __attribute__((unused)) mount_block_device(int fd, const char *path,
+						      const char *fs, int flags)
+{
+	char buf[25];
+	snprintf(buf, sizeof(buf), "/proc/self/fd/%d", fd);
+
+	return mount(buf, path, fs, flags, NULL);
+}
+
+static int __attribute__((unused)) umount_block_device(const char *path)
+{
+	return umount(path);
+}
+
+#endif /* BLOCK_DEVICE_H */

--- a/test/initramfs/src/regression/fs/ext2/shared_block_device.c
+++ b/test/initramfs/src/regression/fs/ext2/shared_block_device.c
@@ -4,12 +4,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#ifndef __asterinas__
-#include <linux/loop.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/ioctl.h>
-#endif
 #include <sched.h>
 #include <string.h>
 #include <sys/mount.h>
@@ -17,81 +11,13 @@
 #include <unistd.h>
 
 #include "../../common/test.h"
+#include "../../common/block_device.h"
 
 #define PRIMARY_MOUNT "/tmp/shared_block_device_primary"
 #define SECONDARY_MOUNT "/tmp/shared_block_device_secondary"
 #define TEST_FILE "shared_instance_test"
 #define PRIMARY_FILE PRIMARY_MOUNT "/" TEST_FILE
 #define SECONDARY_FILE SECONDARY_MOUNT "/" TEST_FILE
-
-#ifdef __asterinas__
-/* `/dev/vda` is already mounted read-write at `/ext2` by init. */
-#define BLOCK_DEVICE "/dev/vdc"
-
-static const char *block_device_path(void)
-{
-	return BLOCK_DEVICE;
-}
-
-static int open_block_device(void)
-{
-	return open(BLOCK_DEVICE, O_RDWR);
-}
-
-static int close_block_device(int fd)
-{
-	return close(fd);
-}
-#else
-#define LOOP_BACKING_FILE "/tmp/shared_block_device.img"
-#define LOOP_BACKING_FILE_SIZE (16 * 1024 * 1024)
-
-static char loop_path[sizeof("/dev/loop") + 10];
-
-static const char *block_device_path(void)
-{
-	return loop_path;
-}
-
-static void make_ext2_image(void)
-{
-	/*
-	 * Linux test runners do not have the Asterinas ext2 disk image, so
-	 * build a fresh loop-backed ext2 block device for the same mount path.
-	 */
-	int image_fd = CHECK(
-		open(LOOP_BACKING_FILE, O_CREAT | O_RDWR | O_TRUNC, 0600));
-
-	CHECK(ftruncate(image_fd, LOOP_BACKING_FILE_SIZE));
-	CHECK(close(image_fd));
-	CHECK_WITH(system("mke2fs -q -t ext2 -F " LOOP_BACKING_FILE),
-		   _ret == 0);
-}
-
-static int open_block_device(void)
-{
-	make_ext2_image();
-
-	/* Keep the loop fd open until both mounts are unmounted. */
-	int control_fd = CHECK(open("/dev/loop-control", O_RDWR));
-	int loop_number = CHECK(ioctl(control_fd, LOOP_CTL_GET_FREE));
-	CHECK(close(control_fd));
-
-	snprintf(loop_path, sizeof(loop_path), "/dev/loop%d", loop_number);
-	int loop_fd = CHECK(open(loop_path, O_RDWR));
-	int image_fd = CHECK(open(LOOP_BACKING_FILE, O_RDWR));
-	CHECK(ioctl(loop_fd, LOOP_SET_FD, image_fd));
-	CHECK(close(image_fd));
-	return loop_fd;
-}
-
-static int close_block_device(int fd)
-{
-	CHECK(ioctl(fd, LOOP_CLR_FD, 0));
-	CHECK(close(fd));
-	return unlink(LOOP_BACKING_FILE);
-}
-#endif
 
 static void ensure_dir(const char *path)
 {
@@ -107,6 +33,8 @@ FN_SETUP(create_mount_dirs)
 {
 	ensure_dir(PRIMARY_MOUNT);
 	ensure_dir(SECONDARY_MOUNT);
+
+	CHECK(unshare(CLONE_NEWNS));
 }
 END_SETUP()
 
@@ -115,20 +43,17 @@ FN_TEST(mounts_of_same_block_device_share_filesystem)
 	const char *payload = "shared ext2 instance";
 	const size_t payload_len = strlen(payload);
 	char buffer[sizeof("shared ext2 instance")] = { 0 };
-	struct stat source_stat;
 
-	int block_device_fd = TEST_SUCC(open_block_device());
-	const char *block_device = block_device_path();
-	TEST_RES(stat(block_device, &source_stat),
-		 S_ISBLK(source_stat.st_mode));
+	int block_device_fd = TEST_SUCC(open_block_device(BLOCK_VDC_EXT2));
 
 	/*
-	 * Mount the same ext2 block device twice in a private mount namespace.
+	 * Mount the same ext2 block device twice.
 	 * Both mount points should refer to one shared filesystem instance.
 	 */
-	TEST_SUCC(unshare(CLONE_NEWNS));
-	TEST_SUCC(mount(block_device, PRIMARY_MOUNT, "ext2", 0, ""));
-	TEST_SUCC(mount(block_device, SECONDARY_MOUNT, "ext2", 0, ""));
+	TEST_SUCC(
+		mount_block_device(block_device_fd, PRIMARY_MOUNT, "ext2", 0));
+	TEST_SUCC(mount_block_device(block_device_fd, SECONDARY_MOUNT, "ext2",
+				     0));
 
 	unlink_if_exists(PRIMARY_FILE);
 	TEST_ERRNO(open(SECONDARY_FILE, O_RDONLY), ENOENT);
@@ -150,22 +75,30 @@ FN_TEST(mounts_of_same_block_device_share_filesystem)
 	TEST_SUCC(unlink(SECONDARY_FILE));
 	TEST_ERRNO(open(PRIMARY_FILE, O_RDONLY), ENOENT);
 
-	TEST_SUCC(umount(SECONDARY_MOUNT));
-	TEST_SUCC(umount(PRIMARY_MOUNT));
+	TEST_SUCC(umount_block_device(SECONDARY_MOUNT));
+	TEST_SUCC(umount_block_device(PRIMARY_MOUNT));
 	TEST_SUCC(close_block_device(block_device_fd));
 }
 END_TEST()
 
 FN_TEST(mounts_of_same_block_device_reject_different_readonly_flags)
 {
-	int block_device_fd = TEST_SUCC(open_block_device());
-	const char *block_device = block_device_path();
+	int block_device_fd = TEST_SUCC(open_block_device(BLOCK_VDC_EXT2));
 
-	TEST_SUCC(unshare(CLONE_NEWNS));
-	TEST_SUCC(mount(block_device, PRIMARY_MOUNT, "ext2", MS_RDONLY, ""));
-	TEST_ERRNO(mount(block_device, SECONDARY_MOUNT, "ext2", 0, ""), EBUSY);
+	TEST_SUCC(mount_block_device(block_device_fd, PRIMARY_MOUNT, "ext2",
+				     MS_RDONLY));
+	TEST_ERRNO(mount_block_device(block_device_fd, SECONDARY_MOUNT, "ext2",
+				      0),
+		   EBUSY);
+	TEST_SUCC(umount_block_device(PRIMARY_MOUNT));
 
-	TEST_SUCC(umount(PRIMARY_MOUNT));
 	TEST_SUCC(close_block_device(block_device_fd));
 }
 END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(rmdir(PRIMARY_MOUNT));
+	CHECK(rmdir(SECONDARY_MOUNT));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/fs/statx/btime.c
+++ b/test/initramfs/src/regression/fs/statx/btime.c
@@ -4,8 +4,6 @@
 
 #include <fcntl.h>
 #include <linux/stat.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
@@ -16,6 +14,7 @@
 #include <unistd.h>
 
 #include "../../common/test.h"
+#include "../../common/block_device.h"
 
 #define RAMFS_MOUNT_POINT "/tmp/statx_btime_ramfs"
 #define RAMFS_TEST_FILE RAMFS_MOUNT_POINT "/statx_btime_test_file"
@@ -25,32 +24,8 @@
 #define EXFAT_TEST_FILE_NOT_REQ \
 	EXFAT_MOUNT_POINT "/statx_btime_test_file_not_req"
 
+static int blk_fd = -1;
 static int fd = -1;
-
-#ifndef __asterinas__
-#include <linux/loop.h>
-#include <sys/ioctl.h>
-
-#define EXFAT_IMAGE "./test/initramfs/build/exfat.img"
-
-static int loop_fd = -1;
-static char loop_path[64];
-
-static void attach_loop_device(void)
-{
-	int control_fd = CHECK(open("/dev/loop-control", O_RDWR));
-	int loop_number = CHECK(ioctl(control_fd, LOOP_CTL_GET_FREE));
-	CHECK(close(control_fd));
-	CHECK_WITH(snprintf(loop_path, sizeof(loop_path), "/dev/loop%d",
-			    loop_number),
-		   _ret > 0 && (size_t)_ret < sizeof(loop_path));
-
-	int image_fd = CHECK(open(EXFAT_IMAGE, O_RDWR));
-	loop_fd = CHECK(open(loop_path, O_RDWR));
-	CHECK(ioctl(loop_fd, LOOP_SET_FD, image_fd));
-	CHECK(close(image_fd));
-}
-#endif
 
 FN_SETUP(prepare)
 {
@@ -63,12 +38,8 @@ FN_SETUP(prepare)
 
 	CHECK_WITH(mkdir(EXFAT_MOUNT_POINT, 0755),
 		   _ret == 0 || errno == EEXIST);
-#ifdef __asterinas__
-	CHECK(mount("/dev/vdb", EXFAT_MOUNT_POINT, "exfat", 0, ""));
-#else
-	attach_loop_device();
-	CHECK(mount(loop_path, EXFAT_MOUNT_POINT, "exfat", 0, ""));
-#endif
+	blk_fd = CHECK(open_block_device(BLOCK_VDB_EXFAT));
+	CHECK(mount_block_device(blk_fd, EXFAT_MOUNT_POINT, "exfat", 0));
 }
 END_SETUP()
 
@@ -133,13 +104,9 @@ FN_SETUP(cleanup)
 	CHECK(unlink(RAMFS_TEST_FILE));
 	CHECK(unlink(EXFAT_TEST_FILE));
 	CHECK(unlink(EXFAT_TEST_FILE_NOT_REQ));
-	CHECK(umount(EXFAT_MOUNT_POINT));
 	CHECK(umount(RAMFS_MOUNT_POINT));
-
-#ifndef __asterinas__
-	CHECK(ioctl(loop_fd, LOOP_CLR_FD));
-	CHECK(close(loop_fd));
-#endif
+	CHECK(umount_block_device(EXFAT_MOUNT_POINT));
+	CHECK(close_block_device(blk_fd));
 
 	CHECK(rmdir(EXFAT_MOUNT_POINT));
 	CHECK(rmdir(RAMFS_MOUNT_POINT));

--- a/test/initramfs/src/regression/io/file_io/block_device.c
+++ b/test/initramfs/src/regression/io/file_io/block_device.c
@@ -3,6 +3,7 @@
 #define _GNU_SOURCE
 
 #include "../../common/test.h"
+#include "../../common/block_device.h"
 #include <fcntl.h>
 #include <linux/fs.h>
 #include <stdint.h>
@@ -11,49 +12,6 @@
 
 #define SECTOR_SIZE 512
 
-#ifdef __asterinas__
-static int open_block_device(void)
-{
-	return open("/dev/vdb", O_RDWR);
-}
-
-static int close_block_device(int fd)
-{
-	return close(fd);
-}
-#else
-#include <linux/loop.h>
-
-#define LOOP_BACKING_FILE "/tmp/block_device_file_io.img"
-#define LOOP_BACKING_FILE_SIZE (SECTOR_SIZE * 8)
-
-static int open_block_device(void)
-{
-	int control_fd = CHECK(open("/dev/loop-control", O_RDWR));
-	int image_fd = CHECK(
-		open(LOOP_BACKING_FILE, O_CREAT | O_RDWR | O_TRUNC, 0600));
-	int loop_number;
-	char loop_path[sizeof("/dev/loop") + 10];
-
-	CHECK(ftruncate(image_fd, LOOP_BACKING_FILE_SIZE));
-	loop_number = CHECK(ioctl(control_fd, LOOP_CTL_GET_FREE));
-	CHECK(close(control_fd));
-
-	snprintf(loop_path, sizeof(loop_path), "/dev/loop%d", loop_number);
-	int loop_fd = CHECK(open(loop_path, O_RDWR));
-	CHECK(ioctl(loop_fd, LOOP_SET_FD, image_fd));
-	CHECK(close(image_fd));
-	return loop_fd;
-}
-
-static int close_block_device(int fd)
-{
-	CHECK(ioctl(fd, LOOP_CLR_FD, 0));
-	CHECK(close(fd));
-	return unlink(LOOP_BACKING_FILE);
-}
-#endif
-
 // Verifies that seeking to the end of a block device reports the same
 // byte-granular size that the block-device ioctl reports.
 FN_TEST(seek_end_matches_block_device_size)
@@ -61,7 +19,7 @@ FN_TEST(seek_end_matches_block_device_size)
 	int fd;
 	uint64_t block_device_size;
 
-	fd = TEST_SUCC(open_block_device());
+	fd = TEST_SUCC(open_block_device(BLOCK_VDB_EXFAT));
 
 	TEST_SUCC(ioctl(fd, BLKGETSIZE64, &block_device_size));
 	TEST_RES(lseek(fd, 0, SEEK_END), (uint64_t)_ret == block_device_size);
@@ -83,7 +41,7 @@ FN_TEST(short_unaligned_pread_matches_sector_bytes)
 		uint8_t bytes[13];
 	} small_read;
 
-	fd = TEST_SUCC(open_block_device());
+	fd = TEST_SUCC(open_block_device(BLOCK_VDB_EXFAT));
 
 	TEST_RES(pread(fd, reference, sizeof(reference), 0),
 		 _ret == sizeof(reference));
@@ -109,7 +67,7 @@ FN_TEST(unaligned_pwrite_preserves_sector_bytes)
 	uint8_t after[SECTOR_SIZE * 2];
 	uint8_t patch[] = { 'X', 'Y', 'Z' };
 
-	fd = TEST_SUCC(open_block_device());
+	fd = TEST_SUCC(open_block_device(BLOCK_VDB_EXFAT));
 
 	TEST_RES(pread(fd, original, sizeof(original), 0),
 		 _ret == sizeof(original));


### PR DESCRIPTION
https://github.com/asterinas/asterinas/blob/4cc2cd3ff375264d97260a686583c6fa941da962/test/initramfs/src/regression/fs/statx/btime.c#L39
https://github.com/asterinas/asterinas/blob/4cc2cd3ff375264d97260a686583c6fa941da962/test/initramfs/src/regression/io/file_io/block_device.c#L30
https://github.com/asterinas/asterinas/blob/4cc2cd3ff375264d97260a686583c6fa941da962/test/initramfs/src/regression/fs/ext2/shared_block_device.c#L71

It's awful to have to repeat similar code three times. I think three times is a reasonable number at which to start unifying it in one place.

So let's unify the code to `test/initramfs/src/regression/common/block_device.h`.

This also fixes an additional bug in the mounting operation. We should follow the symbolic link of the source device. Otherwise, `mount("/proc/self/fd/xx")` will fail. This behavior differs from that of Linux.

I've tested all the changed regression tests in Linux. They do pass.

---

AFAICK, all the tests were originally authored by @cchanging. Could you take a look at the changes here?