### PR TITLE
Separate kernel eventfd state from the file wrapper

### DIFF
--- a/kernel/core/src/events/event_file.rs
+++ b/kernel/core/src/events/event_file.rs
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The eventfd file object and its counter semantics.
+//!
+//! An eventfd maintains a 64-bit counter. Userspace writes add to the counter,
+//! while reads either consume the whole counter or decrement it by one in
+//! semaphore mode. Both operations may wait according to the file's status
+//! flags.
+//!
+//! `EventFile` is the file-descriptor-facing object behind an eventfd.  Its
+//! `KernelEventFile` component owns the counter and notification state shared
+//! with in-kernel producers and consumers.
+
+use core::fmt::Display;
+
+use ostd::sync::{LocalIrqDisabled, WaitQueue};
+
+use crate::{
+    events::IoEvents,
+    fs::{
+        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
+        pseudofs::AnonInodeFs,
+    },
+    prelude::*,
+    process::signal::{PollHandle, Pollable, Pollee},
+};
+
+bitflags! {
+    /// Flags used internally when creating an eventfd file.
+    pub struct EventFileFlags: u32 {
+        const EFD_SEMAPHORE = 1;
+        const EFD_CLOEXEC = CreationFlags::O_CLOEXEC.bits();
+        const EFD_NONBLOCK = StatusFlags::O_NONBLOCK.bits();
+    }
+}
+
+/// The eventfd state shared by the file-descriptor and kernel-facing APIs.
+pub struct KernelEventFile {
+    // Kernel event producers may signal from IRQ context, so counter updates must not sleep.
+    // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L71>.
+    counter: SpinLock<u64, LocalIrqDisabled>,
+    pollee: Pollee,
+    is_semaphore: bool,
+    write_wait_queue: WaitQueue,
+}
+
+impl KernelEventFile {
+    const MAX_COUNTER_VALUE: u64 = u64::MAX - 1;
+
+    fn new(init_val: u64, is_semaphore: bool) -> Self {
+        let counter = SpinLock::new(init_val);
+        let pollee = Pollee::new();
+        let write_wait_queue = WaitQueue::new();
+        Self {
+            counter,
+            pollee,
+            is_semaphore,
+            write_wait_queue,
+        }
+    }
+
+    /// Gets an independently owned kernel-facing state from an eventfd file.
+    /// Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L366>.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub fn from_file(file: &dyn FileLike) -> Result<Arc<Self>> {
+        let event_file = file
+            .downcast_ref::<EventFile>()
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "the file is not an event file"))?;
+        Ok(event_file.kernel_event_file.clone())
+    }
+
+    /// Reports the file-facing I/O readiness of the shared eventfd state.
+    ///
+    /// Kernel consumers can select the readiness relevant to their operation
+    /// through the poll mask. [`IoEvents::OUT`] retains its file-facing meaning:
+    /// userspace can write a value of at least one without blocking. It does not
+    /// constrain [`Self::signal`].
+    fn check_io_events(&self) -> IoEvents {
+        let counter = self.counter.lock();
+
+        let mut events = IoEvents::empty();
+
+        let is_readable = *counter != 0;
+        if is_readable {
+            events |= IoEvents::IN;
+        }
+
+        // If it is possible to write a value of at least "1" without blocking,
+        // the file is writable.
+        if *counter < Self::MAX_COUNTER_VALUE {
+            events |= IoEvents::OUT;
+        }
+
+        if *counter == u64::MAX {
+            events |= IoEvents::ERR;
+        }
+
+        events
+    }
+
+    /// Consumes and returns the counter value.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L176>.
+    pub fn consume(&self) -> Option<u64> {
+        let mut counter = self.counter.lock();
+        let value = if *counter == 0 {
+            return None;
+        } else if self.is_semaphore {
+            *counter -= 1;
+            1
+        } else {
+            let value = *counter;
+            *counter = 0;
+            value
+        };
+        drop(counter);
+
+        // Notify outside the IRQ-disabled critical section.
+        self.pollee.notify(IoEvents::OUT);
+        self.write_wait_queue.wake_all();
+        Some(value)
+    }
+
+    /// Increments the counter by one.
+    ///
+    /// Unlike userspace writes, this operation may bring the counter to
+    /// `u64::MAX`, which is reported through `POLLERR`.
+    /// Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L46>.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub fn signal(&self) {
+        let mut counter = self.counter.lock();
+        *counter = counter.saturating_add(1);
+
+        let events = if *counter == u64::MAX {
+            IoEvents::IN | IoEvents::ERR
+        } else {
+            IoEvents::IN
+        };
+
+        drop(counter);
+
+        // FIXME: Add per-task recursion protection if eventfd observers need to signal another
+        // eventfd.
+        self.pollee.notify(events);
+    }
+}
+
+impl Pollable for KernelEventFile {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
+        self.pollee
+            .poll_with(mask, poller, || self.check_io_events())
+    }
+}
+
+pub struct EventFile {
+    // `KernelEventFile` has an independent lifetime from the outer `EventFile`.
+    // Kernel bindings can continue operating on this state after the outer file is dropped.
+    kernel_event_file: Arc<KernelEventFile>,
+    common: FileCommon,
+}
+
+impl EventFile {
+    pub fn new(init_val: u64, flags: EventFileFlags) -> Self {
+        let is_semaphore = flags.contains(EventFileFlags::EFD_SEMAPHORE);
+        let status_flags = if flags.contains(EventFileFlags::EFD_NONBLOCK) {
+            StatusFlags::O_NONBLOCK
+        } else {
+            StatusFlags::empty()
+        };
+        let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[eventfd]".to_string());
+        Self {
+            kernel_event_file: Arc::new(KernelEventFile::new(init_val, is_semaphore)),
+            common: FileCommon::new(pseudo_path, status_flags),
+        }
+    }
+
+    fn is_nonblocking(&self) -> bool {
+        self.common.is_nonblocking()
+    }
+
+    fn try_read(&self, writer: &mut VmWriter) -> Result<()> {
+        let Some(value) = self.kernel_event_file.consume() else {
+            return_errno_with_message!(Errno::EAGAIN, "the counter is zero");
+        };
+
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L235>.
+        writer.write_fallible(&mut value.as_bytes().into())?;
+        Ok(())
+    }
+
+    /// Adds a userspace-supplied value to the counter.
+    ///
+    /// If the new value overflows or exceeds `MAX_COUNTER_VALUE`, the counter
+    /// is not modified and this method returns `Err(EAGAIN)`.
+    fn add_counter_val(&self, val: u64) -> Result<()> {
+        let mut counter = self.kernel_event_file.counter.lock();
+
+        if let Some(new_value) = (*counter).checked_add(val)
+            && new_value <= KernelEventFile::MAX_COUNTER_VALUE
+        {
+            *counter = new_value;
+        } else {
+            return_errno_with_message!(Errno::EAGAIN, "the new value exceeds MAX_COUNTER_VALUE");
+        }
+
+        drop(counter);
+
+        // Notify outside the IRQ-disabled critical section.
+        self.kernel_event_file.pollee.notify(IoEvents::IN);
+        Ok(())
+    }
+}
+
+impl Pollable for EventFile {
+    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
+        self.kernel_event_file.poll(mask, poller)
+    }
+}
+
+impl FileLike for EventFile {
+    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+        let read_len = size_of::<u64>();
+        if writer.avail() < read_len {
+            return_errno_with_message!(Errno::EINVAL, "the event buffer is too small");
+        }
+
+        if self.is_nonblocking() {
+            self.try_read(writer)?;
+        } else {
+            self.wait_events(IoEvents::IN, None, || self.try_read(writer))?;
+        }
+
+        Ok(read_len)
+    }
+
+    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+        let write_len = size_of::<u64>();
+        if reader.remain() < write_len {
+            return_errno_with_message!(Errno::EINVAL, "the event buffer is too small");
+        }
+
+        let supplied_value = reader.read_val::<u64>()?;
+
+        if supplied_value > KernelEventFile::MAX_COUNTER_VALUE {
+            return_errno_with_message!(
+                Errno::EINVAL,
+                "the written value exceeds MAX_COUNTER_VALUE"
+            );
+        }
+
+        if self.is_nonblocking() {
+            self.add_counter_val(supplied_value)?;
+        } else {
+            self.kernel_event_file
+                .write_wait_queue
+                .pause_until(|| self.add_counter_val(supplied_value).ok())?;
+        }
+
+        Ok(write_len)
+    }
+
+    fn access_mode(&self) -> AccessMode {
+        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L401>.
+        AccessMode::O_RDWR
+    }
+
+    fn common(&self) -> &FileCommon {
+        &self.common
+    }
+
+    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
+        struct FdInfo {
+            inner: Arc<EventFile>,
+            fd_flags: FdFlags,
+            eventfd_count: u64,
+        }
+
+        impl Display for FdInfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let mut flags =
+                    self.inner.common.status_flags().bits() | self.inner.access_mode() as u32;
+                if self.fd_flags.contains(FdFlags::CLOEXEC) {
+                    flags |= CreationFlags::O_CLOEXEC.bits();
+                }
+
+                writeln!(f, "pos:\t{}", 0)?;
+                writeln!(f, "flags:\t0{:o}", flags)?;
+                writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
+                writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())?;
+                writeln!(f, "eventfd-count: {:16x}", self.eventfd_count)
+            }
+        }
+
+        let eventfd_count = *self.kernel_event_file.counter.lock();
+        Box::new(FdInfo {
+            inner: self,
+            fd_flags,
+            eventfd_count,
+        })
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::ktest;
+
+    use super::{EventFile, EventFileFlags, KernelEventFile};
+    use crate::{
+        events::{EpollFile, IoEvents},
+        fs::file::FileLike,
+        prelude::{Arc, VmWriter},
+        process::signal::Pollable,
+    };
+
+    #[ktest]
+    fn kernel_event_file_rejects_non_eventfd() {
+        crate::time::clocks::init_for_ktest();
+
+        let file = EpollFile::new() as Arc<dyn FileLike>;
+
+        assert!(KernelEventFile::from_file(file.as_ref()).is_err());
+    }
+
+    #[ktest]
+    fn kernel_event_file_owns_state_after_file_drop() {
+        crate::time::clocks::init_for_ktest();
+
+        let file = Arc::new(EventFile::new(0, EventFileFlags::empty())) as Arc<dyn FileLike>;
+        let kernel_event_file = KernelEventFile::from_file(file.as_ref()).unwrap();
+        drop(file);
+
+        assert!(
+            !kernel_event_file
+                .poll(IoEvents::IN, None)
+                .contains(IoEvents::IN)
+        );
+        kernel_event_file.signal();
+        assert!(
+            kernel_event_file
+                .poll(IoEvents::IN, None)
+                .contains(IoEvents::IN)
+        );
+        assert_eq!(kernel_event_file.consume(), Some(1));
+        assert!(
+            !kernel_event_file
+                .poll(IoEvents::IN, None)
+                .contains(IoEvents::IN)
+        );
+    }
+
+    #[ktest]
+    fn event_file_signal_consume_and_poll() {
+        crate::time::clocks::init_for_ktest();
+
+        let event_file = EventFile::new(0, EventFileFlags::empty());
+
+        assert!(!event_file.poll(IoEvents::IN, None).contains(IoEvents::IN));
+        event_file.kernel_event_file.signal();
+        event_file.kernel_event_file.signal();
+        assert!(event_file.poll(IoEvents::IN, None).contains(IoEvents::IN));
+        assert_eq!(event_file.kernel_event_file.consume(), Some(2));
+        assert_eq!(event_file.kernel_event_file.consume(), None);
+        assert!(!event_file.poll(IoEvents::IN, None).contains(IoEvents::IN));
+    }
+
+    #[ktest]
+    fn event_file_respects_semaphore_mode() {
+        crate::time::clocks::init_for_ktest();
+
+        let event_file = EventFile::new(0, EventFileFlags::EFD_SEMAPHORE);
+
+        event_file.kernel_event_file.signal();
+        event_file.kernel_event_file.signal();
+        assert_eq!(event_file.kernel_event_file.consume(), Some(1));
+        assert!(event_file.poll(IoEvents::IN, None).contains(IoEvents::IN));
+        assert_eq!(event_file.kernel_event_file.consume(), Some(1));
+        assert_eq!(event_file.kernel_event_file.consume(), None);
+    }
+
+    #[ktest]
+    fn event_file_reports_kernel_signal_overflow() {
+        crate::time::clocks::init_for_ktest();
+
+        let event_file =
+            EventFile::new(KernelEventFile::MAX_COUNTER_VALUE, EventFileFlags::empty());
+
+        event_file.kernel_event_file.signal();
+        let events = event_file.poll(IoEvents::IN | IoEvents::ERR, None);
+        assert!(events.contains(IoEvents::IN));
+        assert!(events.contains(IoEvents::ERR));
+        assert_eq!(event_file.kernel_event_file.consume(), Some(u64::MAX));
+    }
+
+    #[ktest]
+    fn event_file_read_consumes_counter() {
+        crate::time::clocks::init_for_ktest();
+
+        let event_file = EventFile::new(42, EventFileFlags::empty());
+
+        let mut value = [0u8; size_of::<u64>()];
+        let mut writer = VmWriter::from(value.as_mut_slice()).to_fallible();
+        event_file.try_read(&mut writer).unwrap();
+        assert_eq!(u64::from_ne_bytes(value), 42);
+
+        assert_eq!(*event_file.kernel_event_file.counter.lock(), 0);
+        assert!(
+            event_file
+                .kernel_event_file
+                .check_io_events()
+                .contains(IoEvents::OUT)
+        );
+    }
+}

