### PR TITLE
Mark `CpuExceptionType` as private, as it has no users outside of OSTD

### DIFF
--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -210,7 +210,7 @@ pub enum CpuException {
 }
 
 impl CpuException {
-    pub(crate) fn new(trap_num: usize, error_code: usize) -> Option<Self> {
+    pub(in crate::arch) fn new(trap_num: usize, error_code: usize) -> Option<Self> {
         let exception = match trap_num {
             0 => Self::DivisionError,
             1 => Self::Debug,
@@ -274,7 +274,7 @@ impl CpuException {
         }
     }
 
-    pub(crate) const fn is_cpu_exception(trap_num: usize) -> bool {
+    pub(in crate::arch) const fn is_cpu_exception(trap_num: usize) -> bool {
         trap_num <= 31
     }
 }
@@ -304,8 +304,8 @@ impl UserContext {
 
 impl UserContextApiInternal for UserContext {
     fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason {
-        // set interrupt flag so that in user mode it can receive external interrupts
-        // set ID flag which means cpu support CPUID instruction
+        // Set the interrupt flag to enable the reception of external interrupts in user mode.
+        // Set the ID flag to indicate that the CPU supports the CPUID instruction.
         self.user_context.general.rflags |= (RFlags::INTERRUPT_FLAG | RFlags::ID).bits() as usize;
 
         const SYSCALL_TRAPNUM: usize = 0x100;
@@ -389,36 +389,34 @@ impl UserContextApiInternal for UserContext {
     }
 }
 
-/// As Osdev Wiki defines(<https://wiki.osdev.org/Exceptions>):
-/// CPU exceptions are classified as:
+/// Types of CPU exceptions.
 ///
-/// Faults: These can be corrected and the program may continue as if nothing happened.
+/// As defined by Intel, there are three types of x86-64 CPU exceptions:
+///  - **Faults** can be corrected and the program may continue as if nothing happened.
+///  - **Traps** are reported immediately after the execution of the trapping instruction.
+///  - **Aborts** represent some unrecoverable errors.
 ///
-/// Traps: Traps are reported immediately after the execution of the trapping instruction.
-///
-/// Aborts: Some severe unrecoverable error.
-///
-/// But there exists some vector which are special. Vector 1 can be both fault or trap and vector 2 is interrupt.
-/// So here we also define FaultOrTrap and Interrupt
+/// However, there are some special vectors. Vector 1 can be either a fault or a trap, and vector 2
+/// is an interrupt. Here, we also define `FaultOrTrap` and `Interrupt`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CpuExceptionType {
-    /// CPU faults. Faults can be corrected, and the program may continue as if nothing happened.
+enum CpuExceptionType {
+    /// Faults. They can be corrected and the program may continue as if nothing happened.
     Fault,
-    /// CPU traps. Traps are reported immediately after the execution of the trapping instruction
+    /// Traps. They are reported immediately after the execution of the trapping instruction.
     Trap,
-    /// Faults or traps
+    /// Faults or traps.
     FaultOrTrap,
-    /// CPU interrupts
+    /// Interrupts.
     Interrupt,
-    /// Some severe unrecoverable error
+    /// Aborts. They represent some unrecoverable errors.
     Abort,
-    /// Reserved for future use
+    /// Reserved for future use.
     Reserved,
 }
 
 impl CpuExceptionType {
     /// Returns whether this exception type is a fault or a trap.
-    pub fn is_fault_or_trap(self) -> bool {
+    fn is_fault_or_trap(self) -> bool {
         match self {
             CpuExceptionType::Trap | CpuExceptionType::Fault | CpuExceptionType::FaultOrTrap => {
                 true


### PR DESCRIPTION
While reading the related code, I found `CpuExceptionType` has no users outside OSTD, so let's mark it as private.

Additionally, the doc comments do not adhere to the correct style. For instance, the first sentence is not a proper summary line. So I rewrite them.

Restrict some other types' visibility as well. Some `CpuException` methods' visibility should be `pub(in crate::arch)`, which matches the existing RISC-V code as well.
https://github.com/asterinas/asterinas/blob/7001f2b79d0aa8476e35adc21b538373ac728079/ostd/src/arch/riscv/cpu/context.rs#L108