### PR TITLE
Fix MMIO cursor advancement during fork

### DIFF
--- a/kernel/src/vm/vmar/vmar_impls/fork.rs
+++ b/kernel/src/vm/vmar/vmar_impls/fork.rs
@@ -105,7 +105,11 @@ fn cow_copy_pt(src: &mut CursorMut<'_>, dst: &mut CursorMut<'_>, size: usize) ->
                 // Manually advance the source cursor.
                 // In the `MappedRam` case, the cursor is advanced by `protect_next`.
                 // However, this does not apply to the `MappedIoMem` case.
-                src.jump(mapped_va + PAGE_SIZE).unwrap();
+                let next_va = mapped_va + PAGE_SIZE;
+                if next_va == end_va {
+                    break;
+                }
+                src.jump(next_va).unwrap();
             }
         }
 
@@ -258,7 +262,7 @@ mod test {
 
         let vm_space = VmSpace::new();
         let map_range = PAGE_SIZE..(PAGE_SIZE * 2);
-        let cow_range = 0..PAGE_SIZE * 512 * 512;
+        let cow_range = map_range.clone();
         let page_property = PageProperty::new_user(PageFlags::RW, CachePolicy::Uncacheable);
         let preempt_guard = disable_preempt();
 


### PR DESCRIPTION
## Problem

`cow_copy_pt` manually advances the source cursor after copying a `MappedIoMem` page because, unlike `protect_next` in the `MappedRam` branch, copying an I/O-memory mapping does not advance the source cursor.

When the I/O-memory page is the final page in the copied range, the next address is equal to `end_va`. Since the cursor range is half-open, `CursorMut::jump(end_va)` returns `InvalidVaddr`, and the following `unwrap()` causes a kernel panic during `fork`.

This can affect processes that fork while holding device-backed mappings, such as framebuffer, PCI, or GPU mappings.

## Solution

Calculate the next virtual address after copying the MMIO page. If it is the end of the requested range, finish the traversal instead of attempting to jump outside the cursor's valid address range.


The existing MMIO fork test is adjusted so that its copied range ends immediately after the MMIO page. This makes the old implementation panic and verifies the fixed boundary behavior.