### PR TITLE
Pass resolved inodes through the rename interface

### DIFF
--- a/kernel/core/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/mod.rs
@@ -357,8 +357,10 @@ impl Inode for RootInode {
     fn rename(
         &self,
         _old_name: &str,
-        _target: &Arc<dyn Inode>,
+        _old_inode: &Arc<dyn Inode>,
+        _new_dir_inode: &Arc<dyn Inode>,
         _new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         _mode: RenameMode,
     ) -> Result<()> {
         Err(Error::new(Errno::EPERM))

--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -1691,8 +1691,10 @@ impl Inode for ExfatInode {
     fn rename(
         &self,
         old_name: &str,
+        _old_inode: &Arc<dyn Inode>,
         target: &Arc<dyn Inode>,
         new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         if mode == RenameMode::Exchange {

--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -1691,51 +1691,47 @@ impl Inode for ExfatInode {
     fn rename(
         &self,
         old_name: &str,
-        _old_inode: &Arc<dyn Inode>,
-        target: &Arc<dyn Inode>,
+        old_inode: &Arc<dyn Inode>,
+        new_dir_inode: &Arc<dyn Inode>,
         new_name: &str,
-        _replaced_inode: Option<&Arc<dyn Inode>>,
+        replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         if mode == RenameMode::Exchange {
             return_errno_with_message!(Errno::EINVAL, "RENAME_EXCHANGE is not supported on exfat");
         }
-        if is_dot_or_dotdot(old_name) || is_dot_or_dotdot(new_name) {
-            return_errno!(Errno::EISDIR);
-        }
-        if old_name.len() > MAX_NAME_LENGTH || new_name.len() > MAX_NAME_LENGTH {
-            return_errno!(Errno::ENAMETOOLONG)
-        }
-        let Some(target_) = target.downcast_ref::<ExfatInode>() else {
-            return_errno_with_message!(Errno::EINVAL, "not an exfat inode")
-        };
-        if !self.inner.read().inode_type.is_directory()
-            || !target_.inner.read().inode_type.is_directory()
-        {
-            return_errno!(Errno::ENOTDIR)
-        }
+
+        let new_dir_inode = Arc::downcast::<ExfatInode>(new_dir_inode.clone()).unwrap();
+        let old_inode = Arc::downcast::<ExfatInode>(old_inode.clone()).unwrap();
 
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();
-        // Rename something to itself, return success directly.
+
+        // FIXME: Case-only renames are not handled correctly by exFAT. Keep the existing
+        // no-op behavior until the VFS dentry invalidation is applied.
         let up_old_name = fs.upcase_table().lock().str_to_upcase(old_name)?;
         let up_new_name = fs.upcase_table().lock().str_to_upcase(new_name)?;
-        if self.inner.read().ino == target_.inner.read().ino && up_old_name.eq(&up_new_name) {
+        if self.inner.read().ino == new_dir_inode.inner.read().ino && up_old_name.eq(&up_new_name) {
             return Ok(());
         }
 
-        // Read 'old_name' file or dir and its dentries.
-        let old_inode = self
-            .inner
-            .read()
-            .lookup_by_name(old_name, true, &fs_guard)?;
-        // FIXME: Users may be confused, since inode with the same upper case name will be removed.
-        let lookup_exist_result = target_
-            .inner
-            .read()
-            .lookup_by_name(new_name, false, &fs_guard);
+        let replaced_inode = match replaced_inode {
+            Some(inode) => Some(Arc::downcast::<ExfatInode>(inode.clone()).unwrap()),
+            None => {
+                // FIXME: The dentry lookup may miss an existing entry whose name differs only in case,
+                // so perform an additional case-insensitive lookup for the replacement.
+                // The inode found by this fallback is not reported back to the VFS, so the positive
+                // dentry for the old spelling may remain stale after the replacement.
+                new_dir_inode
+                    .inner
+                    .read()
+                    .lookup_by_name(new_name, false, &fs_guard)
+                    .ok()
+            }
+        };
+
         // Check for the corner cases.
-        if let Ok(ref exist_inode) = lookup_exist_result {
+        if let Some(exist_inode) = replaced_inode.as_ref() {
             check_corner_cases_for_rename(&old_inode, exist_inode)?;
         }
 
@@ -1743,7 +1739,7 @@ impl Inode for ExfatInode {
         self.delete_inode(old_inode.clone(), false, &fs_guard)?;
         // Create the new dentries.
         let new_inode =
-            target_.add_entry(new_name, old_inode.type_(), old_inode.mode()?, &fs_guard)?;
+            new_dir_inode.add_entry(new_name, old_inode.type_(), old_inode.mode()?, &fs_guard)?;
         // Update metadata.
         old_inode.copy_dentry_position_from(new_inode);
         // Update its children's parent_hash.
@@ -1751,17 +1747,17 @@ impl Inode for ExfatInode {
         // Insert back.
         let _ = fs.insert_inode(old_inode.clone());
         // Remove the exist 'new_name' file.
-        if let Ok(exist_inode) = lookup_exist_result {
-            target_.delete_inode(exist_inode, true, &fs_guard)?;
+        if let Some(exist_inode) = replaced_inode {
+            new_dir_inode.delete_inode(exist_inode, true, &fs_guard)?;
         }
         // Update the times.
         self.inner.write().update_atime_mtime_and_ctime()?;
-        target_.inner.write().update_atime_mtime_and_ctime()?;
+        new_dir_inode.inner.write().update_atime_mtime_and_ctime()?;
         // Sync
-        if self.inner.read().is_sync() || target_.inner.read().is_sync() {
+        if self.inner.read().is_sync() || new_dir_inode.inner.read().is_sync() {
             // TODO: what if fs crashed between syncing?
             old_inode.inner.read().sync_all(&fs_guard)?;
-            target_.inner.read().sync_all(&fs_guard)?;
+            new_dir_inode.inner.read().sync_all(&fs_guard)?;
             self.inner.read().sync_all(&fs_guard)?;
         }
         Ok(())

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -213,8 +213,10 @@ impl Inode for Ext2Inode {
     fn rename(
         &self,
         old_name: &str,
+        _old_inode: &Arc<dyn Inode>,
         target: &Arc<dyn Inode>,
         new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         if mode == RenameMode::Exchange {

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -213,20 +213,21 @@ impl Inode for Ext2Inode {
     fn rename(
         &self,
         old_name: &str,
-        _old_inode: &Arc<dyn Inode>,
-        target: &Arc<dyn Inode>,
+        old_inode: &Arc<dyn Inode>,
+        new_dir_inode: &Arc<dyn Inode>,
         new_name: &str,
-        _replaced_inode: Option<&Arc<dyn Inode>>,
+        replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         if mode == RenameMode::Exchange {
             return_errno_with_message!(Errno::EINVAL, "RENAME_EXCHANGE is not supported on ext2");
         }
 
-        let target = target
-            .downcast_ref::<Ext2Inode>()
-            .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
-        self.rename(old_name, target, new_name)
+        let new_dir_inode = new_dir_inode.downcast_ref::<Ext2Inode>().unwrap();
+        let old_inode = old_inode.downcast_ref::<Ext2Inode>().unwrap();
+        let replaced_inode = replaced_inode.map(|inode| inode.downcast_ref::<Ext2Inode>().unwrap());
+
+        self.rename(old_name, old_inode, new_dir_inode, new_name, replaced_inode)
     }
 
     fn read_link(&self) -> Result<SymbolicLink> {

--- a/kernel/core/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -231,31 +231,15 @@ impl Inode {
         Ok(())
     }
 
-    /// Renames or moves an entry from this directory to `target` directory.
-    pub(in ext2) fn rename(&self, old_name: &str, target: &Inode, new_name: &str) -> Result<()> {
-        let fs = self.fs()?;
-        let is_same_dir = self.ino == target.ino;
-        if is_same_dir && old_name == new_name {
-            return Ok(());
-        }
-
-        // Step 1: read inode numbers without write locks so we know which
-        // inodes to lock.
-        let old_info = {
-            let source_inner = self.inner.read();
-            source_inner.find_entry_info(old_name)?
-        };
-        let old_ino = old_info.ino;
-        let old_inode = fs.read_inode(old_ino)?;
-        let replaced_inode = {
-            let target_inner = target.inner.read();
-            target_inner
-                .find_entry_info(new_name)
-                .ok()
-                .map(|entry_info| fs.read_inode(entry_info.ino))
-                .transpose()?
-        };
-
+    /// Renames or moves an entry from this directory to directory referred by `new_dir_inode`.
+    pub(in ext2) fn rename(
+        &self,
+        old_name: &str,
+        old_inode: &Inode,
+        new_dir_inode: &Inode,
+        new_name: &str,
+        replaced_inode: Option<&Inode>,
+    ) -> Result<()> {
         // The `DirDentry.children` lock in the VFS layer keeps the parent
         // directory entry stable during this operation, so we only need to
         // lock all related inodes in order, without rechecking the lookup
@@ -263,22 +247,22 @@ impl Inode {
         // Step 2: lock all participating inodes in global ino order.
         let lock_targets = [
             self as &Inode,
-            target,
-            old_inode.as_ref(),
-            replaced_inode.as_deref().unwrap_or(old_inode.as_ref()),
+            new_dir_inode,
+            old_inode,
+            replaced_inode.unwrap_or(old_inode),
         ];
         let mut guards = MultiInodeInnerGuards::lock(&lock_targets);
 
         // Step 3: validate invariants under lock.
-        self.validate_rename_invariants(&guards, &old_inode, replaced_inode.as_deref())?;
+        self.validate_rename_invariants(&guards, old_inode, replaced_inode)?;
 
         // Step 4: apply directory mutations and metadata updates.
         self.apply_dir_mutations(
             &mut guards,
-            target,
+            new_dir_inode,
             old_name,
-            &old_inode,
-            replaced_inode.as_deref(),
+            old_inode,
+            replaced_inode,
             new_name,
         )?;
 
@@ -326,7 +310,7 @@ impl Inode {
     fn apply_dir_mutations(
         &self,
         guards: &mut MultiInodeInnerGuards,
-        target: &Inode,
+        new_dir_inode: &Inode,
         old_name: &str,
         old_inode: &Inode,
         replaced_inode: Option<&Inode>,
@@ -335,7 +319,7 @@ impl Inode {
         let old_is_dir = old_inode.type_ == InodeType::Dir;
         let has_replaced = replaced_inode.is_some();
         let old_ino = old_inode.ino();
-        let is_same_dir = self.ino == target.ino;
+        let is_same_dir = self.ino == new_dir_inode.ino;
         let moved_file_type = DirEntryFileType::from(old_inode.type_);
         let fs = self.fs()?;
 
@@ -356,16 +340,16 @@ impl Inode {
             }
             dir_inner.set_mtime_ctime(utils::now());
         } else {
-            let target_inner = guards.inner_mut(target.ino);
+            let new_dir_inner = guards.inner_mut(new_dir_inode.ino);
             if has_replaced {
-                target_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
+                new_dir_inner.overwrite_entry(new_name, old_ino, moved_file_type)?;
             } else {
-                target_inner.add_new_entry(&fs, new_name, old_ino, moved_file_type)?;
+                new_dir_inner.add_new_entry(&fs, new_name, old_ino, moved_file_type)?;
             }
             if old_is_dir && !has_replaced {
-                target_inner.inc_link_count(1);
+                new_dir_inner.inc_link_count(1);
             }
-            target_inner.set_mtime_ctime(utils::now());
+            new_dir_inner.set_mtime_ctime(utils::now());
             let source_inner = guards.inner_mut(self.ino);
             let old_info = &source_inner.find_entry_info(old_name)?;
             source_inner.delete_entry(old_info)?;
@@ -394,7 +378,11 @@ impl Inode {
         let old_inner = guards.inner_mut(old_inode.ino());
         if old_is_dir && !is_same_dir {
             let dotdot_entry_info = old_inner.find_entry_info("..")?;
-            old_inner.set_entry_target(&dotdot_entry_info, target.ino, DirEntryFileType::Dir)?;
+            old_inner.set_entry_target(
+                &dotdot_entry_info,
+                new_dir_inode.ino,
+                DirEntryFileType::Dir,
+            )?;
             old_inner.remove_flags(FileFlags::INDEX_DIR);
             old_inner.set_mtime_ctime(utils::now());
         } else {

--- a/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
@@ -544,8 +544,10 @@ impl OverlayInode {
     pub(crate) fn rename(
         &self,
         _old_name: &str,
-        _target: &Arc<dyn Inode>,
+        _old_inode: &Arc<dyn Inode>,
+        _new_dir_inode: &Arc<dyn Inode>,
         _new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         _mode: RenameMode,
     ) -> Result<()> {
         // TODO: Support the rename operation based on the `redirect_mode` feature,
@@ -1019,8 +1021,10 @@ impl Inode for OverlayInode {
     fn rename(
         &self,
         old_name: &str,
-        target: &Arc<dyn Inode>,
+        old_inode: &Arc<dyn Inode>,
+        new_dir_inode: &Arc<dyn Inode>,
         new_name: &str,
+        replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()>;
     fn read_link(&self) -> Result<SymbolicLink>;

--- a/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
@@ -221,8 +221,10 @@ impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
     fn rename(
         &self,
         _old_name: &str,
-        _target: &Arc<dyn Inode>,
+        _old_inode: &Arc<dyn Inode>,
+        _new_dir_inode: &Arc<dyn Inode>,
         _new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         _mode: RenameMode,
     ) -> Result<()> {
         Err(Error::new(Errno::EPERM))

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -1107,8 +1107,10 @@ impl Inode for RamInode {
     fn rename(
         &self,
         old_name: &str,
-        target: &Arc<dyn Inode>,
+        _old_inode: &Arc<dyn Inode>,
+        new_dir_inode: &Arc<dyn Inode>,
         new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         // Perform necessary checks to ensure that `dst_inode` can be replaced by `src_inode`.
@@ -1141,10 +1143,10 @@ impl Inode for RamInode {
                 Ok(())
             };
 
-        let target = target.downcast_ref::<RamInode>().unwrap();
+        let new_dir_inode = new_dir_inode.downcast_ref::<RamInode>().unwrap();
 
         // Rename in the same directory
-        if self.ino == target.ino {
+        if self.ino == new_dir_inode.ino {
             let mut self_dir = self.inner.as_direntry().unwrap().write();
             // The source is guaranteed to exist (checked by VFS layer).
             let (src_idx, src_inode) = self_dir.get_entry(old_name).unwrap();
@@ -1188,7 +1190,10 @@ impl Inode for RamInode {
         else {
             let (mut self_dir, mut target_dir) = write_lock_two_direntries_by_ino(
                 (self.ino, self.inner.as_direntry().unwrap()),
-                (target.ino, target.inner.as_direntry().unwrap()),
+                (
+                    new_dir_inode.ino,
+                    new_dir_inode.inner.as_direntry().unwrap(),
+                ),
             );
             let self_inode_arc = self.this.upgrade().unwrap();
             // The source is guaranteed to exist (checked by VFS layer).
@@ -1207,7 +1212,7 @@ impl Inode for RamInode {
 
                 let now = now();
                 DirChange::exchange(&src_inode, &dst_inode).apply(self, now);
-                DirChange::exchange(&dst_inode, &src_inode).apply(target, now);
+                DirChange::exchange(&dst_inode, &src_inode).apply(new_dir_inode, now);
                 src_inode.set_ctime(now);
                 dst_inode.set_ctime(now);
 
@@ -1226,7 +1231,7 @@ impl Inode for RamInode {
 
                 let now = now();
                 DirChange::del(&src_inode).apply(self, now);
-                DirChange::exchange(&dst_inode, &src_inode).apply(target, now);
+                DirChange::exchange(&dst_inode, &src_inode).apply(new_dir_inode, now);
                 dst_inode.set_ctime(now);
                 src_inode.set_ctime(now);
             } else {
@@ -1237,11 +1242,11 @@ impl Inode for RamInode {
 
                 let now = now();
                 DirChange::del(&src_inode).apply(self, now);
-                DirChange::add(&src_inode).apply(target, now);
+                DirChange::add(&src_inode).apply(new_dir_inode, now);
                 src_inode.set_ctime(now);
             }
 
-            src_inode.set_parent_if_dir(target.this.clone());
+            src_inode.set_parent_if_dir(new_dir_inode.this.clone());
         }
         Ok(())
     }

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -465,8 +465,10 @@ impl Inode for VirtioFsInode {
     fn rename(
         &self,
         old_name: &str,
+        _old_inode: &Arc<dyn Inode>,
         target: &Arc<dyn Inode>,
         new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         if mode == RenameMode::Exchange {

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -465,10 +465,10 @@ impl Inode for VirtioFsInode {
     fn rename(
         &self,
         old_name: &str,
-        _old_inode: &Arc<dyn Inode>,
-        target: &Arc<dyn Inode>,
+        old_inode: &Arc<dyn Inode>,
+        new_dir_inode: &Arc<dyn Inode>,
         new_name: &str,
-        _replaced_inode: Option<&Arc<dyn Inode>>,
+        replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         if mode == RenameMode::Exchange {
@@ -478,7 +478,10 @@ impl Inode for VirtioFsInode {
             );
         }
 
-        let target = target.downcast_ref::<VirtioFsInode>().unwrap();
+        let new_dir_inode = new_dir_inode.downcast_ref::<VirtioFsInode>().unwrap();
+        let old_inode = old_inode.downcast_ref::<VirtioFsInode>().unwrap();
+        let replaced_inode =
+            replaced_inode.map(|inode| inode.downcast_ref::<VirtioFsInode>().unwrap());
 
         let fs = self.fs_ref();
 
@@ -487,12 +490,16 @@ impl Inode for VirtioFsInode {
         // pass the cached old dentry down.
         fs.session().do_fuse_op(
             self.nodeid(),
-            RenameOperation::new(RenameReq::new(target.nodeid()), old_name, new_name),
+            RenameOperation::new(RenameReq::new(new_dir_inode.nodeid()), old_name, new_name),
         )?;
 
         self.expire_attr_cache();
-        if self.nodeid() != target.nodeid() {
-            target.expire_attr_cache();
+        if self.nodeid() != new_dir_inode.nodeid() {
+            new_dir_inode.expire_attr_cache();
+        }
+        old_inode.expire_attr_cache();
+        if let Some(replaced_inode) = replaced_inode {
+            replaced_inode.expire_attr_cache();
         }
 
         Ok(())

--- a/kernel/core/src/fs/utils/systree_inode.rs
+++ b/kernel/core/src/fs/utils/systree_inode.rs
@@ -547,8 +547,10 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
     default fn rename(
         &self,
         _old_name: &str,
-        _target: &Arc<dyn Inode>,
+        _old_inode: &Arc<dyn Inode>,
+        _new_dir_inode: &Arc<dyn Inode>,
         _new_name: &str,
+        _replaced_inode: Option<&Arc<dyn Inode>>,
         _mode: RenameMode,
     ) -> Result<()> {
         Err(Error::new(Errno::EPERM))

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -455,8 +455,10 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
     fn rename(
         &self,
         old_name: &str,
-        target: &Arc<dyn Inode>,
+        old_inode: &Arc<dyn Inode>,
+        new_dir_inode: &Arc<dyn Inode>,
         new_name: &str,
+        replaced_inode: Option<&Arc<dyn Inode>>,
         mode: RenameMode,
     ) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))

--- a/kernel/core/src/fs/vfs/path/dentry.rs
+++ b/kernel/core/src/fs/vfs/path/dentry.rs
@@ -799,9 +799,10 @@ impl DirDentry<'_> {
             let mut children = self.children.write();
 
             let old_dentry = self.resolve_child_for_rename(&mut children, old_name)?;
+            let old_inode = old_dentry.inode();
             let new_dentry = match self.resolve_child_for_rename(&mut children, new_name) {
                 Ok(new_dentry) => {
-                    if Arc::ptr_eq(old_dentry.inode(), new_dentry.inode()) {
+                    if Arc::ptr_eq(old_inode, new_dentry.inode()) {
                         return Ok(());
                     }
                     Some(new_dentry)
@@ -812,14 +813,23 @@ impl DirDentry<'_> {
 
             Self::check_rename_mode(mode, new_dentry.as_ref())?;
 
+            let replaced_inode = new_dentry.as_ref().map(|dentry| dentry.inode());
+
             if self.has_sticky_bit()? {
-                self.check_sticky_bit_permission(old_dentry.inode())?;
-                if let Some(new_dentry) = new_dentry.as_ref() {
-                    self.check_sticky_bit_permission(new_dentry.inode())?;
+                self.check_sticky_bit_permission(old_inode)?;
+                if let Some(replaced_inode) = replaced_inode {
+                    self.check_sticky_bit_permission(replaced_inode)?;
                 }
             }
 
-            old_dir_inode.rename(old_name, old_dir_inode, new_name, mode)?;
+            old_dir_inode.rename(
+                old_name,
+                old_inode,
+                old_dir_inode,
+                new_name,
+                replaced_inode,
+                mode,
+            )?;
 
             match mode {
                 RenameMode::Replace | RenameMode::NoReplace => {
@@ -850,9 +860,10 @@ impl DirDentry<'_> {
                 write_lock_children_on_two_dentries(self, new_dir);
 
             let old_dentry = self.resolve_child_for_rename(&mut old_children, old_name)?;
+            let old_inode = old_dentry.inode();
             let new_dentry = match new_dir.resolve_child_for_rename(&mut new_children, new_name) {
                 Ok(new_dentry) => {
-                    if Arc::ptr_eq(old_dentry.inode(), new_dentry.inode()) {
+                    if Arc::ptr_eq(old_inode, new_dentry.inode()) {
                         return Ok(());
                     }
                     Some(new_dentry)
@@ -864,16 +875,25 @@ impl DirDentry<'_> {
             Self::check_rename_mode(mode, new_dentry.as_ref())?;
             Self::check_rename_cycle(mode, self, &old_dentry, new_dir, new_dentry.as_ref())?;
 
+            let replaced_inode = new_dentry.as_ref().map(|dentry| dentry.inode());
+
             if self.has_sticky_bit()? {
-                self.check_sticky_bit_permission(old_dentry.inode())?;
+                self.check_sticky_bit_permission(old_inode)?;
             }
             if new_dir.has_sticky_bit()?
-                && let Some(new_dentry) = new_dentry.as_ref()
+                && let Some(replaced_inode) = replaced_inode
             {
-                new_dir.check_sticky_bit_permission(new_dentry.inode())?;
+                new_dir.check_sticky_bit_permission(replaced_inode)?;
             }
 
-            old_dir_inode.rename(old_name, new_dir_inode, new_name, mode)?;
+            old_dir_inode.rename(
+                old_name,
+                old_inode,
+                new_dir_inode,
+                new_name,
+                replaced_inode,
+                mode,
+            )?;
 
             match mode {
                 RenameMode::Replace | RenameMode::NoReplace => {


### PR DESCRIPTION
  ## Motivation

`DirDentry::rename` has already resolved the source and destination dentries through the dcache before invoking the filesystem-specific rename operation. Therefore, the corresponding source inode and, when present, destination inode are already available at the VFS layer.

However, the existing `Inode::rename` interface only passes the entry names and parent directory inodes. Filesystem implementations may need to look up the entries by name again to obtain their inodes, resulting in unnecessary duplicate lookups.

## Changes

Extend `Inode::rename` to additionally pass inodes(arguments with `*` are new), `old_name` and `new_name` are still passed to find the entries in parent dir:
```rust
  fn rename(
      &self,
      old_name: &str,
      old_inode: &Arc<dyn Inode>, *
      target: &Arc<dyn Inode>,
      new_name: &str,
      new_inode: Option<&Arc<dyn Inode>>, *
      mode: RenameMode,
  ) 
```
The VFS obtains these inodes directly from the already resolved dentries without extra overhead. `Ext2` and `exfat` now uses them instead of looking up the directory entries and reading the inodes again. `Virtio-fs` also uses them to invalidate the attribute caches of the moved and overwritten inodes.

Besides, rename `target` argument to `new_dir_inode` for rename which aligns with `DirDentry::rename(..., new_dir, ...)` interface.

## Alternatives

An alternative is to pass `old_dentry` and `new_dentry` directly to `Inode::rename`.
```rust
fn rename(
  &self,
  old_dentry: &Arc<Dentry>,
  target: &Arc<dyn Inode>,
  new_dentry: Option<&Arc<Dentry>>,
  new_name: &str,
  mode: RenameMode,
)
```

However, this would expose VFS dentry objects through the filesystem-facing inode interface and affect the current visibility and abstraction boundary of `Dentry`. Passing only the resolved inodes provides the information required by filesystem implementations without introducing that side effect.