### PR TITLE
Fix BIO completion ordering

### DIFF
--- a/kernel/core/comps/block/src/bio.rs
+++ b/kernel/core/comps/block/src/bio.rs
@@ -236,8 +236,10 @@ impl SubmittedBio {
         self.metadata.status()
     }
 
-    /// Completes the `Bio` by consuming `self`, releasing the segments, and
-    /// invoking the callback function.
+    /// Completes the `Bio` by consuming `self`, releasing the segments, invoking
+    /// the callback function, and publishing the final status.
+    ///
+    /// The final status becomes visible only after the callback returns.
     ///
     /// When the driver finishes the request for this `Bio`, it will call this method.
     pub fn complete(self, status: BioStatus) {
@@ -250,7 +252,13 @@ impl SubmittedBio {
             ..
         } = self;
 
-        // Set the status.
+        drop(segments);
+
+        // A non-`Submit` status publishes the entire completion, including callback
+        // side effects. Otherwise, the wait queue's lock-free fast path could return
+        // while the callback is still running.
+        general_complete_fn(metadata.type_(), status, complete_fn);
+
         let result = metadata.status.compare_exchange(
             BioStatus::Submit as u32,
             status as u32,
@@ -258,10 +266,6 @@ impl SubmittedBio {
             Ordering::Relaxed,
         );
         assert!(result.is_ok());
-
-        drop(segments);
-
-        general_complete_fn(metadata.type_(), status, complete_fn);
 
         metadata.wait_queue.wake_all();
     }
@@ -299,7 +303,8 @@ impl BioMetadata {
     }
 
     pub fn status(&self) -> BioStatus {
-        BioStatus::try_from(self.status.load(Ordering::Relaxed)).unwrap()
+        // Pairs with the release transition in `SubmittedBio::complete`.
+        BioStatus::try_from(self.status.load(Ordering::Acquire)).unwrap()
     }
 }
 

--- a/kernel/core/comps/block/src/bio.rs
+++ b/kernel/core/comps/block/src/bio.rs
@@ -254,9 +254,8 @@ impl SubmittedBio {
 
         drop(segments);
 
-        // A non-`Submit` status publishes the entire completion, including callback
-        // side effects. Otherwise, the wait queue's lock-free fast path could return
-        // while the callback is still running.
+        // Complete the `complete_fn` before publishing the status change,
+        // so that the effects of the callback function are visible to users.
         general_complete_fn(metadata.type_(), status, complete_fn);
 
         let result = metadata.status.compare_exchange(
@@ -303,7 +302,6 @@ impl BioMetadata {
     }
 
     pub fn status(&self) -> BioStatus {
-        // Pairs with the release transition in `SubmittedBio::complete`.
         BioStatus::try_from(self.status.load(Ordering::Acquire)).unwrap()
     }
 }


### PR DESCRIPTION
## Summary

Fix a race in BIO completion that can let an I/O waiter observe a final BIO status before the completion callback has finished.

The issue was observed in CI:

- https://github.com/asterinas/asterinas/actions/runs/31607671701/job/94150708552
- https://github.com/asterinas/asterinas/actions/runs/31595128709/job/94108702623

Both failures panic in the page-cache VMO path because a page remains `Uninit` after a synchronous backend read appears to have completed.

A block-backed page-cache read marks the page `UpToDate` and releases its page lock in the BIO completion callback. Previously, `SubmittedBio::complete` transitioned the BIO status from `Submit` to its final state before dropping DMA segments and invoking that callback. `IoCompletion::wait` treats any status other than `Submit` as completion, and its lock-free fast path can therefore return in the interval after the final status is published but before the callback updates the page state. The VMO mapping path can then observe `Uninit`, violating its invariant.

Publish the final BIO status only after the completion callback returns. Read the status with Acquire ordering so observing the final status also synchronizes with callback side effects published by the completion-side Release transition.

This may address #3700.