### PR TITLE
Support RWF_NOWAIT for ext2 buffered and direct I/O

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/README.md
@@ -92,7 +92,10 @@ Silently-ignored flags:
 * `RWF_DSYNC`
 * `RWF_HIPRI`
 * `RWF_SYNC`
-* `RWF_NOWAIT`
+
+Partially-supported flags:
+* `RWF_NOWAIT` (ext2: `EAGAIN` or short reads for buffered reads;
+  `EOPNOTSUPP` for buffered writes; `EAGAIN` for direct I/O that would block)
 
 Unsupported flags:
 * `RWF_APPEND`

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/preadv2_and_pwritev2.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-and-directory-operations/preadv2_and_pwritev2.scml
@@ -1,5 +1,5 @@
 // Read data from multiple buffers
-preadv2(fd, iov, iovcnt, offset, flags = 0);
+preadv2(fd, iov, iovcnt, offset, flags = RWF_NOWAIT);
 
 // Write data to multiple buffers
-pwritev2(fd, iov, iovcnt, offset, flags = 0);
+pwritev2(fd, iov, iovcnt, offset, flags = RWF_NOWAIT);

--- a/kernel/core/src/device/evdev/file.rs
+++ b/kernel/core/src/device/evdev/file.rs
@@ -16,7 +16,7 @@ use super::EvdevDevice;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
+        file::{PerOpenFileOps, RwfFlags, SettableStatusFlags, StatusFlags},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -362,6 +362,7 @@ impl FileOps for EvdevFile {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let requested_bytes = writer.avail();
         let max_events = requested_bytes / size_of::<EvdevEvent>();
@@ -399,6 +400,7 @@ impl FileOps for EvdevFile {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         // TODO: In Linux, writing to evdev files is permitted and will inject input events.
         return_errno_with_message!(Errno::ENOSYS, "writing to evdev files is not supported yet");

--- a/kernel/core/src/device/fb.rs
+++ b/kernel/core/src/device/fb.rs
@@ -13,7 +13,7 @@ use crate::{
     events::IoEvents,
     fs::{
         devtmpfs::DevtmpfsNodeMeta,
-        file::{Mappable, PerOpenFileOps, StatusFlags},
+        file::{Mappable, PerOpenFileOps, RwfFlags, StatusFlags},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -411,6 +411,7 @@ impl FileOps for FbHandle {
         offset: usize,
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if !writer.has_avail() {
             return Ok(0);
@@ -451,6 +452,7 @@ impl FileOps for FbHandle {
         offset: usize,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if !reader.has_remain() {
             return Ok(0);

--- a/kernel/core/src/device/mem/file.rs
+++ b/kernel/core/src/device/mem/file.rs
@@ -3,7 +3,7 @@
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, RwfFlags, StatusFlags},
         vfs::inode::FileOps,
     },
     prelude::*,
@@ -102,6 +102,7 @@ impl FileOps for MemFile {
         _offset: usize,
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         match self {
             MemFile::Full | MemFile::Zero => {
@@ -121,6 +122,7 @@ impl FileOps for MemFile {
         _offset: usize,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         match self {
             MemFile::Null | MemFile::Random | MemFile::Urandom | MemFile::Zero => {

--- a/kernel/core/src/device/misc/hwrng.rs
+++ b/kernel/core/src/device/misc/hwrng.rs
@@ -13,7 +13,7 @@ use crate::{
     events::IoEvents,
     fs::{
         devtmpfs::DevtmpfsNodeMeta,
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, RwfFlags, StatusFlags},
         vfs::inode::FileOps,
     },
     prelude::*,
@@ -83,6 +83,7 @@ impl FileOps for HwRngFile {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         // Linux looks up the selected device at `read()`.
         // Reference: <https://elixir.bootlin.com/linux/v6.18/source/drivers/char/hw_random/core.c#L215>.
@@ -131,6 +132,7 @@ impl FileOps for HwRngFile {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         // FIXME: Opening this device with `O_WRONLY` or `O_RDWR` fails on Linux. Therefore, the
         // write operation should never be reached. See the TODO in `HwRngDevice::open`.

--- a/kernel/core/src/device/misc/tdxguest.rs
+++ b/kernel/core/src/device/misc/tdxguest.rs
@@ -58,7 +58,7 @@ use crate::{
     events::IoEvents,
     fs::{
         devtmpfs::DevtmpfsNodeMeta,
-        file::{PerOpenFileOps, StatusFlags},
+        file::{PerOpenFileOps, RwfFlags, StatusFlags},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -161,6 +161,7 @@ impl FileOps for TdxGuestFile {
         _offset: usize,
         _writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "the file is not valid for reading")
     }
@@ -170,6 +171,7 @@ impl FileOps for TdxGuestFile {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(Errno::EINVAL, "the file not valid for writing")
     }

--- a/kernel/core/src/device/pty/file.rs
+++ b/kernel/core/src/device/pty/file.rs
@@ -6,7 +6,7 @@ use crate::{
     device::PtySlave,
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
+        file::{PerOpenFileOps, RwfFlags, SettableStatusFlags, StatusFlags},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -66,6 +66,7 @@ impl FileOps for PtySlaveFile {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.0.read(writer, status_flags)
     }
@@ -75,6 +76,7 @@ impl FileOps for PtySlaveFile {
         _offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.0.write(reader, status_flags)
     }

--- a/kernel/core/src/device/pty/master.rs
+++ b/kernel/core/src/device/pty/master.rs
@@ -9,8 +9,8 @@ use crate::{
     fs::{
         devpts::Ptmx,
         file::{
-            CreationFlags, InodeMode, OpenArgs, PerOpenFileOps, SettableStatusFlags, StatusFlags,
-            file_table::FdFlags,
+            CreationFlags, InodeMode, OpenArgs, PerOpenFileOps, RwfFlags, SettableStatusFlags,
+            StatusFlags, file_table::FdFlags,
         },
         vfs::{inode::FileOps, path::Path},
     },
@@ -97,6 +97,7 @@ impl FileOps for PtyMaster {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         // TODO: Add support for timeout.
         let mut buf = vec![0u8; writer.avail().min(IO_CAPACITY)];
@@ -121,6 +122,7 @@ impl FileOps for PtyMaster {
         _offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let mut buf = vec![0u8; reader.remain().min(IO_CAPACITY)];
         let write_len = reader.read_fallible(&mut buf.as_mut_slice().into())?;

--- a/kernel/core/src/device/registry/block.rs
+++ b/kernel/core/src/device/registry/block.rs
@@ -14,7 +14,7 @@ use crate::{
     events::IoEvents,
     fs::{
         devtmpfs::{self, DevtmpfsNode, DevtmpfsNodeMeta},
-        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags, SyncMode},
+        file::{PerOpenFileOps, RwfFlags, SettableStatusFlags, StatusFlags, SyncMode},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -140,6 +140,7 @@ impl FileOps for OpenBlockFile {
         offset: usize,
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let total = writer.avail();
         if total == 0 {
@@ -168,6 +169,7 @@ impl FileOps for OpenBlockFile {
         offset: usize,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let total = reader.remain();
         if total == 0 {

--- a/kernel/core/src/device/tty/file.rs
+++ b/kernel/core/src/device/tty/file.rs
@@ -6,7 +6,7 @@ use super::{Tty, TtyDriver};
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
+        file::{PerOpenFileOps, RwfFlags, SettableStatusFlags, StatusFlags},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -33,6 +33,7 @@ impl<D: TtyDriver> FileOps for TtyFile<D> {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.0.read(writer, status_flags)
     }
@@ -42,6 +43,7 @@ impl<D: TtyDriver> FileOps for TtyFile<D> {
         _offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.0.write(reader, status_flags)
     }

--- a/kernel/core/src/device/tty/vt/file.rs
+++ b/kernel/core/src/device/tty/vt/file.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, SettableStatusFlags, StatusFlags},
+        file::{PerOpenFileOps, RwfFlags, SettableStatusFlags, StatusFlags},
         vfs::{inode::FileOps, path::Path},
     },
     prelude::*,
@@ -90,6 +90,7 @@ impl FileOps for VtFile {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.0.read(writer, status_flags)
     }
@@ -99,6 +100,7 @@ impl FileOps for VtFile {
         _offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.0.write(reader, status_flags)
     }

--- a/kernel/core/src/events/event_file.rs
+++ b/kernel/core/src/events/event_file.rs
@@ -18,7 +18,10 @@ use ostd::sync::LocalIrqDisabled;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
+        file::{
+            AccessMode, CreationFlags, FileCommon, FileLike, RwfFlags, StatusFlags,
+            file_table::FdFlags,
+        },
         pseudofs::AnonInodeFs,
     },
     prelude::*,
@@ -215,7 +218,7 @@ impl Pollable for EventFile {
 }
 
 impl FileLike for EventFile {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, writer: &mut VmWriter, _rwf_flags: RwfFlags) -> Result<usize> {
         let read_len = size_of::<u64>();
         if writer.avail() < read_len {
             return_errno_with_message!(Errno::EINVAL, "the event buffer is too small");
@@ -230,7 +233,7 @@ impl FileLike for EventFile {
         Ok(read_len)
     }
 
-    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+    fn write(&self, reader: &mut VmReader, _rwf_flags: RwfFlags) -> Result<usize> {
         let write_len = size_of::<u64>();
         if reader.remain() < write_len {
             return_errno_with_message!(Errno::EINVAL, "the event buffer is too small");

--- a/kernel/core/src/fs/file/file_handle.rs
+++ b/kernel/core/src/fs/file/file_handle.rs
@@ -9,8 +9,8 @@ use core::fmt::Display;
 use ostd::io::IoMem;
 
 use super::{
-    AccessMode, FileCommon, InodeHandle, SettableStatusFlags, StatusFlags, file_table::FdFlags,
-    inode_handle::SeekFrom,
+    AccessMode, FileCommon, InodeHandle, RwfFlags, SettableStatusFlags, StatusFlags,
+    file_table::FdFlags, inode_handle::SeekFrom,
 };
 use crate::{
     fs::vfs::{inode::FallocMode, path::Path},
@@ -36,7 +36,7 @@ pub(crate) trait FileLike: Pollable + Send + Sync + Any {
     /// Implementors should override this method if the file type supports reads.
     /// An overriding implementation must check whether `access_mode` is readable
     /// before performing the operation.
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, writer: &mut VmWriter, _rwf_flags: RwfFlags) -> Result<usize> {
         if !self.common().access_mode().is_readable() {
             return_errno_with_message!(Errno::EBADF, "the file is not opened for reading");
         }
@@ -56,7 +56,7 @@ pub(crate) trait FileLike: Pollable + Send + Sync + Any {
     /// Implementors should override this method if the file type supports writes.
     /// An overriding implementation must check whether `access_mode` is writable
     /// before performing the operation.
-    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+    fn write(&self, reader: &mut VmReader, _rwf_flags: RwfFlags) -> Result<usize> {
         if !self.common().access_mode().is_writable() {
             return_errno_with_message!(Errno::EBADF, "the file is not opened for writing");
         }
@@ -69,7 +69,7 @@ pub(crate) trait FileLike: Pollable + Send + Sync + Any {
     /// Unlike [`read`], `read_at` will not change the file offset.
     ///
     /// [`read`]: FileLike::read
-    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter, _rwf_flags: RwfFlags) -> Result<usize> {
         return_errno_with_message!(Errno::ESPIPE, "read_at is not supported");
     }
 
@@ -80,7 +80,12 @@ pub(crate) trait FileLike: Pollable + Send + Sync + Any {
     /// If the file is append-only, the `offset` will be ignored.
     ///
     /// [`write`]: FileLike::write
-    fn write_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+    fn write_at(
+        &self,
+        offset: usize,
+        reader: &mut VmReader,
+        _rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         return_errno_with_message!(Errno::ESPIPE, "write_at is not supported");
     }
 
@@ -252,23 +257,23 @@ impl dyn FileLike {
 
     pub(crate) fn read_bytes(&self, buf: &mut [u8]) -> Result<usize> {
         let mut writer = VmWriter::from(buf).to_fallible();
-        self.read(&mut writer)
+        self.read(&mut writer, RwfFlags::empty())
     }
 
     pub(crate) fn write_bytes(&self, buf: &[u8]) -> Result<usize> {
         let mut reader = VmReader::from(buf).to_fallible();
-        self.write(&mut reader)
+        self.write(&mut reader, RwfFlags::empty())
     }
 
     pub(crate) fn read_bytes_at(&self, offset: usize, buf: &mut [u8]) -> Result<usize> {
         let mut writer = VmWriter::from(buf).to_fallible();
-        self.read_at(offset, &mut writer)
+        self.read_at(offset, &mut writer, RwfFlags::empty())
     }
 
     #[expect(dead_code)]
     pub(crate) fn write_bytes_at(&self, offset: usize, buf: &[u8]) -> Result<usize> {
         let mut reader = VmReader::from(buf).to_fallible();
-        self.write_at(offset, &mut reader)
+        self.write_at(offset, &mut reader, RwfFlags::empty())
     }
 
     pub(crate) fn as_socket_or_err(&self) -> Result<&dyn Socket> {

--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -289,7 +289,13 @@ impl FileLike for InodeHandle {
             return file_ops.read_at(0, writer, status_flags, rwf_flags);
         }
 
-        let mut offset = self.offset.lock();
+        let mut offset = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.offset
+                .try_lock()
+                .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the file offset is locked"))?
+        } else {
+            self.offset.lock()
+        };
 
         let len = file_ops.read_at(*offset, writer, status_flags, rwf_flags)?;
         *offset += len;
@@ -312,7 +318,13 @@ impl FileLike for InodeHandle {
             return file_ops.write_at(0, reader, status_flags, rwf_flags);
         }
 
-        let mut offset = self.offset.lock();
+        let mut offset = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.offset
+                .try_lock()
+                .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the file offset is locked"))?
+        } else {
+            self.offset.lock()
+        };
 
         // FIXME: How can we deal with the `O_APPEND` flag if `open_file` is set?
         if status_flags.contains(StatusFlags::O_APPEND) && self.open_file.is_none() {

--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -5,8 +5,8 @@
 use core::fmt::Display;
 
 use super::{
-    AccessMode, CreationFlags, FileCommon, FileLike, InodeType, Mappable, SettableStatusFlags,
-    StatusFlags, SyncMode, file_table::FdFlags, flock::FlockItem,
+    AccessMode, CreationFlags, FileCommon, FileLike, InodeType, Mappable, RwfFlags,
+    SettableStatusFlags, StatusFlags, SyncMode, file_table::FdFlags, flock::FlockItem,
 };
 use crate::{
     events::IoEvents,
@@ -277,7 +277,7 @@ impl Pollable for InodeHandle {
 }
 
 impl FileLike for InodeHandle {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, writer: &mut VmWriter, rwf_flags: RwfFlags) -> Result<usize> {
         if self.status_flags().contains(StatusFlags::O_PATH) || !self.access_mode().is_readable() {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
         }
@@ -286,18 +286,18 @@ impl FileLike for InodeHandle {
         let status_flags = self.status_flags();
 
         if !is_offset_aware {
-            return file_ops.read_at(0, writer, status_flags);
+            return file_ops.read_at(0, writer, status_flags, rwf_flags);
         }
 
         let mut offset = self.offset.lock();
 
-        let len = file_ops.read_at(*offset, writer, status_flags)?;
+        let len = file_ops.read_at(*offset, writer, status_flags, rwf_flags)?;
         *offset += len;
 
         Ok(len)
     }
 
-    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+    fn write(&self, reader: &mut VmReader, rwf_flags: RwfFlags) -> Result<usize> {
         if self.status_flags().contains(StatusFlags::O_PATH) || !self.access_mode().is_writable() {
             return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
         }
@@ -309,7 +309,7 @@ impl FileLike for InodeHandle {
         let status_flags = self.status_flags();
 
         if !is_offset_aware {
-            return file_ops.write_at(0, reader, status_flags);
+            return file_ops.write_at(0, reader, status_flags, rwf_flags);
         }
 
         let mut offset = self.offset.lock();
@@ -321,13 +321,13 @@ impl FileLike for InodeHandle {
             *offset = self.path().size();
         }
 
-        let len = file_ops.write_at(*offset, reader, status_flags)?;
+        let len = file_ops.write_at(*offset, reader, status_flags, rwf_flags)?;
         *offset += len;
 
         Ok(len)
     }
 
-    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter, rwf_flags: RwfFlags) -> Result<usize> {
         let file_ops = self.file_ops_for_positional_io()?;
         if self.status_flags().contains(StatusFlags::O_PATH) || !self.access_mode().is_readable() {
             return_errno_with_message!(Errno::EBADF, "the file is not opened readable");
@@ -335,10 +335,15 @@ impl FileLike for InodeHandle {
 
         let status_flags = self.status_flags();
 
-        file_ops.read_at(offset, writer, status_flags)
+        file_ops.read_at(offset, writer, status_flags, rwf_flags)
     }
 
-    fn write_at(&self, mut offset: usize, reader: &mut VmReader) -> Result<usize> {
+    fn write_at(
+        &self,
+        mut offset: usize,
+        reader: &mut VmReader,
+        rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         let file_ops = self.file_ops_for_positional_io()?;
         if self.status_flags().contains(StatusFlags::O_PATH) || !self.access_mode().is_writable() {
             return_errno_with_message!(Errno::EBADF, "the file is not opened writable");
@@ -357,7 +362,7 @@ impl FileLike for InodeHandle {
             offset = self.path().size();
         }
 
-        file_ops.write_at(offset, reader, status_flags)
+        file_ops.write_at(offset, reader, status_flags, rwf_flags)
     }
 
     fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {

--- a/kernel/core/src/fs/file/io_flags.rs
+++ b/kernel/core/src/fs/file/io_flags.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Per-I/O flags for `preadv2`/`pwritev2`, mirroring Linux `RWF_*`;
+    /// `RWF_HIPRI`, `RWF_DSYNC`, and `RWF_SYNC` are silently ignored.
+    pub struct RwfFlags: u32 {
+        /// high-priority request
+        const RWF_HIPRI = 0x00000001;
+        /// synchronized I/O, data (per-I/O `O_DSYNC`)
+        const RWF_DSYNC = 0x00000002;
+        /// synchronized I/O, data and metadata (per-I/O `O_SYNC`)
+        const RWF_SYNC = 0x00000004;
+        /// do not wait; return `EAGAIN` if the operation would block
+        const RWF_NOWAIT = 0x00000008;
+    }
+}

--- a/kernel/core/src/fs/file/mod.rs
+++ b/kernel/core/src/fs/file/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod flock;
 mod fs_config_file;
 mod inode_attr;
 mod inode_handle;
+mod io_flags;
 
 pub(crate) use file_attr::{
     access_mode::AccessMode,
@@ -26,3 +27,4 @@ pub(crate) use inode_attr::{
     r#type::InodeType,
 };
 pub(crate) use inode_handle::{InodeHandle, PerOpenFileOps, SeekFrom};
+pub(crate) use io_flags::RwfFlags;

--- a/kernel/core/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/mod.rs
@@ -12,7 +12,7 @@ use self::slave::PtySlaveInode;
 use crate::{
     device::PtyMaster,
     fs::{
-        file::{InodeMode, InodeType, StatusFlags, mkmod},
+        file::{InodeMode, InodeType, RwfFlags, StatusFlags, mkmod},
         pseudofs::AnonDeviceId,
         utils::{DirEntryVecExt, DirentVisitor, NAME_MAX},
         vfs::{
@@ -181,6 +181,7 @@ impl FileOps for RootInode {
         _offset: usize,
         _writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Err(Error::new(Errno::EISDIR))
     }
@@ -190,6 +191,7 @@ impl FileOps for RootInode {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Err(Error::new(Errno::EISDIR))
     }

--- a/kernel/core/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/ptmx.rs
@@ -9,7 +9,7 @@ use crate::{
     device::{Device, DeviceType},
     fs::{
         devtmpfs::DevtmpfsNodeMeta,
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, mkmod},
         vfs::{
             file_system::{FileSystem, SuperBlock},
             inode::{Extension, FileOps, Inode, Metadata},
@@ -67,6 +67,7 @@ impl FileOps for Ptmx {
         _offset: usize,
         _writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Ok(0)
     }
@@ -76,6 +77,7 @@ impl FileOps for Ptmx {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Ok(0)
     }

--- a/kernel/core/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/slave.rs
@@ -9,7 +9,7 @@ use super::{BLOCK_SIZE, DevPts, FIRST_SLAVE_INO};
 use crate::{
     device::{Device, PtySlave},
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, mkmod},
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata},
@@ -55,6 +55,7 @@ impl FileOps for PtySlaveInode {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.device.read(writer, status_flags)
     }
@@ -64,6 +65,7 @@ impl FileOps for PtySlaveInode {
         _offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.device.write(reader, status_flags)
     }

--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -30,7 +30,7 @@ use crate::{
             bitmap::ExfatBitmap, dentry::ExfatDentryIterator, fat::ExfatChain, fs::ExfatFs,
             upcase_table::ExfatUpcaseTable,
         },
-        file::{InodeMode, InodeType, StatusFlags, SyncMode, mkmod},
+        file::{InodeMode, InodeType, RwfFlags, StatusFlags, SyncMode, mkmod},
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
@@ -1345,6 +1345,7 @@ impl FileOps for ExfatInode {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
             self.read_direct_at(offset, writer)
@@ -1358,6 +1359,7 @@ impl FileOps for ExfatInode {
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
             self.write_direct_at(offset, reader)

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -15,7 +15,7 @@ use device_id::DeviceId;
 use crate::{
     device,
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, SyncMode},
         fs_impls::ext2::{FilePerm, Inode as Ext2Inode},
         utils::DirentVisitor,
         vfs::{
@@ -38,6 +38,7 @@ impl FileOps for Ext2Inode {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
             self.read_direct_at(offset, writer)
@@ -51,6 +52,7 @@ impl FileOps for Ext2Inode {
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
             self.write_direct_at(offset, reader)

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -41,14 +41,7 @@ impl FileOps for Ext2Inode {
         rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
-            if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
-                // TODO: Support `RWF_NOWAIT` in the direct I/O path.
-                return_errno_with_message!(
-                    Errno::EOPNOTSUPP,
-                    "RWF_NOWAIT direct I/O is not supported"
-                );
-            }
-            self.read_direct_at(offset, writer)
+            self.read_direct_at(offset, writer, rwf_flags)
         } else {
             self.read_at(offset, writer, rwf_flags)
         }
@@ -61,14 +54,8 @@ impl FileOps for Ext2Inode {
         status_flags: StatusFlags,
         rwf_flags: RwfFlags,
     ) -> Result<usize> {
-        if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
-            if status_flags.contains(StatusFlags::O_DIRECT) {
-                // TODO: Support `RWF_NOWAIT` in the direct I/O path.
-                return_errno_with_message!(
-                    Errno::EOPNOTSUPP,
-                    "RWF_NOWAIT direct I/O is not supported"
-                );
-            }
+        if !status_flags.contains(StatusFlags::O_DIRECT) && rwf_flags.contains(RwfFlags::RWF_NOWAIT)
+        {
             // With `RWF_NOWAIT`, `ext4_buffered_write_iter` rejects buffered
             // writes with `EOPNOTSUPP`, as the file system does not support
             // asynchronous buffered writes (`FOP_BUFFER_WASYNC`).
@@ -78,7 +65,7 @@ impl FileOps for Ext2Inode {
             );
         }
         if status_flags.contains(StatusFlags::O_DIRECT) {
-            self.write_direct_at(offset, reader)
+            self.write_direct_at(offset, reader, rwf_flags)
         } else {
             self.write_at(offset, reader)
         }

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -38,12 +38,19 @@ impl FileOps for Ext2Inode {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
-        _rwf_flags: RwfFlags,
+        rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if status_flags.contains(StatusFlags::O_DIRECT) {
+            if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+                // TODO: Support `RWF_NOWAIT` in the direct I/O path.
+                return_errno_with_message!(
+                    Errno::EOPNOTSUPP,
+                    "RWF_NOWAIT direct I/O is not supported"
+                );
+            }
             self.read_direct_at(offset, writer)
         } else {
-            self.read_at(offset, writer)
+            self.read_at(offset, writer, rwf_flags)
         }
     }
 
@@ -52,8 +59,24 @@ impl FileOps for Ext2Inode {
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
-        _rwf_flags: RwfFlags,
+        rwf_flags: RwfFlags,
     ) -> Result<usize> {
+        if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            if status_flags.contains(StatusFlags::O_DIRECT) {
+                // TODO: Support `RWF_NOWAIT` in the direct I/O path.
+                return_errno_with_message!(
+                    Errno::EOPNOTSUPP,
+                    "RWF_NOWAIT direct I/O is not supported"
+                );
+            }
+            // With `RWF_NOWAIT`, `ext4_buffered_write_iter` rejects buffered
+            // writes with `EOPNOTSUPP`, as the file system does not support
+            // asynchronous buffered writes (`FOP_BUFFER_WASYNC`).
+            return_errno_with_message!(
+                Errno::EOPNOTSUPP,
+                "RWF_NOWAIT is not supported for buffered writes"
+            );
+        }
         if status_flags.contains(StatusFlags::O_DIRECT) {
             self.write_direct_at(offset, reader)
         } else {

--- a/kernel/core/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/block_manager/block_ptr_tree.rs
@@ -37,6 +37,16 @@ pub(in inode) struct BlockPtrTree {
     indirect_blocks_manager: Mutex<IndirectBlockManager>,
 }
 
+/// Whether a block-pointer walk may load indirect blocks from disk.
+#[derive(Clone, Copy)]
+enum WalkMode {
+    /// Load uncached indirect blocks from disk as needed.
+    Blocking,
+    /// Report `None` instead of loading uncached indirect blocks, or
+    /// `EAGAIN` if the indirect-block cache lock is contended.
+    NonBlocking,
+}
+
 impl BlockPtrTree {
     /// Creates a new block-pointer tree from the on-disk raw pointers.
     pub(in inode) fn new(raw_block_ptrs: RawBlockPtrs, fs: Weak<Ext2>) -> Self {
@@ -78,6 +88,28 @@ impl BlockPtrTree {
 
         let walk = self.walk_at(iblock)?;
         self.existing_contiguous_data_blocks(&walk, max_blocks)
+    }
+
+    /// Resolves a logical block to a contiguous physical block range without
+    /// loading indirect blocks from disk.
+    ///
+    /// Returns `Ok(None)` when resolving the range would require reading an
+    /// uncached indirect block, or `EAGAIN` if the indirect-block cache lock
+    /// is contended.
+    pub(in inode) fn try_lookup_block_range(
+        &self,
+        iblock: Iblock,
+        max_blocks: u32,
+    ) -> Result<Option<Range<Ext2Bid>>> {
+        if max_blocks == 0 {
+            return_errno_with_message!(Errno::EINVAL, "zero block range requested");
+        }
+        let Some(walk) = self.try_walk_path(BlockPointerPath::new(iblock)?)? else {
+            return Ok(None);
+        };
+        Ok(Some(
+            self.existing_contiguous_data_blocks(&walk, max_blocks)?,
+        ))
     }
 
     /// Resolves a logical block to physical block (read-only).
@@ -423,42 +455,83 @@ impl BlockPtrTree {
     }
 
     /// Computes a `BlockPointerWalk` by walking the on-disk pointer chain.
-    fn walk_path(&self, path: BlockPointerPath) -> Result<BlockPointerWalk> {
+    ///
+    /// In `WalkMode::NonBlocking`, resolving a path that requires reading an
+    /// uncached indirect block from disk returns `Ok(None)` instead, and
+    /// `EAGAIN` if the indirect-block cache lock is contended.
+    fn walk_path_with(
+        &self,
+        path: BlockPointerPath,
+        mode: WalkMode,
+    ) -> Result<Option<BlockPointerWalk>> {
         let top_bid = self.raw_block_ptrs.block_ptrs[path.slots[0] as usize];
         let num_levels = path.num_levels;
         let mut visited_entries = SmallVec::new();
         if top_bid == 0 {
             // Zero pointer means the path is broken at level 0.
-            return Ok(BlockPointerWalk {
+            return Ok(Some(BlockPointerWalk {
                 path,
                 is_complete: false,
                 visited_entries,
-            });
+            }));
         }
         visited_entries.push(top_bid);
 
-        let mut indirect_blocks_manager = self.indirect_blocks_manager.lock();
+        let mut indirect_blocks_manager = match mode {
+            WalkMode::Blocking => self.indirect_blocks_manager.lock(),
+            WalkMode::NonBlocking => self.indirect_blocks_manager.try_lock().ok_or_else(|| {
+                Error::with_message(Errno::EAGAIN, "the indirect block cache is locked")
+            })?,
+        };
         let mut parent_bid = top_bid;
         for level in 1..num_levels {
-            let next_bid = indirect_blocks_manager
-                .find(parent_bid)?
-                .read_bid(path.slots[level] as usize)?;
+            let next_bid = match mode {
+                WalkMode::Blocking => indirect_blocks_manager
+                    .find(parent_bid)?
+                    .read_bid(path.slots[level] as usize)?,
+                WalkMode::NonBlocking => {
+                    let Some(indirect_block) = indirect_blocks_manager.try_find(parent_bid) else {
+                        return Ok(None);
+                    };
+                    indirect_block.read_bid(path.slots[level] as usize)?
+                }
+            };
             if next_bid == 0 {
-                return Ok(BlockPointerWalk {
+                return Ok(Some(BlockPointerWalk {
                     path,
                     is_complete: false,
                     visited_entries,
-                });
+                }));
             }
             visited_entries.push(next_bid);
             parent_bid = next_bid;
         }
 
-        Ok(BlockPointerWalk {
+        Ok(Some(BlockPointerWalk {
             path,
             is_complete: true,
             visited_entries,
-        })
+        }))
+    }
+
+    /// Computes a `BlockPointerWalk` by walking the on-disk pointer chain,
+    /// loading indirect blocks from disk as needed.
+    fn walk_path(&self, path: BlockPointerPath) -> Result<BlockPointerWalk> {
+        // `WalkMode::Blocking` always resolves the path; the `None` case is
+        // only reachable when uncached indirect blocks are reported instead
+        // of loaded, so this cannot happen here.
+        Ok(self
+            .walk_path_with(path, WalkMode::Blocking)?
+            .expect("blocking walk always resolves the path"))
+    }
+
+    /// Computes a `BlockPointerWalk` without loading indirect blocks from disk.
+    ///
+    /// Returns `Ok(None)` when resolving the path would require reading an
+    /// uncached indirect block, or `EAGAIN` if the indirect-block cache lock
+    /// is contended.
+    fn try_walk_path(&self, path: BlockPointerPath) -> Result<Option<BlockPointerWalk>> {
+        self.walk_path_with(path, WalkMode::NonBlocking)
     }
 
     fn existing_contiguous_data_blocks(

--- a/kernel/core/src/fs/fs_impls/ext2/inode/block_manager/indirect_block_manager.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/block_manager/indirect_block_manager.rs
@@ -41,6 +41,12 @@ impl IndirectBlockManager {
             .expect("indirect block must be cached after ensure_cached"))
     }
 
+    /// Returns a shared reference to the cached indirect block at `bid`, or
+    /// `None` if it has not been loaded yet.
+    pub(super) fn try_find(&mut self, bid: Ext2Bid) -> Option<&IndirectBlock> {
+        self.cache.get(&bid)
+    }
+
     /// Returns a mutable reference to the indirect block at `bid`, loading it if needed.
     pub(super) fn find_mut(&mut self, bid: Ext2Bid) -> Result<&mut IndirectBlock> {
         self.ensure_cached(bid)?;

--- a/kernel/core/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/block_manager/mod.rs
@@ -80,6 +80,17 @@ impl InodeBlockManager {
         IoRangeIter::new(block_range, tree)
     }
 
+    /// Creates a non-blocking iterator over existing and hole block ranges.
+    ///
+    /// The iterator reports `EAGAIN` instead of reading uncached indirect
+    /// blocks from disk or waiting on a contended block-pointer tree.
+    pub(super) fn iter_io_ranges_try(&self, block_range: Range<Iblock>) -> Result<IoRangeIter<'_>> {
+        let tree = self.block_ptr_tree.try_read().ok_or_else(|| {
+            Error::with_message(Errno::EAGAIN, "the block pointer tree is locked")
+        })?;
+        Ok(IoRangeIter::new_non_blocking(block_range, tree))
+    }
+
     /// Truncates blocks to the new_size (best-effort).
     pub(super) fn truncate_to_byte_len(&self, new_size: usize) {
         let fs = match self.fs() {

--- a/kernel/core/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -791,7 +791,8 @@ mod test {
         let old_ino = old.ino();
         let payload = vec![0x6au8; BLOCK_SIZE];
         let mut payload_reader = VmReader::from(payload.as_slice()).to_fallible();
-        old.write_direct_at(0, &mut payload_reader).unwrap();
+        old.write_direct_at(0, &mut payload_reader, crate::fs::file::RwfFlags::empty())
+            .unwrap();
 
         let free_blocks_before = f.ext2.super_block().free_blocks_count();
         root.unlink("old", old.as_ref()).unwrap();

--- a/kernel/core/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/file.rs
@@ -14,12 +14,18 @@ use ostd::mm::io::util::HasVmReaderWriter;
 use super::{super::Ext2, FileFlags, Inode, InodeInner, io_range::IoRange};
 use crate::fs::{
     ext2::{prelude::*, utils},
+    file::RwfFlags,
     vfs::inode::FallocMode,
 };
 
 impl Inode {
     /// Reads file data at `offset` through the page cache.
-    pub(in ext2) fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    pub(in ext2) fn read_at(
+        &self,
+        offset: usize,
+        writer: &mut VmWriter,
+        rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
         }
@@ -28,10 +34,15 @@ impl Inode {
             return Ok(0);
         }
 
-        let read_len = self.inner.read().read_at(offset, writer)?;
-        if read_len > 0 {
-            self.inner.write().set_atime(utils::now());
-        }
+        let read_len = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.inner
+                .try_read()
+                .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the inode is locked"))?
+                .read_at(offset, writer, rwf_flags)?
+        } else {
+            self.inner.read().read_at(offset, writer, rwf_flags)?
+        };
+        self.update_atime(read_len, rwf_flags);
         Ok(read_len)
     }
 
@@ -49,6 +60,23 @@ impl Inode {
         let fs = self.fs()?;
         let mut inner = self.inner.write();
         inner.write_at(&fs, offset, reader)
+    }
+
+    /// Updates the atime after a successful read.
+    ///
+    /// Under `RWF_NOWAIT` the update must not block, so it is skipped when the
+    /// inode write lock is contended.
+    fn update_atime(&self, read_len: usize, rwf_flags: RwfFlags) {
+        if read_len == 0 {
+            return;
+        }
+        if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            if let Some(mut inner) = self.inner.try_write() {
+                inner.set_atime(utils::now());
+            }
+        } else {
+            self.inner.write().set_atime(utils::now());
+        }
     }
 
     /// Direct-I/O read path.
@@ -226,7 +254,7 @@ impl InodeInner {
     }
 
     /// Reads file data at `offset` through the inode page cache.
-    fn read_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    fn read_at(&self, offset: usize, writer: &mut VmWriter, rwf_flags: RwfFlags) -> Result<usize> {
         if writer.avail() == 0 {
             return Ok(0);
         }
@@ -238,8 +266,12 @@ impl InodeInner {
 
         let read_len = writer.avail().min(file_size - offset);
         writer.limit(read_len);
-        self.page_cache().read(offset, writer)?;
-        Ok(read_len)
+        if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.page_cache().try_read(offset, writer)
+        } else {
+            self.page_cache().read(offset, writer)?;
+            Ok(read_len)
+        }
     }
 
     /// Writes file data at `offset` through the inode page cache.

--- a/kernel/core/src/fs/fs_impls/ext2/inode/file.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/file.rs
@@ -80,7 +80,12 @@ impl Inode {
     }
 
     /// Direct-I/O read path.
-    pub(in ext2) fn read_direct_at(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    pub(in ext2) fn read_direct_at(
+        &self,
+        offset: usize,
+        writer: &mut VmWriter,
+        rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
         }
@@ -95,15 +100,27 @@ impl Inode {
         }
 
         let fs = self.fs()?;
-        let read_len = self.inner.read().read_direct_at(&fs, offset, writer)?;
-        if read_len > 0 {
-            self.inner.write().set_atime(utils::now());
-        }
+        let read_len = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.inner
+                .try_read()
+                .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the inode is locked"))?
+                .read_direct_at(&fs, offset, writer, rwf_flags)?
+        } else {
+            self.inner
+                .read()
+                .read_direct_at(&fs, offset, writer, rwf_flags)?
+        };
+        self.update_atime(read_len, rwf_flags);
         Ok(read_len)
     }
 
     /// Direct-I/O write path with pre-allocation and rollback.
-    pub(in ext2) fn write_direct_at(&self, offset: usize, reader: &mut VmReader) -> Result<usize> {
+    pub(in ext2) fn write_direct_at(
+        &self,
+        offset: usize,
+        reader: &mut VmReader,
+        rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
         }
@@ -119,8 +136,14 @@ impl Inode {
         }
 
         let fs = self.fs()?;
-        let mut inner = self.inner.write();
-        inner.write_direct_at(&fs, offset, reader)
+        let mut inner = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.inner
+                .try_write()
+                .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the inode is locked"))?
+        } else {
+            self.inner.write()
+        };
+        inner.write_direct_at(&fs, offset, reader, rwf_flags)
     }
 
     /// Truncates or extends the file to `new_size` bytes.
@@ -304,7 +327,13 @@ impl InodeInner {
     }
 
     /// Reads file data directly after flushing overlapping cached pages.
-    fn read_direct_at(&self, fs: &Ext2, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+    fn read_direct_at(
+        &self,
+        fs: &Ext2,
+        offset: usize,
+        writer: &mut VmWriter,
+        rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         let file_size = self.file_size();
         if offset >= file_size || writer.avail() == 0 {
             return Ok(0);
@@ -314,8 +343,29 @@ impl InodeInner {
         writer.limit(read_len);
         let end = offset + read_len;
 
-        self.page_cache().flush_range(offset..end)?;
-        self.read_direct_blocks(fs, offset, end, writer)?;
+        // Hold the page cache's dio lock across the cache checks and block I/O
+        // so a concurrent mmap fault cannot commit a page in between. Under
+        // `RWF_NOWAIT` lock contention reports `EAGAIN` instead of blocking.
+        let page_cache = self.page_cache().as_vmo().clone();
+        let _dio_guard = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            page_cache
+                .dio_lock()
+                .try_write()
+                .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the page cache is busy"))?
+        } else {
+            page_cache.dio_lock().write()
+        };
+
+        if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            // Report `EAGAIN` instead of flushing when the range needs
+            // writeback.
+            if self.page_cache().needs_writeback(offset..end) {
+                return_errno_with_message!(Errno::EAGAIN, "the range has pages needing writeback");
+            }
+        } else {
+            self.page_cache().flush_range(offset..end)?;
+        }
+        self.read_direct_blocks(fs, offset, end, writer, rwf_flags)?;
         Ok(read_len)
     }
 
@@ -325,6 +375,7 @@ impl InodeInner {
         fs: &Ext2,
         offset: usize,
         reader: &mut VmReader,
+        rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let write_len = reader.remain();
         if write_len == 0 {
@@ -336,6 +387,36 @@ impl InodeInner {
             .ok_or_else(|| Error::with_message(Errno::EINVAL, "write range overflow"))?;
         let old_size = self.file_size();
 
+        // Hold the page cache's dio lock across the cache checks and block I/O
+        // so a concurrent mmap fault cannot commit a page in between. Under
+        // `RWF_NOWAIT` lock contention reports `EAGAIN` instead of blocking.
+        let page_cache = self.page_cache().as_vmo().clone();
+        let _dio_guard = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            page_cache
+                .dio_lock()
+                .try_write()
+                .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the page cache is busy"))?
+        } else {
+            page_cache.dio_lock().write()
+        };
+
+        if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            // Reject writes that extend the file; they need exclusive-lock
+            // semantics and a size update.
+            if end > old_size {
+                return_errno_with_message!(Errno::EAGAIN, "the range extends the file");
+            }
+            // Report `EAGAIN` when any page is cached in the range.
+            if self.page_cache().has_pages(offset..end) {
+                return_errno_with_message!(Errno::EAGAIN, "the range has cached pages");
+            }
+            // Allocating blocks for a hole would require metadata I/O, so
+            // holes report `EAGAIN`.
+            if self.has_holes(offset, end)? {
+                return_errno_with_message!(Errno::EAGAIN, "the range contains holes");
+            }
+        }
+
         if let Err(err) = self.prepare_write(fs, offset, end) {
             self.rollback_write(old_size, end);
             return Err(err);
@@ -343,12 +424,12 @@ impl InodeInner {
 
         let discard_start_bytes = offset.min(old_size);
         let discard_end_bytes = end.min(old_size);
-        if discard_start_bytes < discard_end_bytes {
+        if !rwf_flags.contains(RwfFlags::RWF_NOWAIT) && discard_start_bytes < discard_end_bytes {
             self.page_cache()
                 .invalidate_range(discard_start_bytes..discard_end_bytes)?;
         }
 
-        if let Err(err) = self.write_direct_blocks(fs, offset, reader) {
+        if let Err(err) = self.write_direct_blocks(fs, offset, reader, rwf_flags) {
             self.rollback_write(old_size, end);
             return Err(err);
         }
@@ -360,6 +441,26 @@ impl InodeInner {
         Ok(write_len)
     }
 
+    /// Returns whether any block in the specified byte range is a hole.
+    ///
+    /// The check is non-blocking: uncached indirect blocks and lock
+    /// contention are reported as `EAGAIN` instead of blocking.
+    fn has_holes(&self, offset: usize, end: usize) -> Result<bool> {
+        let iblock_start = Iblock::try_from(offset / BLOCK_SIZE)
+            .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
+        let iblock_end = Iblock::try_from(end.div_ceil(BLOCK_SIZE))
+            .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
+        let mut range_iter = self
+            .block_manager()?
+            .iter_io_ranges_try(iblock_start..iblock_end)?;
+        while let Some(range) = range_iter.next()? {
+            if matches!(range, IoRange::Hole(_)) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     /// Reads file data directly from data blocks into `writer`.
     fn read_direct_blocks(
         &self,
@@ -367,13 +468,18 @@ impl InodeInner {
         offset: usize,
         end: usize,
         writer: &mut VmWriter,
+        rwf_flags: RwfFlags,
     ) -> Result<()> {
         let iblock_start = Iblock::try_from(offset / BLOCK_SIZE)
             .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
         let iblock_end = Iblock::try_from(end.div_ceil(BLOCK_SIZE))
             .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
         let iblock_range = iblock_start..iblock_end;
-        let mut range_iter = self.block_manager()?.iter_io_ranges(iblock_range);
+        let mut range_iter = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.block_manager()?.iter_io_ranges_try(iblock_range)?
+        } else {
+            self.block_manager()?.iter_io_ranges(iblock_range)
+        };
 
         while let Some(range) = range_iter.next()? {
             match range {
@@ -400,6 +506,7 @@ impl InodeInner {
         fs: &Ext2,
         offset: usize,
         reader: &mut VmReader,
+        rwf_flags: RwfFlags,
     ) -> Result<()> {
         let write_len = reader.remain();
         debug_assert_eq!(write_len % BLOCK_SIZE, 0);
@@ -410,7 +517,11 @@ impl InodeInner {
         let iblock_end = Iblock::try_from(end.div_ceil(BLOCK_SIZE))
             .map_err(|_| Error::with_message(Errno::EINVAL, "logical block number overflow"))?;
         let iblock_range = iblock_start..iblock_end;
-        let mut range_iter = self.block_manager()?.iter_io_ranges(iblock_range);
+        let mut range_iter = if rwf_flags.contains(RwfFlags::RWF_NOWAIT) {
+            self.block_manager()?.iter_io_ranges_try(iblock_range)?
+        } else {
+            self.block_manager()?.iter_io_ranges(iblock_range)
+        };
 
         let mut io_batch = IoBatch::new();
         while let Some(range) = range_iter.next()? {
@@ -519,14 +630,15 @@ mod test {
         let base_data = vec![0x44u8; BLOCK_SIZE];
 
         let mut reader = VmReader::from(base_data.as_slice()).to_fallible();
-        file.write_direct_at(0, &mut reader).unwrap();
+        file.write_direct_at(0, &mut reader, RwfFlags::empty())
+            .unwrap();
         let free_before_fail = f.ext2.super_block().free_blocks_count();
         assert_eq!(free_before_fail, 1);
 
         let fail_payload = vec![0x66u8; BLOCK_SIZE * 2];
         let mut fail_reader = VmReader::from(fail_payload.as_slice()).to_fallible();
         assert_errno!(
-            file.write_direct_at(BLOCK_SIZE, &mut fail_reader),
+            file.write_direct_at(BLOCK_SIZE, &mut fail_reader, RwfFlags::empty(),),
             Errno::ENOSPC
         );
 
@@ -535,7 +647,8 @@ mod test {
 
         let mut readback = vec![0u8; BLOCK_SIZE];
         let mut writer = VmWriter::from(readback.as_mut_slice()).to_fallible();
-        file.read_direct_at(0, &mut writer).unwrap();
+        file.read_direct_at(0, &mut writer, RwfFlags::empty())
+            .unwrap();
         assert_eq!(readback, base_data);
     }
 

--- a/kernel/core/src/fs/fs_impls/ext2/inode/io_range.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/io_range.rs
@@ -19,9 +19,19 @@ pub(super) enum IoRange {
 /// Each item preserves the range classification needed by direct I/O:
 /// contiguous device-block mappings remain grouped,
 /// and sparse logical ranges remain explicit holes.
+///
+/// The iterator either reads uncached indirect blocks from disk (blocking) or
+/// reports `EAGAIN` instead (non-blocking).
+#[derive(Clone, Copy)]
+pub(super) enum IoRangeIterMode {
+    Blocking,
+    NonBlocking,
+}
+
 pub(super) struct IoRangeIter<'a> {
     range: Range<Iblock>,
     block_ptr_tree: RwMutexReadGuard<'a, BlockPtrTree>,
+    mode: IoRangeIterMode,
 }
 
 impl<'a> IoRangeIter<'a> {
@@ -33,6 +43,20 @@ impl<'a> IoRangeIter<'a> {
         Self {
             range,
             block_ptr_tree,
+            mode: IoRangeIterMode::Blocking,
+        }
+    }
+
+    /// Creates a non-blocking iterator that reports `EAGAIN` instead of
+    /// reading uncached indirect blocks from disk.
+    pub(super) fn new_non_blocking(
+        range: Range<Iblock>,
+        block_ptr_tree: RwMutexReadGuard<'a, BlockPtrTree>,
+    ) -> Self {
+        Self {
+            range,
+            block_ptr_tree,
+            mode: IoRangeIterMode::NonBlocking,
         }
     }
 
@@ -48,9 +72,20 @@ impl<'a> IoRangeIter<'a> {
 
         let start_iblock = self.range.start;
         let max_blocks = self.range.len() as u32;
-        let device_block_range = self
-            .block_ptr_tree
-            .lookup_block_range(start_iblock, max_blocks)?;
+        let device_block_range = match self.mode {
+            IoRangeIterMode::Blocking => self
+                .block_ptr_tree
+                .lookup_block_range(start_iblock, max_blocks)?,
+            IoRangeIterMode::NonBlocking => {
+                let Some(range) = self
+                    .block_ptr_tree
+                    .try_lookup_block_range(start_iblock, max_blocks)?
+                else {
+                    return_errno_with_message!(Errno::EAGAIN, "the range needs uncached metadata");
+                };
+                range
+            }
+        };
 
         if device_block_range.is_empty() {
             // Linux's ext2 documents the slow case where it iterates unmapped

--- a/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
@@ -19,7 +19,10 @@ use ostd::{
 
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode, mkmod},
+        file::{
+            AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, SyncMode,
+            mkmod,
+        },
         pseudofs::AnonDeviceId,
         utils::{DirentCounter, DirentVisitor, NAME_MAX},
         vfs::{
@@ -317,12 +320,13 @@ impl OverlayInode {
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
         }
         let upper = self.build_upper_recursively_if_needed()?;
-        upper.write_at(offset, reader, status_flags)
+        upper.write_at(offset, reader, status_flags, rwf_flags)
     }
 
     pub(crate) fn read_at(
@@ -330,12 +334,13 @@ impl OverlayInode {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if self.type_ == InodeType::Dir {
             return_errno!(Errno::EISDIR);
         }
         self.get_top_valid_inode()
-            .read_at(offset, writer, status_flags)
+            .read_at(offset, writer, status_flags, rwf_flags)
     }
 
     /// Visits the children objects in a unified view.
@@ -890,10 +895,15 @@ impl OverlayInode {
             .alloc_segment(lower_size.align_up(BLOCK_SIZE) / BLOCK_SIZE)?;
 
         let mut writer = data_buf.writer().to_fallible();
-        let read_len = lower.read_at(0, &mut writer, StatusFlags::empty())?;
+        let read_len = lower.read_at(0, &mut writer, StatusFlags::empty(), RwfFlags::empty())?;
 
         let mut reader = data_buf.reader().to_fallible();
-        let _ = upper.write_at(0, reader.limit(read_len), StatusFlags::empty())?;
+        let _ = upper.write_at(
+            0,
+            reader.limit(read_len),
+            StatusFlags::empty(),
+            RwfFlags::empty(),
+        )?;
         Ok(())
     }
 
@@ -975,12 +985,14 @@ impl FileOps for OverlayInode {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize>;
     fn write_at(
         &self,
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize>;
     fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize>;
 }
@@ -1306,6 +1318,7 @@ mod tests {
                     0,
                     &mut VmReader::from([8u8; 4].as_slice()).to_fallible(),
                     StatusFlags::empty(),
+                    RwfFlags::empty(),
                 )
                 .unwrap();
             f2_inode.set_group(Gid::new(77)).unwrap();
@@ -1455,6 +1468,7 @@ mod tests {
             0,
             &mut VmWriter::from(data.as_mut_slice()).to_fallible(),
             StatusFlags::empty(),
+            RwfFlags::empty(),
         )
         .unwrap();
         assert_eq!(data, [8u8; 4]);
@@ -1617,6 +1631,7 @@ mod tests {
             0,
             &mut VmWriter::from(data.as_mut_slice()).to_fallible(),
             StatusFlags::empty(),
+            RwfFlags::empty(),
         )
         .unwrap();
         assert_eq!(data, [3u8; 1]);

--- a/kernel/core/src/fs/fs_impls/procfs/pid/task/maps.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/pid/task/maps.rs
@@ -6,7 +6,7 @@ use super::TidDirOps;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, PerOpenFileOps, RwfFlags, StatusFlags, mkmod},
         procfs::template::{ProcFile, ProcFileOpsByHandle},
         vfs::inode::{FileOps, Inode},
     },
@@ -78,6 +78,7 @@ impl FileOps for MapsFileHandle {
         offset: usize,
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let mut printer = VmPrinter::new_skip(writer, offset);
 
@@ -114,6 +115,7 @@ impl FileOps for MapsFileHandle {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(Errno::EPERM, "`/proc/[pid]/maps` is not writable");
     }

--- a/kernel/core/src/fs/fs_impls/procfs/pid/task/mem.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/pid/task/mem.rs
@@ -4,7 +4,7 @@ use super::TidDirOps;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, PerOpenFileOps, RwfFlags, StatusFlags, mkmod},
         procfs::template::{ProcFile, ProcFileOpsByHandle},
         vfs::inode::{FileOps, Inode},
     },
@@ -75,6 +75,7 @@ impl FileOps for MemFileHandle {
         offset: usize,
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let Some(process) = self.0.process() else {
             // The process does not exist.
@@ -102,6 +103,7 @@ impl FileOps for MemFileHandle {
         offset: usize,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let Some(process) = self.0.process() else {
             // The process does not exist.

--- a/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
@@ -12,7 +12,7 @@ use inherit_methods_macro::inherit_methods;
 use super::Common;
 use crate::{
     fs::{
-        file::{InodeMode, InodeType, StatusFlags},
+        file::{InodeMode, InodeType, RwfFlags, StatusFlags},
         procfs::{BLOCK_SIZE, ProcFs},
         utils::DirentVisitor,
         vfs::{
@@ -101,6 +101,7 @@ impl<D: ProcDirOps + 'static> FileOps for ProcDir<D> {
         _offset: usize,
         _writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Err(Error::new(Errno::EISDIR))
     }
@@ -110,6 +111,7 @@ impl<D: ProcDirOps + 'static> FileOps for ProcDir<D> {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Err(Error::new(Errno::EISDIR))
     }

--- a/kernel/core/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/file.rs
@@ -9,7 +9,7 @@ use inherit_methods_macro::inherit_methods;
 use super::Common;
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags},
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
@@ -56,6 +56,7 @@ impl<F: ProcFileOps + 'static> FileOps for ProcFile<F> {
         offset: usize,
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.inner.read_at(offset, writer)
     }
@@ -65,6 +66,7 @@ impl<F: ProcFileOps + 'static> FileOps for ProcFile<F> {
         offset: usize,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         self.inner.write_at(offset, reader)
     }

--- a/kernel/core/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/sym.rs
@@ -9,7 +9,7 @@ use inherit_methods_macro::inherit_methods;
 use super::Common;
 use crate::{
     fs::{
-        file::{InodeMode, InodeType, StatusFlags},
+        file::{InodeMode, InodeType, RwfFlags, StatusFlags},
         procfs::{BLOCK_SIZE, ProcFs},
         vfs::{
             file_system::FileSystem,
@@ -53,6 +53,7 @@ impl<S: ProcSymOps + 'static> FileOps for ProcSym<S> {
         _offset: usize,
         _writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Err(Error::new(Errno::EPERM))
     }
@@ -62,6 +63,7 @@ impl<S: ProcSymOps + 'static> FileOps for ProcSym<S> {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         Err(Error::new(Errno::EPERM))
     }

--- a/kernel/core/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/core/src/fs/fs_impls/pseudofs/mod.rs
@@ -40,7 +40,7 @@ use spin::Once;
 
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, mkmod},
         utils::NAME_MAX,
         vfs::{
             file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
@@ -244,6 +244,7 @@ impl FileOps for PseudoInode {
         _offset: usize,
         _writer: &mut VmWriter,
         _status: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(
             Errno::ESPIPE,
@@ -256,6 +257,7 @@ impl FileOps for PseudoInode {
         _offset: usize,
         _reader: &mut VmReader,
         _status: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(
             Errno::ESPIPE,

--- a/kernel/core/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/core/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -11,7 +11,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, InodeHandle, InodeMode, InodeType, PerOpenFileOps, StatusFlags,
+            AccessMode, InodeHandle, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags,
             file_table::{FdFlags, FileDesc},
             mkmod,
         },
@@ -156,12 +156,14 @@ impl<T: NsCommonOps> FileOps for NsInode<T> {
         _offset: usize,
         _writer: &mut VmWriter,
         _status: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize>;
     fn write_at(
         &self,
         _offset: usize,
         _reader: &mut VmReader,
         _status: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize>;
 }
 
@@ -252,6 +254,7 @@ impl<T: NsCommonOps> FileOps for NsFile<T> {
         _offset: usize,
         _writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(
             Errno::EINVAL,
@@ -264,6 +267,7 @@ impl<T: NsCommonOps> FileOps for NsFile<T> {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(
             Errno::EINVAL,

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -19,7 +19,7 @@ use super::{memfd::MemfdInode, xattr::RamXattr, *};
 use crate::{
     device::{self, DeviceType},
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, mkmod},
         pipe::Pipe,
         pseudofs::AnonDeviceId,
         utils::{CStr256, DirentVisitor},
@@ -970,6 +970,7 @@ impl FileOps for RamInode {
         offset: usize,
         writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let read_len = match &self.inner {
             Inner::File(page_cache) => {
@@ -996,6 +997,7 @@ impl FileOps for RamInode {
         offset: usize,
         reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let written_len = match self.typ {
             InodeType::File => {

--- a/kernel/core/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/memfd.rs
@@ -12,7 +12,7 @@ use spin::Once;
 use super::fs::RamInode;
 use crate::{
     fs::{
-        file::{AccessMode, InodeHandle, InodeMode, InodeType, StatusFlags, mkmod},
+        file::{AccessMode, InodeHandle, InodeMode, InodeType, RwfFlags, StatusFlags, mkmod},
         tmpfs::TmpFs,
         vfs::{
             file_system::FileSystem,
@@ -101,6 +101,7 @@ impl FileOps for MemfdInode {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize>;
 
     fn write_at(
@@ -108,6 +109,7 @@ impl FileOps for MemfdInode {
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if !reader.has_remain() {
             return Ok(0);
@@ -141,7 +143,7 @@ impl FileOps for MemfdInode {
             }
         }
 
-        self.inode.write_at(offset, reader, status_flags)
+        self.inode.write_at(offset, reader, status_flags, rwf_flags)
     }
 }
 

--- a/kernel/core/src/fs/fs_impls/sysfs/test.rs
+++ b/kernel/core/src/fs/fs_impls/sysfs/test.rs
@@ -13,7 +13,7 @@ use ostd::prelude::ktest;
 
 use crate::{
     fs::{
-        file::{InodeType, StatusFlags, mkmod},
+        file::{InodeType, RwfFlags, StatusFlags, mkmod},
         sysfs::{self, fs::SysFs},
         utils::DirentVisitor,
         vfs::file_system::FileSystem,
@@ -357,7 +357,7 @@ fn read_attr() {
     let mut buf = [0u8; 64];
     let mut writer = VmWriter::from(&mut buf[..]).to_fallible();
     let bytes_read = r_attr_inode
-        .read_at(0, &mut writer, StatusFlags::empty())
+        .read_at(0, &mut writer, StatusFlags::empty(), RwfFlags::empty())
         .expect("read_at failed");
 
     assert!(bytes_read > 0);
@@ -366,7 +366,7 @@ fn read_attr() {
 
     // Reading a directory should fail (expect EINVAL as per inode.rs)
     let mut writer = VmWriter::from(&mut buf[..]).to_fallible(); // Reset writer
-    let result = leaf1_dir_inode.read_at(0, &mut writer, StatusFlags::empty());
+    let result = leaf1_dir_inode.read_at(0, &mut writer, StatusFlags::empty(), RwfFlags::empty());
     assert!(result.is_err());
 }
 
@@ -391,7 +391,7 @@ fn write_attr() {
     let new_val = "new_value";
     let mut reader = VmReader::from(new_val.as_bytes()).to_fallible();
     let bytes_written = rw_attr_inode
-        .write_at(0, &mut reader, StatusFlags::empty())
+        .write_at(0, &mut reader, StatusFlags::empty(), RwfFlags::empty())
         .expect("write_at failed");
     assert_eq!(bytes_written, new_val.len());
 
@@ -399,19 +399,19 @@ fn write_attr() {
     let mut buf = [0u8; 64];
     let mut writer = VmWriter::from(&mut buf[..]).to_fallible();
     let bytes_read = rw_attr_inode
-        .read_at(0, &mut writer, StatusFlags::empty())
+        .read_at(0, &mut writer, StatusFlags::empty(), RwfFlags::empty())
         .expect("read_at failed");
     let content = core::str::from_utf8(&buf[..bytes_read]).unwrap();
     assert_eq!(content, new_val);
 
     // Write to r_attr1 (should fail - EIO expected from underlying PermissionDenied)
     let mut reader = VmReader::from("attempt_write".as_bytes()).to_fallible();
-    let result = r_attr_inode.write_at(0, &mut reader, StatusFlags::empty());
+    let result = r_attr_inode.write_at(0, &mut reader, StatusFlags::empty(), RwfFlags::empty());
     assert!(result.is_err());
 
     // Writing to a directory should fail (expect EINVAL as per inode.rs)
     let mut reader = VmReader::from("attempt_write".as_bytes()).to_fallible();
-    let result = leaf1_dir_inode.write_at(0, &mut reader, StatusFlags::empty());
+    let result = leaf1_dir_inode.write_at(0, &mut reader, StatusFlags::empty(), RwfFlags::empty());
     assert!(result.is_err());
 }
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
@@ -8,7 +8,7 @@ use super::{inode::VirtioFsInode, open_handle::VirtioFsOpenHandle};
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags, SyncMode},
+        file::{PerOpenFileOps, RwfFlags, StatusFlags, SyncMode},
         utils::DirentVisitor,
         vfs::inode::{FileOps, Inode},
     },
@@ -43,6 +43,7 @@ impl FileOps for VirtioFsDir {
         _offset: usize,
         _writer: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(Errno::EISDIR, "the inode is a directory");
     }
@@ -52,6 +53,7 @@ impl FileOps for VirtioFsDir {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         return_errno_with_message!(Errno::EISDIR, "the inode is a directory");
     }

--- a/kernel/core/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/file.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags, SyncMode},
+        file::{PerOpenFileOps, RwfFlags, StatusFlags, SyncMode},
         vfs::inode::{FileOps, Inode},
     },
     prelude::*,
@@ -89,6 +89,7 @@ impl FileOps for VirtioFsFile {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let fh = self.open_handle.fh();
         let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();
@@ -106,6 +107,7 @@ impl FileOps for VirtioFsFile {
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let fh = self.open_handle.fh();
         let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -39,7 +39,7 @@ use super::{
 };
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode},
+        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, SyncMode},
         utils::DirentVisitor,
         vfs::{
             file_system::FileSystem,
@@ -555,6 +555,7 @@ impl FileOps for VirtioFsInode {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if self.type_ != InodeType::File {
             return_errno_with_message!(
@@ -576,6 +577,7 @@ impl FileOps for VirtioFsInode {
         _offset: usize,
         _reader: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         // No current path should call inode-level `write_at` for virtio-fs:
         // normal writes go through the per-open `VirtioFsFile`, which owns the

--- a/kernel/core/src/fs/initramfs.rs
+++ b/kernel/core/src/fs/initramfs.rs
@@ -31,7 +31,7 @@ use super::{
 use crate::{
     device::tty,
     fs::{
-        file::StatusFlags,
+        file::{RwfFlags, StatusFlags},
         vfs::inode::{Inode, MknodType},
     },
     prelude::*,
@@ -185,7 +185,12 @@ impl io::Write for InodeWriter<'_> {
         let mut reader = VmReader::from(buf).to_fallible();
         let write_len = self
             .inner
-            .write_at(self.offset, &mut reader, StatusFlags::empty())
+            .write_at(
+                self.offset,
+                &mut reader,
+                StatusFlags::empty(),
+                RwfFlags::empty(),
+            )
             .map_err(|_| io::ErrorKind::WriteZero)?;
         self.offset += write_len;
         Ok(write_len)

--- a/kernel/core/src/fs/pipe/anon_pipe.rs
+++ b/kernel/core/src/fs/pipe/anon_pipe.rs
@@ -6,7 +6,10 @@ use inherit_methods_macro::inherit_methods;
 
 use crate::{
     fs::{
-        file::{AccessMode, InodeHandle, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
+        file::{
+            AccessMode, InodeHandle, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags,
+            mkmod,
+        },
         pipe::Pipe,
         pseudofs::{PipeFs, PseudoInode, PseudoInodeType},
         vfs::{
@@ -67,12 +70,14 @@ impl FileOps for AnonPipeInode {
         _offset: usize,
         _writer: &mut VmWriter,
         _status: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize>;
     fn write_at(
         &self,
         _offset: usize,
         _reader: &mut VmReader,
         _status: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize>;
 }
 

--- a/kernel/core/src/fs/pipe/common.rs
+++ b/kernel/core/src/fs/pipe/common.rs
@@ -10,7 +10,7 @@ use ostd::sync::WaitQueue;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, PerOpenFileOps, SettableStatusFlags, StatusFlags},
+        file::{AccessMode, PerOpenFileOps, RwfFlags, SettableStatusFlags, StatusFlags},
         utils::{Endpoint, EndpointState},
         vfs::{inode::FileOps, path::Path},
     },
@@ -102,6 +102,7 @@ impl FileOps for PipeHandle {
         _offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if !writer.has_avail() {
             // Even the peer endpoint has been closed, reading an empty buffer is
@@ -121,6 +122,7 @@ impl FileOps for PipeHandle {
         _offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         if !reader.has_remain() {
             // Even the peer endpoint has been closed, writing an empty buffer is
@@ -662,6 +664,7 @@ mod test {
             0,
             &mut VmWriter::from(buf).to_fallible(),
             StatusFlags::empty(),
+            RwfFlags::empty(),
         )
     }
 
@@ -670,6 +673,7 @@ mod test {
             0,
             &mut VmReader::from(buf).to_fallible(),
             StatusFlags::empty(),
+            RwfFlags::empty(),
         )
     }
 }

--- a/kernel/core/src/fs/utils/systree_inode.rs
+++ b/kernel/core/src/fs/utils/systree_inode.rs
@@ -9,7 +9,10 @@ use aster_systree::{
 
 use crate::{
     fs::{
-        file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, SyncMode, mkmod},
+        file::{
+            AccessMode, InodeMode, InodeType, PerOpenFileOps, RwfFlags, StatusFlags, SyncMode,
+            mkmod,
+        },
         utils::DirentVisitor,
         vfs::{
             file_system::{FileSystem, SuperBlock},
@@ -318,6 +321,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> FileOps for KInode {
         offset: usize,
         buf: &mut VmWriter,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let SysTreeNodeKind::Attr(attr, leaf) = &self.node_kind() else {
             return Err(Error::new(Errno::EINVAL));
@@ -333,6 +337,7 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> FileOps for KInode {
         offset: usize,
         buf: &mut VmReader,
         _status_flags: StatusFlags,
+        _rwf_flags: RwfFlags,
     ) -> Result<usize> {
         let SysTreeNodeKind::Attr(attr, leaf) = &self.node_kind() else {
             return Err(Error::new(Errno::EINVAL));

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -17,7 +17,8 @@ use crate::{
     device::{Device, DeviceType},
     fs::{
         file::{
-            AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, StatusFlags, SyncMode,
+            AccessMode, InodeMode, InodeType, PerOpenFileOps, Permission, RwfFlags, StatusFlags,
+            SyncMode,
         },
         utils::DirentVisitor,
         vfs::path::Path,
@@ -344,6 +345,7 @@ pub(crate) trait FileOps {
         offset: usize,
         writer: &mut VmWriter,
         status_flags: StatusFlags,
+        rwf_flags: RwfFlags,
     ) -> Result<usize>;
 
     /// Writes data from the given `VmReader` into the file.
@@ -352,6 +354,7 @@ pub(crate) trait FileOps {
         offset: usize,
         reader: &mut VmReader,
         status_flags: StatusFlags,
+        rwf_flags: RwfFlags,
     ) -> Result<usize>;
 
     /// Reads directory entries from the given offset.
@@ -653,13 +656,13 @@ impl dyn Inode {
     #[cfg_attr(not(ktest), expect(dead_code))]
     pub(crate) fn read_bytes_at(&self, offset: usize, buf: &mut [u8]) -> Result<usize> {
         let mut writer = VmWriter::from(buf).to_fallible();
-        self.read_at(offset, &mut writer, StatusFlags::empty())
+        self.read_at(offset, &mut writer, StatusFlags::empty(), RwfFlags::empty())
     }
 
     #[cfg_attr(not(ktest), expect(dead_code))]
     pub(crate) fn write_bytes_at(&self, offset: usize, buf: &[u8]) -> Result<usize> {
         let mut reader = VmReader::from(buf).to_fallible();
-        self.write_at(offset, &mut reader, StatusFlags::empty())
+        self.write_at(offset, &mut reader, StatusFlags::empty(), RwfFlags::empty())
     }
 }
 

--- a/kernel/core/src/fs/vfs/notify/inotify.rs
+++ b/kernel/core/src/fs/vfs/notify/inotify.rs
@@ -13,8 +13,8 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, CreationFlags, FileCommon, FileLike, SettableStatusFlags, StatusFlags,
-            file_table::FdFlags,
+            AccessMode, CreationFlags, FileCommon, FileLike, RwfFlags, SettableStatusFlags,
+            StatusFlags, file_table::FdFlags,
         },
         pseudofs::AnonInodeFs,
         vfs::{
@@ -329,7 +329,7 @@ impl Pollable for InotifyFile {
 }
 
 impl FileLike for InotifyFile {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, writer: &mut VmWriter, _rwf_flags: RwfFlags) -> Result<usize> {
         if self.common.is_nonblocking() {
             self.try_read(writer)
         } else {

--- a/kernel/core/src/net/socket/mod.rs
+++ b/kernel/core/src/net/socket/mod.rs
@@ -8,8 +8,8 @@ use util::{MessageHeader, RecvFlags, RecvOutput, SendFlags, SockShutdownCmd, Soc
 use crate::{
     fs::{
         file::{
-            AccessMode, CreationFlags, FileCommon, FileLike, SettableStatusFlags, StatusFlags,
-            file_table::FdFlags,
+            AccessMode, CreationFlags, FileCommon, FileLike, RwfFlags, SettableStatusFlags,
+            StatusFlags, file_table::FdFlags,
         },
         pseudofs::SockFs,
     },
@@ -147,7 +147,7 @@ pub(crate) trait Socket: private::SocketPrivate + Send + Sync {
 }
 
 impl<T: Socket + 'static> FileLike for T {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, writer: &mut VmWriter, _rwf_flags: RwfFlags) -> Result<usize> {
         if !writer.has_avail() {
             // Linux always returns `Ok(0)` in this case, so we follow it.
             return Ok(0);
@@ -158,7 +158,7 @@ impl<T: Socket + 'static> FileLike for T {
             .map(|(output, _)| output.len())
     }
 
-    fn write(&self, reader: &mut VmReader) -> Result<usize> {
+    fn write(&self, reader: &mut VmReader, _rwf_flags: RwfFlags) -> Result<usize> {
         // TODO: Set correct flags
         self.sendmsg(
             reader,

--- a/kernel/core/src/process/pid_file.rs
+++ b/kernel/core/src/process/pid_file.rs
@@ -5,7 +5,10 @@ use core::fmt::Display;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
+        file::{
+            AccessMode, CreationFlags, FileCommon, FileLike, RwfFlags, StatusFlags,
+            file_table::FdFlags,
+        },
         pseudofs::PidfdFs,
     },
     prelude::*,
@@ -72,14 +75,24 @@ impl PidFile {
 }
 
 impl FileLike for PidFile {
-    fn read_at(&self, _offset: usize, _writer: &mut VmWriter) -> Result<usize> {
+    fn read_at(
+        &self,
+        _offset: usize,
+        _writer: &mut VmWriter,
+        _rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         return_errno_with_message!(
             Errno::EINVAL,
             "PID file cannot be read at a specific offset"
         );
     }
 
-    fn write_at(&self, _offset: usize, _reader: &mut VmReader) -> Result<usize> {
+    fn write_at(
+        &self,
+        _offset: usize,
+        _reader: &mut VmReader,
+        _rwf_flags: RwfFlags,
+    ) -> Result<usize> {
         return_errno_with_message!(
             Errno::EINVAL,
             "PID file cannot be written at a specific offset"

--- a/kernel/core/src/syscall/pread64.rs
+++ b/kernel/core/src/syscall/pread64.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs,
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        RwfFlags,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
 };
 
@@ -33,7 +36,7 @@ pub(super) fn sys_pread64(
     let read_len = {
         let user_space = ctx.user_space();
         let mut writer = user_space.writer(user_buf_ptr, user_buf_len)?;
-        file.read_at(offset as usize, &mut writer)?
+        file.read_at(offset as usize, &mut writer, RwfFlags::empty())?
     };
 
     if read_len > 0 {

--- a/kernel/core/src/syscall/preadv.rs
+++ b/kernel/core/src/syscall/preadv.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs,
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        RwfFlags,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
     util::VmWriterArray,
 };
@@ -14,7 +17,7 @@ pub(super) fn sys_readv(
     io_vec_count: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let res = do_sys_readv(raw_fd, io_vec_ptr, io_vec_count, ctx)?;
+    let res = do_sys_readv(raw_fd, io_vec_ptr, io_vec_count, RwfFlags::empty(), ctx)?;
     Ok(SyscallReturn::Return(res as _))
 }
 
@@ -35,7 +38,7 @@ pub(super) fn sys_preadv(
         io_vec_ptr,
         io_vec_count,
         offset,
-        RWFFlag::empty(),
+        RwfFlags::empty(),
         ctx,
     )?;
     Ok(SyscallReturn::Return(res as _))
@@ -54,12 +57,12 @@ pub(super) fn sys_preadv2(
     // 64-bit offset.
     // Reference: <https://elixir.bootlin.com/linux/v6.16.9/source/fs/read_write.c#L1114-L1118>.
     let offset = offset_low.cast_signed();
-    let flags = match RWFFlag::from_bits(flags) {
+    let flags = match RwfFlags::from_bits(flags) {
         Some(flags) => flags,
         None => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported flags"),
     };
     let res = if offset == -1 {
-        do_sys_readv(raw_fd, io_vec_ptr, io_vec_count, ctx)?
+        do_sys_readv(raw_fd, io_vec_ptr, io_vec_count, flags, ctx)?
     } else {
         do_sys_preadv(raw_fd, io_vec_ptr, io_vec_count, offset, flags, ctx)?
     };
@@ -71,7 +74,7 @@ fn do_sys_preadv(
     io_vec_ptr: Vaddr,
     io_vec_count: usize,
     offset: i64,
-    _flags: RWFFlag,
+    flags: RwfFlags,
     ctx: &Context,
 ) -> Result<usize> {
     debug!(
@@ -94,7 +97,7 @@ fn do_sys_preadv(
     if writer_array.writers_mut().is_empty() {
         let mut empty = [0u8; 0];
         let mut writer = VmWriter::from(empty.as_mut_slice()).to_fallible();
-        file.read_at(offset as usize, &mut writer)?;
+        file.read_at(offset as usize, &mut writer, flags)?;
         return Ok(0);
     }
 
@@ -110,7 +113,7 @@ fn do_sys_preadv(
         // but the current implementation does not ensure atomicity.
         // A suitable fix would be to add a `readv` method for the `FileLike` trait,
         // allowing each subsystem to implement atomicity.
-        match file.read_at(cur_offset, writer) {
+        match file.read_at(cur_offset, writer, flags) {
             Ok(read_len) => {
                 total_len += read_len;
                 cur_offset += read_len;
@@ -135,6 +138,7 @@ fn do_sys_readv(
     raw_fd: RawFileDesc,
     io_vec_ptr: Vaddr,
     io_vec_count: usize,
+    flags: RwfFlags,
     ctx: &Context,
 ) -> Result<usize> {
     debug!(
@@ -162,7 +166,7 @@ fn do_sys_readv(
         // but the current implementation does not ensure atomicity.
         // A suitable fix would be to add a `readv` method for the `FileLike` trait,
         // allowing each subsystem to implement atomicity.
-        match file.read(writer) {
+        match file.read(writer, flags) {
             Ok(read_len) => total_len += read_len,
             Err(_) if total_len > 0 => break,
             Err(err) => return Err(err),
@@ -178,13 +182,4 @@ fn do_sys_readv(
     }
 
     Ok(total_len)
-}
-
-bitflags! {
-    struct RWFFlag: u32 {
-        const RWF_DSYNC = 0x00000001;
-        const RWF_HIPRI = 0x00000002;
-        const RWF_SYNC = 0x00000004;
-        const RWF_NOWAIT = 0x00000008;
-    }
 }

--- a/kernel/core/src/syscall/pwrite64.rs
+++ b/kernel/core/src/syscall/pwrite64.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs,
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        RwfFlags,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
 };
 
@@ -32,7 +35,7 @@ pub(super) fn sys_pwrite64(
 
     let user_space = ctx.user_space();
     let mut reader = user_space.reader(user_buf_ptr, user_buf_len)?;
-    let write_len = file.write_at(offset as _, &mut reader)?;
+    let write_len = file.write_at(offset as _, &mut reader, RwfFlags::empty())?;
 
     if write_len > 0 {
         fs::vfs::notify::on_modify(&file);

--- a/kernel/core/src/syscall/pwritev.rs
+++ b/kernel/core/src/syscall/pwritev.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs,
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        RwfFlags,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
     util::VmReaderArray,
 };
@@ -14,7 +17,7 @@ pub(super) fn sys_writev(
     io_vec_count: usize,
     ctx: &Context,
 ) -> Result<SyscallReturn> {
-    let res = do_sys_writev(raw_fd, io_vec_ptr, io_vec_count, ctx)?;
+    let res = do_sys_writev(raw_fd, io_vec_ptr, io_vec_count, RwfFlags::empty(), ctx)?;
     Ok(SyscallReturn::Return(res as _))
 }
 
@@ -35,7 +38,7 @@ pub(super) fn sys_pwritev(
         io_vec_ptr,
         io_vec_count,
         offset,
-        RWFFlag::empty(),
+        RwfFlags::empty(),
         ctx,
     )?;
     Ok(SyscallReturn::Return(res as _))
@@ -54,12 +57,12 @@ pub(super) fn sys_pwritev2(
     // 64-bit offset.
     // Reference: <https://elixir.bootlin.com/linux/v6.16.9/source/fs/read_write.c#L1114-L1118>.
     let offset = offset_low.cast_signed();
-    let flags = match RWFFlag::from_bits(flags) {
+    let flags = match RwfFlags::from_bits(flags) {
         Some(flags) => flags,
         None => return_errno_with_message!(Errno::EOPNOTSUPP, "unsupported flags"),
     };
     let res = if offset == -1 {
-        do_sys_writev(raw_fd, io_vec_ptr, io_vec_count, ctx)?
+        do_sys_writev(raw_fd, io_vec_ptr, io_vec_count, flags, ctx)?
     } else {
         do_sys_pwritev(raw_fd, io_vec_ptr, io_vec_count, offset, flags, ctx)?
     };
@@ -71,10 +74,9 @@ fn do_sys_pwritev(
     io_vec_ptr: Vaddr,
     io_vec_count: usize,
     offset: i64,
-    _flags: RWFFlag,
+    flags: RwfFlags,
     ctx: &Context,
 ) -> Result<usize> {
-    // TODO: Implement flags support
     debug!(
         "raw_fd = {}, io_vec_ptr = 0x{:x}, io_vec_counter = 0x{:x}, offset = 0x{:x}",
         raw_fd, io_vec_ptr, io_vec_count, offset
@@ -95,7 +97,7 @@ fn do_sys_pwritev(
     if reader_array.readers_mut().is_empty() {
         let empty = [0u8; 0];
         let mut reader = VmReader::from(empty.as_slice()).to_fallible();
-        file.write_at(offset as usize, &mut reader)?;
+        file.write_at(offset as usize, &mut reader, flags)?;
         return Ok(0);
     }
 
@@ -111,7 +113,7 @@ fn do_sys_pwritev(
         // but the current implementation does not ensure atomicity.
         // A suitable fix would be to add a `writev` method for the `FileLike` trait,
         // allowing each subsystem to implement atomicity.
-        match file.write_at(cur_offset, reader) {
+        match file.write_at(cur_offset, reader, flags) {
             Ok(write_len) => {
                 total_len += write_len;
                 cur_offset += write_len;
@@ -135,6 +137,7 @@ fn do_sys_writev(
     raw_fd: RawFileDesc,
     io_vec_ptr: Vaddr,
     io_vec_count: usize,
+    flags: RwfFlags,
     ctx: &Context,
 ) -> Result<usize> {
     debug!(
@@ -158,7 +161,7 @@ fn do_sys_writev(
         // but the current implementation does not ensure atomicity.
         // A suitable fix would be to add a `writev` method for the `FileLike` trait,
         // allowing each subsystem to implement atomicity.
-        match file.write(reader) {
+        match file.write(reader, flags) {
             Ok(write_len) => total_len += write_len,
             Err(_) if total_len > 0 => break,
             Err(err) => return Err(err),
@@ -173,13 +176,4 @@ fn do_sys_writev(
     }
 
     Ok(total_len)
-}
-
-bitflags! {
-    struct RWFFlag: u32 {
-        const RWF_DSYNC = 0x00000001;
-        const RWF_HIPRI = 0x00000002;
-        const RWF_SYNC = 0x00000004;
-        const RWF_NOWAIT = 0x00000008;
-    }
 }

--- a/kernel/core/src/syscall/read.rs
+++ b/kernel/core/src/syscall/read.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs,
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        RwfFlags,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
 };
 
@@ -28,7 +31,7 @@ pub(super) fn sys_read(
         if buf_len != 0 {
             let user_space = ctx.user_space();
             let mut writer = user_space.writer(user_buf_addr, buf_len)?;
-            file.read(&mut writer)
+            file.read(&mut writer, RwfFlags::empty())
         } else {
             file.read_bytes(&mut [])
         }

--- a/kernel/core/src/syscall/signalfd.rs
+++ b/kernel/core/src/syscall/signalfd.rs
@@ -16,7 +16,7 @@ use crate::{
     events::IoEvents,
     fs::{
         file::{
-            AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags,
+            AccessMode, CreationFlags, FileCommon, FileLike, RwfFlags, StatusFlags,
             file_table::{FdFlags, RawFileDesc, get_file_fast},
         },
         pseudofs::AnonInodeFs,
@@ -217,7 +217,7 @@ impl Pollable for SignalFile {
 }
 
 impl FileLike for SignalFile {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, writer: &mut VmWriter, _rwf_flags: RwfFlags) -> Result<usize> {
         if writer.avail() < size_of::<SignalfdSiginfo>() {
             return_errno_with_message!(Errno::EINVAL, "the signal buffer is too small");
         }

--- a/kernel/core/src/syscall/write.rs
+++ b/kernel/core/src/syscall/write.rs
@@ -3,7 +3,10 @@
 use super::SyscallReturn;
 use crate::{
     fs,
-    fs::file::file_table::{RawFileDesc, get_file_fast},
+    fs::file::{
+        RwfFlags,
+        file_table::{RawFileDesc, get_file_fast},
+    },
     prelude::*,
 };
 
@@ -28,7 +31,7 @@ pub(super) fn sys_write(
         if user_buf_len != 0 {
             let user_space = ctx.user_space();
             let mut reader = user_space.reader(user_buf_ptr, user_buf_len)?;
-            file.write(&mut reader)
+            file.write(&mut reader, RwfFlags::empty())
         } else {
             file.write_bytes(&[])
         }

--- a/kernel/core/src/time/timerfd.rs
+++ b/kernel/core/src/time/timerfd.rs
@@ -12,7 +12,10 @@ use super::clockid_t;
 use crate::{
     events::IoEvents,
     fs::{
-        file::{AccessMode, CreationFlags, FileCommon, FileLike, StatusFlags, file_table::FdFlags},
+        file::{
+            AccessMode, CreationFlags, FileCommon, FileLike, RwfFlags, StatusFlags,
+            file_table::FdFlags,
+        },
         pseudofs::AnonInodeFs,
     },
     prelude::*,
@@ -206,7 +209,7 @@ impl Pollable for TimerfdFile {
 }
 
 impl FileLike for TimerfdFile {
-    fn read(&self, writer: &mut VmWriter) -> Result<usize> {
+    fn read(&self, writer: &mut VmWriter, _rwf_flags: RwfFlags) -> Result<usize> {
         let read_len = size_of::<u64>();
 
         if writer.avail() < read_len {

--- a/kernel/core/src/vm/page_cache/cache_page.rs
+++ b/kernel/core/src/vm/page_cache/cache_page.rs
@@ -151,6 +151,16 @@ pub(crate) trait CachePageExt: Sized {
         self.wait_queue().wake_all();
     }
 
+    /// Checks if the page is currently being written back to storage.
+    fn is_writing_back(&self) -> bool {
+        self.metadata().is_writing_back.load(Ordering::Acquire)
+    }
+
+    /// Checks if the page is currently locked.
+    fn is_locked(&self) -> bool {
+        self.metadata().lock.load(Ordering::Acquire)
+    }
+
     /// Allocates a new cache page which content and state are uninitialized.
     fn alloc_uninit() -> Result<CachePage> {
         let meta = CachePageMeta::default();

--- a/kernel/core/src/vm/page_cache/mod.rs
+++ b/kernel/core/src/vm/page_cache/mod.rs
@@ -336,6 +336,23 @@ impl PageCache {
         vmo.evict_up_to_date_pages(&range)
     }
 
+    /// Returns whether any page in the specified byte range is present in the page cache.
+    pub(crate) fn has_pages(&self, range: Range<usize>) -> bool {
+        let Some(vmo) = self.0.as_backed_vmo() else {
+            return false;
+        };
+        vmo.has_pages(&range)
+    }
+
+    /// Returns whether any page in the specified byte range is dirty, locked,
+    /// or being written back.
+    pub(crate) fn needs_writeback(&self, range: Range<usize>) -> bool {
+        let Some(vmo) = self.0.as_backed_vmo() else {
+            return false;
+        };
+        vmo.needs_writeback(&range)
+    }
+
     /// Fills the specified range of the page cache with zeros.
     ///
     /// Callers must hold the filesystem-level lock that serializes operations in

--- a/kernel/core/src/vm/page_cache/mod.rs
+++ b/kernel/core/src/vm/page_cache/mod.rs
@@ -338,6 +338,15 @@ impl PageCache {
     pub(crate) fn fill_zeros(&self, range: Range<usize>) -> Result<()> {
         self.0.fill_zeros(range)
     }
+
+    /// Tries to read from the page cache at `offset` into `writer` without blocking.
+    ///
+    /// Returns the number of bytes read. If the read would need backend I/O or
+    /// page initialization, the bytes read so far are returned as a short read,
+    /// or `EAGAIN` if nothing was read.
+    pub(crate) fn try_read(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        self.0.try_read(offset, writer)
+    }
 }
 
 impl VmIo for PageCache {

--- a/kernel/core/src/vm/page_cache/mod.rs
+++ b/kernel/core/src/vm/page_cache/mod.rs
@@ -102,6 +102,11 @@
 //!    use `rmap` to denote the reverse-mapping lock, `PT` to denote the page
 //!    table lock, `page` to denote the page lock, and `xarray` to denote the
 //!    lock of VMO pages. For details, see the comments in the implementation.
+//!
+//!  - `dio_lock` denotes the lock that serializes page-cache population
+//!    from mmap page faults with direct I/O: page faults hold it shared
+//!    while populating pages, and direct I/O takes it exclusively across
+//!    its cache checks and block I/O.
 
 use core::{
     ops::{Deref, Range},

--- a/kernel/core/src/vm/page_cache/tests/mod.rs
+++ b/kernel/core/src/vm/page_cache/tests/mod.rs
@@ -550,3 +550,63 @@ fn delayed_io_completion() {
     assert!(second_flush_result.lock().take().unwrap().is_ok());
     assert_eq!(backend.persisted_page_bytes(0), latest_dirty_pattern);
 }
+
+/// `try_read` never blocks: a cold page reports `EAGAIN` without issuing
+/// I/O, and a partially cached range returns a short read.
+#[ktest]
+fn try_read_non_blocking() {
+    let backend = MockPageCacheBackend::new(2);
+    backend.set_persisted_page_bytes(0, &[0x4c; PAGE_SIZE]);
+    backend.set_persisted_page_bytes(1, &[0x5d; PAGE_SIZE]);
+
+    let page_cache = new_backend_page_cache(&backend, 2);
+    let mut buf = vec![0; 2 * PAGE_SIZE];
+
+    let mut writer = VmWriter::from(buf.as_mut_slice()).to_fallible();
+    let err = page_cache.try_read(0, &mut writer).unwrap_err();
+    assert_eq!(err.error(), Errno::EAGAIN);
+    assert_eq!(backend.read_count(0), 0);
+
+    page_cache.read_bytes(0, &mut buf[..PAGE_SIZE]).unwrap();
+    assert_eq!(&buf[..PAGE_SIZE], &[0x4c; PAGE_SIZE]);
+    assert_eq!(backend.read_count(0), 1);
+
+    let mut writer = VmWriter::from(buf.as_mut_slice()).to_fallible();
+    assert_eq!(page_cache.try_read(0, &mut writer).unwrap(), PAGE_SIZE);
+    assert_eq!(&buf[..PAGE_SIZE], &[0x4c; PAGE_SIZE]);
+    assert_eq!(&buf[PAGE_SIZE..], &[0; PAGE_SIZE]);
+    assert_eq!(backend.read_count(0), 1);
+    assert_eq!(backend.read_count(1), 0);
+
+    page_cache
+        .read_bytes(PAGE_SIZE, &mut buf[PAGE_SIZE..])
+        .unwrap();
+    assert_eq!(backend.read_count(1), 1);
+
+    let mut writer = VmWriter::from(buf.as_mut_slice()).to_fallible();
+    assert_eq!(page_cache.try_read(0, &mut writer).unwrap(), 2 * PAGE_SIZE);
+    assert_eq!(&buf[PAGE_SIZE..], &[0x5d; PAGE_SIZE]);
+    assert_eq!(backend.read_count(0), 1);
+}
+
+/// `has_pages` and `needs_writeback` track the cached page states.
+#[ktest]
+fn has_pages_and_needs_writeback() {
+    let backend = MockPageCacheBackend::new(1);
+    backend.set_persisted_page_bytes(0, &[0x12; PAGE_SIZE]);
+
+    let page_cache = new_backend_page_cache(&backend, 1);
+    assert!(!page_cache.has_pages(0..PAGE_SIZE));
+    assert!(!page_cache.needs_writeback(0..PAGE_SIZE));
+
+    let mut buf = vec![0; PAGE_SIZE];
+    page_cache.read_bytes(0, &mut buf).unwrap();
+    assert!(page_cache.has_pages(0..PAGE_SIZE));
+    assert!(!page_cache.needs_writeback(0..PAGE_SIZE));
+
+    page_cache.write_bytes(0, &[0x34; PAGE_SIZE]).unwrap();
+    assert!(page_cache.needs_writeback(0..PAGE_SIZE));
+
+    page_cache.flush_range(0..PAGE_SIZE).unwrap();
+    assert!(!page_cache.needs_writeback(0..PAGE_SIZE));
+}

--- a/kernel/core/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/core/src/vm/page_cache/vmo/mod.rs
@@ -208,6 +208,7 @@ impl From<ostd::Error> for VmoCommitError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CommitMode {
     Read,
+    ReadNoWait,
     Overwrite,
 }
 
@@ -532,9 +533,34 @@ impl Vmo {
 
     /// Reads data from the VMO at `offset` into `writer`.
     pub(crate) fn read(&self, offset: usize, writer: &mut VmWriter) -> Result<()> {
+        self.read_internal(offset, writer, CommitMode::Read)
+            .map(|_| ())
+    }
+
+    /// Tries to read data from the VMO at `offset` into `writer` without blocking.
+    ///
+    /// Returns the number of bytes read. If the read would need backend I/O or
+    /// page initialization, the bytes read so far are returned as a short
+    /// read, or `EAGAIN` if nothing was read.
+    pub(super) fn try_read(&self, offset: usize, writer: &mut VmWriter) -> Result<usize> {
+        self.read_internal(offset, writer, CommitMode::ReadNoWait)
+    }
+
+    /// The shared implementation of [`Vmo::read`] and [`Vmo::try_read`].
+    ///
+    /// In blocking mode, backend I/O and page initialization are performed
+    /// as needed. In no-wait mode, the read never blocks: the bytes read so
+    /// far are returned as a short read, or `EAGAIN` if nothing was read;
+    /// other errors are returned only if nothing has been read.
+    fn read_internal(
+        &self,
+        offset: usize,
+        writer: &mut VmWriter,
+        commit_mode: CommitMode,
+    ) -> Result<usize> {
         let read_len = writer.avail().min(self.size().saturating_sub(offset));
         if read_len == 0 {
-            return Ok(());
+            return Ok(0);
         }
         let read_end = offset + read_len;
 
@@ -544,18 +570,40 @@ impl Vmo {
         let mut page_offset = offset % PAGE_SIZE;
         let mut page_batch =
             Vec::with_capacity(min(page_idx_range.len(), Self::PAGE_BATCH_CAPACITY));
+        let mut total_read = 0;
 
         while current_idx < page_idx_range.end {
-            self.collect_pages(
+            let collect_result = self.collect_pages(
                 current_idx,
                 page_idx_range.end,
-                CommitMode::Read,
+                commit_mode,
                 &mut page_batch,
-            )?;
+            );
 
             for (_, page) in page_batch.iter() {
-                page.reader().skip(page_offset).read_fallible(writer)?;
+                let copied = match page.reader().skip(page_offset).read_fallible(writer) {
+                    Ok(copied) => copied,
+                    Err((err, written)) => {
+                        // In no-wait mode, return the bytes copied before the fault as a
+                        // short read.
+                        total_read += written;
+                        if commit_mode == CommitMode::ReadNoWait && total_read > 0 {
+                            return Ok(total_read);
+                        }
+                        return Err(Error::from(err));
+                    }
+                };
+                total_read += copied;
                 page_offset = 0;
+            }
+
+            if let Err(err) = collect_result {
+                // Pages committed before the blocking point were copied above;
+                // return them as a short read.
+                if commit_mode == CommitMode::ReadNoWait && total_read > 0 {
+                    return Ok(total_read);
+                }
+                return Err(err);
             }
 
             // `current_idx < page_idx_range.end` guarantees at least one page is successfully
@@ -563,7 +611,7 @@ impl Vmo {
             current_idx = page_batch.last().unwrap().0 + 1;
         }
 
-        Ok(())
+        Ok(total_read)
     }
 
     /// Writes data from `reader` into the VMO at `offset`.
@@ -765,6 +813,10 @@ impl Vmo {
     /// caller receives only successfully committed pages and never needs to
     /// deal with [`VmoCommitError`] directly.
     ///
+    /// In no-wait mode, once a commit operation needs to perform I/O or
+    /// wait for initialization, it will return `EAGAIN` instead of blocking.
+    /// Pages committed before the error remain in `pages`.
+    ///
     /// This helper keeps the returned pages alive, but it does not pin them in
     /// the `XArray`. Callers must still serialize against `evict_range()` /
     /// `invalidate_range()` with a higher-level invalidation lock before they
@@ -791,6 +843,17 @@ impl Vmo {
                 };
             match self.try_operate_on_range_internal(&current_range, &mut operate, commit_mode) {
                 Ok(()) => break 'retry,
+                Err(err) if commit_mode == CommitMode::ReadNoWait => {
+                    return Err(match err {
+                        VmoCommitError::Err(e) => e,
+                        VmoCommitError::NeedIo { .. } | VmoCommitError::WaitUntilInit { .. } => {
+                            Error::with_message(
+                                Errno::EAGAIN,
+                                "the operation would block on page I/O",
+                            )
+                        }
+                    });
+                }
                 Err(err) => {
                     let (idx, page) = self.handle_commit_error(err, commit_mode)?;
                     pages.push((idx, page));

--- a/kernel/core/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/core/src/vm/page_cache/vmo/mod.rs
@@ -139,6 +139,11 @@ pub(crate) struct Vmo {
     pub(super) writable_mapping_status: WritableMappingStatus,
     /// Reserve mappings.
     pub(super) rmap: Mutex<Rmap>,
+    /// Serializes page-cache population with direct I/O.
+    ///
+    /// Page faults hold the read lock while populating pages, and direct I/O
+    /// holds the write lock across its cache checks and block I/O.
+    dio_lock: RwMutex<()>,
 }
 
 impl Debug for Vmo {
@@ -477,6 +482,11 @@ impl Vmo {
     /// locks need to be acquired.
     pub(crate) fn rmap(&self) -> &Mutex<Rmap> {
         &self.rmap
+    }
+
+    /// Returns the dio lock that serializes page-cache population with direct I/O.
+    pub(crate) fn dio_lock(&self) -> &RwMutex<()> {
+        &self.dio_lock
     }
 
     /// Decommits anonymous pages in the specified byte range.

--- a/kernel/core/src/vm/page_cache/vmo/mod.rs
+++ b/kernel/core/src/vm/page_cache/vmo/mod.rs
@@ -938,6 +938,57 @@ impl PageSelection {
 }
 
 impl<'a> BackedVmo<'a> {
+    /// Returns whether any page in the specified byte range is present in the page cache.
+    pub(super) fn has_pages(&self, range: &Range<usize>) -> bool {
+        let page_idx_range = get_page_idx_range(range);
+        if range.is_empty() || page_idx_range.is_empty() {
+            return false;
+        }
+
+        let preempt_guard = disable_preempt();
+        let mut cursor = self
+            .pages
+            .cursor(&preempt_guard, page_idx_range.start as u64);
+        loop {
+            if cursor.load().is_some() {
+                return true;
+            }
+            let Some(next_index) = cursor.next_present() else {
+                return false;
+            };
+            if next_index as usize >= page_idx_range.end {
+                return false;
+            }
+        }
+    }
+
+    /// Returns whether any page in the specified byte range is dirty, locked,
+    /// or being written back.
+    pub(super) fn needs_writeback(&self, range: &Range<usize>) -> bool {
+        let page_idx_range = get_page_idx_range(range);
+        if range.is_empty() || page_idx_range.is_empty() {
+            return false;
+        }
+
+        let preempt_guard = disable_preempt();
+        let mut cursor = self
+            .pages
+            .cursor(&preempt_guard, page_idx_range.start as u64);
+        loop {
+            if let Some(page) = cursor.load()
+                && (page.state().is_dirty() || page.is_locked() || page.is_writing_back())
+            {
+                return true;
+            }
+            let Some(next_index) = cursor.next_present() else {
+                return false;
+            };
+            if next_index as usize >= page_idx_range.end {
+                return false;
+            }
+        }
+    }
+
     /// Writes back dirty pages in the specified byte range to the backend storage.
     pub(super) fn flush_dirty_pages(&self, range: &Range<usize>) -> Result<()> {
         if range.start >= self.size() {

--- a/kernel/core/src/vm/page_cache/vmo/options.rs
+++ b/kernel/core/src/vm/page_cache/vmo/options.rs
@@ -120,6 +120,7 @@ fn alloc_vmo(
         size: AtomicUsize::new(size),
         writable_mapping_status,
         rmap: Mutex::new(rmap),
+        dio_lock: RwMutex::new(()),
     })
 }
 

--- a/kernel/core/src/vm/vmar/vm_mapping.rs
+++ b/kernel/core/src/vm/vmar/vm_mapping.rs
@@ -398,6 +398,14 @@ impl VmMapping {
     ) -> Result<()> {
         self.check_perms_for_page_fault(page_fault_info)?;
 
+        // Hold the page cache's dio lock while populating pages so a
+        // concurrent direct I/O cannot miss a page committed by this fault.
+        let _dio_guard = if let MappedMemory::Vmo(vmo) = &self.mapped_mem {
+            Some(vmo.vmo().dio_lock().read())
+        } else {
+            None
+        };
+
         let page_aligned_addr = page_fault_info.address.align_down(PAGE_SIZE);
         let is_write = page_fault_info.required_perms.contains(VmPerms::WRITE);
 

--- a/test/initramfs/src/conformance/xfstests/ext2/run_list/full.list
+++ b/test/initramfs/src/conformance/xfstests/ext2/run_list/full.list
@@ -67,6 +67,7 @@ generic/443
 generic/452
 generic/453
 generic/466
+generic/471
 generic/488
 generic/532
 generic/558

--- a/test/initramfs/src/conformance/xfstests/ext2/run_list/short.list
+++ b/test/initramfs/src/conformance/xfstests/ext2/run_list/short.list
@@ -61,6 +61,7 @@ generic/443
 generic/452
 generic/453
 generic/466
+generic/471
 generic/488
 generic/532
 generic/568

--- a/test/initramfs/src/regression/fs/ext2/rwf_nowait.c
+++ b/test/initramfs/src/regression/fs/ext2/rwf_nowait.c
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define BASE_DIR "/ext2/rwf_nowait"
+#ifndef RWF_NOWAIT
+#define RWF_NOWAIT 0x8
+#endif
+#define PAGE_SIZE 4096
+
+// File-scope buffers keep the O_DIRECT buffers block-aligned.
+static char buf[PAGE_SIZE] __attribute__((aligned(PAGE_SIZE)));
+static char buf2[2 * PAGE_SIZE] __attribute__((aligned(PAGE_SIZE)));
+
+FN_SETUP(prepare_base_dir)
+{
+	CHECK_WITH(mkdir(BASE_DIR, 0755), _ret == 0 || errno == EEXIST);
+}
+END_SETUP()
+
+FN_TEST(read_cold_page_nowait_eagain)
+{
+	const char *path = BASE_DIR "/cold_page";
+	struct iovec iov = { .iov_base = buf, .iov_len = PAGE_SIZE };
+	int fd = TEST_SUCC(open(path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+
+	TEST_SUCC(ftruncate(fd, 2 * PAGE_SIZE));
+	TEST_ERRNO(syscall(SYS_preadv2, fd, &iov, 1, PAGE_SIZE, 0, RWF_NOWAIT),
+		   EAGAIN);
+
+	TEST_RES(pread(fd, buf, PAGE_SIZE, PAGE_SIZE), _ret == PAGE_SIZE);
+	TEST_RES(syscall(SYS_preadv2, fd, &iov, 1, PAGE_SIZE, 0, RWF_NOWAIT),
+		 _ret == PAGE_SIZE);
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(write_buffered_nowait_eopnotsupp)
+{
+	const char *path = BASE_DIR "/buffered_write";
+	struct iovec iov = { .iov_base = buf, .iov_len = 1 };
+	int fd = TEST_SUCC(open(path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+
+	TEST_ERRNO(syscall(SYS_pwritev2, fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		   EOPNOTSUPP);
+
+	TEST_RES(write(fd, buf, 1), _ret == 1);
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(write_dio_hole_nowait_eagain)
+{
+	const char *path = BASE_DIR "/dio_write";
+	struct iovec iov = { .iov_base = buf, .iov_len = PAGE_SIZE };
+	int fd = TEST_SUCC(
+		open(path, O_RDWR | O_CREAT | O_TRUNC | O_DIRECT, 0600));
+
+	// The first write extends the file, so this EAGAIN comes from the
+	// extending check rather than the hole check.
+	TEST_ERRNO(syscall(SYS_pwritev2, fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		   EAGAIN);
+
+	TEST_RES(syscall(SYS_pwritev2, fd, &iov, 1, 0, 0, 0),
+		 _ret == PAGE_SIZE);
+	TEST_RES(syscall(SYS_pwritev2, fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		 _ret == PAGE_SIZE);
+
+	TEST_SUCC(ftruncate(fd, 2 * PAGE_SIZE));
+	TEST_ERRNO(syscall(SYS_pwritev2, fd, &iov, 1, PAGE_SIZE, 0, RWF_NOWAIT),
+		   EAGAIN);
+
+	TEST_RES(syscall(SYS_pwritev2, fd, &iov, 1, PAGE_SIZE, 0, 0),
+		 _ret == PAGE_SIZE);
+	TEST_RES(syscall(SYS_pwritev2, fd, &iov, 1, PAGE_SIZE, 0, RWF_NOWAIT),
+		 _ret == PAGE_SIZE);
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(read_dio_dirty_cache_nowait_eagain)
+{
+	const char *path = BASE_DIR "/dio_read";
+	struct iovec iov = { .iov_base = buf, .iov_len = PAGE_SIZE };
+	int fd = TEST_SUCC(open(path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+	int dio_fd = TEST_SUCC(open(path, O_RDONLY | O_DIRECT));
+
+	TEST_RES(write(fd, buf, PAGE_SIZE), _ret == PAGE_SIZE);
+	TEST_ERRNO(syscall(SYS_preadv2, dio_fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		   EAGAIN);
+
+	TEST_SUCC(fsync(fd));
+	TEST_RES(syscall(SYS_preadv2, dio_fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		 _ret == PAGE_SIZE);
+
+	TEST_SUCC(close(dio_fd));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(read_partial_cache_nowait_short_read)
+{
+	const char *path = BASE_DIR "/partial_cache";
+	struct iovec iov = { .iov_base = buf2, .iov_len = 2 * PAGE_SIZE };
+	int fd = TEST_SUCC(open(path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+
+	TEST_SUCC(ftruncate(fd, 2 * PAGE_SIZE));
+	TEST_RES(pread(fd, buf, PAGE_SIZE, 0), _ret == PAGE_SIZE);
+
+	// RWF_NOWAIT returns a short read instead of EAGAIN when only part
+	// of the range is cached.
+	TEST_RES(syscall(SYS_preadv2, fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		 _ret == PAGE_SIZE);
+
+	TEST_RES(pread(fd, buf, PAGE_SIZE, PAGE_SIZE), _ret == PAGE_SIZE);
+	TEST_RES(syscall(SYS_preadv2, fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		 _ret == 2 * PAGE_SIZE);
+
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(write_dio_cached_pages_nowait_eagain)
+{
+	const char *path = BASE_DIR "/dio_write_cache";
+	struct iovec iov = { .iov_base = buf, .iov_len = PAGE_SIZE };
+	int fd = TEST_SUCC(open(path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+	int dio_fd = TEST_SUCC(open(path, O_RDWR | O_DIRECT));
+
+	TEST_RES(write(fd, buf, PAGE_SIZE), _ret == PAGE_SIZE);
+
+	// Any cached page in the range reports EAGAIN; a blocking direct
+	// write clears the cache for the next NOWAIT attempt.
+	TEST_ERRNO(syscall(SYS_pwritev2, dio_fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		   EAGAIN);
+
+	TEST_RES(syscall(SYS_pwritev2, dio_fd, &iov, 1, 0, 0, 0),
+		 _ret == PAGE_SIZE);
+	TEST_RES(syscall(SYS_pwritev2, dio_fd, &iov, 1, 0, 0, RWF_NOWAIT),
+		 _ret == PAGE_SIZE);
+
+	TEST_SUCC(close(dio_fd));
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -97,6 +97,7 @@ test_ext2 "/ext2" "test_file.txt"
 ./ext2/readdir
 ./ext2/rename
 ./ext2/rmdir
+./ext2/rwf_nowait
 ./ext2/shared_block_device
 ./ext2/short_rw
 ./ext2/sparse


### PR DESCRIPTION

## Summary

#3142 lists `RWF_NOWAIT` as an ext2 gap: `preadv2`/`pwritev2` accept the flag but block unconditionally, and `EAGAIN` is never returned. The VMO layer already has non-blocking `try_*` primitives; this PR adds the page-cache-level operations on top (`try_read`, `has_pages`, `needs_writeback`) and wires `RWF_NOWAIT` up for ext2 buffered and direct I/O.

Linux ext2 itself does not support `RWF_NOWAIT` (it never sets `FMODE_NOWAIT`, so `preadv2`/`pwritev2` return `EOPNOTSUPP`), so this PR is a compatibility superset rather than a strict Linux fix. Since Asterinas does not have ext4 yet, ext2 is the natural place to implement and validate the path; the primitives added here are file-system agnostic, so they should also carry over to the ext4 work in #3581. I am happy to coordinate or rebase if needed.

## Design Considerations

### Page-cache interfaces mirror the existing `try_*` primitives

The new non-blocking page-cache interfaces (`try_read` and its helpers) follow the naming and semantics of the `try_*` primitives already present in the VMO layer (`try_commit_page`, `try_operate_on_range`, `try_commit_with_cursor`): they never wait and return `EAGAIN` instead. Keeping the same convention makes the page-cache API internally consistent.

### `RwfFlags` moved out of the syscall layer

The per-I/O flag type used to be private to `preadv2`/`pwritev2`. Implementing `RWF_NOWAIT` requires the flags to be threaded from the syscall layer through `FileLike`/`FileOps` down to the file systems, so the type is promoted to a shared definition in `kernel/core/src/fs/file/file_attr/`.

### `RWFFlag` renamed to `RwfFlags`

`file_attr` uses PascalCase for its types (`StatusFlags`, `CreationFlags`, `AccessMode`, `OpenArgs`); the all-caps `RWFFlag` did not fit that convention, so it is renamed to `RwfFlags`.

## Main Changes

- Add `RwfFlags` and pass it through `FileLike::read`/`write`/`read_at`/`write_at` and the `FileOps` trait.
- Add page-cache primitives: `try_read` (returning short read counts like Linux `filemap_read`), `has_pages`, `needs_writeback`. The two queries correspond to Linux's `filemap_range_has_page` and `filemap_range_needs_writeback`.
- ext2 buffered reads: `EAGAIN` if the read would block before reading anything, short read for partially cached ranges.
- ext2 buffered writes: `EINVAL`.
- ext2 direct reads: `EAGAIN` when the range needs writeback.
- ext2 direct writes: `EAGAIN` when the range has cached pages, holes, or extends the file; the whole range is rejected rather than partially writing already-mapped extents, which keeps a failed NOWAIT write atomic. This follows the model of file systems that honor NOWAIT allocation, rather than ext2's legacy iomap path, which ignores `IOMAP_NOWAIT` and would allocate synchronously.
- ext2 direct I/O also returns `EAGAIN` when resolving the block mapping would require reading uncached indirect metadata. The block-pointer walk gains non-blocking variants (`try_lookup_block_range` and a non-blocking `IoRangeIter` mode), following the existing `try_*` convention; the `EAGAIN`-on-uncached-metadata behavior corresponds to Linux `EXT4_GET_BLOCKS_NOWAIT`.
- ext2 I/O under `RWF_NOWAIT` never blocks on the inode lock: contention reports `EAGAIN`, and a contended atime update is skipped.
- Regression tests: page-cache ktests plus `ext2/rwf_nowait` C test.
- Update the syscall-flag-coverage book page (README and `.scml`).
