### PR TITLE
Prefer `alloc::io` than `no_std_io2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,6 @@ dependencies = [
  "logo-ascii-art",
  "loongArch64",
  "lru",
- "no_std_io2",
  "osdk-frame-allocator",
  "osdk-heap-allocator",
  "ostd",
@@ -600,7 +599,6 @@ version = "0.1.0"
 dependencies = [
  "int-to-c-enum",
  "lending-iterator",
- "no_std_io2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,6 @@ intrusive-collections = { version = "0.9.6", features = ["nightly"] }
 libflate = { version = "2.3.0", default-features = false }
 log = "0.4"
 loongArch64 = "0.2.5"
-no_std_io2 = { version = "0.9.3", default-features = false, features = ["alloc", "nightly"] }
 rand = { version = "0.9.2", default-features = false }
 riscv = { version = "0.15.0", features = ["s-mode"] }
 spin = "0.9.4"

--- a/kernel/core/Cargo.toml
+++ b/kernel/core/Cargo.toml
@@ -45,7 +45,6 @@ keyable-arc.workspace = true
 lending-iterator.workspace = true
 logo-ascii-art.workspace = true
 lru.workspace = true
-no_std_io2.workspace = true
 osdk-frame-allocator.workspace = true
 osdk-heap-allocator.workspace = true
 ostd.workspace = true

--- a/kernel/core/src/fs/file/file_handle.rs
+++ b/kernel/core/src/fs/file/file_handle.rs
@@ -169,7 +169,7 @@ impl dyn FileLike {
     /// [`write_at`]: FileLike::write_at
     /// [`resize`]: FileLike::resize
     /// [`fallocate`]: FileLike::fallocate
-    pub fn access_mode(&self) -> AccessMode {
+    pub(crate) fn access_mode(&self) -> AccessMode {
         self.common().access_mode()
     }
 

--- a/kernel/core/src/fs/initramfs.rs
+++ b/kernel/core/src/fs/initramfs.rs
@@ -14,7 +14,7 @@ macro_rules! __log_prefix {
 
 use alloc::{
     borrow::Cow,
-    io::{Cursor, Read},
+    io::{self, Cursor, Read},
 };
 
 use cpio_decoder::{CpioDecoder, CpioEntry, FileMetadata, FileType};
@@ -28,7 +28,13 @@ use super::{
     file::{InodeMode, InodeType},
     vfs::path::{FsPath, Path, PathResolver, is_dot},
 };
-use crate::{fs::vfs::inode::MknodType, prelude::*};
+use crate::{
+    fs::{
+        file::StatusFlags,
+        vfs::inode::{Inode, MknodType},
+    },
+    prelude::*,
+};
 
 /// Unpacks the boot initramfs into the bootstrap root filesystem.
 ///
@@ -108,7 +114,11 @@ fn try_append_entry_to_rootfs<R: Read>(
     match metadata.file_type() {
         FileType::File => {
             let path = parent.new_fs_child(name, InodeType::File, mode)?;
-            entry.read_all(path.inode().writer(0))?;
+            let writer = InodeWriter {
+                inner: path.inode().as_ref(),
+                offset: 0,
+            };
+            entry.read_all(writer)?;
         }
         FileType::Dir => {
             let _ = parent.new_fs_child(name, InodeType::Dir, mode)?;
@@ -139,6 +149,27 @@ fn try_append_entry_to_rootfs<R: Read>(
     }
 
     Ok(())
+}
+
+struct InodeWriter<'a> {
+    inner: &'a dyn Inode,
+    offset: usize,
+}
+
+impl io::Write for InodeWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut reader = VmReader::from(buf).to_fallible();
+        let write_len = self
+            .inner
+            .write_at(self.offset, &mut reader, StatusFlags::empty())
+            .map_err(|_| io::ErrorKind::WriteZero)?;
+        self.offset += write_len;
+        Ok(write_len)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 fn try_device_id_from_metadata(metadata: &FileMetadata) -> Result<u64> {

--- a/kernel/core/src/fs/initramfs.rs
+++ b/kernel/core/src/fs/initramfs.rs
@@ -12,12 +12,14 @@ macro_rules! __log_prefix {
     };
 }
 
-use alloc::borrow::Cow;
+use alloc::{
+    borrow::Cow,
+    io::{Cursor, Read},
+};
 
 use cpio_decoder::{CpioDecoder, CpioEntry, FileMetadata, FileType};
 use device_id::{DeviceId, MajorId, MinorId};
 use lending_iterator::LendingIterator;
-use no_std_io2::io::{Cursor, Read};
 use ostd::boot::boot_info;
 use spin::once::Once;
 use zune_inflate::DeflateDecoder;

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -2,11 +2,13 @@
 
 #![expect(unused_variables)]
 
-use alloc::boxed::ThinBox;
+use alloc::{
+    boxed::ThinBox,
+    io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write},
+};
 use core::time::Duration;
 
 use device_id::DeviceId;
-use no_std_io2::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write};
 use ostd::task::{CurrentTask, Task};
 use spin::Once;
 

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -2,10 +2,7 @@
 
 #![expect(unused_variables)]
 
-use alloc::{
-    boxed::ThinBox,
-    io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write},
-};
+use alloc::boxed::ThinBox;
 use core::time::Duration;
 
 use device_id::DeviceId;
@@ -651,13 +648,6 @@ impl dyn Inode {
         (self as &dyn Any).downcast_ref::<T>()
     }
 
-    pub(crate) fn writer(&self, from_offset: usize) -> InodeWriter<'_> {
-        InodeWriter {
-            inner: self,
-            offset: from_offset,
-        }
-    }
-
     #[cfg_attr(not(ktest), expect(dead_code))]
     pub(crate) fn read_bytes_at(&self, offset: usize, buf: &mut [u8]) -> Result<usize> {
         let mut writer = VmWriter::from(buf).to_fallible();
@@ -668,29 +658,6 @@ impl dyn Inode {
     pub(crate) fn write_bytes_at(&self, offset: usize, buf: &[u8]) -> Result<usize> {
         let mut reader = VmReader::from(buf).to_fallible();
         self.write_at(offset, &mut reader, StatusFlags::empty())
-    }
-}
-
-pub(crate) struct InodeWriter<'a> {
-    inner: &'a dyn Inode,
-    offset: usize,
-}
-
-impl Write for InodeWriter<'_> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
-        let mut reader = VmReader::from(buf).to_fallible();
-        let write_len = self
-            .inner
-            .write_at(self.offset, &mut reader, StatusFlags::empty())
-            .map_err(|_| IoError::new(IoErrorKind::WriteZero, "failed to write buffer"))?;
-        self.offset += write_len;
-        Ok(write_len)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> IoResult<()> {
-        Ok(())
     }
 }
 

--- a/kernel/core/src/lib.rs
+++ b/kernel/core/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 #![deny(unsafe_code)]
+#![feature(alloc_io)]
 #![feature(array_try_from_fn)]
 #![feature(associated_type_defaults)]
 #![feature(btree_cursors)]

--- a/kernel/core/src/process/process/init_proc.rs
+++ b/kernel/core/src/process/process/init_proc.rs
@@ -115,6 +115,7 @@ fn create_init_task(
             ProgramToLoad::from_executable(executable, &path_resolver, argv, envp)?;
         let vmar = process.lock_vmar();
         let elf_load_info = program_to_load.load_to_vmar(vmar.unwrap(), &path_resolver)?;
+
         (elf_load_info, executable_abs_path)
     };
 

--- a/kernel/core/src/syscall/inotify.rs
+++ b/kernel/core/src/syscall/inotify.rs
@@ -25,16 +25,18 @@ pub(super) fn sys_inotify_init1(flags: u32, ctx: &Context) -> Result<SyscallRetu
 }
 
 fn do_inotify_init(flags: u32, ctx: &Context) -> Result<SyscallReturn> {
-    debug!("inotify_init flags = {}", flags);
+    debug!("inotify_init: flags = {}", flags);
     let flags = InotifyFileFlags::from_bits(flags)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "invalid flags"))?;
+
+    let is_nonblocking = flags.contains(InotifyFileFlags::NONBLOCK);
+    let file = InotifyFile::new(is_nonblocking)?;
+
     let fd_flags = if flags.contains(InotifyFileFlags::CLOEXEC) {
         FdFlags::CLOEXEC
     } else {
         FdFlags::empty()
     };
-    let is_nonblocking = flags.contains(InotifyFileFlags::NONBLOCK);
-    let file = InotifyFile::new(is_nonblocking)?;
     let file_table = ctx.thread_local.borrow_file_table();
     let fd = file_table.unwrap().write().insert(file, fd_flags);
     Ok(SyscallReturn::Return(fd.into()))
@@ -47,18 +49,18 @@ pub(super) fn sys_inotify_add_watch(
     ctx: &Context,
 ) -> Result<SyscallReturn> {
     debug!(
-        "raw_fd = {:?}, path = {:?}, flags = {}",
+        "inotify_add_watch: raw_fd = {:?}, path = {:?}, flags = {}",
         raw_fd, path, flags
     );
     if flags == 0 {
-        return_errno_with_message!(Errno::EINVAL, "flags is 0, no events to watch");
+        return_errno_with_message!(Errno::EINVAL, "invalid flags");
     }
-    // Parse flags to InotifyEvents.
+    // Parse flags to `InotifyEvents`.
     let (interesting, options) = parse_inotify_watch_request(flags)?;
 
     if options.contains(InotifyControls::MASK_ADD) && options.contains(InotifyControls::MASK_CREATE)
     {
-        return_errno_with_message!(Errno::EINVAL, "flags is invalid");
+        return_errno_with_message!(Errno::EINVAL, "invalid options");
     }
 
     let path = ctx.user_space().read_cstring(path, MAX_FILENAME_LEN)?;
@@ -68,10 +70,10 @@ pub(super) fn sys_inotify_add_watch(
     // Verify that the file is an inotify file.
     let inotify_file = match file.downcast_ref::<InotifyFile>() {
         Some(inotify_file) => inotify_file,
-        None => return_errno_with_message!(Errno::EINVAL, "file is not an inotify file"),
+        None => return_errno_with_message!(Errno::EINVAL, "the file is not an inotify file"),
     };
 
-    let dentry = {
+    let path = {
         let path = path.to_string_lossy();
         let fs_path = FsPath::try_from(path.as_ref())?;
 
@@ -90,15 +92,15 @@ pub(super) fn sys_inotify_add_watch(
         }
     };
 
-    // Verify caller has read permissions on the inode.
-    let inode = dentry.inode();
+    // Verify that the caller has read permissions on the inode.
+    let inode = path.inode();
     inode.check_permission(Permission::MAY_READ)?;
 
     if options.contains(InotifyControls::ONLYDIR) && inode.type_() != InodeType::Dir {
-        return_errno_with_message!(Errno::ENOTDIR, "path is not a directory");
+        return_errno_with_message!(Errno::ENOTDIR, "the path is not a directory");
     }
 
-    let wd = inotify_file.add_watch(&dentry, interesting, options)?;
+    let wd = inotify_file.add_watch(&path, interesting, options)?;
     Ok(SyscallReturn::Return(wd as _))
 }
 
@@ -107,13 +109,13 @@ pub(super) fn sys_inotify_rm_watch(
     wd: u32,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    debug!("inotify_rm_watch raw_fd = {}, wd = {}", raw_fd, wd);
+    debug!("inotify_rm_watch: raw_fd = {}, wd = {}", raw_fd, wd);
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, raw_fd.try_into()?);
     let inotify_file = match file.downcast_ref::<InotifyFile>() {
         Some(inotify_file) => inotify_file,
-        None => return_errno_with_message!(Errno::EINVAL, "file is not an inotify file"),
+        None => return_errno_with_message!(Errno::EINVAL, "the file is not an inotify file"),
     };
     inotify_file.remove_watch(wd)?;
     Ok(SyscallReturn::Return(0))
@@ -122,8 +124,8 @@ pub(super) fn sys_inotify_rm_watch(
 fn parse_inotify_watch_request(flags: u32) -> Result<(InotifyEvents, InotifyControls)> {
     let interesting = InotifyEvents::from_bits_truncate(flags);
     let options = InotifyControls::from_bits_truncate(flags);
-    let recognized_bits = interesting.bits() | options.bits();
 
+    let recognized_bits = interesting.bits() | options.bits();
     if flags & !recognized_bits != 0 {
         return_errno_with_message!(Errno::EINVAL, "invalid flags");
     }

--- a/kernel/core/src/syscall/truncate.rs
+++ b/kernel/core/src/syscall/truncate.rs
@@ -48,10 +48,9 @@ pub(super) fn sys_truncate(path_ptr: Vaddr, len: isize, ctx: &Context) -> Result
     Ok(SyscallReturn::Return(0))
 }
 
-#[inline]
 fn check_length(len: isize, ctx: &Context) -> Result<()> {
     if len < 0 {
-        return_errno_with_message!(Errno::EINVAL, "length is negative");
+        return_errno_with_message!(Errno::EINVAL, "the length to truncate is negative");
     }
 
     let max_file_size = {
@@ -61,7 +60,7 @@ fn check_length(len: isize, ctx: &Context) -> Result<()> {
             .get_cur() as usize
     };
     if len as usize > max_file_size {
-        return_errno_with_message!(Errno::EFBIG, "length is larger than the maximum file size");
+        return_errno_with_message!(Errno::EFBIG, "the length to truncate is too large");
     }
     Ok(())
 }

--- a/kernel/core/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/map.rs
@@ -326,12 +326,12 @@ impl<'a> VmarMapOptions<'a> {
         // Parse the `Mappable` and prepare the `MappedMemory`.
         let (mapped_mem, io_mem) = match mappable {
             Some(Mappable::Vmo(vmo)) => {
-                if let Some(ref file) = file {
-                    let path = file.path();
+                let path = file.as_ref().map(|file| file.path());
+
+                if let Some(path) = path {
                     debug_assert!(Arc::ptr_eq(&vmo, &path.inode().page_cache().unwrap()));
                 }
 
-                let path = file.as_ref().map(|file| file.path());
                 let is_writable_tracked = if let Some(path) = path
                     && let Some(memfd_inode) = path.inode().downcast_ref::<MemfdInode>()
                     && is_shared

--- a/kernel/libs/cpio-decoder/Cargo.toml
+++ b/kernel/libs/cpio-decoder/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 [dependencies]
 int-to-c-enum.workspace = true
 lending-iterator.workspace = true
-no_std_io2.workspace = true
 
 [lints]
 workspace = true

--- a/kernel/libs/cpio-decoder/src/error.rs
+++ b/kernel/libs/cpio-decoder/src/error.rs
@@ -14,10 +14,9 @@ pub enum Error {
     IoError,
 }
 
-impl From<no_std_io2::io::Error> for Error {
-    #[inline]
-    fn from(err: no_std_io2::io::Error) -> Self {
-        use no_std_io2::io::ErrorKind;
+impl From<alloc::io::Error> for Error {
+    fn from(err: alloc::io::Error) -> Self {
+        use alloc::io::ErrorKind;
 
         match err.kind() {
             ErrorKind::UnexpectedEof => Self::BufferShortError,

--- a/kernel/libs/cpio-decoder/src/lib.rs
+++ b/kernel/libs/cpio-decoder/src/lib.rs
@@ -17,17 +17,20 @@
 
 #![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]
+#![feature(alloc_io)]
 
 extern crate alloc;
 
 #[cfg(not(test))]
 use alloc::string::{String, ToString};
-use alloc::vec;
+use alloc::{
+    io::{Read, Write},
+    vec,
+};
 use core::cmp::min;
 
 use int_to_c_enum::TryFromInt;
 use lending_iterator::prelude::*;
-use no_std_io2::io::{Read, Write};
 
 use crate::error::{Error, Result};
 


### PR DESCRIPTION
Our toolchain version is now `nightly-2026-07-21`.

This is a nice number, which means that https://github.com/rust-lang/rust/pull/158544 has been merged (2026-07-18), so that `alloc::io::Read` is available to use.

https://github.com/asterinas/asterinas/blob/437365615c653bb0ad3993fd3c4afc30d033af46/kernel/core/src/fs/initramfs.rs#L20

Therefore, there is no need to rely on `no_std_io2`. I propose removing it to eliminate another external crate.

We can use `alloc::io::Read` instead. See the changes in this first commit.

(Note: `libflate` still depends on `no_std_io2`. I don't think it is controversial to clean up our dependencies first, though.)

---

I also noticed that `InodeWriter` has only one user. Given that I cannot think of a second user and it does not rely on any inode's implementation details, I think it is better to just move it to where it is used. This is done in the second commit.

The third commit performs some random style cleanups. The correctness should be obvious.