### PR TITLE
Allow kernel threads to use a process VMAR

### DIFF
--- a/kernel/core/src/process/process_vm/mod.rs
+++ b/kernel/core/src/process/process_vm/mod.rs
@@ -84,7 +84,7 @@ pub(crate) struct ProcessVm {
 
 impl ProcessVm {
     /// Creates a new `ProcessVm` without mapping anything.
-    pub(super) fn new(executable_path: Path) -> Self {
+    pub fn new(executable_path: Path) -> Self {
         Self {
             init_stack: InitStack::new(),
             heap: Heap::new_uninitialized(),

--- a/kernel/core/src/thread/exception.rs
+++ b/kernel/core/src/thread/exception.rs
@@ -9,6 +9,7 @@ use ostd::{arch::cpu::context::UserContext, task::Task};
 use crate::{
     prelude::*,
     process::signal::signals::fault::FaultSignal,
+    thread::kernel_thread::AsKernelThread,
     vm::vmar::{PageFaultInfo, Vmar},
 };
 
@@ -69,14 +70,22 @@ fn generate_fault_signal(exception: CpuException, ctx: &Context, user_ctx: &User
 
 pub(super) fn page_fault_handler(info: &CpuException) -> Result<(), ()> {
     let task = Task::current().unwrap();
-    let thread_local = task.as_thread_local().unwrap();
+    let page_fault_info = info.try_into().unwrap();
 
-    if thread_local.is_page_fault_disabled() {
-        // Do nothing if the page fault handler is disabled. This will typically cause the fallible
-        // memory operation to report `EFAULT` errors immediately.
-        return Err(());
+    if let Some(thread_local) = task.as_thread_local() {
+        if thread_local.is_page_fault_disabled() {
+            // Do nothing if the page fault handler is disabled. This will typically cause the
+            // fallible memory operation to report EFAULT errors immediately.
+            return Err(());
+        }
+
+        let user_space = CurrentUserSpace::new(thread_local);
+        handle_page_fault_from_vmar(user_space.vmar(), &page_fault_info)
+    } else {
+        let vmar = task
+            .as_kernel_thread()
+            .and_then(|kernel_thread| kernel_thread.vmar())
+            .ok_or(())?;
+        handle_page_fault_from_vmar(vmar, &page_fault_info)
     }
-
-    let user_space = CurrentUserSpace::new(thread_local);
-    handle_page_fault_from_vmar(user_space.vmar(), &info.try_into().unwrap())
 }

--- a/kernel/core/src/thread/kernel_thread.rs
+++ b/kernel/core/src/thread/kernel_thread.rs
@@ -9,16 +9,45 @@ use super::{AsThread, Thread, oops};
 use crate::{
     prelude::*,
     sched::{Nice, SchedPolicy},
+    vm::vmar::Vmar,
 };
 
 /// The inner data of a kernel thread.
-struct KernelThread;
+pub(super) struct KernelThread {
+    vmar: Option<Arc<Vmar>>,
+}
+
+impl KernelThread {
+    /// Returns the VMAR associated with the kernel thread.
+    pub(super) fn vmar(&self) -> Option<&Arc<Vmar>> {
+        self.vmar.as_ref()
+    }
+}
+
+/// A trait to provide the `as_kernel_thread` method for tasks and threads.
+pub(super) trait AsKernelThread {
+    /// Returns the associated [`KernelThread`].
+    fn as_kernel_thread(&self) -> Option<&KernelThread>;
+}
+
+impl AsKernelThread for Thread {
+    fn as_kernel_thread(&self) -> Option<&KernelThread> {
+        self.data().downcast_ref::<KernelThread>()
+    }
+}
+
+impl AsKernelThread for Task {
+    fn as_kernel_thread(&self) -> Option<&KernelThread> {
+        self.as_thread()?.as_kernel_thread()
+    }
+}
 
 /// Options to create or spawn a new kernel thread.
 pub(crate) struct ThreadOptions {
     func: Option<Box<dyn FnOnce() + Send>>,
     cpu_affinity: CpuSet,
     sched_policy: SchedPolicy,
+    vmar: Option<Arc<Vmar>>,
 }
 
 impl ThreadOptions {
@@ -33,6 +62,7 @@ impl ThreadOptions {
             func: Some(Box::new(func)),
             cpu_affinity,
             sched_policy,
+            vmar: None,
         }
     }
 
@@ -45,6 +75,21 @@ impl ThreadOptions {
     /// Sets the scheduling policy.
     pub(crate) fn sched_policy(mut self, sched_policy: SchedPolicy) -> Self {
         self.sched_policy = sched_policy;
+        self
+    }
+
+    /// Associates a VMAR with the kernel thread.
+    ///
+    /// The VMAR is activated whenever the thread is scheduled, allowing fallible userspace memory
+    /// operations to access it directly and handle page faults against it. The association cannot
+    /// be changed after the thread is built.
+    ///
+    /// The `Arc` keeps the VMAR object alive, but does not prevent its mappings from being cleared
+    /// after the last [`VmarHandle`](crate::vm::vmar::VmarHandle) is dropped. A caller that needs
+    /// the mappings to outlive their userspace owner must hold a separate owner-memory lease.
+    #[cfg_attr(not(ktest), expect(dead_code))]
+    pub(crate) fn vmar(mut self, vmar: Arc<Vmar>) -> Self {
+        self.vmar = Some(vmar);
         self
     }
 }
@@ -61,7 +106,7 @@ impl ThreadOptions {
 
         Arc::new_cyclic(|weak_task| {
             let thread = {
-                let kernel_thread = KernelThread;
+                let kernel_thread = KernelThread { vmar: self.vmar };
                 let cpu_affinity = self.cpu_affinity;
                 let sched_policy = self.sched_policy;
                 Arc::new(Thread::new(
@@ -83,5 +128,150 @@ impl ThreadOptions {
         let thread = task.as_thread().unwrap().clone();
         thread.run();
         thread
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::{Error, cpu::CpuId, prelude::ktest};
+
+    use super::*;
+    use crate::{
+        fs::pseudofs::SockFs,
+        process::ProcessVm,
+        vm::{
+            page_cache::VmoOptions,
+            perms::VmPerms,
+            vmar::{VmarHandle, VmarMapOffset},
+        },
+    };
+
+    fn new_process_vm() -> ProcessVm {
+        crate::time::clocks::init_for_ktest();
+        crate::util::random::init();
+        ProcessVm::new(SockFs::new_path())
+    }
+
+    #[ktest]
+    fn associated_vmar_is_reactivated_after_context_switch() {
+        super::super::init();
+
+        let vmar = VmarHandle::new(new_process_vm());
+        let map_addr = PAGE_SIZE * 16;
+        let map_size = PAGE_SIZE * 4;
+        let vmo = VmoOptions::new(map_size).alloc().unwrap();
+        assert_eq!(
+            vmar.new_map(map_size, VmPerms::READ | VmPerms::WRITE)
+                .unwrap()
+                .offset(VmarMapOffset::FixedNoReplace(map_addr))
+                .vmo(vmo)
+                .build()
+                .unwrap(),
+            map_addr
+        );
+
+        let access_addr = map_addr + 17;
+        let access_len = PAGE_SIZE * 3 + 37;
+        let mut expected = vec![0; access_len];
+        for (index, byte) in expected.iter_mut().enumerate() {
+            *byte = (index % 251) as u8;
+        }
+
+        let source = expected.clone();
+        let result = Arc::new(Mutex::new(None));
+        let worker_result = result.clone();
+        let worker_vmar = vmar.clone_arc();
+        let associated_vmar = worker_vmar.clone();
+        let test_cpu = CpuId::current_racy();
+
+        let switcher_vmar_handle = VmarHandle::new(new_process_vm());
+        let switcher_vmar = switcher_vmar_handle.clone_arc();
+        let associated_switcher_vmar = switcher_vmar.clone();
+
+        let worker = ThreadOptions::new(move || {
+            let current = Thread::current().unwrap();
+            assert!(
+                current
+                    .as_kernel_thread()
+                    .and_then(|kernel_thread| kernel_thread.vmar())
+                    .is_some_and(|vmar| Arc::ptr_eq(vmar, &worker_vmar))
+            );
+
+            let mut user_writer = worker_vmar
+                .vm_space()
+                .writer(access_addr, access_len)
+                .unwrap();
+            let mut source_reader = VmReader::from(source.as_slice()).to_fallible();
+            assert_eq!(
+                user_writer.write_fallible(&mut source_reader).unwrap(),
+                access_len
+            );
+
+            let switcher = ThreadOptions::new(move || {
+                let current = Thread::current().unwrap();
+                assert!(
+                    current
+                        .as_kernel_thread()
+                        .and_then(|kernel_thread| kernel_thread.vmar())
+                        .is_some_and(|vmar| Arc::ptr_eq(vmar, &switcher_vmar))
+                );
+                assert!(switcher_vmar.vm_space().reader(map_addr, 0).is_ok());
+            })
+            .cpu_affinity(test_cpu.into())
+            .vmar(associated_switcher_vmar)
+            .spawn();
+
+            switcher.join();
+
+            let mut user_reader = worker_vmar
+                .vm_space()
+                .reader(access_addr, access_len)
+                .unwrap();
+            let mut output = vec![0; access_len];
+            let mut output_writer = VmWriter::from(output.as_mut_slice()).to_fallible();
+            assert_eq!(
+                user_reader.read_fallible(&mut output_writer).unwrap(),
+                access_len
+            );
+            *worker_result.lock() = Some(output);
+        })
+        .cpu_affinity(test_cpu.into())
+        .vmar(associated_vmar)
+        .spawn();
+
+        worker.join();
+        assert_eq!(result.lock().take().unwrap(), expected);
+    }
+
+    #[ktest]
+    fn unmapped_vmar_access_returns_page_fault() {
+        super::super::init();
+
+        const UNMAPPED_ADDR: usize = PAGE_SIZE * 16;
+        let vmar_handle = VmarHandle::new(new_process_vm());
+        let vmar = vmar_handle.clone_arc();
+        let associated_vmar = vmar.clone();
+
+        let worker = ThreadOptions::new(move || {
+            let mut output = [0u8; 1];
+            let mut output_writer = VmWriter::from(output.as_mut_slice()).to_fallible();
+            let mut user_reader = vmar.vm_space().reader(UNMAPPED_ADDR, 1).unwrap();
+            assert_eq!(
+                user_reader.read_fallible(&mut output_writer),
+                Err((Error::PageFault, 0))
+            );
+
+            let input = [1u8; 1];
+            let mut input_reader = VmReader::from(input.as_slice()).to_fallible();
+            let mut user_writer = vmar.vm_space().writer(UNMAPPED_ADDR, 1).unwrap();
+            assert_eq!(
+                user_writer.write_fallible(&mut input_reader),
+                Err((Error::PageFault, 0))
+            );
+        })
+        .vmar(associated_vmar)
+        .spawn();
+
+        worker.join();
     }
 }

--- a/kernel/core/src/thread/mod.rs
+++ b/kernel/core/src/thread/mod.rs
@@ -11,7 +11,7 @@ use ostd::{
     task::Task,
 };
 
-use self::stats::CONTEXT_SWITCH_COUNTER;
+use self::{kernel_thread::AsKernelThread, stats::CONTEXT_SWITCH_COUNTER};
 use crate::{
     prelude::*,
     sched::{SchedAttr, SchedPolicy},
@@ -48,13 +48,16 @@ fn post_schedule_handler() {
         .add_on_cpu(CpuId::current_racy(), 1);
 
     let task = Task::current().unwrap();
-    let Some(thread_local) = task.as_thread_local() else {
-        return;
-    };
-
-    let vmar = thread_local.vmar().borrow();
-    if let Some(vmar) = vmar.as_ref() {
-        vmar.vm_space().activate()
+    if let Some(thread_local) = task.as_thread_local() {
+        let vmar = thread_local.vmar().borrow();
+        if let Some(vmar) = vmar.as_ref() {
+            vmar.vm_space().activate()
+        }
+    } else if let Some(vmar) = task
+        .as_kernel_thread()
+        .and_then(|kernel_thread| kernel_thread.vmar())
+    {
+        vmar.vm_space().activate();
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds a kernel-thread VMAR association mechanism, similar in spirit to Linux `kthread_use_mm()`. It allows selected kernel threads to run with a user process VMAR activated, so they can access owner userspace memory through the normal VM space access path instead of relying on `read_alien()` / `write_alien()`.

This is intended as a prerequisite for in-kernel vhost backends #3691. In particular, vhost workers need to access memory that belongs to the VMM process while running in kernel-thread context.

## Changes

- Add an optional `user_vmar` field to `ThreadOptions`.
- Add `ThreadOptions::user_vmar(...)` for binding a user VMAR when creating a kernel thread.
- Store the associated VMAR in `KernelThread`.
- Add `Thread::user_vmar()` for scheduler and fault handling.
- Activate the associated VMAR after context switches for bound kernel threads.
- Handle page faults from bound kernel threads through the associated VMAR.
- Keep unbound kernel-thread user faults as errors instead of panicking.
- Add a ktest covering VMAR reactivation after context switches.

## Notes

Holding `Arc<Vmar>` keeps the VMAR object alive, but it does not preserve mappings after the last `VmarHandle` is dropped. This PR only provides the active-address-space mechanism. A follow-up vhost owner-memory layer still needs to handle owner lifetime/mapping validity explicitly.

The intended vhost usage is:

1. Capture the owner process VMAR when setting the vhost owner.
2. Spawn vhost worker threads with `ThreadOptions::user_vmar(owner_vmar)`.
3. Let owner-memory access use the normal VM space reader/writer path from that bound kernel thread.
