### PR TITLE
Two cleanups after `aster-core` visibility restriction

### DIFF
--- a/kernel/core/src/context.rs
+++ b/kernel/core/src/context.rs
@@ -23,10 +23,10 @@ use crate::{
 /// The context that can be accessed from the current POSIX thread.
 #[derive(Clone)]
 pub(crate) struct Context<'a> {
-    pub(crate) process: Arc<Process>,
-    pub(crate) thread_local: &'a ThreadLocal,
-    pub(crate) posix_thread: &'a PosixThread,
-    pub(crate) thread: &'a Thread,
+    pub process: Arc<Process>,
+    pub thread_local: &'a ThreadLocal,
+    pub posix_thread: &'a PosixThread,
+    pub thread: &'a Thread,
     pub task: &'a Task,
 }
 
@@ -40,13 +40,6 @@ impl Context<'_> {
 /// The user's memory space of the current task.
 ///
 /// It provides methods to read from or write to the user space efficiently.
-//
-// FIXME: With `impl VmIo for &CurrentUserSpace<'_>`, the Rust compiler seems to think that
-// `CurrentUserSpace` is a publicly exposed type, despite the fact that it is contained in a
-// private module and is never actually exposed. Consequently, it incorrectly suppresses many dead
-// code lints (for *lots of* types that are recursively reached via `CurrentUserSpace`'s APIs). As
-// a workaround, we mark the type as `pub(crate)`. We can restore it to `pub` once the compiler bug
-// is resolved.
 pub(crate) struct CurrentUserSpace<'a>(Ref<'a, Option<VmarHandle>>);
 
 /// Gets the [`CurrentUserSpace`] from the current task.

--- a/kernel/core/src/syscall/rmdir.rs
+++ b/kernel/core/src/syscall/rmdir.rs
@@ -11,10 +11,10 @@ use crate::{
 };
 
 pub(super) fn sys_rmdir(path_addr: Vaddr, ctx: &Context) -> Result<SyscallReturn> {
-    sys_rmdirat(AT_FDCWD, path_addr, ctx)
+    do_rmdirat(AT_FDCWD, path_addr, ctx)
 }
 
-pub(super) fn sys_rmdirat(
+pub(super) fn do_rmdirat(
     dirfd: RawFileDesc,
     path_addr: Vaddr,
     ctx: &Context,

--- a/kernel/core/src/syscall/unlink.rs
+++ b/kernel/core/src/syscall/unlink.rs
@@ -19,7 +19,7 @@ pub(super) fn sys_unlinkat(
     let flags = UnlinkFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
     if flags.contains(UnlinkFlags::AT_REMOVEDIR) {
-        return super::rmdir::sys_rmdirat(dirfd, path_addr, ctx);
+        return super::rmdir::do_rmdirat(dirfd, path_addr, ctx);
     }
 
     let path_name = ctx.user_space().read_cstring(path_addr, MAX_FILENAME_LEN)?;


### PR DESCRIPTION
The first commit renames `sys_rmdirat` to `do_rmdirat` because it is NOT a system call. But we have no way to distinguish it from other system calls at this moment.

The second commit removes some workarounds because they're outdated now.