### PR TITLE
Fix signal character handling in the TTY line discipline

### DIFF
--- a/kernel/src/device/tty/line_discipline.rs
+++ b/kernel/src/device/tty/line_discipline.rs
@@ -7,7 +7,7 @@ use crate::{
     device::tty::termio::{CInputFlags, CLocalFlags},
     prelude::*,
     process::signal::{
-        constants::{SIGINT, SIGQUIT},
+        constants::{SIGINT, SIGQUIT, SIGTSTP},
         sig_num::SigNum,
     },
     util::ring_buffer::RingBuffer,
@@ -107,7 +107,19 @@ impl LineDiscipline {
 
         if let Some(signum) = char_to_signal(ch, &self.termios) {
             signal_callback(signum);
-            // CBREAK mode may require the character to be echoed, so just go ahead.
+
+            // Unless `NOFLSH` is set, pending input is discarded. (Linux also
+            // discards pending output, but we never buffer output.)
+            if !self.termios.local_flags().contains(CLocalFlags::NOFLSH) {
+                self.drain_input();
+            }
+
+            if self.termios.local_flags().contains(CLocalFlags::ECHO) {
+                self.output_char(ch, echo_callback);
+            }
+
+            // The signal character itself is consumed, not delivered to readers.
+            return Ok(());
         }
 
         // Typically, a TTY in raw mode does not echo. But the TTY can also be in a CBREAK mode,
@@ -304,13 +316,14 @@ fn is_ctrl_char(ch: u8) -> bool {
 }
 
 fn char_to_signal(ch: u8, termios: &CTermios) -> Option<SigNum> {
-    if !termios.is_canonical_mode() || !termios.local_flags().contains(CLocalFlags::ISIG) {
+    if !termios.local_flags().contains(CLocalFlags::ISIG) {
         return None;
     }
 
     match ch {
         ch if ch == termios.special_char(CCtrlCharId::VINTR) => Some(SIGINT),
         ch if ch == termios.special_char(CCtrlCharId::VQUIT) => Some(SIGQUIT),
+        ch if ch == termios.special_char(CCtrlCharId::VSUSP) => Some(SIGTSTP),
         _ => None,
     }
 }

--- a/test/initramfs/src/regression/device/pty/signal_char.c
+++ b/test/initramfs/src/regression/device/pty/signal_char.c
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <pty.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+#include "../../common/test.h"
+
+static int master, slave;
+
+static volatile sig_atomic_t nr_sigint, nr_sigquit, nr_sigtstp;
+
+static void count_signal(int signum)
+{
+	switch (signum) {
+	case SIGINT:
+		nr_sigint++;
+		break;
+	case SIGQUIT:
+		nr_sigquit++;
+		break;
+	case SIGTSTP:
+		nr_sigtstp++;
+		break;
+	}
+}
+
+FN_SETUP(openpty)
+{
+	CHECK(openpty(&master, &slave, NULL, NULL, NULL));
+
+	CHECK(fcntl(master, F_SETFL, O_NONBLOCK));
+	CHECK(fcntl(slave, F_SETFL, O_NONBLOCK));
+}
+END_SETUP()
+
+FN_SETUP(new_session)
+{
+	int status;
+
+	if (CHECK(fork()) != 0) {
+		CHECK_WITH(wait(&status),
+			   WIFEXITED(status) && WEXITSTATUS(status) == 0);
+		exit(EXIT_SUCCESS);
+	}
+
+	CHECK(setsid());
+	CHECK(ioctl(slave, TIOCSCTTY, 0));
+}
+END_SETUP()
+
+FN_SETUP(signal_handlers)
+{
+	struct sigaction sa = { .sa_handler = count_signal,
+				.sa_flags = SA_RESTART };
+
+	CHECK(sigaction(SIGINT, &sa, NULL));
+	CHECK(sigaction(SIGQUIT, &sa, NULL));
+	CHECK(sigaction(SIGTSTP, &sa, NULL));
+}
+END_SETUP()
+
+static void set_lflags(tcflag_t lflags)
+{
+	struct termios termios;
+
+	CHECK(tcgetattr(slave, &termios));
+	termios.c_lflag = lflags;
+	termios.c_cc[VMIN] = 1;
+	termios.c_cc[VTIME] = 0;
+	CHECK(tcsetattr(slave, TCSANOW, &termios));
+}
+
+static void reset_state(void)
+{
+	char buf[64];
+
+	while (read(slave, buf, sizeof(buf)) > 0)
+		;
+	while (read(master, buf, sizeof(buf)) > 0)
+		;
+
+	nr_sigint = nr_sigquit = nr_sigtstp = 0;
+}
+
+// Returns 1 if the signal counter becomes positive before the timeout.
+static int wait_sig(volatile sig_atomic_t *counter)
+{
+	int i;
+
+	for (i = 0; i < 200 && *counter == 0; i++)
+		usleep(10 * 1000);
+
+	// `usleep` may have been interrupted by the signal we are waiting
+	// for. This is expected, so do not let `EINTR` leak to the caller.
+	errno = 0;
+	return *counter > 0;
+}
+
+// Signal characters must be recognized with ISIG alone; canonical mode is
+// not required (e.g., shells keep ISIG on while readline puts the terminal
+// in non-canonical mode). The character itself must be eaten by the line
+// discipline instead of being delivered to readers.
+FN_TEST(raw_isig_signal_chars)
+{
+	char buf[8];
+
+	set_lflags(ISIG);
+	reset_state();
+
+	TEST_RES(write(master, "\x03", 1), _ret == 1);
+	TEST_RES(wait_sig(&nr_sigint), _ret == 1);
+	TEST_ERRNO(read(slave, buf, sizeof(buf)), EAGAIN);
+
+	TEST_RES(write(master, "\x1c", 1), _ret == 1);
+	TEST_RES(wait_sig(&nr_sigquit), _ret == 1);
+	TEST_ERRNO(read(slave, buf, sizeof(buf)), EAGAIN);
+
+	TEST_RES(write(master, "\x1a", 1), _ret == 1);
+	TEST_RES(wait_sig(&nr_sigtstp), _ret == 1);
+	TEST_ERRNO(read(slave, buf, sizeof(buf)), EAGAIN);
+}
+END_TEST()
+
+// Without NOFLSH, a signal character discards pending input.
+FN_TEST(signal_char_flushes_input)
+{
+	char buf[8];
+
+	set_lflags(ISIG);
+	reset_state();
+
+	TEST_RES(write(master, "ab\x03", 3), _ret == 3);
+	TEST_RES(wait_sig(&nr_sigint), _ret == 1);
+	TEST_ERRNO(read(slave, buf, sizeof(buf)), EAGAIN);
+}
+END_TEST()
+
+// With NOFLSH, pending input survives, but the signal character is still
+// consumed.
+FN_TEST(noflsh_keeps_input)
+{
+	char buf[8];
+
+	set_lflags(ISIG | NOFLSH);
+	reset_state();
+
+	TEST_RES(write(master, "cd\x03", 3), _ret == 3);
+	TEST_RES(wait_sig(&nr_sigint), _ret == 1);
+	TEST_RES(read(slave, buf, sizeof(buf)),
+		 _ret == 2 && buf[0] == 'c' && buf[1] == 'd');
+	TEST_ERRNO(read(slave, buf, sizeof(buf)), EAGAIN);
+}
+END_TEST()
+
+// Without ISIG, signal characters are ordinary input.
+FN_TEST(isig_off_passes_through)
+{
+	char buf[8];
+
+	set_lflags(0);
+	reset_state();
+
+	TEST_RES(write(master, "\x03", 1), _ret == 1);
+	TEST_RES(read(slave, buf, sizeof(buf)), _ret == 1 && buf[0] == '\x03');
+
+	usleep(100 * 1000);
+	TEST_RES((int)nr_sigint, _ret == 0);
+}
+END_TEST()
+
+// In canonical mode, a signal character also discards the unfinished line.
+FN_TEST(canonical_isig_flushes_line)
+{
+	char buf[8];
+
+	set_lflags(ICANON | ISIG);
+	reset_state();
+
+	TEST_RES(write(master, "ab\x03", 3), _ret == 3);
+	TEST_RES(wait_sig(&nr_sigint), _ret == 1);
+
+	TEST_RES(write(master, "\n", 1), _ret == 1);
+	TEST_RES(read(slave, buf, sizeof(buf)), _ret == 1 && buf[0] == '\n');
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(slave));
+	CHECK(close(master));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/device/run_test.sh
+++ b/test/initramfs/src/regression/device/run_test.sh
@@ -10,6 +10,7 @@ set -e
 ./pty/open_pty_peer
 ./pty/pty_blocking
 ./pty/pty_packet_mode
+./pty/signal_char
 ./pty/termios2
 
 ./vt/vt_ioctl


### PR DESCRIPTION
Fixes #2758.

### Root cause

`char_to_signal` in the line discipline refuses to generate signals
outside canonical mode:

```rust
if !termios.is_canonical_mode() || !termios.local_flags().contains(CLocalFlags::ISIG) {
    return None;
}
```

POSIX and Linux gate signal characters on `ISIG` alone. Interactive
shells keep `ISIG` set while readline switches the terminal to
non-canonical mode, so VINTR is ignored exactly where users type —
the reported case. The VT keyboard path already maps Ctrl+C to `0x03`
(the keymap's CTRL plane), so the line discipline is the failing stage
on the desktop path.

Two more deviations sit in the same code: a signal character that does
fire is still delivered to readers instead of being consumed, and
`VSUSP` is not handled at all.

### Fix

Match Linux `n_tty` (`isig()`, `n_tty_receive_signal_char()`):

- Recognize signal characters whenever `ISIG` is set.
- Consume the character instead of delivering it to readers. This also
  bypasses the buffer-full check, so VINTR still works when a runaway
  writer has filled the input buffer.
- Discard pending input unless `NOFLSH` is set. (Linux also flushes
  pending output; our TTY driver does not buffer output, so there is
  nothing to flush there.)
- Generate `SIGTSTP` for `VSUSP`.

### Reproduction and A/B validation

The new `device/pty/signal_char` regression test runs a PTY pair whose
slave is the controlling terminal of a foreground session, writes
VINTR/VQUIT/VSUSP into the master under different termios settings, and
asserts on both the delivered signals and the bytes visible to readers.
The same source passes unmodified on host Linux (glibc, QEMU-free), so
the assertions encode Linux semantics rather than Asterinas behavior.

Both kernel sides below are base `ab59d2989` (± this patch only), run
via `make run_kernel AUTO_TEST=regression` (KVM, Docker image
0.18.0-20260702).

| Test case (assertions) | Linux host | unpatched | patched |
|---|---|---|---|
| raw+`ISIG`: VINTR/VQUIT/VSUSP signal, char consumed (9) | 9/9 | 3/9 — no signals, bytes reach the reader | 9/9 |
| signal char discards pending input (3) | 3/3 | 1/3 | 3/3 |
| `NOFLSH` keeps input, char still consumed (4) | 4/4 | 2/4 | 4/4 |
| `ISIG` off: byte passes through, no signal (3) | 3/3 | 3/3 | 3/3 |
| canonical: signal fires, unfinished line discarded (4) | 4/4 | 3/4 — signal fires, line kept | 4/4 |

The two rows that pass on both sides are the control: the ISIG-off
pass-through path and canonical-mode signal generation already worked
and stay untouched. With the patch the full regression suite is green
(`All regression tests passed.`).
