### PR TITLE
Add iperf3 UDP benchmarks

### DIFF
--- a/test/initramfs/src/benchmark/iperf3/summary.yaml
+++ b/test/initramfs/src/benchmark/iperf3/summary.yaml
@@ -1,2 +1,4 @@
 benchmarks:
   - tcp_virtio_bw
+  - udp_virtio_bw_rx
+  - udp_virtio_bw_tx

--- a/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_rx/bench_result.yaml
+++ b/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_rx/bench_result.yaml
@@ -3,8 +3,8 @@ alert:
   threshold: 130%
 chart:
   description: iperf3 -s -B 10.0.2.15
-  legend: Average TCP Bandwidth over virtio-net between Host Linux and Guest {system}
-  title: '[Network] iperf3 receiver performance using TCP (virtio-net)'
+  legend: Average UDP Bandwidth over virtio-net between Host Linux and Guest {system}
+  title: '[Network] iperf3 receiver performance using UDP (virtio-net)'
   unit: Mbits/sec
 result_extraction:
   result_index: 7

--- a/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_rx/host.sh
+++ b/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_rx/host.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    # `-r` means if there's no qemu, the kill won't be executed
+    pgrep qemu | xargs -r kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Run iperf3 client
+echo "Running iperf3 client connected to $GUEST_SERVER_IP_ADDRESS"
+iperf3 -u -b 0 -l 1460 -c $GUEST_SERVER_IP_ADDRESS -f m
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_rx/run.sh
+++ b/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_rx/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "Running iperf3 server..."
+/benchmark/bin/iperf3 -s -B 10.0.2.15 --one-off

--- a/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_tx/bench_result.yaml
+++ b/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_tx/bench_result.yaml
@@ -1,0 +1,11 @@
+alert:
+  bigger_is_better: true
+  threshold: 130%
+chart:
+  description: iperf3 -s -B 10.0.2.15
+  legend: Average UDP Bandwidth over virtio-net between Host Linux and Guest {system}
+  title: '[Network] iperf3 sender performance using UDP (virtio-net)'
+  unit: Mbits/sec
+result_extraction:
+  result_index: 7
+  search_pattern: sender

--- a/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_tx/host.sh
+++ b/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_tx/host.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# Function to stop the guest VM
+stop_guest() {
+    echo "Stopping guest VM..."
+    # `-r` means if there's no qemu, the kill won't be executed
+    pgrep qemu | xargs -r kill
+}
+
+# Trap EXIT signal to ensure guest VM is stopped on script exit
+trap stop_guest EXIT
+
+# Run iperf3 client
+echo "Running iperf3 client connected to $GUEST_SERVER_IP_ADDRESS"
+iperf3 -R -u -b 0 -l 1460 -c $GUEST_SERVER_IP_ADDRESS -f m
+
+# The trap will automatically stop the guest VM when the script exits

--- a/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_tx/run.sh
+++ b/test/initramfs/src/benchmark/iperf3/udp_virtio_bw_tx/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+echo "Running iperf3 server..."
+/benchmark/bin/iperf3 -s -B 10.0.2.15 --one-off


### PR DESCRIPTION
This adds iperf3 UDP sender/receiver benchmarks.

In the existing iperf3 TCP benchmark, Asterinas acts as the receiver. Therefore, the title and result selection should be corrected. However, since TCP is a reliable protocol, the sender and receiver bandwidths should be the same.

See the tracking issue for the benchmark results and plans to optimize performance. I will open one soon.