### PR TITLE
Fix fsync and fdatasync dispatch

### DIFF
--- a/kernel/core/comps/virtio/src/device/filesystem/device/session.rs
+++ b/kernel/core/comps/virtio/src/device/filesystem/device/session.rs
@@ -13,6 +13,7 @@ use aster_fuse::{
     FuseError, FuseFileHandle, FuseNodeId, FuseOperation, MIN_MAX_WRITE,
     ops::{
         forget::{ForgetOperation, ForgetReq},
+        fsync::{FsyncFlags, FsyncOperation, FsyncdirOperation},
         init::{FuseInitFlags, FuseInitFlags2, InitOperation, InitReq},
         read::{ReadOperation, ReadReq},
         readdir::ReaddirOperation,
@@ -307,6 +308,26 @@ impl FuseSession {
         release_options: ReleaseOptions,
     ) -> Result<(), FuseError> {
         self.do_fuse_op(nodeid, ReleaseOperation::new(fh, flags, release_options))
+    }
+
+    /// Requests that the FUSE server synchronize an open file.
+    pub fn fsync(
+        &self,
+        nodeid: FuseNodeId,
+        fh: FuseFileHandle,
+        fsync_flags: FsyncFlags,
+    ) -> Result<(), FuseError> {
+        self.do_fuse_op(nodeid, FsyncOperation::new(fh, fsync_flags))
+    }
+
+    /// Requests that the FUSE server synchronize an open directory.
+    pub fn fsyncdir(
+        &self,
+        nodeid: FuseNodeId,
+        fh: FuseFileHandle,
+        fsync_flags: FsyncFlags,
+    ) -> Result<(), FuseError> {
+        self.do_fuse_op(nodeid, FsyncdirOperation::new(fh, fsync_flags))
     }
 }
 

--- a/kernel/core/src/device/registry/block.rs
+++ b/kernel/core/src/device/registry/block.rs
@@ -2,7 +2,7 @@
 
 use alloc::borrow::ToOwned;
 
-use aster_block::{BLOCK_SIZE, BlockDevice, SECTOR_SIZE};
+use aster_block::{BLOCK_SIZE, BlockDevice, SECTOR_SIZE, bio::BioStatus};
 use aster_nvme::NvmeBlockDevice;
 use aster_virtio::device::block::device::BlockDevice as VirtIoBlockDevice;
 use device_id::DeviceId;
@@ -14,7 +14,7 @@ use crate::{
     events::IoEvents,
     fs::{
         devtmpfs::{self, DevtmpfsNode, DevtmpfsNodeMeta},
-        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
+        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags, SyncMode},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -242,6 +242,18 @@ impl PerOpenFileOps for OpenBlockFile {
 
     fn settable_status_flags(&self) -> SettableStatusFlags {
         SettableStatusFlags::minimal().with_o_direct()
+    }
+
+    fn sync(&self, _mode: SyncMode) -> Result<()> {
+        match self.0.sync()? {
+            // Linux treats an unsupported block-device flush as success.
+            // Reference: <https://github.com/torvalds/linux/blob/v6.16/block/fops.c#L609-L611>
+            BioStatus::Complete | BioStatus::NotSupported => Ok(()),
+            status @ (BioStatus::NoSpace | BioStatus::IoError) => Err(status.into()),
+            BioStatus::Init | BioStatus::Submit | BioStatus::Zeros => {
+                return_errno_with_message!(Errno::EIO, "invalid block device flush status")
+            }
+        }
     }
 }
 

--- a/kernel/core/src/fs/file/file_handle.rs
+++ b/kernel/core/src/fs/file/file_handle.rs
@@ -143,6 +143,15 @@ pub(crate) trait FileLike: Pollable + Send + Sync + Any {
     ///    collected later in its `Display::display()` method, after dropping the file table's spin
     ///    lock.
     fn dump_proc_fdinfo(self: Arc<Self>, fd_flags: FdFlags) -> Box<dyn Display>;
+
+    /// Synchronizes the file according to `mode`.
+    ///
+    /// File-like objects do not support synchronization by default. Linux returns `EINVAL`
+    /// when a file's operations do not provide an `fsync` method.
+    /// Reference: <https://github.com/torvalds/linux/blob/v6.16/fs/sync.c#L179-L188>
+    fn sync(&self, _mode: SyncMode) -> Result<()> {
+        return_errno_with_message!(Errno::EINVAL, "the file does not support synchronization")
+    }
 }
 
 impl dyn FileLike {
@@ -339,4 +348,13 @@ pub(crate) enum Mappable {
     Vmo(Arc<Vmo>),
     /// An MMIO region.
     IoMem(IoMem),
+}
+
+/// Specifies the extent of a file synchronization operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SyncMode {
+    /// Synchronizes file data and the metadata required to retrieve it.
+    Data,
+    /// Synchronizes file data and all associated metadata.
+    Full,
 }

--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -6,7 +6,7 @@ use core::fmt::Display;
 
 use super::{
     AccessMode, CreationFlags, FileCommon, FileLike, InodeType, Mappable, SettableStatusFlags,
-    StatusFlags, file_table::FdFlags, flock::FlockItem,
+    StatusFlags, SyncMode, file_table::FdFlags, flock::FlockItem,
 };
 use crate::{
     events::IoEvents,
@@ -514,6 +514,21 @@ impl FileLike for InodeHandle {
             fd_flags,
         })
     }
+
+    fn sync(&self, mode: SyncMode) -> Result<()> {
+        if self.status_flags().contains(StatusFlags::O_PATH) {
+            return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
+        }
+
+        if let Some(ref open_file) = self.open_file {
+            return open_file.sync(mode);
+        }
+
+        match mode {
+            SyncMode::Data => self.path().sync_data(),
+            SyncMode::Full => self.path().sync_all(),
+        }
+    }
 }
 
 impl Drop for InodeHandle {
@@ -591,6 +606,14 @@ pub(crate) trait PerOpenFileOps: Pollable + FileOps + Any + Send + Sync + 'stati
         // `O_ASYNC` and `O_DIRECT` can only be set on file descriptions that explicitly
         // support them.
         SettableStatusFlags::minimal()
+    }
+
+    /// Synchronizes the file according to `mode`.
+    ///
+    /// Per-open file operations do not support synchronization by default.
+    /// Implementations that support synchronization must override this method.
+    fn sync(&self, _mode: SyncMode) -> Result<()> {
+        return_errno_with_message!(Errno::EINVAL, "the file does not support synchronization")
     }
 }
 

