### PR TITLE
Fix shebang argument and execveat handling

### DIFF
--- a/kernel/core/src/process/execve.rs
+++ b/kernel/core/src/process/execve.rs
@@ -34,6 +34,7 @@ use crate::{
 pub fn do_execve(
     elf_file: Path,
     thread_name: ThreadName,
+    shebang_script_path: CString,
     argv_ptr_ptr: Vaddr,
     envp_ptr_ptr: Vaddr,
     ctx: &Context,
@@ -57,8 +58,13 @@ pub fn do_execve(
         envp
     );
 
-    let program_to_load =
-        ProgramToLoad::build_from_file(elf_file.clone(), &path_resolver, argv, envp)?;
+    let program_to_load = ProgramToLoad::build_from_file(
+        elf_file.clone(),
+        &path_resolver,
+        shebang_script_path,
+        argv,
+        envp,
+    )?;
 
     let new_vmar = VmarHandle::new(ProcessVm::new(elf_file.clone()));
     let elf_load_info = program_to_load.load_to_vmar(&new_vmar, &path_resolver)?;

--- a/kernel/core/src/process/execve.rs
+++ b/kernel/core/src/process/execve.rs
@@ -31,10 +31,18 @@ use crate::{
     vm::vmar::VmarHandle,
 };
 
+/// Describes how a shebang interpreter can access the script after exec.
+pub enum ShebangScriptPath {
+    /// A path accessible to the interpreter after exec.
+    Accessible(CString),
+    /// A path inaccessible to the interpreter after exec.
+    Inaccessible,
+}
+
 pub fn do_execve(
     elf_file: Path,
     thread_name: ThreadName,
-    shebang_script_path: CString,
+    shebang_script_path: ShebangScriptPath,
     argv_ptr_ptr: Vaddr,
     envp_ptr_ptr: Vaddr,
     ctx: &Context,

--- a/kernel/core/src/process/mod.rs
+++ b/kernel/core/src/process/mod.rs
@@ -25,7 +25,7 @@ mod wait;
 
 pub use clone::{CloneArgs, CloneFlags, clone_child};
 pub use credentials::{Credentials, Gid, Uid};
-pub use execve::do_execve;
+pub use execve::{ShebangScriptPath, do_execve};
 pub use kill::{kill, kill_all, kill_group, tgkill};
 pub use namespace::{
     nsproxy::{ContextSetNsAdminApi, NsProxy, NsProxyBuilder, check_unsupported_ns_flags},

--- a/kernel/core/src/process/process/init_proc.rs
+++ b/kernel/core/src/process/process/init_proc.rs
@@ -146,12 +146,18 @@ fn create_init_task(
 
     let (elf_load_info, elf_abs_path) = {
         let path_resolver = fs.resolver().read();
+        let elf_abs_path = path_resolver.make_abs_path(&elf_path).into_string();
+        let shebang_script_path = CString::new(elf_abs_path.clone()).unwrap();
 
-        let program_to_load =
-            ProgramToLoad::build_from_file(elf_path.clone(), &path_resolver, argv, envp)?;
+        let program_to_load = ProgramToLoad::build_from_file(
+            elf_path.clone(),
+            &path_resolver,
+            shebang_script_path,
+            argv,
+            envp,
+        )?;
         let vmar = process.lock_vmar();
         let elf_load_info = program_to_load.load_to_vmar(vmar.unwrap(), &path_resolver)?;
-        let elf_abs_path = path_resolver.make_abs_path(&elf_path).into_string();
 
         (elf_load_info, elf_abs_path)
     };

--- a/kernel/core/src/process/process/init_proc.rs
+++ b/kernel/core/src/process/process/init_proc.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        Credentials, ProcessVm, UserNamespace, pid_table,
+        Credentials, ProcessVm, ShebangScriptPath, UserNamespace, pid_table,
         posix_thread::{PosixThreadBuilder, allocate_posix_tid, derive_thread_name},
         program_loader::ProgramToLoad,
         rlimit::new_resource_limits_for_init,
@@ -147,7 +147,8 @@ fn create_init_task(
     let (elf_load_info, elf_abs_path) = {
         let path_resolver = fs.resolver().read();
         let elf_abs_path = path_resolver.make_abs_path(&elf_path).into_string();
-        let shebang_script_path = CString::new(elf_abs_path.clone()).unwrap();
+        let shebang_script_path =
+            ShebangScriptPath::Accessible(CString::new(elf_abs_path.clone()).unwrap());
 
         let program_to_load = ProgramToLoad::build_from_file(
             elf_path.clone(),

--- a/kernel/core/src/process/program_loader/mod.rs
+++ b/kernel/core/src/process/program_loader/mod.rs
@@ -36,6 +36,7 @@ impl ProgramToLoad {
     pub(super) fn build_from_file(
         mut elf_file: Path,
         path_resolver: &PathResolver,
+        mut script_path: CString,
         mut argv: Vec<CString>,
         envp: Vec<CString>,
     ) -> Result<Self> {
@@ -64,16 +65,24 @@ impl ProgramToLoad {
             }
             recursive_limit -= 1;
 
+            let interpreter_filename = new_argv[0].clone();
             let interpreter = {
-                let filename = new_argv[0].to_str()?.to_string();
-                let fs_path = FsPath::try_from(filename.as_str())?;
+                let filename = interpreter_filename.to_str()?;
+                let fs_path = FsPath::try_from(filename)?;
                 path_resolver.lookup(&fs_path)?
             };
             check_executable_inode(interpreter.inode().as_ref())?;
 
             // Update the argument list and the executable inode. Then, try again.
-            new_argv.extend(argv);
+            //
+            // The interpreter receives the script path as its first argument,
+            // regardless of the caller-supplied `argv[0]`. For example,
+            // `exec -a custom ./script arg` with `#!/bin/sh` must execute
+            // `/bin/sh ./script arg`, not `/bin/sh custom arg`.
+            new_argv.push(script_path);
+            new_argv.extend(argv.into_iter().skip(1));
             argv = new_argv;
+            script_path = interpreter_filename;
             elf_file = interpreter;
         };
 

--- a/kernel/core/src/process/program_loader/mod.rs
+++ b/kernel/core/src/process/program_loader/mod.rs
@@ -7,6 +7,7 @@ use self::{
     elf::{ElfHeaders, ElfLoadInfo, load_elf_to_vmar},
     shebang::parse_shebang_line,
 };
+use super::execve::ShebangScriptPath;
 use crate::{
     fs::{
         file::{InodeType, Permission},
@@ -36,7 +37,7 @@ impl ProgramToLoad {
     pub(super) fn build_from_file(
         mut elf_file: Path,
         path_resolver: &PathResolver,
-        mut script_path: CString,
+        mut script_path: ShebangScriptPath,
         mut argv: Vec<CString>,
         envp: Vec<CString>,
     ) -> Result<Self> {
@@ -60,6 +61,20 @@ impl ProgramToLoad {
                 break (file_first_page, len);
             };
 
+            // A shebang interpreter must reopen the original script path after exec. A path
+            // synthesized from a close-on-exec file descriptor will no longer be accessible then,
+            // so fail before changing the process state. Linux does the same through
+            // `BINPRM_FLAGS_PATH_INACCESSIBLE` in `fs/binfmt_script.c`.
+            let current_script_path = match script_path {
+                ShebangScriptPath::Accessible(path) => path,
+                ShebangScriptPath::Inaccessible => {
+                    return_errno_with_message!(
+                        Errno::ENOENT,
+                        "the script path is inaccessible after closing close-on-exec file descriptors"
+                    );
+                }
+            };
+
             if recursive_limit == 0 {
                 return_errno_with_message!(Errno::ELOOP, "the recursieve limit is reached");
             }
@@ -79,10 +94,10 @@ impl ProgramToLoad {
             // regardless of the caller-supplied `argv[0]`. For example,
             // `exec -a custom ./script arg` with `#!/bin/sh` must execute
             // `/bin/sh ./script arg`, not `/bin/sh custom arg`.
-            new_argv.push(script_path);
+            new_argv.push(current_script_path);
             new_argv.extend(argv.into_iter().skip(1));
             argv = new_argv;
-            script_path = interpreter_filename;
+            script_path = ShebangScriptPath::Accessible(interpreter_filename);
             elf_file = interpreter;
         };
 

--- a/kernel/core/src/syscall/execve.rs
+++ b/kernel/core/src/syscall/execve.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use alloc::format;
+
 use ostd::arch::cpu::context::UserContext;
 
 use super::{SyscallReturn, constants::*};
@@ -22,7 +24,7 @@ pub fn sys_execve(
     ctx: &Context,
     user_context: &mut UserContext,
 ) -> Result<SyscallReturn> {
-    let (elf_file, thread_name) = {
+    let (elf_file, thread_name, shebang_script_path) = {
         let flags = OpenFlags::empty();
         lookup_executable_file(AT_FDCWD, filename_ptr, flags, ctx)?
     };
@@ -30,6 +32,7 @@ pub fn sys_execve(
     do_execve(
         elf_file,
         thread_name,
+        shebang_script_path,
         argv_ptr_ptr,
         envp_ptr_ptr,
         ctx,
@@ -47,7 +50,7 @@ pub fn sys_execveat(
     ctx: &Context,
     user_context: &mut UserContext,
 ) -> Result<SyscallReturn> {
-    let (elf_file, thread_name) = {
+    let (elf_file, thread_name, shebang_script_path) = {
         let flags = OpenFlags::from_bits(flags)
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
         lookup_executable_file(dfd, filename_ptr, flags, ctx)?
@@ -56,6 +59,7 @@ pub fn sys_execveat(
     do_execve(
         elf_file,
         thread_name,
+        shebang_script_path,
         argv_ptr_ptr,
         envp_ptr_ptr,
         ctx,
@@ -69,7 +73,7 @@ fn lookup_executable_file(
     filename_ptr: Vaddr,
     flags: OpenFlags,
     ctx: &Context,
-) -> Result<(Path, ThreadName)> {
+) -> Result<(Path, ThreadName, CString)> {
     let filename = ctx
         .user_space()
         .read_cstring(filename_ptr, MAX_FILENAME_LEN)?;
@@ -96,7 +100,18 @@ fn lookup_executable_file(
         derive_thread_name(&filename)
     };
 
-    Ok((path, thread_name))
+    // Preserve the path that a shebang interpreter must use to reopen the script.
+    // For `execveat` relative to a file descriptor, use a `/dev/fd/...` path.
+    let shebang_script_path = if dfd == AT_FDCWD || filename.starts_with('/') {
+        filename.into_owned()
+    } else if filename.is_empty() {
+        format!("/dev/fd/{dfd}")
+    } else {
+        format!("/dev/fd/{dfd}/{filename}")
+    };
+    let shebang_script_path = CString::new(shebang_script_path).unwrap();
+
+    Ok((path, thread_name, shebang_script_path))
 }
 
 bitflags::bitflags! {

--- a/kernel/core/src/syscall/execve.rs
+++ b/kernel/core/src/syscall/execve.rs
@@ -7,12 +7,12 @@ use ostd::arch::cpu::context::UserContext;
 use super::{SyscallReturn, constants::*};
 use crate::{
     fs::{
-        file::file_table::RawFileDesc,
+        file::file_table::{FdFlags, RawFileDesc},
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
     },
     prelude::*,
     process::{
-        do_execve,
+        ShebangScriptPath, do_execve,
         posix_thread::{ThreadName, derive_thread_name},
     },
 };
@@ -73,7 +73,7 @@ fn lookup_executable_file(
     filename_ptr: Vaddr,
     flags: OpenFlags,
     ctx: &Context,
-) -> Result<(Path, ThreadName, CString)> {
+) -> Result<(Path, ThreadName, ShebangScriptPath)> {
     let filename = ctx
         .user_space()
         .read_cstring(filename_ptr, MAX_FILENAME_LEN)?;
@@ -101,15 +101,31 @@ fn lookup_executable_file(
     };
 
     // Preserve the path that a shebang interpreter must use to reopen the script.
-    // For `execveat` relative to a file descriptor, use a `/dev/fd/...` path.
+    // For `execveat` relative to a file descriptor, use a `/dev/fd/...` path unless the
+    // descriptor is close-on-exec, in which case mark the path as unavailable. This matches Linux.
     let shebang_script_path = if dfd == AT_FDCWD || filename.starts_with('/') {
-        filename.into_owned()
-    } else if filename.is_empty() {
-        format!("/dev/fd/{dfd}")
+        ShebangScriptPath::Accessible(CString::new(filename.into_owned()).unwrap())
     } else {
-        format!("/dev/fd/{dfd}/{filename}")
+        let is_cloexec = {
+            let file_table = ctx.thread_local.borrow_file_table();
+            let file_table_locked = file_table.unwrap().read();
+            file_table_locked
+                .get_entry(dfd.try_into()?)?
+                .flags()
+                .contains(FdFlags::CLOEXEC)
+        };
+
+        if is_cloexec {
+            ShebangScriptPath::Inaccessible
+        } else {
+            let path = if filename.is_empty() {
+                format!("/dev/fd/{dfd}")
+            } else {
+                format!("/dev/fd/{dfd}/{filename}")
+            };
+            ShebangScriptPath::Accessible(CString::new(path).unwrap())
+        }
     };
-    let shebang_script_path = CString::new(shebang_script_path).unwrap();
 
     Ok((path, thread_name, shebang_script_path))
 }

--- a/test/initramfs/src/regression/process/execve/execveat.c
+++ b/test/initramfs/src/regression/process/execve/execveat.c
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define EXECUTABLE_PATH "/test/process/execve/hello"
+
+static int check_execveat_result(int fd, const char *filename, int flags,
+				 int expected_errno)
+{
+	char *const argv[] = { "execveat-child", NULL };
+	char *const envp[] = { NULL };
+	pid_t pid = fork();
+	if (pid < 0)
+		return -1;
+
+	if (pid == 0) {
+		execveat(fd, filename, argv, envp, flags);
+
+		int exec_errno = errno;
+		if (exec_errno != expected_errno) {
+			fprintf(stderr, "execveat returned %s, expected %s\n",
+				strerror(exec_errno), strerror(expected_errno));
+		}
+		_exit(exec_errno == expected_errno ? EXIT_SUCCESS :
+						     EXIT_FAILURE);
+	}
+
+	int status;
+	if (waitpid(pid, &status, 0) != pid)
+		return -1;
+
+	return WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SUCCESS ? 0 :
+									  -1;
+}
+
+FN_TEST(execveat_cloexec)
+{
+	char test_dir[] = "/tmp/execveat-shebang-cloexec-XXXXXX";
+	char script_path[sizeof(test_dir) + sizeof("/script")];
+	static const char script[] = "#!/bin/sh\nexit 42\n";
+
+	int executable_fd =
+		TEST_SUCC(open(EXECUTABLE_PATH, O_RDONLY | O_CLOEXEC));
+	TEST_RES(check_execveat_result(executable_fd, "", AT_EMPTY_PATH, 0),
+		 _ret == 0);
+	TEST_SUCC(close(executable_fd));
+
+	TEST_RES(mkdtemp(test_dir), _ret != NULL);
+	TEST_RES(snprintf(script_path, sizeof(script_path), "%s/script",
+			  test_dir),
+		 _ret > 0 && (size_t)_ret < sizeof(script_path));
+
+	int script_create_fd = TEST_SUCC(
+		open(script_path, O_WRONLY | O_CREAT | O_TRUNC, 0700));
+	TEST_RES(write(script_create_fd, script, sizeof(script) - 1),
+		 _ret == (ssize_t)(sizeof(script) - 1));
+	TEST_SUCC(close(script_create_fd));
+	TEST_SUCC(chmod(script_path, 0700));
+
+	int script_fd = TEST_SUCC(open(script_path, O_RDONLY | O_CLOEXEC));
+	TEST_RES(check_execveat_result(script_fd, "", AT_EMPTY_PATH, ENOENT),
+		 _ret == 0);
+	TEST_SUCC(close(script_fd));
+
+	int dirfd =
+		TEST_SUCC(open(test_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC));
+	TEST_RES(check_execveat_result(dirfd, "script", 0, ENOENT), _ret == 0);
+	TEST_SUCC(close(dirfd));
+
+	TEST_SUCC(unlink(script_path));
+	TEST_SUCC(rmdir(test_dir));
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -22,6 +22,7 @@ fi
 ./execve/execve_err
 ./execve/execve_memfd
 ./execve/execve_mt_parent
+./execve/execveat
 
 ./exit/exit_code
 ./exit/exit_procfs

--- a/test/nixos/tests/system-core/src/main.rs
+++ b/test/nixos/tests/system-core/src/main.rs
@@ -21,6 +21,27 @@ fn bash_run_script(nixos_shell: &mut Session) -> Result<(), Error> {
 }
 
 #[nixos_test]
+fn bash_exec_a_shebang_script(nixos_shell: &mut Session) -> Result<(), Error> {
+    nixos_shell.run_cmd(
+        r#"printf '%s\n' '#!/bin/sh' 'printf "script=%s argument=%s\n" "$0" "$1"' > /tmp/test-exec-a.sh"#,
+    )?;
+    nixos_shell.run_cmd("chmod +x /tmp/test-exec-a.sh")?;
+    nixos_shell.run_cmd_and_expect(
+        "/tmp/test-exec-a.sh test-argument",
+        "script=/tmp/test-exec-a.sh argument=test-argument",
+    )?;
+    nixos_shell.run_cmd_and_expect(
+        "cd /tmp && ./test-exec-a.sh test-argument",
+        "script=./test-exec-a.sh argument=test-argument",
+    )?;
+    nixos_shell.run_cmd_and_expect(
+        "bash -c 'exec -a custom-argv0 /tmp/test-exec-a.sh test-argument'",
+        "script=/tmp/test-exec-a.sh argument=test-argument",
+    )?;
+    Ok(())
+}
+
+#[nixos_test]
 fn fish_run_script(nixos_shell: &mut Session) -> Result<(), Error> {
     nixos_shell.run_cmd("echo 'echo \"Hello from Fish\"' > /tmp/test_fish.fish")?;
     nixos_shell.run_cmd_and_expect("fish /tmp/test_fish.fish", "Hello from Fish")?;


### PR DESCRIPTION
This is part of the groundwork for #3653.

This fixes two related issues in shebang execution.

When loading a script, the kernel previously appended the caller-supplied argument vector unchanged after the shebang interpreter arguments. As a result, a custom `argv[0]`—for example, one set by Bash's `exec -a`—could be passed in place of the script path. The interpreter now receives the actual script path followed by the caller's arguments starting at `argv[1]`.

For `execveat` calls relative to a file descriptor, this PR synthesizes a `/dev/fd/...` path to pass the script filename to the interpreter. If that descriptor has `FD_CLOEXEC`, however, the interpreter cannot reopen the synthesized path after exec. The loader therefore rejects only shebang files in this case with `ENOENT`, matching Linux behavior, while continuing to allow directly executable ELF files through the same descriptor.
