### PR TITLE
Refine the safety condition of `drop_meta_in_place`

### DIFF
--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -406,7 +406,7 @@ impl MetaSlot {
     /// # Safety
     ///
     /// The caller should ensure that:
-    ///  - the reference count is `0` (so we are the sole owner of the frame);
+    ///  - the reference count is `0` or [`REF_COUNT_UNIQUE`] (so we are the sole owner of the frame);
     ///  - the metadata is initialized;
     pub(super) unsafe fn drop_meta_in_place(&self) {
         let paddr = self.frame_paddr();


### PR DESCRIPTION
The safety condition of `drop_meta_in_place` states that 

> The caller should ensure that:
>     ///  - the reference count is `0` (so we are the sole owner of the frame)

This PR corrects this constraint to allow `REF_COUNT_UNIQUE`, which is exactly how it is used in `UniqueFrame::repurpose`.
https://github.com/asterinas/asterinas/blob/491b35b0faab07cd9a47a886de5b01792306080a/ostd/src/mm/frame/unique.rs#L87-L92