### PR TITLE
Remove `EventFile::write_wait_queue`

### DIFF
--- a/kernel/core/src/events/event_file.rs
+++ b/kernel/core/src/events/event_file.rs
@@ -13,7 +13,7 @@
 
 use core::fmt::Display;
 
-use ostd::sync::{LocalIrqDisabled, WaitQueue};
+use ostd::sync::LocalIrqDisabled;
 
 use crate::{
     events::IoEvents,
@@ -41,7 +41,6 @@ pub struct KernelEventFile {
     counter: SpinLock<u64, LocalIrqDisabled>,
     pollee: Pollee,
     is_semaphore: bool,
-    write_wait_queue: WaitQueue,
 }
 
 impl KernelEventFile {
@@ -50,12 +49,10 @@ impl KernelEventFile {
     fn new(init_val: u64, is_semaphore: bool) -> Self {
         let counter = SpinLock::new(init_val);
         let pollee = Pollee::new();
-        let write_wait_queue = WaitQueue::new();
         Self {
             counter,
             pollee,
             is_semaphore,
-            write_wait_queue,
         }
     }
 
@@ -117,7 +114,6 @@ impl KernelEventFile {
 
         // Notify outside the IRQ-disabled critical section.
         self.pollee.notify(IoEvents::OUT);
-        self.write_wait_queue.wake_all();
         Some(value)
     }
 
@@ -251,9 +247,7 @@ impl FileLike for EventFile {
         if self.is_nonblocking() {
             self.add_counter_val(supplied_value)?;
         } else {
-            self.kernel_event_file
-                .write_wait_queue
-                .pause_until(|| self.add_counter_val(supplied_value).ok())?;
+            self.wait_events(IoEvents::OUT, None, || self.add_counter_val(supplied_value))?;
         }
 
         Ok(write_len)

--- a/kernel/core/src/syscall/eventfd.rs
+++ b/kernel/core/src/syscall/eventfd.rs
@@ -28,15 +28,15 @@ pub fn sys_eventfd2(init_val: u32, flags: u32, ctx: &Context) -> Result<SyscallR
 }
 
 fn do_sys_eventfd2(init_val: u32, flags: EventFileFlags, ctx: &Context) -> Result<SyscallReturn> {
-    let event_file = EventFile::new(init_val as u64, flags);
-    let file_table = ctx.thread_local.borrow_file_table();
-    let mut file_table_locked = file_table.unwrap().write();
+    let event_file = Arc::new(EventFile::new(init_val as u64, flags));
     let fd_flags = if flags.contains(EventFileFlags::EFD_CLOEXEC) {
         FdFlags::CLOEXEC
     } else {
         FdFlags::empty()
     };
 
-    let fd = file_table_locked.insert(Arc::new(event_file), fd_flags);
+    let file_table = ctx.thread_local.borrow_file_table();
+    let mut file_table_locked = file_table.unwrap().write();
+    let fd = file_table_locked.insert(event_file, fd_flags);
     Ok(SyscallReturn::Return(fd.into()))
 }


### PR DESCRIPTION
While reviewing https://github.com/asterinas/asterinas/pull/3686, I don't believe that we need `write_wait_queue`.

However, this does not seem to be a problem introduced by that PR, so I am submitting a separate PR anyway.

I have also moved two lines in `kernel/core/src/syscall/eventfd.rs` because I think it makes more sense to read it that way. (**EDIT:** Also move out a heap allocation outside the file table lock's critical section.)