### PR TITLE
Fix errno precedence in timer gettime syscalls

### DIFF
--- a/kernel/core/src/process/process/timer_manager.rs
+++ b/kernel/core/src/process/process/timer_manager.rs
@@ -24,6 +24,7 @@ use crate::{
         Timer, TimerManager,
         clocks::{ProfClock, RealTimeClock},
         timer::TimerGuard,
+        timer_t,
     },
 };
 
@@ -128,6 +129,7 @@ fn create_process_timer_callback(
 impl PosixTimerManager {
     pub(super) fn new(prof_clock: &Arc<ProfClock>, process_ref: &Weak<Process>) -> Self {
         const MAX_NUM_OF_POSIX_TIMERS: usize = 10000;
+        const { assert!(MAX_NUM_OF_POSIX_TIMERS <= timer_t::MAX as usize) };
 
         let callback = create_process_timer_callback(process_ref);
 
@@ -178,8 +180,8 @@ impl PosixTimerManager {
     }
 
     /// Adds a POSIX timer to the managed `posix_timers`, and allocate a timer ID for this timer.
-    /// Return the timer ID, or `None` if allocation failed.
-    pub(crate) fn add_posix_timer(&self, posix_timer: Arc<Timer>) -> Option<usize> {
+    /// Returns the timer ID, or `None` if allocation failed.
+    pub(crate) fn add_posix_timer(&self, posix_timer: Arc<Timer>) -> Option<timer_t> {
         let mut timers = self.posix_timers.lock();
         // Holding the lock of `posix_timers` is required to operate the `id_allocator`.
         let timer_id = self.id_allocator.lock().alloc()?;
@@ -189,11 +191,12 @@ impl PosixTimerManager {
         // The ID allocated is not used by any other timers so this index in `timers`
         // must be `None`.
         timers[timer_id] = Some(posix_timer);
-        Some(timer_id)
+        Some(timer_id as timer_t)
     }
 
     /// Finds a POSIX timer by the input `timer_id`.
-    pub(crate) fn find_posix_timer(&self, timer_id: usize) -> Option<Arc<Timer>> {
+    pub(crate) fn find_posix_timer(&self, timer_id: timer_t) -> Option<Arc<Timer>> {
+        let timer_id = timer_id as usize;
         let timers = self.posix_timers.lock();
         if timer_id >= timers.len() {
             return None;
@@ -203,7 +206,8 @@ impl PosixTimerManager {
     }
 
     /// Removes the POSIX timer with the ID `timer_id`.
-    pub(crate) fn remove_posix_timer(&self, timer_id: usize) -> Option<Arc<Timer>> {
+    pub(crate) fn remove_posix_timer(&self, timer_id: timer_t) -> Option<Arc<Timer>> {
+        let timer_id = timer_id as usize;
         let mut timers = self.posix_timers.lock();
         if timer_id >= timers.len() {
             return None;

--- a/kernel/core/src/syscall/setsid.rs
+++ b/kernel/core/src/syscall/setsid.rs
@@ -3,8 +3,8 @@
 use super::SyscallReturn;
 use crate::prelude::*;
 
-pub(super) fn sys_setsid(_ctx: &Context) -> Result<SyscallReturn> {
-    let sid = current!().to_new_session()?;
+pub(super) fn sys_setsid(ctx: &Context) -> Result<SyscallReturn> {
+    let sid = ctx.process.to_new_session()?;
 
     Ok(SyscallReturn::Return(sid as _))
 }

--- a/kernel/core/src/syscall/timer_create.rs
+++ b/kernel/core/src/syscall/timer_create.rs
@@ -34,11 +34,10 @@ pub(super) fn sys_timer_create(
     timer_id_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let current_process = current!();
     let sent_signal: Box<dyn Fn() + Send + Sync + 'static> = {
         // If `sigevent_addr` is NULL, use the default method (like `sys_alarm`) to send signal.
         if sigevent_addr == 0 {
-            let process = current_process.clone();
+            let process = ctx.process.clone();
             let signal = KernelSignal::new(SIGALRM);
             Box::new(move || {
                 process.enqueue_signal(Box::new(signal));
@@ -53,7 +52,7 @@ pub(super) fn sys_timer_create(
                 SigNotify::SIGEV_NONE => Box::new(|| {}),
                 // Send a signal to the current process when the timer is expired.
                 SigNotify::SIGEV_SIGNAL => {
-                    let process = current_process.clone();
+                    let process = ctx.process.clone();
                     let signal = KernelSignal::new(SigNum::try_from(signo as u8)?);
                     Box::new(move || {
                         process.enqueue_signal(Box::new(signal));
@@ -74,7 +73,7 @@ pub(super) fn sys_timer_create(
                         Error::with_message(Errno::EINVAL, "the target thread does not exist")
                     })?;
                     let posix_thread = thread.as_posix_thread().unwrap();
-                    if posix_thread.process().pid() != current_process.pid() {
+                    if posix_thread.process().pid() != ctx.process.pid() {
                         return_errno_with_message!(
                             Errno::EINVAL,
                             "the target thread does not belong to the current process"
@@ -102,19 +101,18 @@ pub(super) fn sys_timer_create(
 
     let timer = create_timer(clockid, func, ctx)?;
 
-    let Some(timer_id) = current_process.timer_manager().add_posix_timer(timer) else {
+    let Some(timer_id) = ctx.process.timer_manager().add_posix_timer(timer) else {
         return_errno_with_message!(Errno::EAGAIN, "timer IDs are exhausted");
     };
     if let Err(error) = ctx.user_space().write_val(timer_id_addr, &timer_id) {
-        let _ = current_process.timer_manager().remove_posix_timer(timer_id);
+        let _ = ctx.process.timer_manager().remove_posix_timer(timer_id);
         return Err(error.into());
     }
     Ok(SyscallReturn::Return(0))
 }
 
-pub(super) fn sys_timer_delete(timer_id: timer_t, _ctx: &Context) -> Result<SyscallReturn> {
-    let current_process = current!();
-    let Some(timer) = current_process.timer_manager().remove_posix_timer(timer_id) else {
+pub(super) fn sys_timer_delete(timer_id: timer_t, ctx: &Context) -> Result<SyscallReturn> {
+    let Some(timer) = ctx.process.timer_manager().remove_posix_timer(timer_id) else {
         return_errno_with_message!(Errno::EINVAL, "invalid timer ID");
     };
 

--- a/kernel/core/src/syscall/timer_create.rs
+++ b/kernel/core/src/syscall/timer_create.rs
@@ -33,13 +33,6 @@ pub(super) fn sys_timer_create(
     timer_id_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    if timer_id_addr == 0 {
-        return_errno_with_message!(
-            Errno::EINVAL,
-            "the address of timer_id_addr should be valid"
-        );
-    }
-
     let current_process = current!();
     let sent_signal: Box<dyn Fn() + Send + Sync + 'static> = {
         // If `sigevent_addr` is NULL, use the default method (like `sys_alarm`) to send signal.

--- a/kernel/core/src/syscall/timer_create.rs
+++ b/kernel/core/src/syscall/timer_create.rs
@@ -24,6 +24,7 @@ use crate::{
         Timer, clockid_t,
         clocks::{BootTimeClock, MonotonicClock, RealTimeClock},
         timer::TimerGuard,
+        timer_t,
     },
 };
 
@@ -104,11 +105,14 @@ pub(super) fn sys_timer_create(
     let Some(timer_id) = current_process.timer_manager().add_posix_timer(timer) else {
         return_errno_with_message!(Errno::EAGAIN, "timer IDs are exhausted");
     };
-    ctx.user_space().write_val(timer_id_addr, &timer_id)?;
+    if let Err(error) = ctx.user_space().write_val(timer_id_addr, &timer_id) {
+        let _ = current_process.timer_manager().remove_posix_timer(timer_id);
+        return Err(error.into());
+    }
     Ok(SyscallReturn::Return(0))
 }
 
-pub(super) fn sys_timer_delete(timer_id: usize, _ctx: &Context) -> Result<SyscallReturn> {
+pub(super) fn sys_timer_delete(timer_id: timer_t, _ctx: &Context) -> Result<SyscallReturn> {
     let current_process = current!();
     let Some(timer) = current_process.timer_manager().remove_posix_timer(timer_id) else {
         return_errno_with_message!(Errno::EINVAL, "invalid timer ID");

--- a/kernel/core/src/syscall/timer_settime.rs
+++ b/kernel/core/src/syscall/timer_settime.rs
@@ -66,9 +66,6 @@ pub(super) fn sys_timer_gettime(
     itimerspec_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    if itimerspec_addr == 0 {
-        return_errno_with_message!(Errno::EINVAL, "invalid pointer to return value");
-    }
     let Some(timer) = ctx.process.timer_manager().find_posix_timer(timer_id) else {
         return_errno_with_message!(Errno::EINVAL, "invalid timer ID");
     };

--- a/kernel/core/src/syscall/timer_settime.rs
+++ b/kernel/core/src/syscall/timer_settime.rs
@@ -7,11 +7,11 @@ use ostd::mm::VmIo;
 use super::SyscallReturn;
 use crate::{
     prelude::*,
-    time::{TIMER_ABSTIME, itimerspec_t, timer::Timeout, timespec_t},
+    time::{TIMER_ABSTIME, itimerspec_t, timer::Timeout, timer_t, timespec_t},
 };
 
 pub(super) fn sys_timer_settime(
-    timer_id: usize,
+    timer_id: timer_t,
     flags: i32,
     new_itimerspec_addr: Vaddr,
     old_itimerspec_addr: Vaddr,
@@ -62,7 +62,7 @@ pub(super) fn sys_timer_settime(
 }
 
 pub(super) fn sys_timer_gettime(
-    timer_id: usize,
+    timer_id: timer_t,
     itimerspec_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {

--- a/kernel/core/src/syscall/timerfd_gettime.rs
+++ b/kernel/core/src/syscall/timerfd_gettime.rs
@@ -14,10 +14,6 @@ pub(super) fn sys_timerfd_gettime(
     itimerspec_addr: Vaddr,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    if itimerspec_addr == 0 {
-        return_errno_with_message!(Errno::EINVAL, "invalid pointer to return value");
-    }
-
     let file_table = ctx.thread_local.borrow_file_table();
     let file_table_locked = file_table.unwrap().read();
     let timerfd_file = file_table_locked.get_file(raw_fd.try_into()?)?;

--- a/kernel/core/src/time/mod.rs
+++ b/kernel/core/src/time/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod wait;
 
 pub(crate) type clockid_t = i32;
 pub(crate) type time_t = i64;
+pub(crate) type timer_t = i32;
 pub(crate) type suseconds_t = i64;
 
 const NSEC_PER_USEC: i64 = 1_000;

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1712,19 +1712,19 @@ timerfd01
 timerfd02
 # timerfd04
 timerfd_create01
-# timerfd_gettime01
+timerfd_gettime01
 # timerfd_settime01
 # timerfd_settime02
 
 # timer_create01
-# timer_create02
+timer_create02
 timer_create03
 
 # timer_delete01
 timer_delete02
 
 # timer_getoverrun01
-# timer_gettime01
+timer_gettime01
 
 # timer_settime01
 # timer_settime02


### PR DESCRIPTION
Remove the early NULL output-pointer checks from `timer_gettime` and `timerfd_gettime`. Validate the timer ID or file descriptor first, then let the userspace copy report EFAULT for invalid output addresses.