### PR TITLE
Ping the version of minicov crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ osdk-heap-allocator = { path = "osdk/deps/heap-allocator" }
 acpi = "=5.2.0" # This upstream often bump minor versions with API changes
 bit_field = "0.10.1"
 gimli = { version = "0.28", default-features = false, features = ["read-core"] }
-minicov = "0.3"
+minicov = "=0.3.8" # This upstream may use an LLVM version which is incompatible with the one used by the Rust toolchain.
 multiboot2 = "0.24.0"
 num-traits = { version = "0.2", default-features = false }
 sbi-rt = "0.0.3"


### PR DESCRIPTION
Currently, our CI `osdk test` has been consistently hanging. I took a look, and it seems to be getting stuck on the `basic_coverage` test. The reason is that on August 14, upstream `minicov` was upgraded to version `0.3.9`, which uses the LLVM 23.1 profiling runtime (this is because the latest Rust toolchain seems to already depend on LLVM 23), while our current Rust toolchain is still based on LLVM 22. As a result, `minicov::capture_coverage` hangs.

Another option would be to upgrade to the latest toolchain as well, but I’m concerned that it could cause other issues if some of our upstream libraries haven’t been updated quickly enough.