--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -524,10 +524,7 @@ impl FileLike for InodeHandle {
             return open_file.sync(mode);
         }
 
-        match mode {
-            SyncMode::Data => self.path().sync_data(),
-            SyncMode::Full => self.path().sync_all(),
-        }
+        self.path().sync(mode)
     }
 }
 

--- a/kernel/core/src/fs/file/mod.rs
+++ b/kernel/core/src/fs/file/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use file_attr::{
     status_flags::{AtomicStatusFlags, SettableStatusFlags, StatusFlags},
 };
 pub(crate) use file_common::FileCommon;
-pub(crate) use file_handle::{FileLike, Mappable, StatusFlagsUpdate};
+pub(crate) use file_handle::{FileLike, Mappable, StatusFlagsUpdate, SyncMode};
 pub(crate) use fs_config_file::{DetachedMountFile, FsConfigFile};
 pub(crate) use inode_attr::{
     mode::{InodeMode, chmod, mkmod, perms_to_mask, who_and_perms_to_mask, who_to_mask},

--- a/kernel/core/src/fs/fs_impls/exfat/fs.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/fs.rs
@@ -30,6 +30,7 @@ use super::{
 use crate::{
     fs::{
         exfat::{constants::*, inode::Ino},
+        file::SyncMode,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
             inode::Inode,
@@ -142,7 +143,7 @@ impl ExfatFs {
             if inode.is_deleted() {
                 inode.reclaim_space()?;
             } else {
-                inode.sync_all()?;
+                inode.sync(SyncMode::Full)?;
             }
         }
         self.inodes.write().remove(&hash);
@@ -421,7 +422,7 @@ impl FileSystem for ExfatFs {
 
     fn sync(&self) -> Result<()> {
         for inode in self.inodes.read().values() {
-            inode.sync_all()?;
+            inode.sync(SyncMode::Full)?;
         }
         self.meta_cache.flush_range(0..self.fs_size())?;
         Ok(())

--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -30,7 +30,7 @@ use crate::{
             bitmap::ExfatBitmap, dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFs,
             upcase_table::ExfatUpcaseTable,
         },
-        file::{InodeMode, InodeType, StatusFlags, mkmod},
+        file::{InodeMode, InodeType, StatusFlags, SyncMode, mkmod},
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
@@ -1771,22 +1771,14 @@ impl Inode for ExfatInode {
         return_errno_with_message!(Errno::EINVAL, "unsupported operation")
     }
 
-    fn sync_all(&self) -> Result<()> {
+    fn sync(&self, mode: SyncMode) -> Result<()> {
         let inner = self.inner.read();
         let fs = inner.fs();
         let fs_guard = fs.lock();
-        inner.sync_all(&fs_guard)?;
-
-        fs.block_device().sync()?;
-
-        Ok(())
-    }
-
-    fn sync_data(&self) -> Result<()> {
-        let inner = self.inner.read();
-        let fs = inner.fs();
-        let fs_guard = fs.lock();
-        inner.sync_data(&fs_guard)?;
+        match mode {
+            SyncMode::Data => inner.sync_data(&fs_guard)?,
+            SyncMode::Full => inner.sync_all(&fs_guard)?,
+        }
 
         fs.block_device().sync()?;
 

--- a/kernel/core/src/fs/fs_impls/ext2/block_group.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/block_group.rs
@@ -38,7 +38,7 @@ use super::{
     prelude::*,
     super_block::SuperBlock,
 };
-use crate::fs::utils::IdBitmap;
+use crate::fs::{file::SyncMode, utils::IdBitmap, vfs::inode::Inode as VfsInode};
 
 /// Represents one block group in an ext2 filesystem.
 ///
@@ -218,13 +218,13 @@ impl BlockGroup {
     /// Syncs cached inodes.
     fn sync_inodes(&self) -> Result<()> {
         // Clone the `Arc` handles under the read lock, then drop the lock before
-        // calling `sync_all()`.  Otherwise `sync_all()` acquires `inner.write()` while
+        // calling `sync`. Otherwise `sync` acquires `inner.write()` while
         // we still hold `inode_cache.read()`, creating a lock-order inversion with
         // `create`/`unlink`/`rmdir`/`rename` which take `inner.write()` first, then
         // `inode_cache.write()`.
         let inodes: Vec<Arc<Inode>> = self.inode_cache.read().values().cloned().collect();
         for inode in inodes {
-            inode.sync_all()?;
+            inode.sync(SyncMode::Full)?;
         }
         self.sync_inode_table()
     }

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -15,7 +15,7 @@ use device_id::DeviceId;
 use crate::{
     device,
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode},
         fs_impls::ext2::{FilePerm, Inode as Ext2Inode},
         utils::DirentVisitor,
         vfs::{
@@ -236,19 +236,11 @@ impl Inode for Ext2Inode {
         self.write_link(target)
     }
 
-    fn sync_all(&self) -> Result<()> {
-        self.sync_all()?;
-        let fs = self.fs()?;
-        let block_group = fs.block_group(self.block_group_idx());
-        block_group.sync_inode_table()?;
-        if fs.block_device().sync()? != BioStatus::Complete {
-            return_errno_with_message!(Errno::EIO, "failed to flush block device");
+    fn sync(&self, mode: SyncMode) -> Result<()> {
+        match mode {
+            SyncMode::Data => self.sync_data()?,
+            SyncMode::Full => self.sync_all()?,
         }
-        Ok(())
-    }
-
-    fn sync_data(&self) -> Result<()> {
-        self.sync_data()?;
         let fs = self.fs()?;
         let block_group = fs.block_group(self.block_group_idx());
         block_group.sync_inode_table()?;

--- a/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
@@ -19,7 +19,7 @@ use ostd::{
 
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode, mkmod},
         pseudofs::AnonDeviceId,
         utils::{DirentCounter, DirentVisitor, NAME_MAX},
         vfs::{
@@ -558,12 +558,8 @@ impl OverlayInode {
         );
     }
 
-    pub(crate) fn sync_all(&self) -> Result<()> {
-        self.upper().map_or(Ok(()), |upper| upper.sync_all())
-    }
-
-    pub(crate) fn sync_data(&self) -> Result<()> {
-        self.upper().map_or(Ok(()), |upper| upper.sync_data())
+    pub(crate) fn sync(&self, mode: SyncMode) -> Result<()> {
+        self.upper().map_or(Ok(()), |upper| upper.sync(mode))
     }
 }
 
@@ -1029,8 +1025,7 @@ impl Inode for OverlayInode {
     ) -> Result<()>;
     fn read_link(&self) -> Result<SymbolicLink>;
     fn write_link(&self, target: &str) -> Result<()>;
-    fn sync_all(&self) -> Result<()>;
-    fn sync_data(&self) -> Result<()>;
+    fn sync(&self, mode: SyncMode) -> Result<()>;
     fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()>;
     fn fs(&self) -> Arc<dyn FileSystem>;
     fn set_xattr(
@@ -1610,7 +1605,7 @@ mod tests {
             .write(0, &mut VmReader::from([3].as_slice()).to_fallible())
             .unwrap();
         f1.set_atime(Duration::default());
-        f1.sync_data().unwrap();
+        f1.sync(SyncMode::Data).unwrap();
         let mut data = [0u8; 1];
         f1.read_at(
             0,

--- a/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
@@ -8,9 +8,9 @@ use super::{inode::VirtioFsInode, open_handle::VirtioFsOpenHandle};
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, StatusFlags, SyncMode},
         utils::DirentVisitor,
-        vfs::inode::FileOps,
+        vfs::inode::{FileOps, Inode},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -80,6 +80,15 @@ impl PerOpenFileOps for VirtioFsDir {
         }
 
         Ok(())
+    }
+
+    fn sync(&self, mode: SyncMode) -> Result<()> {
+        // FIXME: Send a `FUSE_FSYNCDIR` request using this directory's open handle,
+        // set `FUSE_FSYNC_FDATASYNC` for `SyncMode::Data`, and return any server error.
+        match mode {
+            SyncMode::Data => self.inode.sync_data(),
+            SyncMode::Full => self.inode.sync_all(),
+        }
     }
 
     fn is_offset_aware(&self) -> bool {

--- a/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
@@ -85,10 +85,7 @@ impl PerOpenFileOps for VirtioFsDir {
     fn sync(&self, mode: SyncMode) -> Result<()> {
         // FIXME: Send a `FUSE_FSYNCDIR` request using this directory's open handle,
         // set `FUSE_FSYNC_FDATASYNC` for `SyncMode::Data`, and return any server error.
-        match mode {
-            SyncMode::Data => self.inode.sync_data(),
-            SyncMode::Full => self.inode.sync_all(),
-        }
+        self.inode.sync(mode)
     }
 
     fn is_offset_aware(&self) -> bool {

--- a/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
@@ -2,7 +2,7 @@
 
 //! Open directory handles for `virtiofs`.
 
-use aster_fuse::FuseOpenFlags;
+use aster_fuse::{FsyncFlags, FuseOpenFlags};
 
 use super::{inode::VirtioFsInode, open_handle::VirtioFsOpenHandle};
 use crate::{
@@ -83,9 +83,20 @@ impl PerOpenFileOps for VirtioFsDir {
     }
 
     fn sync(&self, mode: SyncMode) -> Result<()> {
-        // FIXME: Send a `FUSE_FSYNCDIR` request using this directory's open handle,
-        // set `FUSE_FSYNC_FDATASYNC` for `SyncMode::Data`, and return any server error.
-        self.inode.sync(mode)
+        self.inode.sync(mode)?;
+
+        let fsync_flags = match mode {
+            SyncMode::Data => FsyncFlags::FDATASYNC,
+            SyncMode::Full => FsyncFlags::empty(),
+        };
+
+        self.inode.fs_ref().session().fsyncdir(
+            self.inode.nodeid(),
+            self.open_handle.fh(),
+            fsync_flags,
+        )?;
+
+        Ok(())
     }
 
     fn is_offset_aware(&self) -> bool {

--- a/kernel/core/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/file.rs
@@ -150,10 +150,7 @@ impl PerOpenFileOps for VirtioFsFile {
         // FIXME: After flushing the local page cache, send a `FUSE_FSYNC` request using
         // this file's open handle, set `FUSE_FSYNC_FDATASYNC` for `SyncMode::Data`, and
         // return any server error.
-        match mode {
-            SyncMode::Data => self.inode.sync_data(),
-            SyncMode::Full => self.inode.sync_all(),
-        }
+        self.inode.sync(mode)
     }
 
     fn is_offset_aware(&self) -> bool {

--- a/kernel/core/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/file.rs
@@ -2,7 +2,7 @@
 
 //! Open regular-file handles for `virtiofs`.
 
-use aster_fuse::FuseOpenFlags;
+use aster_fuse::{FsyncFlags, FuseOpenFlags};
 use ostd::warn;
 
 use super::{
@@ -147,10 +147,20 @@ impl PerOpenFileOps for VirtioFsFile {
     }
 
     fn sync(&self, mode: SyncMode) -> Result<()> {
-        // FIXME: After flushing the local page cache, send a `FUSE_FSYNC` request using
-        // this file's open handle, set `FUSE_FSYNC_FDATASYNC` for `SyncMode::Data`, and
-        // return any server error.
-        self.inode.sync(mode)
+        self.inode.sync(mode)?;
+
+        let fsync_flags = match mode {
+            SyncMode::Data => FsyncFlags::FDATASYNC,
+            SyncMode::Full => FsyncFlags::empty(),
+        };
+
+        self.inode.fs_ref().session().fsync(
+            self.inode.nodeid(),
+            self.open_handle.fh(),
+            fsync_flags,
+        )?;
+
+        Ok(())
     }
 
     fn is_offset_aware(&self) -> bool {

--- a/kernel/core/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/file.rs
@@ -12,8 +12,8 @@ use super::{
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
-        vfs::inode::FileOps,
+        file::{PerOpenFileOps, StatusFlags, SyncMode},
+        vfs::inode::{FileOps, Inode},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
@@ -144,6 +144,16 @@ impl PerOpenFileOps for VirtioFsFile {
             return_errno_with_message!(Errno::ESPIPE, "the file is not seekable");
         }
         Ok(())
+    }
+
+    fn sync(&self, mode: SyncMode) -> Result<()> {
+        // FIXME: After flushing the local page cache, send a `FUSE_FSYNC` request using
+        // this file's open handle, set `FUSE_FSYNC_FDATASYNC` for `SyncMode::Data`, and
+        // return any server error.
+        match mode {
+            SyncMode::Data => self.inode.sync_data(),
+            SyncMode::Full => self.inode.sync_all(),
+        }
     }
 
     fn is_offset_aware(&self) -> bool {

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -39,7 +39,7 @@ use super::{
 };
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode},
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
@@ -503,7 +503,7 @@ impl Inode for VirtioFsInode {
         Ok(())
     }
 
-    fn sync_data(&self) -> Result<()> {
+    fn sync(&self, _mode: SyncMode) -> Result<()> {
         let inner = self.inner.write();
         let Some(page_cache) = &inner.page_cache else {
             return Ok(());

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -147,7 +147,7 @@ impl VirtioFsInode {
         })
     }
 
-    fn fs_ref(&self) -> Arc<VirtioFs> {
+    pub(super) fn fs_ref(&self) -> Arc<VirtioFs> {
         self.fs.upgrade().unwrap()
     }
 

--- a/kernel/core/src/fs/utils/systree_inode.rs
+++ b/kernel/core/src/fs/utils/systree_inode.rs
@@ -9,7 +9,7 @@ use aster_systree::{
 
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode, mkmod},
         utils::DirentVisitor,
         vfs::{
             file_system::{FileSystem, SuperBlock},
@@ -604,11 +604,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         None
     }
 
-    default fn sync_all(&self) -> Result<()> {
-        Ok(())
-    }
-
-    default fn sync_data(&self) -> Result<()> {
+    default fn sync(&self, _mode: SyncMode) -> Result<()> {
         Ok(())
     }
 

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -16,7 +16,9 @@ use super::{
 use crate::{
     device::{Device, DeviceType},
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags},
+        file::{
+            AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags, SyncMode,
+        },
         utils::DirentVisitor,
         vfs::path::Path,
     },
@@ -474,11 +476,7 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
         Err(Error::new(Errno::EISDIR))
     }
 
-    fn sync_all(&self) -> Result<()> {
-        Ok(())
-    }
-
-    fn sync_data(&self) -> Result<()> {
+    fn sync(&self, _mode: SyncMode) -> Result<()> {
         Ok(())
     }
 

--- a/kernel/core/src/fs/vfs/path/mod.rs
+++ b/kernel/core/src/fs/vfs/path/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     fs::{
         file::{
             CreationFlags, InodeHandle, InodeMode, InodeType, OpenArgs, Permission, StatusFlags,
+            SyncMode,
         },
         pseudofs::NsInode,
         vfs::{
@@ -724,8 +725,7 @@ impl Path {
 #[inherit_methods(from = "self.inode()")]
 impl Path {
     pub(crate) fn fs(&self) -> Arc<dyn FileSystem>;
-    pub(crate) fn sync_all(&self) -> Result<()>;
-    pub(crate) fn sync_data(&self) -> Result<()>;
+    pub(crate) fn sync(&self, mode: SyncMode) -> Result<()>;
     pub(crate) fn metadata(&self) -> Result<Metadata>;
     pub(crate) fn mode(&self) -> Result<InodeMode>;
     pub(crate) fn set_mode(&self, mode: InodeMode) -> Result<()>;

--- a/kernel/core/src/syscall/fsync.rs
+++ b/kernel/core/src/syscall/fsync.rs
@@ -2,7 +2,10 @@
 
 use super::SyscallReturn;
 use crate::{
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        SyncMode,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
 };
 
@@ -11,8 +14,7 @@ pub(super) fn sys_fsync(raw_fd: RawFileDesc, ctx: &Context) -> Result<SyscallRet
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
-    let path = file.as_inode_handle_or_err()?.path();
-    path.sync_all()?;
+    file.sync(SyncMode::Full)?;
     Ok(SyscallReturn::Return(0))
 }
 
@@ -21,7 +23,6 @@ pub(super) fn sys_fdatasync(raw_fd: RawFileDesc, ctx: &Context) -> Result<Syscal
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
-    let path = file.as_inode_handle_or_err()?.path();
-    path.sync_data()?;
+    file.sync(SyncMode::Data)?;
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/core/src/syscall/msync.rs
+++ b/kernel/core/src/syscall/msync.rs
@@ -3,7 +3,9 @@
 use align_ext::AlignExt;
 
 use super::SyscallReturn;
-use crate::{prelude::*, thread::kernel_thread::ThreadOptions, vm::vmar::VMAR_CAP_ADDR};
+use crate::{
+    fs::file::SyncMode, prelude::*, thread::kernel_thread::ThreadOptions, vm::vmar::VMAR_CAP_ADDR,
+};
 
 pub(super) fn sys_msync(
     addr: Vaddr,
@@ -55,7 +57,7 @@ pub(super) fn sys_msync(
     let task_fn = move || {
         for inode in inodes {
             // TODO: Sync a necessary range instead of syncing the whole inode.
-            let _ = inode.sync_all();
+            let _ = inode.sync(SyncMode::Full);
         }
     };
 

--- a/kernel/libs/aster-fuse/src/lib.rs
+++ b/kernel/libs/aster-fuse/src/lib.rs
@@ -39,6 +39,7 @@ pub use self::{
     ops::{
         create::{CreateOperation, CreateReq},
         forget::{ForgetOperation, ForgetReq},
+        fsync::{FsyncFlags, FsyncOperation, FsyncReq, FsyncdirOperation},
         getattr::{FuseAttrReply, GetattrFlags, GetattrOperation, GetattrReq},
         init::{FuseInitFlags, FuseInitFlags2, InitOperation, InitReply, InitReq},
         link::{LinkOperation, LinkReq},

--- a/kernel/libs/aster-fuse/src/ops/fsync.rs
+++ b/kernel/libs/aster-fuse/src/ops/fsync.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! `FUSE_FSYNC` synchronizes an open file handle, and `FUSE_FSYNCDIR`
+//! synchronizes an open directory handle.
+//!
+//! Both request bodies contain [`FsyncReq`]. Successful replies do not carry
+//! a payload.
+
+use bitflags::bitflags;
+use ostd::mm::{Infallible, VmReader, VmWriter};
+
+use crate::{FuseError, FuseFileHandle, FuseOpcode, FuseOperation, FuseResult, ReplyExpectation};
+
+/// Request body shared by `FUSE_FSYNC` and `FUSE_FSYNCDIR`.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/linux/fuse.h#L860-L864>
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod)]
+pub struct FsyncReq {
+    /// Open file or directory handle to synchronize.
+    fh: FuseFileHandle,
+    /// Selects the synchronization behavior.
+    fsync_flags: FsyncFlags,
+    padding: u32,
+}
+
+impl FsyncReq {
+    pub const fn new(fh: FuseFileHandle, fsync_flags: FsyncFlags) -> Self {
+        Self {
+            fh,
+            fsync_flags,
+            padding: 0,
+        }
+    }
+}
+
+bitflags! {
+    /// Flags for `FUSE_FSYNC` and `FUSE_FSYNCDIR` requests.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v6.18/source/include/uapi/linux/fuse.h#L569-L574>
+    #[repr(C)]
+    #[derive(Pod)]
+    pub struct FsyncFlags: u32 {
+        /// Sync data only, not metadata.
+        const FDATASYNC = 1 << 0;
+    }
+}
+
+pub struct FsyncOperation {
+    fsync_req: FsyncReq,
+}
+
+impl FsyncOperation {
+    pub const fn new(fh: FuseFileHandle, fsync_flags: FsyncFlags) -> Self {
+        Self {
+            fsync_req: FsyncReq::new(fh, fsync_flags),
+        }
+    }
+}
+
+impl FuseOperation for FsyncOperation {
+    type Output = ();
+
+    fn opcode(&self) -> FuseOpcode {
+        FuseOpcode::Fsync
+    }
+
+    fn body_len(&self) -> usize {
+        size_of::<FsyncReq>()
+    }
+
+    fn write_body(&mut self, writer: &mut VmWriter<'_, Infallible>) -> FuseResult<()> {
+        writer
+            .write_val(&self.fsync_req)
+            .map_err(|_| FuseError::BufferTooSmall)
+    }
+
+    fn reply_expectation(&self) -> ReplyExpectation {
+        ReplyExpectation::HeaderOnly
+    }
+
+    fn parse_reply(
+        _payload_len: usize,
+        _reader: &mut VmReader<'_, Infallible>,
+    ) -> FuseResult<Self::Output> {
+        Ok(())
+    }
+}
+
+pub struct FsyncdirOperation {
+    fsync_req: FsyncReq,
+}
+
+impl FsyncdirOperation {
+    pub const fn new(fh: FuseFileHandle, fsync_flags: FsyncFlags) -> Self {
+        Self {
+            fsync_req: FsyncReq::new(fh, fsync_flags),
+        }
+    }
+}
+
+impl FuseOperation for FsyncdirOperation {
+    type Output = ();
+
+    fn opcode(&self) -> FuseOpcode {
+        FuseOpcode::Fsyncdir
+    }
+
+    fn body_len(&self) -> usize {
+        size_of::<FsyncReq>()
+    }
+
+    fn write_body(&mut self, writer: &mut VmWriter<'_, Infallible>) -> FuseResult<()> {
+        writer
+            .write_val(&self.fsync_req)
+            .map_err(|_| FuseError::BufferTooSmall)
+    }
+
+    fn reply_expectation(&self) -> ReplyExpectation {
+        ReplyExpectation::HeaderOnly
+    }
+
+    fn parse_reply(
+        _payload_len: usize,
+        _reader: &mut VmReader<'_, Infallible>,
+    ) -> FuseResult<Self::Output> {
+        Ok(())
+    }
+}

--- a/kernel/libs/aster-fuse/src/ops/mod.rs
+++ b/kernel/libs/aster-fuse/src/ops/mod.rs
@@ -16,6 +16,7 @@ mod util;
 
 pub mod create;
 pub mod forget;
+pub mod fsync;
 pub mod getattr;
 pub mod init;
 pub mod link;

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -447,7 +447,7 @@ fstatfs02_64
 
 # fsync01
 fsync02
-# fsync03
+fsync03
 # fsync04
 
 ftruncate01

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -19,6 +19,7 @@ fchownat01
 fchownat02
 fstat02
 fstat02_64
+fsync03
 ftruncate01
 ftruncate01_64
 getcwd03


### PR DESCRIPTION
Dispatch synchronization through `FileLike` and per-open file operations so unsupported file types return `EINVAL` instead of falling through to no-op inode synchronization.