### PR TITLE
Support mmap for virtio fs

### DIFF
--- a/kernel/core/comps/virtio/src/device/filesystem/device/session.rs
+++ b/kernel/core/comps/virtio/src/device/filesystem/device/session.rs
@@ -40,9 +40,9 @@ pub struct FuseSession {
     /// The maximum write size accepted by the server.
     max_write: u32,
     /// The feature flags selected by `FUSE_INIT`.
-    //
-    // TODO: Apply negotiated `FUSE_INIT` flags to conduct virtio-fs behavior.
     negotiated_flags: FuseInitFlags,
+    /// The extended feature flags selected by `FUSE_INIT`.
+    negotiated_flags2: FuseInitFlags2,
 }
 
 impl FuseSession {
@@ -67,6 +67,7 @@ impl FuseSession {
             attr_version: AtomicU64::new(1),
             max_write,
             negotiated_flags: init_reply.flags(),
+            negotiated_flags2: init_reply.flags2(),
         });
 
         info!(
@@ -142,6 +143,11 @@ impl FuseSession {
     /// Returns the FUSE feature flags selected after negotiation.
     pub fn negotiated_flags(&self) -> FuseInitFlags {
         self.negotiated_flags
+    }
+
+    /// Returns the extended FUSE feature flags selected after negotiation.
+    pub fn negotiated_flags2(&self) -> FuseInitFlags2 {
+        self.negotiated_flags2
     }
 
     /// Returns the maximum write size accepted by the server.

--- a/kernel/core/src/device/fb.rs
+++ b/kernel/core/src/device/fb.rs
@@ -19,6 +19,7 @@ use crate::{
     prelude::*,
     process::signal::{PollHandle, Pollable},
     util::ioctl::{RawIoctl, dispatch_ioctl},
+    vm::vmar::FileMmapRequest,
 };
 
 #[derive(Debug)]
@@ -499,7 +500,7 @@ impl PerOpenFileOps for FbHandle {
         true
     }
 
-    fn mappable(&self) -> Result<Mappable> {
+    fn mappable(&self, _request: FileMmapRequest) -> Result<Mappable> {
         let iomem = self.framebuffer.io_mem();
         Ok(Mappable::IoMem(iomem.clone()))
     }

--- a/kernel/core/src/fs/file/file_handle.rs
+++ b/kernel/core/src/fs/file/file_handle.rs
@@ -18,7 +18,7 @@ use crate::{
     prelude::*,
     process::{Process, signal::Pollable},
     util::ioctl::RawIoctl,
-    vm::page_cache::Vmo,
+    vm::{page_cache::Vmo, vmar::FileMmapRequest},
 };
 
 /// The basic operations defined on a file
@@ -95,7 +95,10 @@ pub(crate) trait FileLike: Pollable + Send + Sync + Any {
     ///
     /// If this file has a corresponding mappable object of [`Mappable`],
     /// then it can be either an inode or an MMIO region.
-    fn mappable(&self) -> Result<Mappable> {
+    ///
+    /// Implementations may inspect the mapping request to reject unsupported
+    /// mapping semantics.
+    fn mappable(&self, request: FileMmapRequest) -> Result<Mappable> {
         // `ENODEV` means that "The underlying filesystem of the specified file does not support
         // memory mapping".
         // Reference: <https://man7.org/linux/man-pages/man2/mmap.2.html>.
@@ -117,7 +120,7 @@ pub(crate) trait FileLike: Pollable + Send + Sync + Any {
         return_errno_with_message!(Errno::ESPIPE, "seek is not supported");
     }
 
-    fn fallocate(&self, _mode: FallocMode, _offset: usize, _len: usize) -> Result<()> {
+    fn fallocate(&self, mode: FallocMode, offset: usize, len: usize) -> Result<()> {
         return_errno_with_message!(
             Errno::ENODEV,
             "fallocate is not supported for this file type"

--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -23,6 +23,7 @@ use crate::{
     prelude::*,
     process::signal::{PollHandle, Pollable},
     util::ioctl::RawIoctl,
+    vm::vmar::FileMmapRequest,
 };
 
 pub(crate) struct InodeHandle {
@@ -372,20 +373,22 @@ impl FileLike for InodeHandle {
         return_errno_with_message!(Errno::ENOTTY, "ioctl is not supported");
     }
 
-    fn mappable(&self) -> Result<Mappable> {
+    fn mappable(&self, request: FileMmapRequest) -> Result<Mappable> {
         if self.status_flags().contains(StatusFlags::O_PATH) {
             return_errno_with_message!(Errno::EBADF, "the file is opened as a path");
         }
 
+        if let Some(ref open_file) = self.open_file {
+            // If the file is a special file (e.g., device file), we should
+            // return the file-specific mappable object.
+            return open_file.mappable(request);
+        }
+
         let inode = self.path().inode();
         if let Some(page_cache) = inode.page_cache() {
-            // If the inode has a page cache, it is a file-backed mapping and
-            // we return the VMO as the mappable object.
+            // Otherwise, if the inode has a page cache, it is a file-backed
+            // mapping and we return the VMO as the mappable object.
             Ok(Mappable::Vmo(page_cache))
-        } else if let Some(ref open_file) = self.open_file {
-            // Otherwise, it is a special file (e.g. device file) and we should
-            // return the file-specific mappable object.
-            open_file.mappable()
         } else {
             return_errno_with_message!(Errno::ENODEV, "the file is not mappable");
         }
@@ -590,7 +593,7 @@ pub(crate) trait PerOpenFileOps: Pollable + FileOps + Any + Send + Sync + 'stati
     }
 
     // See `FileLike::mappable`.
-    fn mappable(&self) -> Result<Mappable> {
+    fn mappable(&self, _request: FileMmapRequest) -> Result<Mappable> {
         return_errno_with_message!(Errno::EINVAL, "the file is not mappable");
     }
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/file.rs
@@ -2,7 +2,7 @@
 
 //! Open regular-file handles for `virtiofs`.
 
-use aster_fuse::{FsyncFlags, FuseOpenFlags};
+use aster_fuse::{FsyncFlags, FuseOpenFlags, ops::init::FuseInitFlags2};
 use ostd::warn;
 
 use super::{
@@ -12,12 +12,13 @@ use super::{
 use crate::{
     events::IoEvents,
     fs::{
-        file::{PerOpenFileOps, StatusFlags, SyncMode},
+        file::{Mappable, PerOpenFileOps, StatusFlags, SyncMode},
         vfs::inode::{FileOps, Inode},
     },
     prelude::*,
     process::signal::{PollHandle, Pollable},
     thread::work_queue::{self, WorkPriority},
+    vm::vmar::FileMmapRequest,
 };
 
 /// A per-open file object backed by a FUSE file handle.
@@ -135,6 +136,32 @@ impl FileOps for VirtioFsFile {
 }
 
 impl PerOpenFileOps for VirtioFsFile {
+    fn mappable(&self, request: FileMmapRequest) -> Result<Mappable> {
+        // `FuseOpenFlags::FOPEN_DIRECT_IO` permits private mappings. Shared
+        // mappings additionally require `FuseInitFlags2::DIRECT_IO_ALLOW_MMAP`
+        // to have been negotiated.
+        let is_mmap_allowed = !self
+            .open_handle
+            .open_flags()
+            .contains(FuseOpenFlags::FOPEN_DIRECT_IO)
+            || !request.is_shared()
+            || self
+                .inode
+                .fs_ref()
+                .session()
+                .negotiated_flags2()
+                .contains(FuseInitFlags2::DIRECT_IO_ALLOW_MMAP);
+
+        if !is_mmap_allowed {
+            return_errno_with_message!(Errno::ENODEV, "the file is not mappable");
+        }
+
+        self.inode
+            .page_cache()
+            .map(Mappable::Vmo)
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "the file is not mappable"))
+    }
+
     fn check_seekable(&self) -> Result<()> {
         if self
             .open_handle
@@ -181,6 +208,7 @@ impl PerOpenFileOps for VirtioFsFile {
 pub(super) enum CachePolicy {
     /// I/O goes through the page cache.
     Cached,
-    /// I/O bypasses the page cache and hits the FUSE server directly.
+    /// I/O bypasses the page cache and hits the FUSE server directly, due to
+    /// either `O_DIRECT` or `FOPEN_DIRECT_IO`.
     Direct,
 }

--- a/kernel/core/src/syscall/mmap.rs
+++ b/kernel/core/src/syscall/mmap.rs
@@ -9,7 +9,7 @@ use crate::{
     vm::{
         page_cache::VmoOptions,
         perms::VmPerms,
-        vmar::{VMAR_CAP_ADDR, VMAR_LOWEST_ADDR, VmarMapOffset},
+        vmar::{MmapMode, VMAR_CAP_ADDR, VMAR_LOWEST_ADDR, VmarMapOffset},
     },
 };
 
@@ -99,7 +99,7 @@ fn do_sys_mmap(
         }
 
         if option.typ().is_shared() {
-            options = options.is_shared(true);
+            options = options.map_mode(MmapMode::Shared);
         }
 
         if option.flags().contains(MMapFlags::MAP_ANONYMOUS) {

--- a/kernel/core/src/vm/vmar/mod.rs
+++ b/kernel/core/src/vm/vmar/mod.rs
@@ -16,7 +16,10 @@ pub(crate) use self::{
     handle::VmarHandle,
     rmap::{Rmap, RmapEntry},
     vmar_impls::{
-        RssType, Vmar, map::VmarMapOffset, page_fault::PageFaultInfo, remap::RemapOldMappingAction,
+        RssType, Vmar,
+        map::{FileMmapRequest, MmapMode, VmarMapOffset},
+        page_fault::PageFaultInfo,
+        remap::RemapOldMappingAction,
     },
 };
 

--- a/kernel/core/src/vm/vmar/vm_mapping.rs
+++ b/kernel/core/src/vm/vmar/vm_mapping.rs
@@ -20,7 +20,7 @@ use ostd::{
 };
 
 use super::{
-    PageFaultInfo, Rmap, RssType, Vmar, interval_set::Interval, util::is_intersected,
+    MmapMode, PageFaultInfo, Rmap, RssType, Vmar, interval_set::Interval, util::is_intersected,
     vmar_impls::RssDelta,
 };
 use crate::{
@@ -75,11 +75,11 @@ pub(crate) struct VmMapping {
     /// If the mapping is VMO-backed, the `mapped_mem` field should be the page
     /// cache of the inode referenced by the file's path.
     file: Option<Arc<dyn FileLike>>,
-    /// Whether the mapping is shared.
+    /// The sharing mode of the mapping.
     ///
     /// The updates to a shared mapping are visible among processes, or carried
     /// through to the underlying file for file-backed shared mappings.
-    is_shared: bool,
+    map_mode: MmapMode,
     /// Whether the mapping needs to handle surrounding pages when handling
     /// page fault.
     handle_page_faults_around: bool,
@@ -96,7 +96,7 @@ impl Debug for VmMapping {
             .field("map_to_addr", &self.map_to_addr)
             .field("mapped_mem", &self.mapped_mem)
             .field("file", &self.file.as_ref().map(|file| file.path()))
-            .field("is_shared", &self.is_shared)
+            .field("map_mode", &self.map_mode)
             .field("handle_page_faults_around", &self.handle_page_faults_around)
             .field("perms", &self.perms)
             .finish()
@@ -117,7 +117,7 @@ impl VmMapping {
         map_to_addr: Vaddr,
         mapped_mem: MappedMemory,
         file: Option<Arc<dyn FileLike>>,
-        is_shared: bool,
+        map_mode: MmapMode,
         handle_page_faults_around: bool,
         perms: VmPerms,
     ) -> Self {
@@ -126,7 +126,7 @@ impl VmMapping {
             map_to_addr,
             mapped_mem,
             file,
-            is_shared,
+            map_mode,
             handle_page_faults_around,
             perms,
         }
@@ -202,7 +202,7 @@ impl VmMapping {
     // file content changes later on.
     pub(super) fn vmo_for_rmap(&self) -> Option<&Arc<Vmo>> {
         match &self.mapped_mem {
-            MappedMemory::Vmo(vmo) if self.is_shared => Some(vmo.vmo()),
+            MappedMemory::Vmo(vmo) if self.map_mode.is_shared() => Some(vmo.vmo()),
             _ => None,
         }
     }
@@ -222,7 +222,7 @@ impl VmMapping {
 
     /// Returns the shared futex backing identity for the address if available.
     pub(crate) fn futex_backing(&self, addr: Vaddr) -> Result<Option<(Weak<Vmo>, usize)>> {
-        if !self.is_shared {
+        if !self.map_mode.is_shared() {
             return Ok(None);
         }
 
@@ -297,7 +297,7 @@ impl VmMapping {
         } else {
             '-'
         };
-        let shared_char = if self.is_shared { 's' } else { 'p' };
+        let shared_char = if self.map_mode.is_shared() { 's' } else { 'p' };
         let offset = self.vmo().map(|vmo| vmo.offset).unwrap_or(0);
         let (dev_major, dev_minor) = self
             .inode()
@@ -359,7 +359,7 @@ impl VmMapping {
             }
 
             // Reference: <https://github.com/google/gvisor/blob/38123b53da96ff6983fcc103dfe2a9cc4e0d80c8/test/syscalls/linux/proc.cc#L1158-L1172>
-            if matches!(&self.mapped_mem, MappedMemory::Vmo(_)) && self.is_shared {
+            if matches!(&self.mapped_mem, MappedMemory::Vmo(_)) && self.map_mode.is_shared() {
                 return Some(Cow::Borrowed("/dev/zero (deleted)"));
             }
 
@@ -382,7 +382,7 @@ impl VmMapping {
     ///
     /// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/include/linux/mm.h#L1470-L1473>
     fn is_cow(&self) -> bool {
-        !self.is_shared && self.perms.contains(VmPerms::MAY_WRITE)
+        !self.map_mode.is_shared() && self.perms.contains(VmPerms::MAY_WRITE)
     }
 }
 
@@ -493,7 +493,7 @@ impl VmMapping {
                     assert!(is_write);
 
                     // For shared mappings, ensure that the VMO allows the page to be written.
-                    if self.is_shared
+                    if self.map_mode.is_shared()
                         && let MappedMemory::Vmo(vmo) = &self.mapped_mem
                         && let Err(err) = vmo.get_committed_frame(
                             page_aligned_addr - self.map_to_addr,
@@ -514,7 +514,7 @@ impl VmMapping {
 
                     let new_flags = PageFlags::W | PageFlags::ACCESSED | PageFlags::DIRTY;
 
-                    if self.is_shared || only_reference {
+                    if self.map_mode.is_shared() || only_reference {
                         cursor.protect_next(PAGE_SIZE, |flags, _cache| {
                             *flags |= new_flags;
                         });
@@ -607,14 +607,14 @@ impl VmMapping {
         };
 
         let page_offset = page_aligned_addr - self.map_to_addr;
-        if !self.is_shared && page_offset >= vmo.valid_size() {
+        if !self.map_mode.is_shared() && page_offset >= vmo.valid_size() {
             // The page index is outside the VMO. This is only allowed in private mapping.
             return Ok((FrameAllocOptions::new().alloc_frame()?.into(), is_readonly));
         }
 
         let (page, mode) =
             vmo.get_committed_frame(page_offset, self.vmo_map_mode_from_is_write(is_write))?;
-        if !self.is_shared && is_write {
+        if !self.map_mode.is_shared() && is_write {
             // Write access to private VMO-backed mapping. Performs COW directly.
             Ok((duplicate_frame(&page.into())?.into(), is_readonly))
         } else {
@@ -622,13 +622,13 @@ impl VmMapping {
             // If read access to private VMO-backed mapping triggers a page fault,
             // the map should be readonly. If user next tries to write to the frame,
             // another page fault will be triggered which will performs a COW (Copy-On-Write).
-            is_readonly = !self.is_shared || mode != VmoMapMode::SharedWrite;
+            is_readonly = !self.map_mode.is_shared() || mode != VmoMapMode::SharedWrite;
             Ok((page.into(), is_readonly))
         }
     }
 
     fn vmo_map_mode_from_is_write(&self, is_write: bool) -> VmoMapMode {
-        if !self.is_shared {
+        if !self.map_mode.is_shared() {
             VmoMapMode::Private
         } else if !is_write {
             VmoMapMode::SharedRead
@@ -669,7 +669,7 @@ impl VmMapping {
         }
 
         let vm_perms = self.perms - VmPerms::WRITE;
-        let mode = if !self.is_shared {
+        let mode = if !self.map_mode.is_shared() {
             VmoMapMode::Private
         } else {
             VmoMapMode::SharedRead
@@ -1056,7 +1056,7 @@ impl Drop for MappedVmo {
 /// [`Vmar`]: crate::vm::vmar::Vmar
 fn try_merge(left: &VmMapping, right: &VmMapping) -> Option<VmMapping> {
     let is_adjacent = left.map_end() == right.map_to_addr();
-    let is_type_equal = left.is_shared == right.is_shared
+    let is_type_equal = left.map_mode == right.map_mode
         && left.handle_page_faults_around == right.handle_page_faults_around
         && left.perms == right.perms
         && match (&left.file, &right.file) {

--- a/kernel/core/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/map.rs
@@ -63,10 +63,10 @@ pub(crate) struct VmarMapOptions<'a> {
     size: usize,
     offset: VmarMapOffset,
     align: usize,
-    // Whether the mapping is mapped with `MAP_SHARED`.
-    is_shared: bool,
-    // Whether the mapping needs to handle surrounding pages when handling
-    // page fault.
+    /// The sharing mode of the mapping.
+    map_mode: MmapMode,
+    /// Whether the mapping needs to handle surrounding pages when handling
+    /// page fault.
     handle_page_faults_around: bool,
 }
 
@@ -115,7 +115,7 @@ impl<'a> VmarMapOptions<'a> {
             size,
             offset: VmarMapOffset::Any,
             align: PAGE_SIZE,
-            is_shared: false,
+            map_mode: MmapMode::Private,
             handle_page_faults_around: false,
         }
     }
@@ -195,15 +195,13 @@ impl<'a> VmarMapOptions<'a> {
         self
     }
 
-    /// Sets whether the mapping can be shared with other process.
+    /// Sets the sharing mode of the mapping.
     ///
-    /// The default value is false.
+    /// The default value is [`MmapMode::Private`].
     ///
-    /// If this value is set to true, the mapping will be shared with child
-    /// process when forking.
-    #[expect(clippy::wrong_self_convention)]
-    pub(crate) fn is_shared(mut self, is_shared: bool) -> Self {
-        self.is_shared = is_shared;
+    /// A shared mapping is shared with child processes when forking.
+    pub(crate) fn map_mode(mut self, map_mode: MmapMode) -> Self {
+        self.map_mode = map_mode;
         self
     }
 
@@ -235,7 +233,7 @@ impl<'a> VmarMapOptions<'a> {
             panic!("Cannot set `mappable` when `file` is already set");
         }
 
-        let mappable = file.mappable()?;
+        let mappable = file.mappable(FileMmapRequest::new(self.map_mode))?;
         self.mappable = Some(mappable);
         self.file = Some(file);
 
@@ -259,7 +257,7 @@ impl<'a> VmarMapOptions<'a> {
             size: map_size,
             offset,
             align,
-            is_shared,
+            map_mode,
             handle_page_faults_around,
         } = self;
 
@@ -333,7 +331,7 @@ impl<'a> VmarMapOptions<'a> {
 
                 let is_writable_tracked = if let Some(path) = path
                     && let Some(memfd_inode) = path.inode().downcast_ref::<MemfdInode>()
-                    && is_shared
+                    && map_mode.is_shared()
                     && may_perms.contains(VmPerms::MAY_WRITE)
                 {
                     memfd_inode.check_writable(perms, &mut may_perms)?;
@@ -356,7 +354,7 @@ impl<'a> VmarMapOptions<'a> {
             map_to_addr,
             mapped_mem,
             file,
-            is_shared,
+            map_mode,
             handle_page_faults_around,
             perms | may_perms,
         );
@@ -429,5 +427,36 @@ impl<'a> VmarMapOptions<'a> {
 
         let vm_perms = self.perms | self.may_perms;
         vm_perms.check()
+    }
+}
+
+/// Properties of a virtual memory mapping that may affect file-specific behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct FileMmapRequest {
+    mode: MmapMode,
+}
+
+impl FileMmapRequest {
+    pub(crate) const fn new(mode: MmapMode) -> Self {
+        Self { mode }
+    }
+
+    pub(crate) const fn is_shared(self) -> bool {
+        self.mode.is_shared()
+    }
+}
+
+/// The sharing mode of a virtual memory mapping.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MmapMode {
+    /// Private mappings use copy-on-write semantics.
+    Private,
+    /// Shared mappings propagate updates to the underlying mapped object.
+    Shared,
+}
+
+impl MmapMode {
+    pub(crate) const fn is_shared(self) -> bool {
+        matches!(self, Self::Shared)
     }
 }


### PR DESCRIPTION
## Summary

This PR enables file-backed `mmap` for cached virtio-fs files.

It builds on PR #3399, where `VmMapping` was changed to retain the corresponding `FileLike`. This allows a mapping to keep the virtio-fs file handle alive after the last file descriptor is closed, preventing `FUSE_RELEASE` from being issued while the mapping is still active.

## Consistency Semantics

### Host Modifications and Existing Mappings

For an existing mapping, accessing an already resident page does not issue `GETATTR` merely because the attribute timeout has expired. Therefore, host-side modifications are not automatically visible to existing mappings.

Currently, virtiofsd does not support host-initiated invalidation notifications. As a result, an existing mapping may continue to observe cached data until the corresponding page cache is invalidated and the page is faulted again.

### Reopening the File

With `cache=auto`, opening a file without `FOPEN_KEEP_CACHE` invalidates the inode page cache. Subsequent page faults from an existing mapping can then fetch the updated contents from the host.

This provides `close-to-open` consistency at the guest `open()` boundary: reopening the file establishes the consistency boundary, while an existing mapping may observe the new contents only after the affected pages are faulted again.

### Dirty Mappings vs. Host Writes

If a guest has a dirty mapping while the host concurrently writes to the same data, the final contents depend on which write completes last. The later write overwrites the earlier one.

No automatic merge or conflict resolution is attempted. This is consistent with Linux behavior, which does not guarantee that concurrent writes through `mmap` and external file access will be merged.

## Direct-I/O Mapping Policy

The virtio-fs protocol distinguishes the following cases:

* `FOPEN_DIRECT_IO` + `MAP_PRIVATE`: allowed.
* `FOPEN_DIRECT_IO` + `MAP_SHARED` without `FUSE_DIRECT_IO_ALLOW_MMAP`: rejected with `ENODEV`.