### PR TITLE
Stream LTP test output in real-time

### DIFF
--- a/test/initramfs/src/conformance/ltp/run_ltp_test.sh
+++ b/test/initramfs/src/conformance/ltp/run_ltp_test.sh
@@ -5,7 +5,6 @@
 LTP_DIR=$(dirname "$0")
 TEST_TMP_DIR=${CONFORMANCE_TEST_WORKDIR:-/tmp}
 KIRK_TMP_DIR=${KIRK_TMP_DIR:-/tmp}
-LOG_FILE=$TEST_TMP_DIR/result.log
 JSON_REPORT=$TEST_TMP_DIR/result.json
 RESULT=0
 
@@ -18,19 +17,18 @@ export LTP_COLORIZE_OUTPUT=0
 export KCONFIG_SKIP_CHECK=1
 
 chmod 1777 "$TEST_TMP_DIR" 2>/dev/null || true
-rm -f "$LOG_FILE" "$JSON_REPORT"
+rm -f "$JSON_REPORT"
 KIRK_ARGS="--run-suite syscalls"
 if [ "$KIRK_VERBOSE" = "1" ]; then
     KIRK_ARGS="--verbose $KIRK_ARGS"
 fi
 
 CREATE_ENTRIES=1 "$LTP_DIR/kirk" --no-colors --tmp-dir "$KIRK_TMP_DIR" \
-    --json-report "$JSON_REPORT" $KIRK_ARGS > "$LOG_FILE" 2>&1
+    --json-report "$JSON_REPORT" $KIRK_ARGS
 if [ $? -ne 0 ]; then
     RESULT=1
 fi
 
-cat "$LOG_FILE"
 if [ -f "$JSON_REPORT" ]; then
     STATS_BLOCK=$(sed -n '/"stats": {/,/}/p' "$JSON_REPORT")
     if ! echo "$STATS_BLOCK" | grep -q '"failed": 0' ||


### PR DESCRIPTION
This PR streams LTP test output directly to the console instead of saving it to `result.log` and printing it only after the entire test suite finishes.

This makes test progress and failures visible immediately, preventing CI jobs from appearing silent during long-running LTP tests. The JSON report is still retained for final result validation.