--- a/kernel/core/src/events/mod.rs
+++ b/kernel/core/src/events/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod epoll;
+mod event_file;
 #[expect(clippy::module_inception)]
 mod events;
 mod io_events;
@@ -9,6 +10,7 @@ mod subject;
 
 pub use self::{
     epoll::{EpollCtl, EpollEvent, EpollFile, EpollFlags},
+    event_file::{EventFile, EventFileFlags},
     events::{Events, EventsFilter},
     io_events::IoEvents,
     observer::Observer,

--- a/kernel/core/src/syscall/eventfd.rs
+++ b/kernel/core/src/syscall/eventfd.rs
@@ -1,54 +1,37 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! `eventfd()` creates an "eventfd object" (we name it as `EventFile`)
-//! which serves as a mechanism for event wait/notify.
-//!
-//! `EventFile` holds a `u64` integer counter.
-//! Writing to `EventFile` increments the counter by the written value.
-//! Reading from `EventFile` returns the current counter value and resets it
-//! (It is also possible to only read 1,
-//! depending on whether the `EFD_SEMAPHORE` flag is set).
-//! The read/write operations may be blocked based on file flags.
+//! `eventfd()` creates an eventfd object used for event notification.
 //!
 //! For more detailed information about this syscall,
 //! refer to the man 2 eventfd documentation.
-//!
-
-use core::fmt::Display;
-
-use ostd::sync::WaitQueue;
 
 use super::SyscallReturn;
 use crate::{
-    events::IoEvents,
-    fs::{
-        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
-        pseudofs::AnonInodeFs,
-    },
+    events::{EventFile, EventFileFlags},
+    fs::file::file_table::FdFlags,
     prelude::*,
-    process::signal::{PollHandle, Pollable, Pollee},
 };
 
 pub fn sys_eventfd(init_val: u32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("init_val = 0x{:x}", init_val);
 
-    do_sys_eventfd2(init_val, Flags::empty(), ctx)
+    do_sys_eventfd2(init_val, EventFileFlags::empty(), ctx)
 }
 
 pub fn sys_eventfd2(init_val: u32, flags: u32, ctx: &Context) -> Result<SyscallReturn> {
     debug!("raw flags = {}", flags);
-    let flags = Flags::from_bits(flags)
+    let flags = EventFileFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown flags"))?;
     debug!("init_val = 0x{:x}, flags = {:?}", init_val, flags);
 
     do_sys_eventfd2(init_val, flags, ctx)
 }
 
-fn do_sys_eventfd2(init_val: u32, flags: Flags, ctx: &Context) -> Result<SyscallReturn> {
+fn do_sys_eventfd2(init_val: u32, flags: EventFileFlags, ctx: &Context) -> Result<SyscallReturn> {
     let event_file = EventFile::new(init_val as u64, flags);
     let file_table = ctx.thread_local.borrow_file_table();
     let mut file_table_locked = file_table.unwrap().write();
-    let fd_flags = if flags.contains(Flags::EFD_CLOEXEC) {
+    let fd_flags = if flags.contains(EventFileFlags::EFD_CLOEXEC) {
         FdFlags::CLOEXEC
     } else {
         FdFlags::empty()
@@ -56,197 +39,4 @@ fn do_sys_eventfd2(init_val: u32, flags: Flags, ctx: &Context) -> Result<Syscall
 
     let fd = file_table_locked.insert(Arc::new(event_file), fd_flags);
     Ok(SyscallReturn::Return(fd.into()))
-}
-
-bitflags! {
-    struct Flags: u32 {
-        const EFD_SEMAPHORE = 1;
-        const EFD_CLOEXEC = CreationFlags::O_CLOEXEC.bits();
-        const EFD_NONBLOCK = StatusFlags::O_NONBLOCK.bits();
-    }
-}
-
-struct EventFile {
-    counter: Mutex<u64>,
-    pollee: Pollee,
-    is_semaphore: bool,
-    common: FileCommon,
-    write_wait_queue: WaitQueue,
-}
-
-impl EventFile {
-    const MAX_COUNTER_VALUE: u64 = u64::MAX - 1;
-
-    fn new(init_val: u64, flags: Flags) -> Self {
-        let counter = Mutex::new(init_val);
-        let pollee = Pollee::new();
-        let write_wait_queue = WaitQueue::new();
-        let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[eventfd]".to_string());
-        let is_semaphore = flags.contains(Flags::EFD_SEMAPHORE);
-        let status_flags = if flags.contains(Flags::EFD_NONBLOCK) {
-            StatusFlags::O_NONBLOCK
-        } else {
-            StatusFlags::empty()
-        };
-        Self {
-            counter,
-            pollee,
-            is_semaphore,
-            common: FileCommon::new(pseudo_path, status_flags),
-            write_wait_queue,
-        }
-    }
-
-    fn is_nonblocking(&self) -> bool {
-        self.common.is_nonblocking()
-    }
-
-    fn check_io_events(&self) -> IoEvents {
-        let counter = self.counter.lock();
-
-        let mut events = IoEvents::empty();
-
-        let is_readable = *counter != 0;
-        if is_readable {
-            events |= IoEvents::IN;
-        }
-
-        // If it is possible to write a value of at least "1"
-        // without blocking, the file is writable
-        let is_writable = *counter < Self::MAX_COUNTER_VALUE;
-        if is_writable {
-            events |= IoEvents::OUT;
-        }
-
-        events
-    }
-
-    fn try_read(&self, writer: &mut VmWriter) -> Result<()> {
-        let mut counter = self.counter.lock();
-
-        // Wait until the counter becomes non-zero
-        if *counter == 0 {
-            return_errno_with_message!(Errno::EAGAIN, "the counter is zero");
-        }
-
-        // Copy the value from the counter and set the new counter value
-        if self.is_semaphore {
-            writer.write_fallible(&mut 1u64.as_bytes().into())?;
-            *counter -= 1;
-        } else {
-            writer.write_fallible(&mut (*counter).as_bytes().into())?;
-            *counter = 0;
-        }
-
-        self.pollee.notify(IoEvents::OUT);
-        self.write_wait_queue.wake_all();
-
-        Ok(())
-    }
-
-    /// Adds a value to the counter.
-    ///
-    /// If the new value overflows or exceeds `MAX_COUNTER_VALUE`, the counter value
-    /// will not be modified and this method will return `Err(EAGAIN)`.
-    fn add_counter_val(&self, val: u64) -> Result<()> {
-        let mut counter = self.counter.lock();
-
-        if let Some(new_value) = (*counter).checked_add(val)
-            && new_value <= Self::MAX_COUNTER_VALUE
-        {
-            *counter = new_value;
-            self.pollee.notify(IoEvents::IN);
-            return Ok(());
-        }
-
-        return_errno_with_message!(Errno::EAGAIN, "the new value exceeds MAX_COUNTER_VALUE");
-    }
-}
-
-impl Pollable for EventFile {
-    fn poll(&self, mask: IoEvents, poller: Option<&mut PollHandle>) -> IoEvents {
-        self.pollee
-            .poll_with(mask, poller, || self.check_io_events())
-    }
-}
-
-impl FileLike for EventFile {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
-        let read_len = size_of::<u64>();
-        if writer.avail() < read_len {
-            return_errno_with_message!(Errno::EINVAL, "the event buffer is too small");
-        }
-
-        if self.is_nonblocking() {
-            self.try_read(writer)?;
-        } else {
-            self.wait_events(IoEvents::IN, None, || self.try_read(writer))?;
-        }
-
-        Ok(read_len)
-    }
-
-    fn write(&self, reader: &mut VmReader) -> Result<usize> {
-        let write_len = size_of::<u64>();
-        if reader.remain() < write_len {
-            return_errno_with_message!(Errno::EINVAL, "the event buffer is too small");
-        }
-
-        let supplied_value = reader.read_val::<u64>()?;
-
-        if supplied_value > EventFile::MAX_COUNTER_VALUE {
-            return_errno_with_message!(
-                Errno::EINVAL,
-                "the written value exceeds MAX_COUNTER_VALUE"
-            );
-        }
-
-        if self.is_nonblocking() {
-            // Try to add the value
-            self.add_counter_val(supplied_value)?;
-        } else {
-            // Wait until the value can be added
-            self.write_wait_queue
-                .pause_until(|| self.add_counter_val(supplied_value).ok())?;
-        }
-
-        Ok(write_len)
-    }
-
-    fn access_mode(&self) -> AccessMode {
-        // Reference: <https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L401>.
-        AccessMode::O_RDWR
-    }
-
-    fn common(&self) -> &FileCommon {
-        &self.common
-    }
-
-    fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display> {
-        struct FdInfo {
-            inner: Arc<EventFile>,
-            fd_flags: FdFlags,
-        }
-
-        impl Display for FdInfo {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut flags =
-                    self.inner.common.status_flags().bits() | self.inner.access_mode() as u32;
-                if self.fd_flags.contains(FdFlags::CLOEXEC) {
-                    flags |= CreationFlags::O_CLOEXEC.bits();
-                }
-
-                writeln!(f, "pos:\t{}", 0)?;
-                writeln!(f, "flags:\t0{:o}", flags)?;
-                writeln!(f, "mnt_id:\t{}", AnonInodeFs::mount_node().id())?;
-                writeln!(f, "ino:\t{}", AnonInodeFs::shared_inode().ino())?;
-                writeln!(f, "eventfd-count: {:16x}", *self.inner.counter.lock())
-            }
-        }
-
-        Box::new(FdInfo {
-            inner: self,
-            fd_flags,
-        })
-    }
 }


### PR DESCRIPTION
## Summary

- Move the eventfd file implementation out of `kernel/core/src/syscall/eventfd.rs` into `kernel/core/src/events/event_file.rs`.
- Split eventfd into two layers: `EventFile` provides file-descriptor and VFS behavior, while `KernelEventFile` owns the counter, notification state, and kernel-facing operations.
- Give the kernel-facing eventfd state an independent reference-counted lifetime and make it pollable for kernel waiters.
- Add kernel tests for type validation, independent lifetime, signaling, consuming, semaphore mode, overflow reporting, polling, and userspace-read consumption.

## Motivation

Both vhost and future KVM irqfd/ioeventfd paths need to validate an eventfd supplied through a userspace file descriptor and retain its context in a kernel registration.

Such a registration may outlive the original file-table lookup and must remain valid even if userspace closes the original file descriptor. Kernel consumers should therefore retain only the eventfd counter and notification state, rather than the complete VFS-facing file wrapper.

This PR provides that reusable primitive independently from vhost or KVM device logic.

## Design

`EventFile` is the file-descriptor and VFS wrapper. It owns `FileCommon` and an `Arc<KernelEventFile>`. `KernelEventFile` owns the counter, `Pollee`, write wait queue, semaphore mode, and the kernel-facing `signal()`, `consume()`, and polling operations.

`KernelEventFile::from_file()` borrows a `dyn FileLike`, validates it by downcasting to `EventFile`, and returns a cloned `Arc<KernelEventFile>`. The inner `Arc` is intentional: vhost and KVM registrations retain the eventfd state until replacement, unbind, or device teardown. If `KernelEventFile` were embedded in `EventFile` by value, every kernel binding would instead have to retain the entire `Arc<EventFile>`, including `FileCommon` and the VFS-facing behavior.

This corresponds to the independently reference-counted Linux eventfd context:

- [The file-to-context conversion](https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L358) validates the file type and acquires a context reference.
- [Kernel signaling](https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L46) permits the counter to reach `u64::MAX` as an overflow condition.
- [Counter consumption](https://elixir.bootlin.com/linux/v7.0/source/fs/eventfd.c#L176) provides the semantics shared by kernel and userspace readers.

The counter uses an IRQ-disabling spin lock because kernel producers may signal outside a sleepable task context. Notifications and waiter wakeups are performed after leaving that short critical section.

`KernelEventFile` is pollable for kernel consumers such as vhost kick waiters, which monitor `IoEvents::IN` without retaining the outer `EventFile`. Its readiness check still reports the complete eventfd file state: `IoEvents::OUT` means that userspace can write a value of at least one without blocking; it does not constrain the kernel-only `signal()` operation. Poll masks keep those uses separate.

The Linux-style recursion guard represented by `eventfd_signal_allowed()` remains a documented follow-up if Asterinas gains eventfd observers that can recursively signal another eventfd.