### PR TITLE
Fix page table cursor for exact huge-page ranges

### DIFF
--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -98,7 +98,10 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig>(
         let start_idx = pte_index::<C>(va.start, cur_level);
         let level_too_high = {
             let end_idx = pte_index::<C>(va.end - 1, cur_level);
-            cur_level > 1 && start_idx == end_idx
+            let entry_size = page_size::<C>(cur_level);
+            let fills_entry = va.start.is_multiple_of(entry_size) && va.len() == entry_size;
+
+            cur_level > 1 && start_idx == end_idx && !fills_entry
         };
         if !level_too_high {
             break;

--- a/ostd/src/mm/page_table/test.rs
+++ b/ostd/src/mm/page_table/test.rs
@@ -753,15 +753,70 @@ mod unmap {
             panic!("expected to take a stray page table");
         };
 
-        // Should take a level-2 page table with 512 entries.
-        assert_eq!(va, PAGE_SIZE * 512);
-        assert_eq!(len, PAGE_SIZE * 512);
+        // Should take the level-2 page table node covering the whole range.
+        assert_eq!(va, 0);
+        assert_eq!(len, PAGE_SIZE * 512 * 512);
         assert_eq!(num_frames, 1);
     }
 }
 
 mod mapping {
     use super::{test_utils::*, *};
+
+    // Regression for #3731: a full level-2 slot must remain at its parent subtree root so
+    // `CursorMut::map` can install the huge leaf.
+
+    #[ktest]
+    fn maps_single_huge_page_with_exact_cursor_range() {
+        const HUGE_PAGE_SIZE: usize = PAGE_SIZE * 512;
+
+        let page_table = PageTable::<TestPtConfig>::empty();
+        let virtual_range = HUGE_PAGE_SIZE..HUGE_PAGE_SIZE * 2;
+        let physical_range = HUGE_PAGE_SIZE * 2..HUGE_PAGE_SIZE * 3;
+        let page_property = PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback);
+
+        map_untracked(
+            &page_table,
+            virtual_range.clone(),
+            physical_range.start,
+            page_property,
+        );
+
+        assert_eq!(
+            page_table.page_walk(virtual_range.start).unwrap().0,
+            physical_range.start
+        );
+        assert_eq!(
+            page_table.page_walk(virtual_range.end - 1).unwrap().0,
+            physical_range.end - 1
+        );
+    }
+
+    #[ktest]
+    fn maps_single_huge_page_filling_exact_level3_slot() {
+        const SLOT_1GIB: usize = PAGE_SIZE * 512 * 512;
+
+        let page_table = PageTable::<TestPtConfig>::empty();
+        let virtual_range = SLOT_1GIB..SLOT_1GIB * 2;
+        let physical_range = SLOT_1GIB * 2..SLOT_1GIB * 3;
+        let page_property = PageProperty::new_user(PageFlags::RW, CachePolicy::Writeback);
+
+        map_untracked(
+            &page_table,
+            virtual_range.clone(),
+            physical_range.start,
+            page_property,
+        );
+
+        assert_eq!(
+            page_table.page_walk(virtual_range.start).unwrap().0,
+            physical_range.start
+        );
+        assert_eq!(
+            page_table.page_walk(virtual_range.end - 1).unwrap().0,
+            physical_range.end - 1
+        );
+    }
 
     #[ktest]
     fn mixed_granularity_map_unmap() {


### PR DESCRIPTION
## Summary

Fix cursor subtree-root selection for virtual ranges that exactly fill one
huge-page entry.

- Stop descending when the range covers the current entry exactly.
- Preserve descent for strict subranges.
- Add level-2 (2 MiB) and level-3 (1 GiB) regression tests.
- Update the `take_next` expectation to the corrected subtree granularity.

## Root cause

The lock traversal previously treated an exact entry-sized range as if it
were strictly inside that entry. It created a cursor rooted one level too low;
when `CursorMut::map` then handled a valid huge leaf, its level adjustment
exceeded the guard and panicked.

## Validation

- `cargo fmt --all --check`
- Direct 2 MiB regression: `1 passed; 0 failed; 204 filtered out`
- Direct 1 GiB regression: `1 passed; 0 failed; 204 filtered out`
- Full OSTD ktest: `205 passed; 0 failed`
- `OSDK_TARGET_ARCH=x86_64 ./tools/clippy_check.sh workspace`

The local host lacked Docker's WSL integration, so the ktests used the
project's pinned `linux_vdso` revision with KVM, QEMU direct boot, SeaBIOS,
and ignored temporary disk images. CI remains the authoritative container
matrix.

Fixes #3731.
