### PR TITLE
Avoid persona reload SKILL.md

### DIFF
--- a/.agents/skills/aster-code-review/SKILL.md
+++ b/.agents/skills/aster-code-review/SKILL.md
@@ -161,7 +161,7 @@ each in a CLEAN context with only its own persona block (selective exposure):
 **Never spawn a pass by re-running `aster_code_review.sh` / `run_agent.sh`,
 nor by re-issuing the skill's own arguments** (e.g. `codex exec … diff <base> <out>`).
 A pass is a *reviewer* invocation whose input is the `build_pass_prompt.sh` text
-— not another run of this skill.
+— not another run of this skill. It is already inside the active workflow and must not load this `SKILL.md` again.
 Re-entering the launcher spawns another orchestrator that spawns another … , an infinite fork bomb;
 the launcher now refuses it (`ACR_AGENT_RUNNING`).
 

--- a/.agents/skills/aster-code-review/scripts/pass_contract.md
+++ b/.agents/skills/aster-code-review/scripts/pass_contract.md
@@ -1,5 +1,13 @@
 # Pass contract
 
+This is an internal persona review pass of an already-running aster-code-review workflow.
+Do not load or invoke the top-level aster-code-review skill,
+do not read its SKILL.md,
+and do not resolve targets, activate or spawn personas, assemble fragments,
+verify the merged review, or write the final review file.
+The prompt already contains the complete contract, persona scope, guideline catalog,
+and canonical review input needed by this pass.
+
 You are a reviewer applying the persona guideline(s) included below to the change or files under review
 (the **REVIEW INPUT** at the very end of this prompt).
 Find as many real defects as possible within the included persona(s)' remit


### PR DESCRIPTION
When analyzing the logs of the fan-out mode, I found that persona would reload `SKILL.md` . This is not the desired outcome because `SKILL.md` is only accessible to the orchestrator agent. So my approach was to add behavioral constraints for the persona in the `pass_contract.md` file.