### PR TITLE
Fix coverage test failure

### DIFF
--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -46,6 +46,13 @@ jobs:
         image: ['asterinas/kernel-dev:0.18.1-20260805', 'asterinas/osdk-dev:0.18.1-20260805']
     steps:
       - uses: actions/checkout@v4
+
+      # TODO: Remove this step after the next release includes Clang in the dev images.
+      - name: Install Clang temporarily
+        run: |
+          apt-get update
+          apt-get install -y clang
+
       - name: Run OSDK tests
         uses: ./.github/actions/test
         with:

--- a/osdk/tools/docker/Dockerfile
+++ b/osdk/tools/docker/Dockerfile
@@ -185,6 +185,7 @@ EOF
 # Install all OSDK dependent packages
 RUN apt update \
     && apt install -y --no-install-recommends \
+    clang               `# Used by the build script of minicov` \
     curl \
     gdb                 `# A part of OSDK debug support` \
     grub-efi-amd64 \


### PR DESCRIPTION
It adds `clang` back to the OSDK dev image. Clang was mistakenly removed in #3677 . I thought it was not used.