### PR TITLE
Support stack unwinding on LoongArch

### DIFF
--- a/osdk/src/base_crate/loongarch64.ld.template
+++ b/osdk/src/base_crate/loongarch64.ld.template
@@ -16,6 +16,8 @@ SECTIONS
 
     __kernel_start = . + KERNEL_VMA_OFFSET;
 
+    PROVIDE(__executable_start = __kernel_start);
+
     .boot                   : AT(ADDR(.boot)) {
         KEEP(*(.boot))
         # FIXME: We want to create a separate .boot.stack section so that the

--- a/osdk/src/base_crate/riscv64.ld.template
+++ b/osdk/src/base_crate/riscv64.ld.template
@@ -12,6 +12,8 @@ SECTIONS
 
     __kernel_start = . + KERNEL_VMA_OFFSET;
 
+    PROVIDE(__executable_start = __kernel_start);
+
     .boot                   : AT(ADDR(.boot)) {
         KEEP(*(.boot))
         # FIXME: We want to create a separate .boot.stack section so that the

--- a/osdk/src/base_crate/x86_64.ld.template
+++ b/osdk/src/base_crate/x86_64.ld.template
@@ -49,6 +49,8 @@ SECTIONS
 
     __kernel_start = .;
 
+    PROVIDE(__executable_start = __kernel_start);
+
     .multiboot_header       : AT(ADDR(.multiboot_header) - KERNEL_VMA) {
         KEEP(*(.multiboot_header))
     } : header

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -62,6 +62,7 @@ unwinding = { workspace = true, features = ["fde-static"] }
 [target.loongarch64-unknown-none-softfloat.dependencies]
 fdt.workspace = true
 loongArch64.workspace = true
+unwinding = { workspace = true, features = ["fde-gnu-eh-frame-hdr"] }
 
 [features]
 default = ["cvm_guest"]

--- a/ostd/src/panic.rs
+++ b/ostd/src/panic.rs
@@ -74,13 +74,11 @@ impl PanicGuard {
     }
 }
 
-#[cfg(not(target_arch = "loongarch64"))]
 pub use unwinding::panic::{begin_panic, catch_unwind};
 
 /// Prints the stack trace of the current thread to the console.
 ///
 /// The printing procedure is protected by a spin lock to prevent interleaving.
-#[cfg(not(target_arch = "loongarch64"))]
 pub fn print_stack_trace() {
     use core::ffi::c_void;
 
@@ -121,6 +119,7 @@ pub fn print_stack_trace() {
             let reg_name = cfg_select! {
                 target_arch = "x86_64" => gimli::X86_64::register_name(Register(i)),
                 target_arch = "riscv64" => gimli::RiscV::register_name(Register(i)),
+                target_arch = "loongarch64" => gimli::LoongArch::register_name(Register(i)),
                 target_arch = "aarch64" => gimli::AArch64::register_name(Register(i)),
                 _ => None,
             };
@@ -136,26 +135,4 @@ pub fn print_stack_trace() {
 
     let mut data = CallbackData { counter: 0 };
     _Unwind_Backtrace(callback, &mut data as *mut _ as _);
-}
-
-/// Catches unwinding panics.
-#[cfg(target_arch = "loongarch64")]
-pub fn catch_unwind<R, F: FnOnce() -> R>(
-    f: F,
-) -> Result<R, alloc::boxed::Box<dyn core::any::Any + Send>> {
-    // TODO: Support unwinding in LoongArch.
-    Ok(f())
-}
-
-/// Begins panic handling
-#[cfg(target_arch = "loongarch64")]
-pub fn begin_panic<R>(_: alloc::boxed::Box<R>) {
-    // TODO: Support panic context in LoongArch.
-}
-
-/// Prints the stack trace of the current thread to the console.
-#[cfg(target_arch = "loongarch64")]
-pub fn print_stack_trace() {
-    // TODO: Support stack trace print in LoongArch.
-    early_println!("Printing stack trace:");
 }


### PR DESCRIPTION
<img width="700" height="1262" alt="image" src="https://github.com/user-attachments/assets/c078bd7b-2d01-4315-b525-bacca2caccc3" />

<img width="948" height="502" alt="image" src="https://github.com/user-attachments/assets/87cca7d1-b244-4708-aba7-1e9ec6a646f2" />

The `unwinding` crate has supported LoongArch since v0.2.9 (nbdd0121/unwinding#50, which I contributed upstream) and the workspace already pins v0.2.10, so those loongarch stack unwinding stubs in Asterinas can go.

This enables `unwinding` for the `loongarch64-unknown-none-softfloat` target with the `fde-gnu-eh-frame-hdr` FDE finder, the same one x86-64 uses. RISC-V needs `fde-static` because `riscv64imac-unknown-none-elf` sets `eh-frame-header: false` and the linker therefore emits no `.eh_frame_hdr`; the LoongArch target does not disable it, and `loongarch64.ld.template` already places the section and labels it `__GNU_EH_FRAME_HDR`, so the search table is available. `Oops` recovery and panic backtraces now behave the same as on the other architectures.

### The linker script also needs `__executable_start`

Enabling the dependency alone is not enough, and the failure is silent: `_Unwind_Backtrace` prints an empty trace and `catch_unwind` never catches anything, with no error anywhere.

The `fde-gnu-eh-frame-hdr` finder rejects any program counter outside `__executable_start..__etext` before it ever looks at the search table. `__etext` is defined by the linker scripts; `__executable_start` was not, so it was left to the linker, which places it at address zero. Whether that address can actually be materialised at run time turns out to depend on the kernel VMA and the code model, which is what makes the guard silently architecture-dependent:

```
x86-64     movq  $0x0,0x20(%rsp)            absolute immediate, reads back as 0
RISC-V     auipc a0, 0x7f668                pc-relative, reaches 0 by wrapping past
           addi  a1, a0, -0x686             2^64; the kernel is within 2 GiB of it
LoongArch  pcalau12i $a0, 0x7F3F9           pc-relative, cannot reach 0 at all
           addi.d    $a1, $a0, 0            reads back as 0x9000_0001_0000_0000
```

On x86-64 and RISC-V the symbol really does read back as zero, so `0..__etext` contains every kernel pc and the check passes vacuously. On LoongArch the kernel VMA is `0x9000_0000_8000_0000`, so address zero is several exabytes away in both directions — far outside the range a `pcalau12i` displacement can express. The relocation is truncated with no diagnostic, the symbol reads back *above* `__etext`, and the resulting empty range rejects every program counter.

Instrumenting `find_fde` on LoongArch showed the `.eh_frame_hdr` data itself was always fine — 16510 entries, correctly sorted, with the target pc resolving to an FDE covering exactly the right range when the table is walked by hand. Only the range guard in front of it was wrong.

Since neither the "is it reachable" nor the "is it correct" part is something the linker can diagnose here, the first commit defines `__executable_start` on all three architectures rather than leaving x86-64 and RISC-V relying on a value the linker invents.

### Testing

All in `asterinas/asterinas:0.18.0-20260702`.

Before and after on LoongArch, same kernel with a `panic!()` temporarily injected into `main`:

```
 before                                   after
 __executable_start = 0x0                 __executable_start = 0x9000000080000000
 (reads back as 0x9000000100000000)

 ERROR: Uncaught panic:                   ERROR: Uncaught panic:
     demonstrating LoongArch ...              demonstrating LoongArch ...
     at kernel/src/lib.rs:28                  at kernel/src/lib.rs:28
     on CPU 0 by thread None                  on CPU 0 by thread None
 Printing stack trace:                    Printing stack trace:
 ERROR: Failed to power off ...              1: fn 0x9000000080b70660 - pc ...
                                             2: fn 0x9000000080374fa0 - pc ...
 (no frames at all)                          ... 13 frames ...
```

Resolving each frame's FDE start address against the kernel ELF gives exactly the call path that was taken:

```
 #   fn (FDE start)       pc                   symbol
 1   0x9000000080b70660   0x9000000080b706b4   ostd::panic::print_stack_trace            ostd/src/panic.rs:137
 2   0x9000000080374fa0   0x90000000803755b0   aster_core::thread::oops::panic_handler   kernel/core/src/thread/oops.rs:118
 3   0x9000000080376da0   0x9000000080376db4   __ostd_panic_handler
 4   0x9000000080042000   0x9000000080042014   __rustc::rust_begin_unwind
 5   0x9000000080c6f3c0   0x9000000080c6f410   core::panicking::panic_fmt
 6   0x9000000080042180   0x90000000800421ac   asterinas::unwind_demo::inner
 7   0x90000000800421e0   0x90000000800421f0   asterinas::unwind_demo::middle            kernel/src/lib.rs:24
 8   0x90000000800421c0   0x90000000800421d0   asterinas::unwind_demo::outer             kernel/src/lib.rs:19
 9   0x9000000080042040   0x9000000080042050   asterinas::main                           kernel/src/lib.rs:12
10   0x9000000080042080   0x9000000080042090   __ostd_main                               kernel/src/lib.rs:9
11   0x9000000080bfeb40   0x9000000080bfeb58   ostd::boot::start_kernel
12   0x9000000080bed900   0x9000000080beda6c   loongarch_boot
13   0x0                  0x80000000           boot entry, still at its physical address, no FDE
```

Every frame matches the real call path, and the walk terminates cleanly at the boot entry. The registers are right too: `$r0` is always zero, `$r1` (`ra`) matches the frame's pc, and `$r3` (`sp`) increases monotonically as the walk moves up the stack.

The temporary patch used above:

```rust
// kernel/src/lib.rs
#[ostd::main]
fn main() {
    unwind_demo::outer();
    aster_core::boot();
}

mod unwind_demo {
    #[inline(never)]
    pub fn outer() {
        middle();
    }

    #[inline(never)]
    fn middle() {
        inner();
    }

    #[inline(never)]
    fn inner() {
        panic!("demonstrating LoongArch stack unwinding");
    }
}
```

Since the first commit tightens the range guard on x86-64 and RISC-V from vacuously true to actually meaningful, all three architectures were re-checked:

| | `make check` | `make kernel` | `make ktest` |
|---|---|---|---|
| x86-64 | pass | pass | pass, all crates, `ostd` 203/203 |
| RISC-V 64 | pass | pass | pass, all crates, `ostd` 206/206 |
| LoongArch 64 | pass | pass | `ostd` 180/200, see below |

The tests that exercise the unwinder directly pass on all three, including the `#[should_panic]` ones, which only work if a panic is raised, unwound, and its payload delivered back to `catch_unwind`:

```
test ostd::test::trivial_assertion ... ok
test ostd::test::failing_assertion ... ok      // #[should_panic]
test ostd::test::expect_panic ... ok           // #[should_panic(expected = "...")]
```

Kernel unit tests now build and run on LoongArch for the first time. On `main`, `cargo osdk test` for this target does not even compile:

```
error: unwinding panics are not supported without std
error: could not compile `osdk-frame-allocator-osdk-bin` (bin "osdk-frame-allocator-osdk-bin")
```

### The 20 failing `ostd` tests

They are all in `mm`, and none of them touch unwinding:

- `mm::dma::test::dma_stream::{to_device, from_device}`
- `mm::kspace::test::{kvirt_area_tracked_map_pages, kvirt_area_untracked_map_pages}`
- `mm::page_table::test::*` (10 tests: `arch_pte_impls`, `boot_pt`, `mapping`, `navigation`, `page_properties`, `protection_and_query`, `unmap`)
- `mm::test::vmspace::*` (6 tests, including the two `iomem` ones)

These are pre-existing LoongArch MMU/DMA gaps that simply had no way of being observed before, since kernel unit tests could not be built for the target. This change cannot have introduced them: the base crate was already compiled with `panic = "unwind"`, so codegen is unchanged, and before this change a failing assertion aborted the whole kernel (`An uncaught panic occurred: ...`) instead of being reported as a test failure. They look worth a separate issue, and they do not affect CI, whose LoongArch matrix is lint and compile only.

### Note on running `cargo osdk test` on LoongArch

The LoongArch port registers no poweroff handler, so QEMU does not exit after the run finishes:

```
[ktest runner] All crates tested.
ERROR: Failed to power off the system because a poweroff handler is missing
ERROR: Halting the machine...
```

Not related to this change, but it does mean `make ktest TARGET_ARCH=loongarch64` has to be babysat for now. Also worth a separate issue.


