### PR TITLE
Add the `encode-intent-in-vis` coding guideline

### DIFF
--- a/book/src/to-contribute/coding-guidelines/for-maintainability/README.md
+++ b/book/src/to-contribute/coding-guidelines/for-maintainability/README.md
@@ -50,6 +50,7 @@ with a one-line gist so a reader (or a review tool) can grasp the guideline befo
     - [`workspace-deps`](rust-specific/crates-and-modules.md#workspace-deps): Declare shared dependencies in `[workspace.dependencies]` and reference them with `.workspace = true`.
     - [`module-docs`](rust-specific/crates-and-modules.md#module-docs): Open a major module with a `//!` doc: purpose, key types, relation to neighbors.
     - [`narrow-visibility`](rust-specific/crates-and-modules.md#narrow-visibility): Start private; widen visibility only when an actual consumer requires it.
+    - [`encode-intent-in-vis`](rust-specific/crates-and-modules.md#encode-intent-in-vis): A visibility modifier declares an item's maximum intended exposure, regardless of what its ancestors allow.
     - [`layered-kernel-crates`](rust-specific/crates-and-modules.md#layered-kernel-crates): Organize kernel crates as an acyclic layered graph, and keep new subsystems, drivers, and utilities outside `aster-core` by default.
     - [`qualified-fn-imports`](rust-specific/crates-and-modules.md#qualified-fn-imports): Import the parent module and call free functions/statics through it, not by bare name.
 - [Types & Traits](rust-specific/types-and-traits.md)

--- a/book/src/to-contribute/coding-guidelines/for-maintainability/README.md
+++ b/book/src/to-contribute/coding-guidelines/for-maintainability/README.md
@@ -48,10 +48,10 @@ with a one-line gist so a reader (or a review tool) can grasp the guideline befo
     - [`closure-fn-suffix`](rust-specific/naming.md#closure-fn-suffix): End a variable holding a closure or fn pointer with `_fn`.
 - [Crates & Modules](rust-specific/crates-and-modules.md)
     - [`workspace-deps`](rust-specific/crates-and-modules.md#workspace-deps): Declare shared dependencies in `[workspace.dependencies]` and reference them with `.workspace = true`.
+    - [`layered-kernel-crates`](rust-specific/crates-and-modules.md#layered-kernel-crates): Organize kernel crates as an acyclic layered graph, and keep new subsystems, drivers, and utilities outside `aster-core` by default.
     - [`module-docs`](rust-specific/crates-and-modules.md#module-docs): Open a major module with a `//!` doc: purpose, key types, relation to neighbors.
     - [`narrow-visibility`](rust-specific/crates-and-modules.md#narrow-visibility): Start private; widen visibility only when an actual consumer requires it.
     - [`encode-intent-in-vis`](rust-specific/crates-and-modules.md#encode-intent-in-vis): A visibility modifier declares an item's maximum intended exposure, regardless of what its ancestors allow.
-    - [`layered-kernel-crates`](rust-specific/crates-and-modules.md#layered-kernel-crates): Organize kernel crates as an acyclic layered graph, and keep new subsystems, drivers, and utilities outside `aster-core` by default.
     - [`qualified-fn-imports`](rust-specific/crates-and-modules.md#qualified-fn-imports): Import the parent module and call free functions/statics through it, not by bare name.
 - [Types & Traits](rust-specific/types-and-traits.md)
     - [`rust-type-invariants`](rust-specific/types-and-traits.md#rust-type-invariants): Use the type system (newtypes, enums, generics) to make illegal states unrepresentable.

--- a/book/src/to-contribute/coding-guidelines/for-maintainability/rust-specific/crates-and-modules.md
+++ b/book/src/to-contribute/coding-guidelines/for-maintainability/rust-specific/crates-and-modules.md
@@ -19,6 +19,30 @@ ostd.workspace = true
 bitflags.workspace = true
 ```
 
+### Keep the kernel crate graph layered and acyclic (`layered-kernel-crates`) {#layered-kernel-crates}
+
+For modularity,
+the Asterinas kernel under `kernel/` is decomposed into
+an acyclic graph of kernel crates arranged in layers.
+A kernel crate may depend on crates in the same layer or any lower layer.
+The layers are, from highest to lowest:
+
+1. The assembler crate (`kernel/src/`).
+2. High-level component crates (`kernel/comps/`).
+3. The `aster-core` crate (`kernel/core/`).
+4. Low-level component crates (`kernel/core/comps/`).
+5. Kernel libraries (`kernel/libs/`).
+
+A new kernel subsystem, driver, or utility type
+should be added as a separate crate outside `aster-core` by default.
+Add new code directly to `aster-core` only when necessary.
+
+All these kernel crates may depend on OSTD.
+
+When lower-layer code needs behavior implemented above it,
+define the interface and registration mechanism in the lower layer
+and let the higher component register its implementation.
+
 ### Add module-level documentation for major components (`module-docs`) {#module-docs}
 
 A module file that serves as
@@ -90,30 +114,6 @@ so its real visibility remains locally obvious.
 This guideline is partially enforced by the rustc lint
 [`unreachable_pub`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub),
 which flags any `pub` item not actually reachable from outside its crate.
-
-### Keep the kernel crate graph layered and acyclic (`layered-kernel-crates`) {#layered-kernel-crates}
-
-For modularity,
-the Asterinas kernel under `kernel/` is decomposed into
-an acyclic graph of kernel crates arranged in layers.
-A kernel crate may depend on crates in the same layer or any lower layer.
-The layers are, from highest to lowest:
-
-1. The assembler crate (`kernel/src/`).
-2. High-level component crates (`kernel/comps/`).
-3. The `aster-core` crate (`kernel/core/`).
-4. Low-level component crates (`kernel/core/comps/`).
-5. Kernel libraries (`kernel/libs/`).
-
-A new kernel subsystem, driver, or utility type
-should be added as a separate crate outside `aster-core` by default.
-Add new code directly to `aster-core` only when necessary.
-
-All these kernel crates may depend on OSTD.
-
-When lower-layer code needs behavior implemented above it,
-define the interface and registration mechanism in the lower layer
-and let the higher component register its implementation.
 
 ### Restrict subsystem visibility with a short name (`short-vis-path`) {#short-vis-path}
 

--- a/book/src/to-contribute/coding-guidelines/for-maintainability/rust-specific/crates-and-modules.md
+++ b/book/src/to-contribute/coding-guidelines/for-maintainability/rust-specific/crates-and-modules.md
@@ -58,6 +58,39 @@ pub static I8042_CONTROLLER: ...
 
 The `asterinas` assembler crate does not expose any `pub` Rust items.
 
+### Visibility modifiers encode intent, not just effect (`encode-intent-in-vis`) {#encode-intent-in-vis}
+
+A plain `pub` says "export me as far as possible":
+along its defining module path,
+the item's _effective_ visibility is capped
+by every enclosing module up to the crate root
+(and a `pub use` elsewhere can re-export it around that cap entirely).
+In a large project like Asterinas,
+a `pub` item may sit deep in the module hierarchy,
+making its effective visibility hard to see locally
+and fragile against visibility changes in its ancestors.
+
+Therefore, a visibility modifier in Asterinas declares
+the maximum _intended_ exposure of an item,
+regardless of what its ancestors happen to allow:
+
+* `pub` means "exported from this crate".
+  Reserve it for items with an actual consumer in another crate.
+* `pub(crate)`, `pub(super)`, `pub(in super::super)`, and `pub(in crate::a)`
+  mean "this item must never escape the named scope",
+  even when an enclosing private module already restricts it further.
+  If the `path` part of a `pub(in path)` modifier is long,
+  apply [`short-vis-path`](#short-vis-path).
+
+One exception is struct fields and union fields:
+a `pub` field of a visibility-restricted struct or union is acceptable,
+because the field sits only a few lines from the type's own modifier,
+so its real visibility remains locally obvious.
+
+This guideline is partially enforced by the rustc lint
+[`unreachable_pub`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub),
+which flags any `pub` item not actually reachable from outside its crate.
+
 ### Keep the kernel crate graph layered and acyclic (`layered-kernel-crates`) {#layered-kernel-crates}
 
 For modularity,


### PR DESCRIPTION
This PR adds a new coding guideline, `encode-intent-in-vis`, to the maintainability guidelines: a visibility modifier in Asterinas declares an item's maximum _intended_ exposure, regardless of what its enclosing modules happen to allow. It grew out of the discussion in [#3710](https://github.com/asterinas/asterinas/pull/3710#discussion_r3772053709).

This PR includes a secondary change that reorders the guidelines in the "Crates & Modules" pages to make related guidelines close to each other.