### PR TITLE
Fix `VT_MANAGER` panic on early keyboard input

### DIFF
--- a/kernel/src/device/tty/vt/mod.rs
+++ b/kernel/src/device/tty/vt/mod.rs
@@ -118,8 +118,10 @@ impl TryFrom<i32> for VtIndex {
 }
 
 pub(super) fn init_in_first_process() -> Result<()> {
-    keyboard::init_in_first_process();
+    // The keyboard handler may run from IRQ context as soon as it is
+    // registered, so `VT_MANAGER` must be initialized first.
     manager::init_in_first_process()?;
+    keyboard::init_in_first_process();
     device::init_in_first_process();
     Ok(())
 }


### PR DESCRIPTION
Fixes #3670.

### Root cause

`vt::init_in_first_process` registers the VT keyboard handler before
`manager::init_in_first_process` initializes `VT_MANAGER`:

```rust
keyboard::init_in_first_process();   // registers the input handler
manager::init_in_first_process()?;   // VT_MANAGER.call_once(...)
```

The handler is invoked synchronously from the i8042 IRQ path
(`submit_events` → `handle_events` → `handle_key_event`), so it can run as
soon as registration completes. A key event arriving before `call_once`
panics in interrupt context:

```
Uncaught panic:
        `VT_MANAGER` is not initialized
        at kernel/src/device/tty/vt/keyboard/handler.rs:76
```

The same ordering also turns a failed `VtManager::new()` into a permanent
any-keypress panic, since the handler stays registered while `VT_MANAGER`
remains uninitialized.

### Fix

Initialize the manager before registering the handler. `VtManager::new`
creates the TTY devices and activates VT1; it does not depend on the
keyboard state (the keysym table is consumed only at event translation
time), so the reorder is safe.

### Reproduction and A/B validation

Reproduced without `make run_nixos`, using a plain kernel ISO with a
framebuffer console (grub `gfxpayload=1024x768x32`, OVMF) and key events
injected via QMP `send-key` every 15 ms from the start of boot (QEMU 8.2,
TCG). On the unpatched kernel the panic fires ~10 ms after
"Virtual terminal keyboard handler connected to device: i8042_keyboard".
Both sides of the table below boot the same initramfs, whose init opens
`/dev/tty2` (keyboard switching to an unallocated VT is rejected by
design) and then idles.

| Kernel (same base, e2e2a2d7b) | Boots with early key storm | `VT_MANAGER` panic | Alt+F2 after boot switches to VT2 |
|---|---|---|---|
| unpatched | 10 | 10 | n/a (panics) |
| patched | 10 | 0 | 10/10 ("Switched to VT2") |

A patched no-input control boot comes up normally and also handles the
post-boot Alt+F2 switch.
