### PR TITLE
Add minimal AArch64 support

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Test type (general, osdk, boot, conformance, regression)'
     required: true
   arch:
-    description: 'Architecture (x86_64/riscv64/loongarch64)'
+    description: 'Architecture (x86_64/riscv64/loongarch64/aarch64)'
     required: false
   release:
     description: 'Whether to run in release mode'

--- a/.github/workflows/test_aarch64.yml
+++ b/.github/workflows/test_aarch64.yml
@@ -1,0 +1,27 @@
+name: "Test aarch64  "
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  basic-test:
+    runs-on: ubuntu-latest
+    container:
+      image: asterinas/kernel-dev:0.18.1-20260901
+      options: -v /dev:/dev --privileged
+    strategy:
+      matrix:
+        id: ['lint', 'compile']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run basic tests
+        uses: ./.github/actions/test
+        with:
+          auto_test: 'general'
+          runs_on: 'ubuntu-latest'
+          arch: 'aarch64'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,8 @@
         "riscv64imac-unknown-none-elf",
         "--target",
         "loongarch64-unknown-none-softfloat",
+        "--target",
+        "aarch64-unknown-none-softfloat",
         "-Zbuild-std=core,alloc,compiler_builtins",
         "-Zbuild-std-features=compiler-builtins-mem"
     ],

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,8 @@ ifeq ($(SCHEME), "")
 	SCHEME = riscv
 	else ifeq ($(TARGET_ARCH), loongarch64)
 	SCHEME = loongarch
+	else ifeq ($(TARGET_ARCH), aarch64)
+	SCHEME = aarch64
 	endif
 endif
 

--- a/OSDK.toml
+++ b/OSDK.toml
@@ -89,3 +89,9 @@ qemu.args = """\
     -device virtconsole,chardev=mux \
     -rtc base=utc
 """
+
+[scheme."aarch64"]
+supported_archs = ["aarch64"]
+boot.method = "qemu-direct"
+build.strip_elf = false
+qemu.args = "$(./tools/qemu_args.sh aarch64)"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://github.com/user-attachments/assets/eabf8674-8503-44f7-abcc-52395d2ca4a3
 
 <p align="center">
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86.yml/badge.svg?event=push" alt="Test x86-64" style="max-width: 100%;"></a>
+    <a href="https://github.com/asterinas/asterinas/actions/workflows/test_aarch64.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_aarch64.yml/badge.svg?event=push" alt="Test aarch64" style="max-width: 100%;"></a>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_riscv.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_riscv.yml/badge.svg?event=push" alt="Test riscv64" style="max-width: 100%;"></a>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_loongarch.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_loongarch.yml/badge.svg?event=push" alt="Test loongarch64" style="max-width: 100%;"></a>
     <a href="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml"><img src="https://github.com/asterinas/asterinas/actions/workflows/test_x86_tdx.yml/badge.svg" alt="Test Intel TDX" style="max-width: 100%;"></a>
@@ -117,6 +118,7 @@ that Asterinas can run on as an OS kernel.
 | x86-64              | Tier 1 |
 | x86-64 (Intel TDX)  | Tier 2 |
 | RISC-V 64           | Tier 2 |
+| ARM 64              | Tier 3 |
 | LoongArch 64        | Tier 3 |
 
 Tier definitions:

--- a/book/src/kernel/README.md
+++ b/book/src/kernel/README.md
@@ -46,6 +46,7 @@ that Asterinas can run on as an OS kernel.
 | x86-64              | Tier 1 |
 | x86-64 (Intel TDX)  | Tier 2 |
 | RISC-V 64           | Tier 2 |
+| ARM 64              | Tier 3 |
 | LoongArch 64        | Tier 3 |
 
 Tier definitions:

--- a/book/src/kernel/linux-compatibility/README.md
+++ b/book/src/kernel/linux-compatibility/README.md
@@ -367,7 +367,7 @@ which are summarized in the table below.
     - N/A = not applicable (e.g., syscall not supported)
 
 Most of these system calls (or their variants) are also supported
-for the RISC-V and LoongArch architectures.
+for the ARM, RISC-V, and LoongArch architectures.
 
 ## File systems
 

--- a/kernel/comps/uart/src/arch/arm/mod.rs
+++ b/kernel/comps/uart/src/arch/arm/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(super) fn init() {
+    // TODO: Add UART support in ARM.
+}

--- a/kernel/comps/uart/src/arch/arm/mod.rs
+++ b/kernel/comps/uart/src/arch/arm/mod.rs
@@ -1,5 +1,55 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use ostd::{
+    arch::serial::{Pl011Uart, SERIAL_PORT},
+    sync::{LocalIrqDisabled, SpinLock},
+};
+
+use crate::{
+    alloc::string::ToString,
+    console::{Uart, UartConsole},
+};
+
 pub(super) fn init() {
-    // TODO: Add UART support in ARM.
+    let Some(uart) = SERIAL_PORT.get() else {
+        return;
+    };
+
+    let uart_console = UartConsole::new(uart);
+
+    aster_console::register_device(
+        aster_console::UART_CONSOLE_NAME.to_string(),
+        uart_console.clone(),
+    );
+
+    // TODO: Set up the IRQ line and handle the received data.
+    // Suppress the dead code warnings of the related methods.
+    let _ = || uart_console.trigger_input_callbacks();
+    let _ = || uart.flush();
+
+    ostd::info!("Registered PL011 as a console");
+}
+
+impl Uart for &'static SpinLock<Pl011Uart, LocalIrqDisabled> {
+    fn send(&self, buf: &[u8]) {
+        let mut uart = self.lock();
+
+        for byte in buf {
+            // TODO: This is termios-specific behavior and should be part of the TTY implementation
+            // instead of the serial console implementation. See the ONLCR flag for more details.
+            if *byte == b'\n' {
+                uart.send(b'\r');
+            }
+            uart.send(*byte);
+        }
+    }
+
+    fn recv(&self, _buf: &mut [u8]) -> usize {
+        // TODO: Set up the IRQ line and handle the received data.
+        0
+    }
+
+    fn flush(&self) {
+        // TODO: Set up the IRQ line and flush the received data.
+    }
 }

--- a/kernel/comps/uart/src/lib.rs
+++ b/kernel/comps/uart/src/lib.rs
@@ -19,6 +19,7 @@ macro_rules! __log_prefix {
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86/mod.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv/mod.rs")]
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch/mod.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "arch/arm/mod.rs")]
 mod arch;
 
 mod console;

--- a/kernel/core/comps/pci/src/arch/arm/mod.rs
+++ b/kernel/core/comps/pci/src/arch/arm/mod.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! PCI bus access
+
+use core::ops::RangeInclusive;
+
+use ostd::Error;
+
+use crate::PciDeviceLocation;
+
+pub(crate) fn write32(
+    _location: &PciDeviceLocation,
+    _offset: u32,
+    _value: u32,
+) -> Result<(), Error> {
+    Err(Error::IoError)
+}
+
+pub(crate) fn read32(_location: &PciDeviceLocation, _offset: u32) -> Result<u32, Error> {
+    Err(Error::IoError)
+}
+
+/// Initializes the platform-specific module for accessing the PCI configuration space.
+///
+/// Returns a range for the PCI bus number, or [`None`] if there is no PCI bus.
+pub(crate) fn init() -> Option<RangeInclusive<u8>> {
+    // TODO: Support the PCI bus in ARM.
+    None
+}
+
+pub(crate) const MSIX_DEFAULT_MSG_ADDR: u32 = 0x2400_0000;
+
+pub(crate) fn construct_remappable_msix_address(_remapping_index: u32) -> u32 {
+    unimplemented!()
+}

--- a/kernel/core/comps/pci/src/lib.rs
+++ b/kernel/core/comps/pci/src/lib.rs
@@ -65,6 +65,7 @@ macro_rules! __log_prefix {
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86/mod.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv/mod.rs")]
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch/mod.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "arch/arm/mod.rs")]
 mod arch;
 
 pub mod bus;

--- a/kernel/core/comps/time/src/rtc/mod.rs
+++ b/kernel/core/comps/time/src/rtc/mod.rs
@@ -8,6 +8,7 @@ use crate::SystemTime;
 pub trait Driver {
     /// Creates a RTC driver.
     /// Returns [`Some<Self>`] on success, [`None`] otherwise (e.g. platform unsupported).
+    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     fn try_new() -> Option<Self>
     where
         Self: Sized;

--- a/kernel/core/comps/virtio/src/transport/mmio/bus/arch/arm.rs
+++ b/kernel/core/comps/virtio/src/transport/mmio/bus/arch/arm.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// TODO: Add `MappedIrqLine` support for ARM.
+pub(super) use ostd::irq::IrqLine as MappedIrqLine;
+
+pub(super) fn probe_for_device() {
+    // TODO: Probe virtio devices on the MMIO bus in ARM.
+    // Then, register them by calling `super::try_register_mmio_device`.
+}

--- a/kernel/core/comps/virtio/src/transport/mmio/bus/mod.rs
+++ b/kernel/core/comps/virtio/src/transport/mmio/bus/mod.rs
@@ -14,6 +14,7 @@ use crate::transport::mmio::bus::common_device::{
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv.rs")]
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "arch/arm.rs")]
 mod arch;
 
 #[expect(clippy::module_inception)]
@@ -42,7 +43,10 @@ pub(super) fn init() {
 ///
 /// Returns `Ok(())` if the device was registered, or a specific
 /// `MmioRegisterError` otherwise.
-#[cfg_attr(target_arch = "loongarch64", expect(unused))]
+#[cfg_attr(
+    any(target_arch = "loongarch64", target_arch = "aarch64"),
+    expect(unused)
+)]
 fn try_register_mmio_device<F>(
     mmio_range: Range<usize>,
     map_irq_line: F,

--- a/kernel/core/src/arch/arm/cpu.rs
+++ b/kernel/core/src/arch/arm/cpu.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::fmt;
+
+use ostd::{
+    arch::cpu::context::UserContext, cpu::PinCurrentCpu, task::DisabledPreemptGuard,
+    user::UserContextApi,
+};
+
+use crate::cpu::LinuxAbi;
+
+impl LinuxAbi for UserContext {
+    fn syscall_num(&self) -> usize {
+        self.x8()
+    }
+
+    fn syscall_ret(&self) -> usize {
+        self.x0()
+    }
+
+    fn set_syscall_ret(&mut self, ret: usize) {
+        self.set_x0(ret)
+    }
+
+    fn syscall_args(&self) -> [usize; 6] {
+        [
+            self.x0(),
+            self.x1(),
+            self.x2(),
+            self.x3(),
+            self.x4(),
+            self.x5(),
+        ]
+    }
+}
+
+macro_rules! copy_gp_regs {
+    ($regs: ident) => {
+        copy_reg!(0, x0, $regs);
+        copy_reg!(1, x1, $regs);
+        copy_reg!(2, x2, $regs);
+        copy_reg!(3, x3, $regs);
+        copy_reg!(4, x4, $regs);
+        copy_reg!(5, x5, $regs);
+        copy_reg!(6, x6, $regs);
+        copy_reg!(7, x7, $regs);
+        copy_reg!(8, x8, $regs);
+        copy_reg!(9, x9, $regs);
+        copy_reg!(10, x10, $regs);
+        copy_reg!(11, x11, $regs);
+        copy_reg!(12, x12, $regs);
+        copy_reg!(13, x13, $regs);
+        copy_reg!(14, x14, $regs);
+        copy_reg!(15, x15, $regs);
+        copy_reg!(16, x16, $regs);
+        copy_reg!(17, x17, $regs);
+        copy_reg!(18, x18, $regs);
+        copy_reg!(19, x19, $regs);
+        copy_reg!(20, x20, $regs);
+        copy_reg!(21, x21, $regs);
+        copy_reg!(22, x22, $regs);
+        copy_reg!(23, x23, $regs);
+        copy_reg!(24, x24, $regs);
+        copy_reg!(25, x25, $regs);
+        copy_reg!(26, x26, $regs);
+        copy_reg!(27, x27, $regs);
+        copy_reg!(28, x28, $regs);
+        copy_reg!(29, x29, $regs);
+        copy_reg!(30, x30, $regs);
+    };
+}
+
+/// Represents the context of a signal handler.
+///
+/// This contains the context saved before a signal handler is invoked; it will be restored by
+/// `sys_rt_sigreturn`.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/arm64/include/uapi/asm/sigcontext.h#L28>
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(crate) struct SigContext {
+    fault_address: u64,
+    regs: [u64; 31],
+    sp: u64,
+    pc: u64,
+    pstate: u64,
+    _pad: u64,
+    // In ARM, the signal stack layout places the FPU context directly
+    // after the general-purpose registers.
+}
+
+impl SigContext {
+    pub(crate) fn copy_user_regs_to(&self, dst: &mut UserContext) {
+        macro_rules! copy_reg {
+            ($idx: literal, $name: ident, $regs: ident) => {
+                $regs.$name = self.regs[$idx] as usize;
+            };
+        }
+
+        let gp_regs = dst.general_regs_mut();
+        copy_gp_regs!(gp_regs);
+        dst.set_stack_pointer(self.sp as usize);
+        dst.set_instruction_pointer(self.pc as usize);
+        dst.set_process_state(self.pstate as usize);
+    }
+
+    pub(crate) fn copy_user_regs_from(&mut self, src: &UserContext) {
+        macro_rules! copy_reg {
+            ($idx:literal, $name:ident, $regs: ident) => {
+                self.regs[$idx] = $regs.$name as u64;
+            };
+        }
+
+        let gp_regs = src.general_regs();
+        copy_gp_regs!(gp_regs);
+        self.sp = src.stack_pointer() as u64;
+        self.pc = src.instruction_pointer() as u64;
+        self.pstate = src.process_state() as u64;
+    }
+}
+
+/// CPU information to be shown in `/proc/cpuinfo`.
+///
+/// Different CPUs may have different information, such as the core ID. Therefore, [`Self::new`]
+/// should be called on every CPU.
+//
+// TODO: Implement CPU information retrieval on ARM platforms.
+pub(crate) struct CpuInformation {
+    processor: u32,
+}
+
+impl CpuInformation {
+    /// Constructs the information for the current CPU.
+    pub(crate) fn new(guard: &DisabledPreemptGuard) -> Self {
+        Self {
+            processor: guard.current_cpu().into(),
+        }
+    }
+}
+
+impl fmt::Display for CpuInformation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "processor\t: {}", self.processor)
+    }
+}

--- a/kernel/core/src/arch/arm/cpu.rs
+++ b/kernel/core/src/arch/arm/cpu.rs
@@ -3,11 +3,16 @@
 use core::fmt;
 
 use ostd::{
-    arch::cpu::context::UserContext, cpu::PinCurrentCpu, task::DisabledPreemptGuard,
+    arch::cpu::context::{CpuException, UserContext},
+    cpu::PinCurrentCpu,
+    task::DisabledPreemptGuard,
     user::UserContextApi,
 };
 
-use crate::cpu::LinuxAbi;
+use crate::{
+    cpu::LinuxAbi,
+    vm::{perms::VmPerms, vmar::PageFaultInfo},
+};
 
 impl LinuxAbi for UserContext {
     fn syscall_num(&self) -> usize {
@@ -117,6 +122,28 @@ impl SigContext {
         self.sp = src.stack_pointer() as u64;
         self.pc = src.instruction_pointer() as u64;
         self.pstate = src.process_state() as u64;
+    }
+}
+
+impl TryFrom<&CpuException> for PageFaultInfo {
+    // [`Err`] indicates that the [`CpuException`] is not a page fault, with no
+    // additional error information.
+    type Error = ();
+
+    fn try_from(value: &CpuException) -> Result<Self, ()> {
+        let (addr, required_perms) = match value {
+            CpuException::InstructionAbort { address } => (address, VmPerms::READ | VmPerms::EXEC),
+            CpuException::DataAbort { is_write, address } => (
+                address,
+                if *is_write {
+                    VmPerms::READ | VmPerms::WRITE
+                } else {
+                    VmPerms::READ
+                },
+            ),
+            _ => return Err(()),
+        };
+        Ok(PageFaultInfo::new(*addr, required_perms))
     }
 }
 

--- a/kernel/core/src/arch/arm/mod.rs
+++ b/kernel/core/src/arch/arm/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) mod cpu;
+pub(crate) mod signal;
+
+pub(crate) fn init() {}

--- a/kernel/core/src/arch/arm/signal.rs
+++ b/kernel/core/src/arch/arm/signal.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use ostd::arch::cpu::context::UserContext;
+
+use crate::process::signal::{SignalContext, sig_num::SigNum};
+
+impl SignalContext for UserContext {
+    fn set_arguments(&mut self, sig_num: SigNum, siginfo_addr: usize, ucontext_addr: usize) {
+        self.set_x0(sig_num.as_u8() as usize);
+        self.set_x1(siginfo_addr);
+        self.set_x2(ucontext_addr);
+    }
+}

--- a/kernel/core/src/arch/arm/signal.rs
+++ b/kernel/core/src/arch/arm/signal.rs
@@ -1,13 +1,59 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use ostd::arch::cpu::context::UserContext;
+use ostd::{
+    arch::cpu::context::{CpuException, UserContext},
+    user::UserContextApi,
+};
 
-use crate::process::signal::{SignalContext, sig_num::SigNum};
+use crate::{
+    process::signal::{SignalContext, sig_num::SigNum, signals::fault::FaultSignal},
+    thread::exception::ToFaultSignal,
+};
 
 impl SignalContext for UserContext {
     fn set_arguments(&mut self, sig_num: SigNum, siginfo_addr: usize, ucontext_addr: usize) {
         self.set_x0(sig_num.as_u8() as usize);
         self.set_x1(siginfo_addr);
         self.set_x2(ucontext_addr);
+    }
+}
+
+impl ToFaultSignal for CpuException {
+    fn to_fault_signal(&self, user_ctx: &UserContext) -> Option<FaultSignal> {
+        use crate::process::signal::constants::*;
+
+        let elr = user_ctx.instruction_pointer() as u64;
+
+        let (num, code, addr) = match self {
+            CpuException::Unknown
+            | CpuException::WfiInstruction
+            | CpuException::FpuInstruction
+            | CpuException::IllegalState
+            | CpuException::SystemInstruction => (SIGILL, ILL_ILLOPC, Some(elr)),
+            CpuException::InstructionAbort { address }
+            | CpuException::DataAbort { address, .. } => {
+                // FIXME: Derive the signal number and code from the error code.
+                // See <https://elixir.bootlin.com/linux/v7.0/source/arch/arm64/mm/fault.c#L861>.
+                (SIGSEGV, SEGV_MAPERR, Some(*address as u64))
+            }
+            CpuException::PcAlignmentFault => (SIGBUS, BUS_ADRALN, Some(elr)),
+            CpuException::SpAlignmentFault => {
+                (SIGBUS, BUS_ADRALN, Some(user_ctx.stack_pointer() as u64))
+            }
+            CpuException::FpuException => {
+                // TODO: Derive the code from the floating-point status.
+                (SIGFPE, FPE_FLTDIV, Some(elr))
+            }
+            CpuException::SoftwareStep => (SIGTRAP, TRAP_TRACE, Some(elr)),
+            CpuException::BrkInstruction => (SIGTRAP, TRAP_BRKPT, Some(elr)),
+
+            CpuException::Breakpoint | CpuException::Watchpoint => {
+                // TODO: Properly handle these exceptions once hardware debugging is supported.
+                return None;
+            }
+            CpuException::SvcInstruction | CpuException::SErrorInterrupt => return None,
+        };
+
+        Some(FaultSignal::new(num, code, addr))
     }
 }

--- a/kernel/core/src/lib.rs
+++ b/kernel/core/src/lib.rs
@@ -38,6 +38,7 @@ macro_rules! __log_prefix {
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86/mod.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv/mod.rs")]
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch/mod.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "arch/arm/mod.rs")]
 mod arch;
 
 mod context;

--- a/kernel/core/src/process/program_loader/elf/elf_file.rs
+++ b/kernel/core/src/process/program_loader/elf/elf_file.rs
@@ -256,6 +256,8 @@ fn check_elf_header(elf_header: &ElfHeader) -> Result<()> {
     // Reference: <https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html#_e_machine_identifies_the_machine>
     #[cfg(target_arch = "loongarch64")]
     const EXPECTED_ELF_MACHINE: header::Machine = header::Machine::Other(258);
+    #[cfg(target_arch = "aarch64")]
+    const EXPECTED_ELF_MACHINE: header::Machine = header::Machine::AArch64;
 
     if elf_header.pt1.class() != header::Class::SixtyFour {
         return_errno_with_message!(Errno::ENOEXEC, "the ELF file is not 64-bit");

--- a/kernel/core/src/process/signal/c_types.rs
+++ b/kernel/core/src/process/signal/c_types.rs
@@ -206,7 +206,12 @@ pub(crate) struct ucontext_t {
 
 /// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/riscv/include/uapi/asm/ucontext.h>
 /// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/include/uapi/asm/ucontext.h>
-#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
+/// Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/arm64/include/uapi/asm/ucontext.h>
+#[cfg(any(
+    target_arch = "riscv64",
+    target_arch = "loongarch64",
+    target_arch = "aarch64"
+))]
 #[padding_struct]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod)]
@@ -224,7 +229,11 @@ pub(crate) struct ucontext_t {
 // derive the `Default` implementation once that is done.
 //
 // See <https://github.com/rust-lang/rust/issues/61415>.
-#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
+#[cfg(any(
+    target_arch = "riscv64",
+    target_arch = "loongarch64",
+    target_arch = "aarch64"
+))]
 impl Default for ucontext_t {
     fn default() -> Self {
         Self {

--- a/kernel/core/src/process/signal/mod.rs
+++ b/kernel/core/src/process/signal/mod.rs
@@ -151,6 +151,8 @@ pub(crate) fn handle_pending_signal(user_ctx: &mut UserContext, ctx: &Context) {
                 const SYSCALL_INSTR_LEN: usize = 4; // ecall
                 #[cfg(target_arch = "loongarch64")]
                 const SYSCALL_INSTR_LEN: usize = 4; // syscall
+                #[cfg(target_arch = "aarch64")]
+                const SYSCALL_INSTR_LEN: usize = 4; // svc
 
                 user_ctx.set_syscall_ret(orig_syscall_ret);
                 user_ctx
@@ -398,16 +400,16 @@ pub(crate) fn handle_user_signal(
             );
             let fpu_context_addr = (ucontext_addr as usize) + size_of::<ucontext_t>();
         }
-        target_arch = "loongarch64" => {
-            // FIXME: It seems that we need to allocate an `sctx_info` structure.
-            // Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/kernel/signal.c#L848>
+        any(target_arch = "loongarch64", target_arch = "aarch64") => {
+            // FIXME: Allocate the FPU context.
+            // Example: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/kernel/signal.c#L848>
             let ucontext_addr = alloc_aligned_in_user_stack(
                 stack_pointer,
                 size_of::<ucontext_t>() + fpu_context_bytes.len(),
                 align_of::<ucontext_t>(),
             );
-            // TODO: Set the flags in the context structure.
-            // Reference: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/kernel/signal.c#L805>
+            // FIXME: Set the FPU flags
+            // Example: <https://elixir.bootlin.com/linux/v6.15.7/source/arch/loongarch/kernel/signal.c#L805>
             let fpu_context_addr = (ucontext_addr as usize) + size_of::<ucontext_t>();
         }
         _ => {
@@ -446,6 +448,9 @@ pub(crate) fn handle_user_signal(
         }
         any(target_arch = "riscv64", target_arch = "loongarch64") => {
             user_ctx.set_ra(retaddr);
+        }
+        target_arch = "aarch64" => {
+            user_ctx.set_x30(retaddr);
         }
         _ => {
             compile_error!("unsupported target");

--- a/kernel/core/src/syscall/arch/arm.rs
+++ b/kernel/core/src/syscall/arch/arm.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! System call dispatch in the ARM architecture.
+
+#[path = "./generic.rs"]
+mod generic;
+
+generic::define_syscalls_with_generic_syscall_table! {
+    // TODO: Add ARM specific syscalls here.
+}

--- a/kernel/core/src/syscall/mod.rs
+++ b/kernel/core/src/syscall/mod.rs
@@ -3,7 +3,11 @@
 //! System call handlers.
 
 #![cfg_attr(
-    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    any(
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "aarch64"
+    ),
     expect(dead_code)
 )]
 
@@ -16,6 +20,7 @@ use crate::{cpu::LinuxAbi, prelude::*};
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv.rs")]
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "arch/arm.rs")]
 mod arch;
 
 mod accept;

--- a/kernel/core/src/syscall/rt_sigreturn.rs
+++ b/kernel/core/src/syscall/rt_sigreturn.rs
@@ -35,9 +35,9 @@ pub(super) fn sys_rt_sigreturn(ctx: &Context, user_ctx: &mut UserContext) -> Res
     // Restore the FPU context.
     let fpu_context_addr = cfg_select! {
         target_arch = "x86_64" => ucontext.uc_mcontext.fpu_context_addr(),
-        any(target_arch = "riscv64", target_arch = "loongarch64") => {
-            // In RISC-V/LoongArch64, the FPU context is placed directly after `ucontext_t` on the
-            // signal stack.
+        any(target_arch = "riscv64", target_arch = "loongarch64", target_arch = "aarch64") => {
+            // In RISC-V/LoongArch64/ARM, the FPU context is placed directly after `ucontext_t` on
+            // the signal stack.
             sig_context_addr + size_of::<ucontext_t>()
         }
         _ => compile_error!("unsupported target"),

--- a/osdk/src/base_crate/aarch64.ld.template
+++ b/osdk/src/base_crate/aarch64.ld.template
@@ -103,4 +103,5 @@ SECTIONS
     }
 
     __kernel_end = .;
+    __kernel_size = . - __kernel_start;
 }

--- a/osdk/src/base_crate/aarch64.ld.template
+++ b/osdk/src/base_crate/aarch64.ld.template
@@ -1,0 +1,106 @@
+ENTRY(_start)
+OUTPUT_ARCH(aarch64)
+
+KERNEL_LMA = 0x40200000;
+KERNEL_VMA = 0xffffffff40200000;
+KERNEL_VMA_OFFSET = KERNEL_VMA - KERNEL_LMA;
+
+SECTIONS
+{
+    # First, we use physical addresses for the boot sections.
+    . = KERNEL_LMA;
+
+    __kernel_start = . + KERNEL_VMA_OFFSET;
+
+    PROVIDE(__executable_start = __kernel_start);
+
+    .boot                   : AT(ADDR(.boot)) {
+        KEEP(*(.boot))
+        # FIXME: We want to create a separate .boot.stack section so that the
+        # executable doesn't contain the boot stack (which is just hundreds of
+        # kilobytes of zeros). But it is currently in the .boot section because
+        # the linker will otherwise complain unexpected relocation failures.
+        KEEP(*(.boot.stack))
+        . = ALIGN(4096);
+    }
+
+    .ap_boot                : AT(LOADADDR(.boot) + SIZEOF(.boot)) {
+        KEEP(*(.ap_boot))
+        . = ALIGN(4096);
+    }
+
+    # Then, we switch to virtual addresses for all the other sections.
+    . += KERNEL_VMA_OFFSET;
+
+    .text                   : AT(ADDR(.text) - KERNEL_VMA_OFFSET) {
+        *(.text .text.*)
+        PROVIDE(__etext = .);
+    }
+
+    # The section to store exception table (ExTable).
+    # This table is used for recovering from specific exception handling faults
+    # occurring at known points in the code.
+    # Ref: /ostd/src/ex_table.rs
+    .ex_table               : AT(ADDR(.ex_table) - KERNEL_VMA_OFFSET) {
+        __ex_table = .;
+        KEEP(*(SORT(.ex_table)))
+        __ex_table_end = .;
+    }
+
+    .rodata                 : AT(ADDR(.rodata) - KERNEL_VMA_OFFSET) {
+        *(.rodata .rodata.*)
+    }
+
+    .eh_frame_hdr           : AT(ADDR(.eh_frame_hdr) - KERNEL_VMA_OFFSET) {
+        PROVIDE(__GNU_EH_FRAME_HDR = .);
+        KEEP(*(.eh_frame_hdr .eh_frame_hdr.*))
+    }
+    . = ALIGN(8);
+    .eh_frame               : AT(ADDR(.eh_frame) - KERNEL_VMA_OFFSET) {
+        PROVIDE(__eh_frame = .);
+        KEEP(*(.eh_frame .eh_frame.*))
+    }
+
+    # The list of unit test function symbols that should be executed while
+    # doing `cargo osdk test`.
+    .ktest_array            : AT(ADDR(.ktest_array) - KERNEL_VMA_OFFSET) {
+        __ktest_array = .;
+        KEEP(*(SORT(.ktest_array)))
+        __ktest_array_end = .;
+    }
+
+    .init_array             : AT(ADDR(.init_array) - KERNEL_VMA_OFFSET) {
+        __sinit_array = .;
+        KEEP(*(SORT(.init_array .init_array.*)))
+        __einit_array = .;
+    }
+
+    # A list of the sensitive IoPort ranges in OSTD which will be used during
+    # the initialization of IoPortAllocator.
+    .sensitive_io_ports     : AT(ADDR(.sensitive_io_ports) - KERNEL_VMA_OFFSET) {
+        __sensitive_io_ports_start = .;
+        KEEP(*(.sensitive_io_ports))
+        __sensitive_io_ports_end = .;
+    }
+
+    .data                   : AT(ADDR(.data) - KERNEL_VMA_OFFSET) {
+        *(.data .data.*)
+    }
+
+    # The CPU local data storage. It is readable and writable for the bootstrap
+    # processor, while it would be copied to other dynamically allocated memory
+    # areas for the application processors.
+    .cpu_local              : AT(ADDR(.cpu_local) - KERNEL_VMA_OFFSET) {
+        __cpu_local_start = .;
+        KEEP(*(SORT(.cpu_local)))
+        __cpu_local_end = .;
+    }
+
+    .bss                    : AT(ADDR(.bss) - KERNEL_VMA_OFFSET) {
+        __bss = .;
+        *(.bss .bss.*)
+        __bss_end = .;
+    }
+
+    __kernel_end = .;
+}

--- a/osdk/src/base_crate/mod.rs
+++ b/osdk/src/base_crate/mod.rs
@@ -16,6 +16,7 @@ const LINKER_SCRIPTS: &[(&str, &str)] = &[
     ("x86_64.ld", include_str!("x86_64.ld.template")),
     ("riscv64.ld", include_str!("riscv64.ld.template")),
     ("loongarch64.ld", include_str!("loongarch64.ld.template")),
+    ("aarch64.ld", include_str!("aarch64.ld.template")),
 ];
 
 /// Compares two files byte-by-byte to check if they are identical.
@@ -180,8 +181,7 @@ fn do_new_base_crate(
     let original_dir = std::env::current_dir().unwrap();
     std::env::set_current_dir(&base_crate_path).unwrap();
 
-    // TODO: currently just x86_64 works; add support for other architectures
-    // here when OSTD is ready
+    // Add linker script files
     for (file_name, contents) in LINKER_SCRIPTS {
         fs::write(base_crate_path.as_ref().join(file_name), contents).unwrap();
     }

--- a/osdk/src/commands/build/bin.rs
+++ b/osdk/src/commands/build/bin.rs
@@ -155,6 +155,56 @@ pub fn make_elf_for_qemu(elf: AsterBin) -> AsterBin {
     elf
 }
 
+pub fn make_aarch64_image(install_path: impl AsRef<Path>, aster_elf: &AsterBin) -> AsterBin {
+    let result_elf_path = {
+        let full_elf_name = aster_elf.path().file_name().unwrap().to_str().unwrap();
+        let elf_name = full_elf_name
+            .strip_suffix(".qemu_elf")
+            .unwrap_or(full_elf_name);
+        install_path
+            .as_ref()
+            .join(elf_name.to_string() + ".qemu_bin")
+    };
+
+    // QEMU treats ELF kernels as non-Linux [1], where the initrd will not be loaded [2] and the
+    // device tree address will not be passed [3]. Therefore, we remove the ELF information and use
+    // the Linux AArch64 boot protocol [4] to boot the raw image instead.
+    //
+    // [1]: https://github.com/qemu/qemu/blob/499039798cdad7d86b787fec0eaf1da4151c0f05/hw/arm/boot.c#L920
+    // [2]: https://github.com/qemu/qemu/blob/499039798cdad7d86b787fec0eaf1da4151c0f05/hw/arm/boot.c#L1010
+    // [3]: https://github.com/qemu/qemu/blob/499039798cdad7d86b787fec0eaf1da4151c0f05/hw/arm/boot.c#L1091
+    // [4]: https://docs.kernel.org/arch/arm64/booting.html
+    let status = new_command_checked_exists("rust-objcopy")
+        .arg("-O")
+        .arg("binary")
+        .arg(aster_elf.path())
+        .arg(result_elf_path.as_os_str())
+        .status();
+
+    match status {
+        Ok(status) => {
+            if !status.success() {
+                panic!("Failed to generate AArch64 Image");
+            }
+        }
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => panic!(
+                "`rust-objcopy` command not found. Please
+                    try `cargo install cargo-binutils` and then rerun."
+            ),
+            _ => panic!("Generate AArch64 Image failed, error: {:#?}", err),
+        },
+    }
+
+    AsterBin::new(
+        &result_elf_path,
+        aster_elf.arch(),
+        aster_elf.typ().clone(),
+        aster_elf.version().clone(),
+        aster_elf.stripped(),
+    )
+}
+
 fn install_setup_with_arch(
     install_dir: impl AsRef<Path>,
     target_dir: impl AsRef<Path>,

--- a/osdk/src/commands/build/mod.rs
+++ b/osdk/src/commands/build/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::SystemTime,
 };
 
-use bin::{make_elf_for_qemu, make_install_bzimage, make_stripped_boot_elf};
+use bin::{make_aarch64_image, make_elf_for_qemu, make_install_bzimage, make_stripped_boot_elf};
 
 use super::util::{COMMON_CARGO_ARGS, DEFAULT_TARGET_RELPATH, cargo, profile_name_adapter};
 use crate::{
@@ -185,15 +185,18 @@ pub fn do_cached_build(
             bundle.consume_aster_bin(aster_elf);
         }
         BootMethod::QemuDirect => {
-            let aster_bin = match grub.boot_protocol {
-                BootProtocol::Linux => make_install_bzimage(
+            let aster_bin = if config.target_arch == Arch::Aarch64 {
+                make_aarch64_image(&osdk_output_directory, &boot_elf)
+            } else if grub.boot_protocol == BootProtocol::Linux {
+                make_install_bzimage(
                     &osdk_output_directory,
                     &osdk_output_directory,
                     &boot_elf,
                     build.linux_x86_legacy_boot,
                     config.build.encoding.clone(),
-                ),
-                _ => make_elf_for_qemu(boot_elf),
+                )
+            } else {
+                make_elf_for_qemu(boot_elf)
             };
             bundle.consume_aster_bin(aster_bin);
         }

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -17,7 +17,6 @@ targets = ["x86_64-unknown-none"]
 
 [dependencies]
 align_ext.workspace = true
-bit_field.workspace = true
 bitflags.workspace = true
 bitvec.workspace = true
 gimli.workspace = true
@@ -44,6 +43,7 @@ zerocopy.workspace = true
 
 [target.x86_64-unknown-none.dependencies]
 acpi.workspace = true
+bit_field.workspace = true
 int-to-c-enum.workspace = true
 linux-boot-params.workspace = true
 multiboot2.workspace = true
@@ -54,6 +54,7 @@ x86.workspace = true
 x86_64.workspace = true
 
 [target.riscv64imac-unknown-none-elf.dependencies]
+bit_field.workspace = true
 fdt.workspace = true
 riscv.workspace = true
 sbi-rt.workspace = true
@@ -63,6 +64,10 @@ unwinding = { workspace = true, features = ["fde-static"] }
 fdt.workspace = true
 loongArch64.workspace = true
 unwinding = { workspace = true, features = ["fde-gnu-eh-frame-hdr"] }
+
+[target.aarch64-unknown-none-softfloat.dependencies]
+fdt.workspace = true
+unwinding = { workspace = true, features = ["fde-static"] }
 
 [features]
 default = ["cvm_guest"]

--- a/ostd/src/arch/arm/boot/bsp_boot.S
+++ b/ostd/src/arch/arm/boot/bsp_boot.S
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+// The boot routine executed by the bootstrap processor (BSP) on ARM.
+
+KERNEL_VMA             = 0xffffffff00000000
+
+# Translation Control Register (TCR)
+#
+# Bits separated for:    [  TTBR1  ]   [  TTBR0  ]
+TCR_TG_4K              = ( 2 << 30 ) | ( 0 << 14 )  // Page size: 4 KiB
+TCR_SH_INNER           = ( 3 << 28 ) | ( 3 << 12 )  // Shareability: Inner sharable
+TCR_ORGN_WBWA          = ( 1 << 26 ) | ( 1 << 10 )  // Outer cacheability: Write-back write-allocate
+TCR_IRGN_WBWA          = ( 1 << 24 ) | ( 1 <<  8 )  // Inner cacheability: Write-back write-allocate
+TCR_TSZ_48             = (16 << 16 ) | (16 <<  0 )  // Virtual address width: 48 bits
+# Bits for both tables:
+TCR_IPS_48             =   5 << 32                  // Physical address width: 48 bits
+
+# Memory Attribute Indirection Register (MAIR)
+MAIR_0WBWA             = (0xFF << 0)  // Attr0: Normal memory, write-back, write-allocate
+MAIR_1DEVICE           = (0x00 << 8)  // Attr1: Device-nGnRnE memory
+
+# System Control Register (SCTLR)
+SCTLR_I                = 1 << 12      // Instruction access cacheability: Cacheable
+SCTLR_C                = 1 <<  2      // Data access cacheability: Cacheable
+SCTLR_M                = 1 <<  0      // MMU state: Enabled
+
+# PTE flags
+PTE_VALID              = 1 <<  0      // Valid
+PTE_NON_HUGE           = 1 <<  1      // Non-huge: Middle-level non-leaf or last-level leaf
+PTE_SH_INNER           = 3 <<  8      // Shareability: Inner sharable
+PTE_ACCESS             = 1 << 10      // Access: Accessed
+
+# PTE size
+PTE_SIZE               = 8
+
+.section ".boot", "awx", @progbits
+
+# `_start` is also the entrypoint specified in the linker script.
+.global _start
+_start:
+    # Set up translation control.
+    ldr     x4, =(TCR_TG_4K | TCR_SH_INNER | TCR_ORGN_WBWA | TCR_IRGN_WBWA | TCR_TSZ_48 | TCR_IPS_48)
+    msr     tcr_el1, x4
+
+    # Set up memory attributes.
+    mov     x4, #(MAIR_0WBWA | MAIR_1DEVICE)
+    msr     mair_el1, x4
+
+    # Load translation tables.
+    ldr     x4, =boot_l4pt
+    msr     ttbr0_el1, x4
+    msr     ttbr1_el1, x4
+
+    # Synchronize the new translation context.
+    isb
+
+    # Flush TLBs before enabling MMU.
+    tlbi    vmalle1
+    dsb     nsh
+
+    # Enable MMU and cache.
+    mov     x4, #(SCTLR_I | SCTLR_C | SCTLR_M)
+    msr     sctlr_el1, x4
+    isb
+
+    # Update SP/PC to use the virtual address.
+    ldr     x4, =(boot_stack_top + KERNEL_VMA)
+    mov     sp, x4
+    ldr     x4, =_start_virt
+    br      x4
+
+.balign 4096
+boot_l4pt:
+    .quad boot_l3pt_linear_id + PTE_VALID + PTE_NON_HUGE  // identity
+    .zero 255 * PTE_SIZE
+    .quad boot_l3pt_linear_id + PTE_VALID + PTE_NON_HUGE  // linear
+    .zero 254 * PTE_SIZE
+    .quad boot_l3pt_kernel    + PTE_VALID + PTE_NON_HUGE  // code
+boot_l3pt_linear_id:  # 0xffff_8000_0000_0000 -> 0x0000_0000_0000_0000
+    .set i, 0
+    .rept 512  // linear 0~512 GiB
+        .quad (i << 30) | PTE_VALID | PTE_SH_INNER | PTE_ACCESS
+        .set i, i + 1
+    .endr
+boot_l3pt_kernel:  # 0xffff_ffff_0000_0000 -> 0x0000_0000_0000_0000
+    .zero 508 * PTE_SIZE
+    .quad (0 << 30) | PTE_VALID | PTE_SH_INNER | PTE_ACCESS  // code 0~1 GiB
+    .quad (1 << 30) | PTE_VALID | PTE_SH_INNER | PTE_ACCESS  // code 1~2 GiB
+    .quad (2 << 30) | PTE_VALID | PTE_SH_INNER | PTE_ACCESS  // code 2~3 GiB
+    .quad 0
+
+.section ".boot.stack", "awx", @nobits
+
+boot_stack_bottom:
+    .balign 4096
+    .skip 0x40000
+boot_stack_top:
+
+# From here, we no longer use physical address.
+
+.text
+
+_start_virt:
+    # Initialize TPIDR to the CPU-local storage's base address.
+.extern __cpu_local_start
+    ldr     x4, =__cpu_local_start
+    msr     tpidr_el1, x4
+
+    # Jump into Rust code.
+    b       arm_boot

--- a/ostd/src/arch/arm/boot/bsp_boot.S
+++ b/ostd/src/arch/arm/boot/bsp_boot.S
@@ -4,6 +4,13 @@
 
 KERNEL_VMA             = 0xffffffff00000000
 
+# The base address of the DRAM.
+#
+# This is necessary because the AArch64 Linux boot protocol only allows the
+# text offset to be specified relative to the DRAM base. We may want to figure
+# out a better way since this constant is likely specific to QEMU.
+DRAM_BASE              = 0x40000000
+
 # Translation Control Register (TCR)
 #
 # Bits separated for:    [  TTBR1  ]   [  TTBR0  ]
@@ -35,9 +42,49 @@ PTE_SIZE               = 8
 
 .section ".boot", "awx", @progbits
 
+# AArch64 Linux Boot Protocol
+# Reference: <https://www.kernel.org/doc/html/v7.1/arch/arm64/booting.html#call-the-kernel-image>
+_header:
+    bl      _start               // Executable code
+_header_4:
+    .long   0                    // Executable code
+    .quad   _header - DRAM_BASE  // Image load offset, little endian
+.extern __kernel_size
+    .quad   __kernel_size        // Effective image size, little endian
+    .quad   0b0010               // Kernel flags, little endian
+                                 //   Endianness: LE (Bit 0, value 0)
+                                 //   Page size: 4K (Bit 1-2, value 1)
+                                 //   Physical placement: close to the DRAM base (Bit 3, value 0)
+    .quad   0                    // Reserved
+    .quad   0                    // Reserved
+    .quad   0                    // Reserved
+    .long   0x644d5241           // Magic number, little endian, "ARM\x64"
+    .long   0                    // Reserved
+
 # `_start` is also the entrypoint specified in the linker script.
 .global _start
 _start:
+    # Arguments passed from the boot loader:
+    #   x0 = physical address of device tree blob (dtb) in system RAM
+    #   x1 = 0 (reserved for future use)
+    #   x2 = 0 (reserved for future use)
+    #   x3 = 0 (reserved for future use)
+    # We do not touch them here. They are passed to the Rust entrypoint `arm_boot`.
+
+    # Die if the kernel is loaded at a wrong address.
+    # We need to relocate, which is not supported.
+    ldr     x4, =_header_4
+    cmp     x4, x30
+die_load_address:
+    b.ne    die_load_address
+
+    # Die if the kernel is executed at a wrong exception level.
+    # We do not support exception levels other than EL1.
+    mrs     x4, currentel
+    cmp     x4, #(0b01 << 2)  // EL, bits [3:2]: 01 = EL1
+die_exception_level:
+    b.ne    die_exception_level
+
     # Set up translation control.
     ldr     x4, =(TCR_TG_4K | TCR_SH_INNER | TCR_ORGN_WBWA | TCR_IRGN_WBWA | TCR_TSZ_48 | TCR_IPS_48)
     msr     tcr_el1, x4

--- a/ostd/src/arch/arm/boot/mod.rs
+++ b/ostd/src/arch/arm/boot/mod.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The ARM boot module defines the entrypoints of Asterinas.
+
+pub(crate) mod smp;
+
+use core::arch::global_asm;
+
+use fdt::Fdt;
+use spin::Once;
+
+use crate::{
+    boot::{
+        BootloaderAcpiArg, BootloaderFramebufferArg,
+        memory_region::{MemoryRegion, MemoryRegionArray, MemoryRegionType},
+    },
+    mm::paddr_to_vaddr,
+};
+
+global_asm!(include_str!("bsp_boot.S"));
+
+/// The Flattened Device Tree of the platform.
+pub static DEVICE_TREE: Once<Fdt> = Once::new();
+
+fn parse_bootloader_name() -> &'static str {
+    "Unknown"
+}
+
+fn parse_kernel_commandline() -> &'static str {
+    DEVICE_TREE.get().unwrap().chosen().bootargs().unwrap_or("")
+}
+
+fn parse_initramfs() -> Option<&'static [u8]> {
+    let (start, end) = parse_initramfs_range()?;
+
+    let base_va = paddr_to_vaddr(start);
+    let length = end - start;
+    // SAFETY:
+    // 1. The initramfs is safe to read because of the contract with the loader.
+    // 2. We reserve the initramfs region in `parse_memory_regions`, so it will live as an immutable
+    //    reference for `'static`.
+    Some(unsafe { core::slice::from_raw_parts(base_va as *const u8, length) })
+}
+
+fn parse_acpi_arg() -> BootloaderAcpiArg {
+    // TDDO: Add ACPI support for ARM, maybe.
+    BootloaderAcpiArg::NotProvided
+}
+
+fn parse_framebuffer_info() -> Option<BootloaderFramebufferArg> {
+    // TODO: Parse framebuffer info from device tree.
+    None
+}
+
+fn parse_memory_regions(device_tree_paddr: usize) -> MemoryRegionArray {
+    let mut regions = MemoryRegionArray::new();
+
+    for region in DEVICE_TREE.get().unwrap().memory().regions() {
+        if region.size.unwrap_or(0) > 0 {
+            regions
+                .push(MemoryRegion::new(
+                    region.starting_address as usize,
+                    region.size.unwrap(),
+                    MemoryRegionType::Usable,
+                ))
+                .unwrap();
+        }
+    }
+
+    if let Some(node) = DEVICE_TREE.get().unwrap().find_node("/reserved-memory") {
+        for child in node.children() {
+            if let Some(reg_iter) = child.reg() {
+                for region in reg_iter {
+                    regions
+                        .push(MemoryRegion::new(
+                            region.starting_address as usize,
+                            region.size.unwrap(),
+                            MemoryRegionType::Reserved,
+                        ))
+                        .unwrap();
+                }
+            }
+        }
+    }
+
+    // Add the kernel region.
+    regions.push(MemoryRegion::kernel()).unwrap();
+
+    // Add the initramfs region.
+    if let Some((start, end)) = parse_initramfs_range() {
+        regions
+            .push(MemoryRegion::new(
+                start,
+                end - start,
+                MemoryRegionType::Module,
+            ))
+            .unwrap();
+    }
+
+    // Add the device tree region.
+    regions
+        .push(MemoryRegion::new(
+            device_tree_paddr,
+            DEVICE_TREE.get().unwrap().total_size(),
+            MemoryRegionType::Module,
+        ))
+        .unwrap();
+
+    regions.into_non_overlapping()
+}
+
+fn parse_initramfs_range() -> Option<(usize, usize)> {
+    let chosen = DEVICE_TREE.get().unwrap().find_node("/chosen").unwrap();
+    let initrd_start = chosen.property("linux,initrd-start")?.as_usize()?;
+    let initrd_end = chosen.property("linux,initrd-end")?.as_usize()?;
+    Some((initrd_start, initrd_end))
+}
+
+/// The entry point of the Rust code portion of Asterinas.
+///
+/// # Safety
+///
+/// - This function must be called only once at a proper timing in the BSP's boot assembly code.
+/// - The caller must follow C calling conventions and put the right arguments in registers.
+// SAFETY: The name does not collide with other symbols.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn arm_boot(device_tree_paddr: usize) -> ! {
+    let device_tree_ptr = paddr_to_vaddr(device_tree_paddr) as *const u8;
+    // SAFETY: The caller ensures the correctness of `device_tree_ptr`.
+    let fdt = unsafe { Fdt::from_ptr(device_tree_ptr).unwrap() };
+    DEVICE_TREE.call_once(|| fdt);
+
+    use crate::boot::{EARLY_INFO, EarlyBootInfo, start_kernel};
+
+    EARLY_INFO.call_once(|| EarlyBootInfo {
+        bootloader_name: parse_bootloader_name(),
+        kernel_cmdline: parse_kernel_commandline(),
+        initramfs: parse_initramfs(),
+        acpi_arg: parse_acpi_arg(),
+        framebuffer_arg: parse_framebuffer_info(),
+        memory_regions: parse_memory_regions(device_tree_paddr),
+    });
+
+    // SAFETY: The safety is guaranteed by the safety preconditions and the fact that we call it
+    // once after setting up necessary resources.
+    unsafe { start_kernel() };
+}

--- a/ostd/src/arch/arm/boot/smp.rs
+++ b/ostd/src/arch/arm/boot/smp.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Multiprocessor Boot Support
+
+use crate::{boot::smp::PerApRawInfo, mm::Paddr};
+
+pub(crate) fn count_processors() -> Option<u32> {
+    Some(1)
+}
+
+pub(crate) unsafe fn bringup_all_aps(
+    _info_ptr: *const PerApRawInfo,
+    _pr_ptr: Paddr,
+    _num_cpus: u32,
+) {
+    unimplemented!()
+}

--- a/ostd/src/arch/arm/cpu/context.rs
+++ b/ostd/src/arch/arm/cpu/context.rs
@@ -2,7 +2,10 @@
 
 //! CPU execution context control.
 
+use alloc::boxed::Box;
 use core::{arch::asm, fmt::Debug};
+
+use zerocopy::IntoBytes;
 
 use crate::{
     arch::trap::{RawUserContext, TrapFrame},
@@ -346,3 +349,77 @@ cpu_context_impl_getter_setter!(
     [x29, set_x29],
     [x30, set_x30]
 );
+
+/// The FPU context of user task.
+#[derive(Clone, Debug)]
+pub struct FpuContext {
+    fpsimd: Box<FpSimdContext>,
+}
+
+impl FpuContext {
+    // TODO: This is for Linux compatibility and is Linux-specific.
+    // It should be defined outside of OSTD.
+    //
+    // Reference: <https://elixir.bootlin.com/linux/v7.0/source/arch/arm64/include/uapi/asm/sigcontext.h#L75>
+    const FPSIMD_MAGIC: u32 = 0x46508001;
+
+    /// Creates a new FPU context.
+    pub fn new() -> Self {
+        let mut fpsimd = Box::new(FpSimdContext::default());
+
+        fpsimd.magic = Self::FPSIMD_MAGIC;
+        fpsimd.size = size_of::<FpSimdContext>() as u32;
+
+        Self { fpsimd }
+    }
+
+    /// Saves CPU's current FPU context to this instance.
+    pub fn save(&mut self) {
+        // SAFETY: It is safe to save FPU registers.
+        unsafe { save_fpsimd_context(self.fpsimd.as_mut()) };
+    }
+
+    /// Loads CPU's FPU context from this instance.
+    pub fn load(&self) {
+        // SAFETY: It is safe to load FPU registers, as the FPU state does not affect the kernel's
+        // memory safety.
+        unsafe { load_fpsimd_context(self.fpsimd.as_ref()) };
+    }
+
+    /// Returns the FPU context as a byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.fpsimd.as_bytes()
+    }
+
+    /// Returns the FPU context as a mutable byte slice.
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self.fpsimd.as_mut_bytes()
+    }
+}
+
+impl Default for FpuContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Float-point and SIMD context.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+struct FpSimdContext {
+    // Header.
+    magic: u32,
+    size: u32,
+
+    // Float-point and SMID registers.
+    fpsr: u32,
+    fpcr: u32,
+    vregs: [u128; 32],
+}
+
+core::arch::global_asm!(include_str!("fpu.S"));
+
+unsafe extern "C" {
+    unsafe fn save_fpsimd_context(ctx: *mut FpSimdContext);
+    unsafe fn load_fpsimd_context(ctx: *const FpSimdContext);
+}

--- a/ostd/src/arch/arm/cpu/context.rs
+++ b/ostd/src/arch/arm/cpu/context.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! CPU execution context control.
+
+use core::fmt::Debug;
+
+use crate::{
+    arch::trap::{RawUserContext, TrapFrame},
+    user::{ReturnReason, UserContextApi, UserContextApiInternal},
+};
+
+/// Userspace CPU context, including general-purpose registers and exception information.
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct UserContext {
+    user_context: RawUserContext,
+    exception: Option<CpuException>,
+}
+
+/// General registers.
+#[expect(missing_docs)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct GeneralRegs {
+    pub x1: usize,
+    pub x2: usize,
+    pub x3: usize,
+    pub x4: usize,
+    pub x5: usize,
+    pub x6: usize,
+    pub x7: usize,
+    pub x8: usize,
+    pub x9: usize,
+    pub x10: usize,
+    pub x11: usize,
+    pub x12: usize,
+    pub x13: usize,
+    pub x14: usize,
+    pub x15: usize,
+    pub x16: usize,
+    pub x17: usize,
+    pub x18: usize,
+    pub x19: usize,
+    pub x20: usize,
+    pub x21: usize,
+    pub x22: usize,
+    pub x23: usize,
+    pub x24: usize,
+    pub x25: usize,
+    pub x26: usize,
+    pub x27: usize,
+    pub x28: usize,
+    pub x29: usize,
+    pub __reserved: usize, // for alignment
+    pub x30: usize,
+    // put here deliberately for ease of asm
+    pub x0: usize,
+    // x31 means special
+}
+
+/// ARM CPU exceptions.
+///
+/// Every enum variant corresponds to one exception defined by the ARM
+/// architecture.
+#[derive(Clone, Debug)]
+pub enum CpuException {
+    Unknown,
+}
+
+impl UserContext {
+    // Methods shared across all architectures (i.e., general registers and exceptions).
+
+    /// Returns a reference to the general registers.
+    pub fn general_regs(&self) -> &GeneralRegs {
+        &self.user_context.general
+    }
+
+    /// Returns a mutable reference to the general registers.
+    pub fn general_regs_mut(&mut self) -> &mut GeneralRegs {
+        &mut self.user_context.general
+    }
+
+    /// Takes the CPU exception out.
+    pub fn take_exception(&mut self) -> Option<CpuException> {
+        self.exception.take()
+    }
+
+    // Architecture-specific methods.
+
+    /// Gets the value of the thread-local storage pointer.
+    pub fn tls_pointer(&self) -> usize {
+        self.user_context.tpidr
+    }
+
+    /// Sets the value of the thread-local storage pointer.
+    pub fn set_tls_pointer(&mut self, tls: usize) {
+        self.user_context.tpidr = tls;
+    }
+
+    /// Gets the value of the process state (PSTATE) register.
+    pub fn process_state(&self) -> usize {
+        self.user_context.spsr
+    }
+
+    /// Sets the value of the process state (PSTATE) register.
+    ///
+    /// We only allow the setting or clearing of arithmetic condition flags and states for Software
+    /// Step and Illegal Execution. Any other bits will be ignored and will remain unchanged.
+    pub fn set_process_state(&mut self, pstate: usize) {
+        // Be careful. We can only allow bits to be set that won't affect soundness.
+        const USER_MODIFIABLE_PSTATE: usize =
+            // Condition flags: Negative (N), Zero (Z), Carry (C), Overflow (V).
+            (0b1111 << 28)
+            // Software Step (SS) state.
+            | (1 << 21)
+            // Illegal Execution (IL) state.
+            | (1 << 20);
+
+        self.user_context.spsr =
+            (self.user_context.spsr & !USER_MODIFIABLE_PSTATE) | (pstate & USER_MODIFIABLE_PSTATE);
+    }
+}
+
+impl UserContextApiInternal for UserContext {
+    fn as_trap_frame(&self) -> TrapFrame {
+        TrapFrame {
+            trap_num: self.user_context.trap_num,
+            __reserved: self.user_context.__reserved,
+            elr: self.user_context.elr,
+            spsr: self.user_context.spsr,
+            sp: self.user_context.sp,
+            tpidr: self.user_context.tpidr,
+            general: self.user_context.general,
+        }
+    }
+}
+
+impl UserContextApi for UserContext {
+    fn instruction_pointer(&self) -> usize {
+        self.user_context.elr
+    }
+
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.user_context.elr = ip;
+    }
+
+    fn stack_pointer(&self) -> usize {
+        self.user_context.sp
+    }
+
+    fn set_stack_pointer(&mut self, sp: usize) {
+        self.user_context.sp = sp;
+    }
+}
+
+macro_rules! cpu_context_impl_getter_setter {
+    ( $( [ $field: ident, $setter_name: ident] ),*) => {
+        impl UserContext {
+            $(
+                #[doc = concat!("Gets the value of ", stringify!($field))]
+                #[inline(always)]
+                pub fn $field(&self) -> usize {
+                    self.user_context.general.$field
+                }
+
+                #[doc = concat!("Sets the value of ", stringify!($field))]
+                #[inline(always)]
+                pub fn $setter_name(&mut self, $field: usize) {
+                    self.user_context.general.$field = $field;
+                }
+            )*
+        }
+    };
+}
+
+cpu_context_impl_getter_setter!(
+    [x0, set_x0],
+    [x1, set_x1],
+    [x2, set_x2],
+    [x3, set_x3],
+    [x4, set_x4],
+    [x5, set_x5],
+    [x6, set_x6],
+    [x7, set_x7],
+    [x8, set_x8],
+    [x9, set_x9],
+    [x10, set_x10],
+    [x11, set_x11],
+    [x12, set_x12],
+    [x13, set_x13],
+    [x14, set_x14],
+    [x15, set_x15],
+    [x16, set_x16],
+    [x17, set_x17],
+    [x18, set_x18],
+    [x19, set_x19],
+    [x20, set_x20],
+    [x21, set_x21],
+    [x22, set_x22],
+    [x23, set_x23],
+    [x24, set_x24],
+    [x25, set_x25],
+    [x26, set_x26],
+    [x27, set_x27],
+    [x28, set_x28],
+    [x29, set_x29],
+    [x30, set_x30]
+);

--- a/ostd/src/arch/arm/cpu/context.rs
+++ b/ostd/src/arch/arm/cpu/context.rs
@@ -2,11 +2,11 @@
 
 //! CPU execution context control.
 
-use core::fmt::Debug;
+use core::{arch::asm, fmt::Debug};
 
 use crate::{
     arch::trap::{RawUserContext, TrapFrame},
-    user::{ReturnReason, UserContextApi, UserContextApiInternal},
+    user::{ReturnReason, UserContextApi, UserContextApiInternal, UserModeHooks},
 };
 
 /// Userspace CPU context, including general-purpose registers and exception information.
@@ -64,7 +64,113 @@ pub struct GeneralRegs {
 /// architecture.
 #[derive(Clone, Debug)]
 pub enum CpuException {
+    /// Unknown reason.
     Unknown,
+    /// 000001 - Trapped WFI or WFE instruction execution.
+    WfiInstruction,
+    /// 000111 - Access to Advanced SIMD or floating-point functionality.
+    FpuInstruction,
+    /// 001110 - Illegal Execution state.
+    IllegalState,
+    /// 010101 - SVC instruction execution in AArch64 state.
+    SvcInstruction,
+    /// 011000 - Trapped MSR, MRS, or System instruction execution.
+    SystemInstruction,
+    /// 10000x - Instruction Abort from a lower or the same Execution level.
+    InstructionAbort {
+        /// The fault address that caused the exception.
+        address: usize,
+    },
+    /// 100010 - PC alignment fault.
+    PcAlignmentFault,
+    /// 10010x - Data Abort from a lower or the same Exception level.
+    DataAbort {
+        /// Whether the exception was generated on a write instruction.
+        is_write: bool,
+        /// The fault address that caused the exception.
+        address: usize,
+    },
+    /// 100110 - SP alignment fault.
+    SpAlignmentFault,
+    /// 101100 - Trapped floating-point exception taken from AArch64 state.
+    FpuException,
+    /// 101111 - SError interrupt.
+    SErrorInterrupt,
+    /// 11000x - Breakpoint exception from a lower or the same Exception level.
+    Breakpoint,
+    /// 11001x - Software Step exception from a lower or the same Exception level.
+    SoftwareStep,
+    /// 11010x - Watchpoint exception from a lower or the same Exception level.
+    Watchpoint,
+    /// 111100 - BRK instruction execution in AArch64 state.
+    BrkInstruction,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::arch) enum CpuTrap {
+    Exception(CpuException),
+    Interrupt,
+    FastInterrupt,
+    SError,
+}
+
+impl CpuTrap {
+    pub(in crate::arch) fn new(trap_num: usize) -> Option<Self> {
+        match trap_num >> 16 {
+            // 0: Synchronous
+            0 => (),
+            // 1: IRQ or vIRQ
+            1 => return Some(Self::Interrupt),
+            // 2: FIQ or vFIQ
+            2 => return Some(Self::FastInterrupt),
+            // 3: SError or vSError
+            3 => return Some(Self::SError),
+
+            _ => return None,
+        }
+
+        let esr_el1: usize;
+        // SAFETY: It is safe to read the Exception Syndrome Register (ESR).
+        unsafe { asm!("mrs {}, esr_el1", out(reg) esr_el1) };
+
+        fn fault_address() -> usize {
+            let far_el1;
+            // SAFETY: It is safe to read the Fault Address Register (FAR).
+            unsafe { asm!("mrs {}, far_el1", out(reg) far_el1) };
+            far_el1
+        }
+
+        // WnR, bit [6]: Write not Read.
+        const ESR_WNR: usize = 1 << 6;
+
+        // EC, bits[31:26]: The Exception class field.
+        let exception = match esr_el1 >> 26 {
+            0b000001 => CpuException::WfiInstruction,
+            0b000111 => CpuException::FpuInstruction,
+            0b001110 => CpuException::IllegalState,
+            0b010101 => CpuException::SvcInstruction,
+            0b011000 => CpuException::SystemInstruction,
+            0b100000 | 0b100001 => CpuException::InstructionAbort {
+                address: fault_address(),
+            },
+            0b100010 => CpuException::PcAlignmentFault,
+            0b100100 | 0b100101 => CpuException::DataAbort {
+                is_write: esr_el1 & ESR_WNR != 0,
+                address: fault_address(),
+            },
+            0b100110 => CpuException::SpAlignmentFault,
+            0b101100 => CpuException::FpuException,
+            0b101111 => CpuException::SErrorInterrupt,
+            0b110000 | 0b110001 => CpuException::Breakpoint,
+            0b110010 | 0b110011 => CpuException::SoftwareStep,
+            0b110100 | 0b110101 => CpuException::Watchpoint,
+            0b111100 => CpuException::BrkInstruction,
+
+            0b000000 => CpuException::Unknown,
+            _ => CpuException::Unknown,
+        };
+        Some(Self::Exception(exception))
+    }
 }
 
 impl UserContext {
@@ -122,6 +228,40 @@ impl UserContext {
 }
 
 impl UserContextApiInternal for UserContext {
+    fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason {
+        #[expect(clippy::never_loop)] // This will loop once we add support for IRQ handling.
+        loop {
+            crate::task::scheduler::might_preempt();
+
+            let guard = crate::irq::disable_local();
+            hooks.pre_user_run(&guard);
+            self.user_context.run(guard);
+
+            let trap = CpuTrap::new(self.user_context.trap_num);
+            match trap {
+                Some(CpuTrap::Exception(CpuException::SvcInstruction)) => {
+                    crate::arch::irq::enable_local();
+                    break ReturnReason::UserSyscall;
+                }
+                Some(CpuTrap::Exception(exception)) => {
+                    crate::arch::irq::enable_local();
+                    self.exception = Some(exception);
+                    break ReturnReason::UserException;
+                }
+                _ => panic!(
+                    "Cannot handle user CPU exception: {:?}; trapframe: {:#?}",
+                    trap,
+                    self.as_trap_frame()
+                ),
+            }
+
+            #[expect(unreachable_code)] // This can be reached once we add support for IRQ handling.
+            if hooks.has_kernel_event() {
+                break ReturnReason::KernelEvent;
+            }
+        }
+    }
+
     fn as_trap_frame(&self) -> TrapFrame {
         TrapFrame {
             trap_num: self.user_context.trap_num,

--- a/ostd/src/arch/arm/cpu/fpu.S
+++ b/ostd/src/arch/arm/cpu/fpu.S
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+.arch_extension fp
+
+.macro VREGS op
+    \op      q0,  q1, [x0, #16 * 1]
+    \op      q2,  q3, [x0, #16 * 3]
+    \op      q4,  q5, [x0, #16 * 5]
+    \op      q6,  q7, [x0, #16 * 7]
+    \op      q8,  q9, [x0, #16 * 9]
+    \op     q10, q11, [x0, #16 * 11]
+    \op     q12, q13, [x0, #16 * 13]
+    \op     q14, q15, [x0, #16 * 15]
+    \op     q16, q17, [x0, #16 * 17]
+    \op     q18, q19, [x0, #16 * 19]
+    \op     q20, q21, [x0, #16 * 21]
+    \op     q22, q23, [x0, #16 * 23]
+    \op     q24, q25, [x0, #16 * 25]
+    \op     q26, q27, [x0, #16 * 27]
+    \op     q28, q29, [x0, #16 * 29]
+    \op     q30, q31, [x0, #16 * 31]
+.endm
+
+.global save_fpsimd_context
+.type save_fpsimd_context, @function
+save_fpsimd_context:
+    VREGS    stp
+
+    mrs      x1, fpsr
+    mrs      x2, fpcr
+    stp      w1, w2, [x0, #8]
+
+    ret
+.size save_fpsimd_context, .-save_fpsimd_context
+
+.global load_fpsimd_context
+.type load_fpsimd_context, @function
+load_fpsimd_context:
+    ldp     w1, w2, [x0, #8]
+    msr     fpsr, x1
+    msr     fpcr, x2
+
+    VREGS   ldp
+
+    ret
+.size load_fpsimd_context, .-load_fpsimd_context
+
+.arch_extension nofp

--- a/ostd/src/arch/arm/cpu/local.rs
+++ b/ostd/src/arch/arm/cpu/local.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Architecture dependent CPU-local information utilities.
+
+use core::arch::asm;
+
+pub(crate) fn get_base() -> u64 {
+    let base;
+    // SAFETY: It is safe to read the register containing the CPU-local base.
+    unsafe {
+        asm!(
+            "mrs {base}, tpidr_el1",
+            base = out(reg) base,
+            options(preserves_flags, nostack)
+        );
+    }
+    base
+}

--- a/ostd/src/arch/arm/cpu/mod.rs
+++ b/ostd/src/arch/arm/cpu/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! CPU context & state control and CPU local memory.
+
+pub mod context;
+pub mod local;

--- a/ostd/src/arch/arm/device/io_port.rs
+++ b/ostd/src/arch/arm/device/io_port.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! I/O port access.
+
+/// An access marker type indicating that a port is only allowed to write values.
+pub struct WriteOnlyAccess;
+/// An access marker type indicating that a port is allowed to read or write values.
+pub struct ReadWriteAccess;
+
+/// A marker trait for access types which allow writing port values.
+pub trait IoPortWriteAccess {}
+/// A marker trait for access types which allow reading port values.
+pub trait IoPortReadAccess {}
+
+impl IoPortWriteAccess for WriteOnlyAccess {}
+impl IoPortWriteAccess for ReadWriteAccess {}
+impl IoPortReadAccess for ReadWriteAccess {}
+
+/// A helper trait that implements the read port operation.
+pub trait PortRead: Sized {
+    /// Reads a `Self` value from the given port.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
+    unsafe fn read_from_port(_port: u16) -> Self {
+        unimplemented!()
+    }
+}
+
+/// A helper trait that implements the write port operation.
+pub trait PortWrite: Sized {
+    /// Writes a `Self` value to the given port.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
+    unsafe fn write_to_port(_port: u16, _value: Self) {
+        unimplemented!()
+    }
+}
+
+impl PortRead for u8 {}
+impl PortWrite for u8 {}
+impl PortRead for u16 {}
+impl PortWrite for u16 {}
+impl PortRead for u32 {}
+impl PortWrite for u32 {}

--- a/ostd/src/arch/arm/device/mod.rs
+++ b/ostd/src/arch/arm/device/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Device-related APIs.
+
+pub mod io_port;

--- a/ostd/src/arch/arm/io/io_mem.rs
+++ b/ostd/src/arch/arm/io/io_mem.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! I/O memory utilities.
+
+use crate::{
+    arch::mm::__memcpy_fallible,
+    io::io_mem::util::{copy_from_mmio_val, copy_to_mmio_val, for_aligned_chunks, memset_mmio_val},
+    mm::PodOnce,
+};
+
+/// Reads from a pointer with a non-tearing memory load.
+///
+/// This function is semantically equivalent to `core::ptr::read_volatile`
+/// but is manually implemented with a single memory load instruction.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::read_volatile`.
+///
+/// # Guarantee
+///
+/// The single-memory-load-instruction guarantee is particularly useful for
+/// Confidential VMs (CVMs),
+/// where the memory loads may cause CPU exceptions
+/// and the kernel has to handle such exceptions
+/// by decoding the faulting CPU instruction.
+/// As such, the kernel must be compiled to emit simple load/store CPU instructions.
+pub(crate) unsafe fn read_once<T: PodOnce>(ptr: *const T) -> T {
+    // TODO: Use arch-specific single-instruction load for ARM.
+    // For detail, see https://github.com/asterinas/asterinas/issues/2948.
+    // SAFETY: The caller upholds the preconditions of `read_volatile`.
+    unsafe { core::ptr::read_volatile(ptr) }
+}
+
+/// Writes to a pointer with a non-tearing memory store.
+///
+/// # Safety
+///
+/// Same as the safety requirement of `core::ptr::write_volatile`.
+///
+/// # Guarantee
+///
+/// Refer to the "Guarantee" section of [`read_once`].
+pub(crate) unsafe fn write_once<T: PodOnce>(ptr: *mut T, val: T) {
+    // TODO: Use arch-specific single-instruction store for ARM.
+    // For detail, see https://github.com/asterinas/asterinas/issues/2948.
+    // SAFETY: The caller upholds the preconditions of `write_volatile`.
+    unsafe { core::ptr::write_volatile(ptr, val) }
+}
+
+/// Copies from MMIO to regular memory.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio(mut dst_ptr: *mut u8, mut src_io_ptr: *const u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `src_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        src_io_ptr.addr(),
+        count,
+        8,
+        copy_from_mmio_val(&mut dst_ptr, &mut src_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from regular memory to MMIO.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio(mut src_ptr: *const u8, mut dst_io_ptr: *mut u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `dst_io_ptr` alignment.
+    let copied = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        copy_to_mmio_val(&mut src_ptr, &mut dst_io_ptr)
+    );
+    debug_assert_eq!(copied, count);
+}
+
+/// Copies from MMIO to fallible memory and returns bytes copied.
+///
+/// # Safety
+///
+/// - `dst_ptr` must be valid or in user space for writes of `count` bytes.
+/// - `src_io_ptr` must be valid for MMIO reads of `count` bytes.
+pub(crate) unsafe fn copy_from_mmio_fallible(
+    dst_ptr: *mut u8,
+    src_io_ptr: *const u8,
+    count: usize,
+) -> usize {
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_ptr, src_io_ptr, count) };
+    count - failed_bytes
+}
+
+/// Copies from fallible memory to MMIO and returns bytes copied.
+///
+/// # Safety
+///
+/// - `src_ptr` must be valid or in user space for reads of `count` bytes.
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn copy_to_mmio_fallible(
+    src_ptr: *const u8,
+    dst_io_ptr: *mut u8,
+    count: usize,
+) -> usize {
+    // SAFETY: The caller guarantees the source and destination are valid.
+    let failed_bytes = unsafe { __memcpy_fallible(dst_io_ptr, src_ptr, count) };
+    count - failed_bytes
+}
+
+/// Fills MMIO with `value` for `count` bytes.
+///
+/// # Safety
+///
+/// - `dst_io_ptr` must be valid for MMIO writes of `count` bytes.
+pub(crate) unsafe fn memset_mmio(mut dst_io_ptr: *mut u8, value: u8, count: usize) {
+    // SAFETY: The caller guarantees source/destination validity for `count` bytes,
+    // and `for_aligned_chunks!` only selects chunk sizes compatible with `dst_io_ptr` alignment.
+    let written = for_aligned_chunks!(
+        dst_io_ptr.addr(),
+        count,
+        8,
+        memset_mmio_val(&mut dst_io_ptr, value)
+    );
+    debug_assert_eq!(written, count);
+}

--- a/ostd/src/arch/arm/io/mod.rs
+++ b/ostd/src/arch/arm/io/mod.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! I/O memory utilities.
+
+use alloc::vec::Vec;
+
+use crate::{boot::memory_region::MemoryRegionType, io::IoMemAllocatorBuilder};
+
+pub(crate) mod io_mem;
+
+/// Initializes the allocatable MMIO area based on the ARM memory
+/// distribution map.
+///
+/// Here we consider all the holes (filtering usable RAM) in the physical
+/// address space as MMIO regions.
+///
+/// # Safety
+///
+/// 1. This function must be called only once in the boot context of the
+///    bootstrapping processor.
+/// 2. This function must be called after the kernel page table is activated on
+///    the bootstrapping processor.
+pub(super) unsafe fn construct_io_mem_allocator_builder() -> IoMemAllocatorBuilder {
+    let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
+    let reserved_filter = regions.iter().filter(|r| {
+        r.typ() != MemoryRegionType::Unknown
+            && r.typ() != MemoryRegionType::Reserved
+            && r.typ() != MemoryRegionType::Framebuffer
+    });
+
+    let mut ranges = Vec::new();
+
+    let mut current_address = 0;
+    for region in reserved_filter {
+        if current_address < region.base() {
+            ranges.push(current_address..region.base());
+        }
+        current_address = region.end();
+    }
+    if current_address < usize::MAX {
+        ranges.push(current_address..usize::MAX);
+    }
+
+    // SAFETY:
+    // 1. This is the only place that creates an `IoMemAllocatorBuilder`. The
+    //    caller ensures that the function is only called once.
+    // 2. The caller ensures that the kernel page table is already activated.
+    // 3. The range is guaranteed not to access physical memory.
+    unsafe { IoMemAllocatorBuilder::new(ranges) }
+}

--- a/ostd/src/arch/arm/iommu/mod.rs
+++ b/ostd/src/arch/arm/iommu/mod.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The IOMMU support.
+
+use crate::mm::{Daddr, Paddr};
+
+/// An enumeration representing possible errors related to IOMMU.
+#[derive(Debug)]
+pub(crate) enum IommuError {
+    /// No IOMMU is available.
+    NoIommu,
+}
+
+/// # Safety
+///
+/// While the physical address is mapped as the device address (i.e. from calling this method to
+/// calling [`unmap`]), it must point to an untyped memory page. Otherwise, the device may corrupt
+/// kernel data, which could lead to memory safety issues.
+pub(crate) unsafe fn map(_daddr: Daddr, _paddr: Paddr) -> Result<(), IommuError> {
+    Err(IommuError::NoIommu)
+}
+
+pub(crate) fn unmap(_daddr: Daddr) -> Result<(), IommuError> {
+    Err(IommuError::NoIommu)
+}
+
+pub(crate) fn init() -> Result<(), IommuError> {
+    // TODO: We will support IOMMU on ARM
+    Err(IommuError::NoIommu)
+}
+
+pub(crate) fn has_dma_remapping() -> bool {
+    false
+}
+
+pub(crate) fn has_interrupt_remapping() -> bool {
+    false
+}

--- a/ostd/src/arch/arm/irq/ipi.rs
+++ b/ostd/src/arch/arm/irq/ipi.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Inter-processor interrupts.
+
+use crate::{cpu::PinCurrentCpu, prelude::Result};
+
+/// Hardware-specific, architecture-dependent CPU ID.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HwCpuId(u32);
+
+impl HwCpuId {
+    pub(crate) fn read_current(_guard: &dyn PinCurrentCpu) -> Self {
+        // TODO: Support SMP in ARM.
+        Self(0)
+    }
+}
+
+/// Sends a general inter-processor interrupt (IPI) to the specified CPU.
+pub(crate) fn send_ipi(_hw_cpu_id: HwCpuId, _guard: &dyn PinCurrentCpu) -> Result<()> {
+    // To suppress unused function lint errors. We should be using it here.
+    let _ = crate::smp::do_inter_processor_call;
+    unimplemented!()
+}

--- a/ostd/src/arch/arm/irq/mod.rs
+++ b/ostd/src/arch/arm/irq/mod.rs
@@ -7,6 +7,7 @@ mod ops;
 mod remapping;
 
 pub(crate) use ipi::{HwCpuId, send_ipi};
+pub(super) use ops::PSTATE_I;
 pub(crate) use ops::{
     disable_local, disable_local_and_halt, enable_local, enable_local_and_halt, is_local_enabled,
 };

--- a/ostd/src/arch/arm/irq/mod.rs
+++ b/ostd/src/arch/arm/irq/mod.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Interrupts.
+
+mod ipi;
+mod ops;
+mod remapping;
+
+pub(crate) use ipi::{HwCpuId, send_ipi};
+pub(crate) use ops::{
+    disable_local, disable_local_and_halt, enable_local, enable_local_and_halt, is_local_enabled,
+};
+pub(crate) use remapping::IrqRemapping;
+
+pub(crate) const IRQ_NUM_MIN: u8 = 0;
+pub(crate) const IRQ_NUM_MAX: u8 = 255;
+
+/// An IRQ line with additional information that helps acknowledge the interrupt
+/// on hardware.
+///
+/// On ARM, it's the software that routes the interrupt to the IRQ line.
+/// Therefore, the software needs to maintain interrupt source information that
+/// bridges between software abstraction (e.g., `IRQ_CHIP`) and hardware
+/// mechanism (e.g., GIC).
+pub(crate) struct HwIrqLine {
+    irq_num: u8,
+}
+
+impl HwIrqLine {
+    pub(crate) fn irq_num(&self) -> u8 {
+        self.irq_num
+    }
+
+    pub(crate) fn ack(&self) {
+        unimplemented!()
+    }
+}

--- a/ostd/src/arch/arm/irq/ops.rs
+++ b/ostd/src/arch/arm/irq/ops.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Interrupt operations.
+
+use core::arch::asm;
+
+// FIXME: Mark this as unsafe. See
+// <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
+pub(crate) fn enable_local() {
+    // SAFETY: The safety is upheld by the caller.
+    unsafe { asm!("msr daifclr, 0b0010") };
+}
+
+/// Enables local IRQs and halts the CPU to wait for interrupts.
+///
+/// This method guarantees that no interrupts can occur in the middle. In other words, IRQs must
+/// either have been processed before this method is called, or they must wake the CPU up from the
+/// halting state.
+//
+// FIXME: Mark this as unsafe. See
+// <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
+pub(crate) fn enable_local_and_halt() {
+    // ARM(R) Architecture Reference Manual (ARMv8, for ARMv8-A architecture profile) says:
+    // "The following are WFI wake-up events: [..] IRQ interrupt [..] regardless of the value of the
+    // corresponding PSTATE.{A,I,F} mask bit."
+    //
+    // So we can use `wfi` even if IRQs are disabled. Pending IRQs can still wake up the CPU, but
+    // they will only occur later when we enable local IRQs.
+    //
+    // SAFETY: It is safe to halt the CPU and wait for interrupts.
+    unsafe { asm!("wfi") };
+
+    enable_local();
+}
+
+pub(crate) fn disable_local() {
+    // SAFETY: It is safe to disable local IRQs.
+    unsafe { asm!("msr daifset, 0b0010") };
+}
+
+/// Disables local IRQs and halts the CPU forever.
+pub(crate) fn disable_local_and_halt() -> ! {
+    disable_local();
+    loop {
+        // SAFETY: It is safe to halt the CPU and wait for interrupts.
+        unsafe { asm!("wfi") };
+    }
+}
+
+// Process state (Pstate), IRQ mask (I) bit.
+pub(in crate::arch) const PSTATE_I: usize = 1 << 7;
+
+pub(crate) fn is_local_enabled() -> bool {
+    let daif: usize;
+    // SAFETY: It is safe to read the Interrupt Mask Bits (DAIF).
+    unsafe { asm!("mrs {}, daif", out(reg) daif) };
+    // Note that this differs from what should be written to the DAIFset and DAIFclr registers.
+    daif & PSTATE_I == 0
+}

--- a/ostd/src/arch/arm/irq/remapping.rs
+++ b/ostd/src/arch/arm/irq/remapping.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+pub(crate) struct IrqRemapping {
+    _private: (),
+}
+
+impl IrqRemapping {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Initializes the remapping entry for the specific IRQ number.
+    ///
+    /// This will do nothing if the entry is already initialized or interrupt
+    /// remapping is disabled or not supported by the architecture.
+    pub(crate) fn init(&self, _irq_num: u8) {}
+
+    /// Gets the remapping index of the IRQ line.
+    ///
+    /// This method will return `None` if interrupt remapping is disabled or
+    /// not supported by the architecture.
+    pub(crate) fn remapping_index(&self) -> Option<u16> {
+        None
+    }
+}

--- a/ostd/src/arch/arm/mm/atomic_cmpxchg_fallible.S
+++ b/ostd/src/arch/arm/mm/atomic_cmpxchg_fallible.S
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+.text
+
+# Atomically compares and exchanges a 32-bit integer value. This function works
+# with exception handling and can recover from a page fault.
+#
+# Returns the previous value or `!0u64` if failed to update.
+.global __atomic_cmpxchg_fallible
+.type __atomic_cmpxchg_fallible, @function
+__atomic_cmpxchg_fallible: # (ptr: *mut u32, old_val: u32, new_val: u32) -> u64
+cmpxchg_load:
+    ldxr    w4, [x0]
+    cmp     w1, w4
+    b.ne    cmpxchg_done
+cmpxchg_store:
+    stxr    w5, w2, [x0]
+    cbnz    w5, cmpxchg_load
+cmpxchg_done:
+    mov     w0, w4
+    ret
+cmpxchg_fault:
+    mov     x0, #-1
+    ret
+.size __atomic_cmpxchg_fallible, .-__atomic_cmpxchg_fallible
+
+.pushsection .ex_table, "a", @progbits
+    .balign 8
+    .quad cmpxchg_load
+    .quad cmpxchg_fault
+    .quad cmpxchg_store
+    .quad cmpxchg_fault
+.popsection

--- a/ostd/src/arch/arm/mm/atomic_load_fallible.S
+++ b/ostd/src/arch/arm/mm/atomic_load_fallible.S
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+.text
+
+# Atomically loads a 32-bit integer value. This function works with exception
+# handling and can recover from a page fault.
+#
+# Returns the loaded value or `!0u64` if failed to load.
+.global __atomic_load_fallible
+.type __atomic_load_fallible, @function
+__atomic_load_fallible: # (ptr: *const u32) -> u64;
+load:
+    ldr     w0, [x0]
+    ret
+load_fault:
+    mov     x0, #-1
+    ret
+.size __atomic_load_fallible, .-__atomic_load_fallible
+
+.pushsection .ex_table, "a", @progbits
+    .balign 8
+    .quad load
+    .quad load_fault
+.popsection

--- a/ostd/src/arch/arm/mm/memcpy_fallible.S
+++ b/ostd/src/arch/arm/mm/memcpy_fallible.S
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+.text
+
+# Copies `size` bytes from `src` to `dst`. This function works with exception
+# handling and can recover from a page fault. The source range must not overlap
+# with the destination range (In virtual address level. Their corresponding
+# physical addresses can be overlapped).
+#
+# Returns number of bytes that failed to copy.
+.global __memcpy_fallible
+.type __memcpy_fallible, @function
+__memcpy_fallible: # (dst: *mut u8, src: *const u8, size: usize) -> usize
+memcpy_loop:
+    cbz     x2, memcpy_exit
+memcpy_load:
+    ldrb    w3, [x1], #1
+memcpy_store:
+    strb    w3, [x0], #1
+    add     x2, x2, #-1
+    b       memcpy_loop
+memcpy_exit:
+    mov     x0, x2
+    ret
+.size __memcpy_fallible, .-__memcpy_fallible
+
+.pushsection .ex_table, "a", @progbits
+    .balign 8
+    .quad memcpy_load
+    .quad memcpy_exit
+    .quad memcpy_store
+    .quad memcpy_exit
+.popsection

--- a/ostd/src/arch/arm/mm/memset_fallible.S
+++ b/ostd/src/arch/arm/mm/memset_fallible.S
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+.text
+
+# Sets `size` bytes of memory at `dst` to the byte value given by `value`.
+# This function works with exception handling and can recover from a page fault.
+#
+# Returns number of bytes that failed to set.
+.global __memset_fallible
+.type __memset_fallible, @function
+__memset_fallible: # (dst: *mut u8, value: u8, size: usize) -> usize
+memset_loop:
+    cbz     x2, memset_exit
+memset_store:
+    strb    w1, [x0], #1
+    add     x2, x2, #-1
+    b       memset_loop
+memset_exit:
+    mov     x0, x2
+    ret
+.size __memset_fallible, .-__memset_fallible
+
+.pushsection .ex_table, "a", @progbits
+    .balign 8
+    .quad memset_store
+    .quad memset_exit
+.popsection

--- a/ostd/src/arch/arm/mm/mod.rs
+++ b/ostd/src/arch/arm/mm/mod.rs
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::{arch::asm, ops::Range};
+
+use crate::mm::{
+    PAGE_SIZE, Paddr, PagingConstsTrait, PagingLevel, PodOnce, Vaddr,
+    dma::DmaDirection,
+    page_prop::{
+        CachePolicy, PageFlags, PageProperty, PageTableFlags, PrivilegedPageFlags as PrivFlags,
+    },
+    page_table::{PteScalar, PteTrait},
+};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PagingConsts {}
+
+impl PagingConstsTrait for PagingConsts {
+    const BASE_PAGE_SIZE: usize = 4096;
+    const NR_LEVELS: PagingLevel = 4;
+    const ADDRESS_WIDTH: usize = 48;
+    const VA_SIGN_EXT: bool = true;
+    const HIGHEST_TRANSLATION_LEVEL: PagingLevel = 4;
+    const PTE_SIZE: usize = size_of::<PageTableEntry>();
+}
+
+bitflags::bitflags! {
+    /// Possible flags for a page table entry.
+    #[repr(C)]
+    #[derive(Pod)]
+    pub(crate) struct PteFlags: usize {
+        /// Specifies whether the mapped frame or page table is valid.
+        const VALID =           1 << 0;
+        /// Specifies whether the mapping does not point to a huge frame; this bit must also be set
+        /// for all the valid last-level entries.
+        const NON_HUGE =        1 << 1;
+        /// Controls whether accesses from userspace (i.e. EL0) are permitted.
+        const USER =            1 << 6;
+        /// Controls whether writes to the mapped frames are disallowed.
+        const NO_WRITE =        1 << 7;
+        /// Whether the memory area represented by this entry is accessed.
+        const ACCESSED =        1 << 10;
+        /// Indicates that the mapping isn't present in all address spaces, so it is flushed from
+        /// the TLB on an address space switch.
+        const NON_GLOBAL =      1 << 11;
+
+        /// Whether the memory area represented by this entry is modified.
+        const DIRTY =           1 << 51;
+        /// Forbid execute codes on the page from kernel space (i.e. EL1).
+        const NO_EXECUTE_KERN = 1 << 53;
+        /// Forbid execute codes on the page from userspace (i.e. EL0).
+        const NO_EXECUTE_USER = 1 << 54;
+
+        /// Ignored by the hardware. Free to use.
+        const HIGH_IGN1 =       1 << 55;
+        /// Ignored by the hardware. Free to use.
+        const HIGH_IGN2 =       1 << 56;
+
+        // Be careful that the following fields contain multiple bits!
+        //
+        /// Bit 2-4: Device memory, nGnRnE.
+        const ATTR_DEVICE =     1 << 2;
+        /// Bit 8-9: Inner shareability (effective only for Normal memory).
+        const SH_INNER =        3 << 8;
+    }
+}
+
+const SHARED_ASID: usize = 0;
+
+/// The bit offset of the ASID field in TTBR registers and TLBI operands.
+const ASID_SHIFT: u32 = 48;
+
+pub(crate) fn tlb_flush_addr(vaddr: Vaddr) {
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe {
+        asm!(
+            "dsb nshst",
+            "tlbi vaae1, {vpn}",
+            "dsb nsh",
+            "isb",
+            vpn = in(reg) vaddr_to_vpn(vaddr),
+        );
+    }
+}
+
+pub(crate) fn tlb_flush_addr_range(range: &Range<Vaddr>) {
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe {
+        asm!("dsb nshst");
+        for vaddr in range.clone().step_by(PAGE_SIZE) {
+            asm!("tlbi vaae1, {vpn}", vpn = in(reg) vaddr_to_vpn(vaddr));
+        }
+        asm!("dsb nsh", "isb");
+    }
+}
+
+fn vaddr_to_vpn(vaddr: Vaddr) -> usize {
+    // Bits 43-0: Bits[55:12] of the virtual address to match.
+    (vaddr >> 12) & ((1 << 44) - 1)
+}
+
+pub(crate) fn tlb_flush_all_excluding_global() {
+    // We use `SHARED_ASID` all the time, so all non-global pages are associated with it.
+    //
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe {
+        asm!("dsb nshst", "tlbi aside1, {asid}", "dsb nsh", "isb", asid = in(reg) SHARED_ASID << ASID_SHIFT)
+    };
+}
+
+pub(crate) fn tlb_flush_all_including_global() {
+    // SAFETY: This invalidates the TLB, which doesn't affect the memory safety.
+    unsafe { asm!("dsb nshst", "tlbi vmalle1", "dsb nsh", "isb") };
+}
+
+pub(crate) fn can_sync_dma() -> bool {
+    false
+}
+
+/// # Safety
+///
+/// The caller must ensure that
+///  - the virtual address range and DMA direction correspond correctly to a
+///    DMA region;
+///  - `can_sync_dma()` is `true`.
+#[expect(clippy::extra_unused_type_parameters)]
+pub(crate) unsafe fn sync_dma_range<D: DmaDirection>(_range: Range<Vaddr>) {
+    unreachable!("`can_sync_dma()` never returns `true`");
+}
+
+/// Activates the given root-level page table.
+///
+/// # Safety
+///
+/// Changing the root-level page table is unsafe, because it's possible to violate memory safety by
+/// changing the page mapping.
+pub(crate) unsafe fn activate_page_table(root_paddr: Paddr) {
+    debug_assert_eq!(root_paddr >> ASID_SHIFT, 0);
+    let ttbr = root_paddr | (SHARED_ASID << ASID_SHIFT);
+
+    // SAFETY: The safety is upheld by the caller.
+    unsafe {
+        asm!(
+            "msr ttbr0_el1, {ttbr}",
+            "msr ttbr1_el1, {ttbr}",
+            "isb",
+            ttbr = in(reg) ttbr,
+        );
+    }
+
+    // We reuse `SHARED_ASID`, so we need to flush the TLB entries.
+    tlb_flush_all_excluding_global();
+}
+
+pub(crate) fn current_page_table_paddr() -> Paddr {
+    let ttbr: usize;
+    // SAFETY: It is safe to read the register containing the root-level page table address.
+    unsafe {
+        asm!(
+            "mrs {ttbr}, ttbr0_el1",
+            ttbr = out(reg) ttbr,
+        );
+    }
+
+    debug_assert_eq!(ttbr >> ASID_SHIFT, SHARED_ASID);
+    ttbr - (SHARED_ASID << ASID_SHIFT)
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod)]
+pub(crate) struct PageTableEntry(usize);
+
+/// Parses a bit-flag bits `val` in the representation of `from` to `to` in bits.
+macro_rules! parse_flags {
+    ($val:expr, $from:expr, $to:expr) => {
+        (($val as usize & $from.bits() as usize) >> $from.bits().ilog2() << $to.bits().ilog2())
+    };
+}
+
+impl PageTableEntry {
+    const PHYS_ADDR_MASK: usize = 0x0000_FFFF_FFFF_F000;
+
+    fn is_present(&self) -> bool {
+        if self.0 & PteFlags::VALID.bits() != 0 {
+            // Child page tables and readable pages.
+            true
+        } else if self.0 & PteFlags::SH_INNER.bits() != 0 {
+            // Non-readable pages (`new_page()` always sets `SH_INNER`).
+            true
+        } else {
+            // Nothing.
+            false
+        }
+    }
+
+    fn is_last(&self, level: PagingLevel) -> bool {
+        level == 1 || self.0 & PteFlags::NON_HUGE.bits() == 0
+    }
+
+    fn paddr(&self) -> Paddr {
+        self.0 & Self::PHYS_ADDR_MASK
+    }
+
+    fn prop(&self) -> PageProperty {
+        let mut flags = parse_flags!(self.0, PteFlags::VALID, PageFlags::R)
+            | parse_flags!(!self.0, PteFlags::NO_WRITE, PageFlags::W)
+            | parse_flags!(self.0, PteFlags::ACCESSED, PageFlags::ACCESSED)
+            | parse_flags!(self.0, PteFlags::DIRTY, PageFlags::DIRTY)
+            | parse_flags!(self.0, PteFlags::HIGH_IGN2, PageFlags::AVAIL2);
+        if self.0 & PteFlags::USER.bits() != 0 {
+            flags |= parse_flags!(!self.0, PteFlags::NO_EXECUTE_USER, PageFlags::X);
+        } else {
+            flags |= parse_flags!(!self.0, PteFlags::NO_EXECUTE_KERN, PageFlags::X);
+        }
+
+        let priv_flags = parse_flags!(self.0, PteFlags::USER, PrivFlags::USER)
+            | parse_flags!(!self.0, PteFlags::NON_GLOBAL, PrivFlags::GLOBAL)
+            | parse_flags!(self.0, PteFlags::HIGH_IGN1, PrivFlags::AVAIL1);
+
+        let cache = if self.0 & PteFlags::ATTR_DEVICE.bits() != 0 {
+            CachePolicy::Uncacheable
+        } else {
+            CachePolicy::Writeback
+        };
+
+        PageProperty {
+            flags: PageFlags::from_bits(flags as u8).unwrap(),
+            cache,
+            priv_flags: PrivFlags::from_bits(priv_flags as u8).unwrap(),
+        }
+    }
+
+    fn pt_flags(&self) -> PageTableFlags {
+        let bits = PageTableFlags::empty().bits() as usize
+            | parse_flags!(self.0, PteFlags::HIGH_IGN1, PageTableFlags::AVAIL1)
+            | parse_flags!(self.0, PteFlags::HIGH_IGN2, PageTableFlags::AVAIL2);
+        PageTableFlags::from_bits(bits as u8).unwrap()
+    }
+
+    fn new_page(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self {
+        // FIXME: To avoid the Access Flag Fault,
+        // we set the `ACCESSED` bit to 1 all the time.
+        let mut flags = PteFlags::ACCESSED.bits();
+        if level == 1 {
+            flags |= PteFlags::NON_HUGE.bits();
+        }
+
+        flags |= parse_flags!(prop.flags.bits(), PageFlags::R, PteFlags::VALID)
+            | parse_flags!(!prop.flags.bits(), PageFlags::W, PteFlags::NO_WRITE)
+            | parse_flags!(prop.flags.bits(), PageFlags::ACCESSED, PteFlags::ACCESSED)
+            | parse_flags!(prop.flags.bits(), PageFlags::DIRTY, PteFlags::DIRTY)
+            | parse_flags!(prop.priv_flags.bits(), PrivFlags::USER, PteFlags::USER)
+            | parse_flags!(
+                !prop.priv_flags.bits(),
+                PrivFlags::GLOBAL,
+                PteFlags::NON_GLOBAL
+            )
+            | parse_flags!(
+                prop.priv_flags.bits(),
+                PrivFlags::AVAIL1,
+                PteFlags::HIGH_IGN1
+            )
+            | parse_flags!(prop.flags.bits(), PageFlags::AVAIL2, PteFlags::HIGH_IGN2);
+        if prop.priv_flags.contains(PrivFlags::USER) {
+            flags |= PteFlags::NO_EXECUTE_KERN.bits()
+                | parse_flags!(!prop.flags.bits(), PageFlags::X, PteFlags::NO_EXECUTE_USER);
+        } else {
+            flags |= PteFlags::NO_EXECUTE_USER.bits()
+                | parse_flags!(!prop.flags.bits(), PageFlags::X, PteFlags::NO_EXECUTE_KERN);
+        }
+
+        flags |= PteFlags::SH_INNER.bits();
+        match prop.cache {
+            CachePolicy::Writeback => (),
+            CachePolicy::Uncacheable => {
+                // TODO: Currently Asterinas uses `Uncacheable` only for I/O
+                // memory. Normal memory can also be `Noncacheable`, where the
+                // attribute should not be set to `ATTR_DEVICE`.
+                flags |= PteFlags::ATTR_DEVICE.bits();
+            }
+            _ => panic!("unsupported cache policy"),
+        }
+
+        debug_assert_eq!(
+            paddr & !Self::PHYS_ADDR_MASK,
+            0,
+            "page physical address contains invalid bits"
+        );
+        Self(paddr | flags)
+    }
+
+    fn new_pt(paddr: Paddr, flags: PageTableFlags) -> Self {
+        let flags = PteFlags::VALID.bits()
+            | PteFlags::NON_HUGE.bits()
+            | parse_flags!(flags.bits(), PageTableFlags::AVAIL1, PteFlags::HIGH_IGN1)
+            | parse_flags!(flags.bits(), PageTableFlags::AVAIL2, PteFlags::HIGH_IGN2);
+
+        debug_assert_eq!(
+            paddr & !Self::PHYS_ADDR_MASK,
+            0,
+            "page table physical address contains invalid bits"
+        );
+        Self(paddr | flags)
+    }
+}
+
+impl PodOnce for PageTableEntry {}
+
+// SAFETY: The implementation is safe because:
+//  - `from_usize` and `into_usize` are not overridden;
+//  - `from_repr` and `repr` are correctly implemented;
+//  - a zeroed PTE represents an absent entry.
+unsafe impl PteTrait for PageTableEntry {
+    fn from_repr(repr: &PteScalar, level: PagingLevel) -> Self {
+        match repr {
+            PteScalar::Absent => PageTableEntry(0),
+            PteScalar::PageTable(paddr, flags) => Self::new_pt(*paddr, *flags),
+            PteScalar::Mapped(paddr, prop) => Self::new_page(*paddr, level, *prop),
+        }
+    }
+
+    fn to_repr(&self, level: PagingLevel) -> PteScalar {
+        if !self.is_present() {
+            return PteScalar::Absent;
+        }
+
+        if self.is_last(level) {
+            PteScalar::Mapped(self.paddr(), self.prop())
+        } else {
+            PteScalar::PageTable(self.paddr(), self.pt_flags())
+        }
+    }
+}

--- a/ostd/src/arch/arm/mm/mod.rs
+++ b/ostd/src/arch/arm/mm/mod.rs
@@ -2,6 +2,10 @@
 
 use core::{arch::asm, ops::Range};
 
+pub(crate) use util::{
+    __atomic_cmpxchg_fallible, __atomic_load_fallible, __memcpy_fallible, __memset_fallible,
+};
+
 use crate::mm::{
     PAGE_SIZE, Paddr, PagingConstsTrait, PagingLevel, PodOnce, Vaddr,
     dma::DmaDirection,
@@ -10,6 +14,8 @@ use crate::mm::{
     },
     page_table::{PteScalar, PteTrait},
 };
+
+mod util;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PagingConsts {}

--- a/ostd/src/arch/arm/mm/util.rs
+++ b/ostd/src/arch/arm/mm/util.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+
+core::arch::global_asm!(include_str!("memcpy_fallible.S"));
+core::arch::global_asm!(include_str!("memset_fallible.S"));
+
+core::arch::global_asm!(include_str!("atomic_load_fallible.S"));
+core::arch::global_asm!(include_str!("atomic_cmpxchg_fallible.S"));
+
+unsafe extern "C" {
+    /// Copies `size` bytes from `src` to `dst`. This function works with exception handling
+    /// and can recover from page fault.
+    /// Returns number of bytes that failed to copy.
+    pub(crate) fn __memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> usize;
+    /// Fills `size` bytes in the memory pointed to by `dst` with the value `value`.
+    /// This function works with exception handling and can recover from page fault.
+    /// Returns number of bytes that failed to set.
+    pub(crate) fn __memset_fallible(dst: *mut u8, value: u8, size: usize) -> usize;
+
+    /// Atomically loads a 32-bit integer value. This function works with exception handling
+    /// and can recover from page fault.
+    /// Returns the loaded value or `!0u64` if failed to load.
+    pub(crate) fn __atomic_load_fallible(ptr: *const u32) -> u64;
+    /// Atomically compares and exchanges a 32-bit integer value. This function works with
+    /// exception handling and can recover from page fault.
+    /// Returns the previous value or `!0u64` if failed to update.
+    pub(crate) fn __atomic_cmpxchg_fallible(ptr: *mut u32, old_val: u32, new_val: u32) -> u64;
+}

--- a/ostd/src/arch/arm/mod.rs
+++ b/ostd/src/arch/arm/mod.rs
@@ -88,4 +88,20 @@ pub fn read_random() -> Option<u64> {
     None
 }
 
-pub(crate) fn enable_cpu_features() {}
+pub(crate) fn enable_cpu_features() {
+    use core::arch::asm;
+
+    // SAFETY: It is safe to enable access to the FPU, as the FPU state does not
+    // affect the kernel's memory safety.
+    unsafe {
+        // Architectural Feature Access Control Register (CPACR).
+        // FPEN, bits [21:20] = 11: Instructions that use the registers associated
+        // with Advanced SIMD and floating-point execution can be used at EL0/EL1.
+        asm!(
+            "mov {tmp}, #(3 << 20)",
+            "msr cpacr_el1, {tmp}",
+            "isb",
+            tmp = out(reg) _,
+        );
+    }
+}

--- a/ostd/src/arch/arm/mod.rs
+++ b/ostd/src/arch/arm/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod io;
 pub(crate) mod iommu;
 pub mod irq;
 pub(crate) mod mm;
+mod power;
 pub mod serial;
 pub(crate) mod task;
 mod timer;
@@ -46,6 +47,8 @@ pub(crate) unsafe fn late_init_on_bsp() {
     // 1. All the system device memory have been removed from the builder.
     // 2. ARM platforms do not have port I/O.
     unsafe { crate::io::init(io_mem_builder) };
+
+    power::init();
 }
 
 /// Initializes application-processor-specific state.

--- a/ostd/src/arch/arm/mod.rs
+++ b/ostd/src/arch/arm/mod.rs
@@ -60,6 +60,26 @@ pub(crate) unsafe fn init_on_ap() {
     unimplemented!()
 }
 
+/// Returns the frequency of TSC. The unit is Hz.
+pub fn tsc_freq() -> u64 {
+    use core::arch::asm;
+
+    let cntfrq;
+    // SAFETY: It is safe to read a time-related counter.
+    unsafe { asm!("mrs {}, cntfrq_el0", out(reg) cntfrq) };
+    cntfrq
+}
+
+/// Reads the current value of the processor's time-stamp counter (TSC).
+pub fn read_tsc() -> u64 {
+    use core::arch::asm;
+
+    let cntvct;
+    // SAFETY: It is safe to read a time-related counter.
+    unsafe { asm!("mrs {}, cntvct_el0", out(reg) cntvct) };
+    cntvct
+}
+
 /// Reads a hardware generated 64-bit random value.
 ///
 /// Returns `None` if no random value was generated.

--- a/ostd/src/arch/arm/mod.rs
+++ b/ostd/src/arch/arm/mod.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Platform-specific code for the ARM platform.
+
+#![expect(dead_code)]
+
+pub mod boot;
+pub mod cpu;
+pub mod device;
+pub(crate) mod io;
+pub(crate) mod iommu;
+pub mod irq;
+pub(crate) mod mm;
+pub mod serial;
+pub(crate) mod task;
+mod timer;
+pub mod trap;
+
+#[cfg(feature = "cvm_guest")]
+pub(crate) fn init_cvm_guest() {
+    // Unimplemented, no-op
+}
+
+/// Architecture-specific initialization on the bootstrapping processor.
+///
+/// It should be called when the heap and frame allocators are available.
+///
+/// # Safety
+///
+/// 1. This function must be called only once in the boot context of the
+///    bootstrapping processor.
+/// 2. This function must be called after the kernel page table is activated on
+///    the bootstrapping processor.
+pub(crate) unsafe fn late_init_on_bsp() {
+    // SAFETY: This is only called once on this BSP in the boot context.
+    unsafe { trap::init_on_cpu() };
+
+    // SAFETY: The caller ensures that this function is only called once on BSP,
+    // after the kernel page table is activated.
+    let io_mem_builder = unsafe { io::construct_io_mem_allocator_builder() };
+
+    // SAFETY: We're on the BSP and we're ready to boot all APs.
+    unsafe { crate::boot::smp::boot_all_aps() };
+
+    // SAFETY:
+    // 1. All the system device memory have been removed from the builder.
+    // 2. ARM platforms do not have port I/O.
+    unsafe { crate::io::init(io_mem_builder) };
+}
+
+/// Initializes application-processor-specific state.
+///
+/// # Safety
+///
+/// 1. This function must be called only once on each application processor.
+/// 2. This function must be called after the BSP's call to [`late_init_on_bsp`]
+///    and before any other architecture-specific code in this module is called
+///    on this AP.
+pub(crate) unsafe fn init_on_ap() {
+    unimplemented!()
+}
+
+/// Reads a hardware generated 64-bit random value.
+///
+/// Returns `None` if no random value was generated.
+pub fn read_random() -> Option<u64> {
+    // FIXME: Implement a hardware random number generator on ARM platforms.
+    None
+}
+
+pub(crate) fn enable_cpu_features() {}

--- a/ostd/src/arch/arm/power.rs
+++ b/ostd/src/arch/arm/power.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Power management.
+//!
+//! This implements ARM Power State Coordination Interface (PSCI).
+//!
+//! Reference: <https://developer.arm.com/documentation/den0022/fb/>
+
+use core::arch::asm;
+
+use fdt::node::FdtNode;
+use spin::Once;
+
+use crate::{
+    arch::boot::DEVICE_TREE,
+    power::{ExitCode, inject_poweroff_handler, inject_restart_handler},
+};
+
+#[derive(Debug)]
+enum PsciMethod {
+    Smc,
+    Hvc,
+}
+
+impl PsciMethod {
+    fn parse(node: &FdtNode) -> Option<Self> {
+        let method = node.property("method")?.as_str()?;
+        match method {
+            "smc" => Some(Self::Smc),
+            "hvc" => Some(Self::Hvc),
+            _ => None,
+        }
+    }
+}
+
+static PSCI_METHOD: Once<PsciMethod> = Once::new();
+
+#[repr(u32)]
+enum PsciFunc {
+    SystemOff = 0x8400_0008,
+    SystemReset = 0x8400_0009,
+}
+
+fn try_poweroff(_code: ExitCode) {
+    psci_call(PsciFunc::SystemOff);
+}
+
+fn try_restart(_code: ExitCode) {
+    psci_call(PsciFunc::SystemReset);
+}
+
+fn psci_call(func_id: PsciFunc) {
+    // If possible, keep this method panic-free because it may be called by the panic handler.
+    let Some(psci_method) = PSCI_METHOD.get() else {
+        return;
+    };
+
+    // For the SMC Calling Convention (SMCCC) version 1.1 and higher, we only need to clobber
+    // registers `x0`-`x3`. Since we don't check the SMCC version, we clobber registers `x0`-`x17`,
+    // which are required by SMCC v1.0.
+    macro_rules! asm_smccc {
+        ($insn:literal, $func_id:expr) => {
+            asm!(
+                $insn,
+                in("w0") $func_id,
+                lateout("x0") _, out("x1") _, out("x2") _, out("x3") _, out("x4") _, out("x5") _,
+                out("x6") _, out("x7") _, out("x8") _, out("x9") _, out("x10") _, out("x11") _,
+                out("x12") _, out("x13") _, out("x14") _, out("x15") _, out("x16") _, out("x17") _,
+            )
+        }
+    }
+
+    // SAFETY: We've checked that PSCI exists vis the device tree. Then it is safe to invoke a PCSI
+    // function using the correct calling convention.
+    unsafe {
+        match psci_method {
+            PsciMethod::Smc => asm_smccc!("smc #0", func_id as u32),
+            PsciMethod::Hvc => asm_smccc!("hvc #0", func_id as u32),
+        }
+    }
+}
+
+pub(super) fn init() {
+    // Reference: <https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/psci.txt>
+    const FDT_COMPATIBLE: &[&str] = &["arm,psci-0.2", "arm,psci-1.0"];
+
+    let device_tree = DEVICE_TREE.get().unwrap();
+
+    let Some(psci_node) = device_tree.find_compatible(FDT_COMPATIBLE) else {
+        return;
+    };
+    let Some(psci_method) = PsciMethod::parse(&psci_node) else {
+        crate::warn!("PSCI node has an invalid method");
+        return;
+    };
+
+    crate::info!("PSCI detected: {:?}", psci_method);
+
+    PSCI_METHOD.call_once(|| psci_method);
+    inject_poweroff_handler(try_poweroff);
+    inject_restart_handler(try_restart);
+}

--- a/ostd/src/arch/arm/serial.rs
+++ b/ostd/src/arch/arm/serial.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The console I/O.
+
+use core::fmt;
+
+use bitflags::bitflags;
+use spin::Once;
+
+use super::boot::DEVICE_TREE;
+use crate::{
+    boot::EarlyCmdline,
+    mm::paddr_to_vaddr,
+    sync::{LocalIrqDisabled, SpinLock},
+};
+
+/// The primary serial port, which serves as an early console.
+pub static SERIAL_PORT: Once<SpinLock<Pl011Uart, LocalIrqDisabled>> = Once::new();
+
+/// A PL011 serial port.
+pub struct Pl011Uart(*mut u32);
+
+unsafe impl Send for Pl011Uart {}
+unsafe impl Sync for Pl011Uart {}
+
+bitflags! {
+    // Reference: <https://developer.arm.com/documentation/ddi0183/g/programmers-model/register-descriptions/flag-register--uartfr>
+    struct Status: u32 {
+        /// Transmit FIFO full.
+        const TXFF = 1 << 5;
+    }
+}
+
+impl Pl011Uart {
+    // Reference: <https://developer.arm.com/documentation/ddi0183/g/programmers-model/summary-of-registers>
+    const OFFSET_UARTDR: usize = 0x000; // Data Register.
+    const OFFSET_UARTFR: usize = 0x018; // Flag Register.
+
+    /// # Safety
+    ///
+    /// The caller must ensure that the base address is a valid serial base address and that it has
+    /// exclusive ownership of the serial registers.
+    pub(self) const unsafe fn new(base: *mut u32) -> Self {
+        Self(base)
+    }
+
+    /// Sends a byte to the serial port.
+    pub fn send(&mut self, byte: u8) {
+        while self.read_status().contains(Status::TXFF) {
+            core::hint::spin_loop();
+        }
+        self.write_data(byte);
+    }
+
+    fn write_data(&mut self, data: u8) {
+        // SAFETY: `self.0 + OFFSET_UARTDR` is a valid register of the serial port.
+        unsafe {
+            self.0
+                .byte_add(Self::OFFSET_UARTDR)
+                .write_volatile(data as u32);
+        }
+    }
+
+    fn read_status(&self) -> Status {
+        // SAFETY: `self.0 + OFFSET_UARTFR` is a valid register of the serial port.
+        let raw = unsafe { self.0.byte_add(Self::OFFSET_UARTFR).read_volatile() };
+        Status::from_bits_truncate(raw)
+    }
+}
+
+impl fmt::Write for Pl011Uart {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.as_bytes() {
+            self.send(*c);
+        }
+        Ok(())
+    }
+}
+
+/// Initializes the serial port.
+pub(crate) fn init(early_cmdline: &EarlyCmdline) {
+    if !early_cmdline.has_early_console {
+        return;
+    }
+
+    let Some(base_address) = lookup_pl011_base_address() else {
+        return;
+    };
+
+    // SAFETY:
+    // 1. The base address is valid and correct because it is acquired from the device tree.
+    // 2. FIXME: We should ensure the address region is mapped in the boot page table and it
+    //    has a correct memory attribute (i.e., device memory).
+    // 3. FIXME: We should reserve the address region in `io_mem_allocator` to ensure the
+    //    exclusive ownership.
+    let pl011 = unsafe { Pl011Uart::new(paddr_to_vaddr(base_address) as *mut u32) };
+    SERIAL_PORT.call_once(|| SpinLock::new(pl011));
+}
+
+fn lookup_pl011_base_address() -> Option<usize> {
+    let device_tree = DEVICE_TREE.get().unwrap();
+    let stdout_path = device_tree
+        .find_node("/chosen")?
+        .property("stdout-path")?
+        .as_str()?;
+    let stdout = device_tree.find_node(stdout_path)?;
+    if stdout.compatible()?.all().any(|c| c == "arm,pl011") {
+        Some(stdout.reg()?.next()?.starting_address as usize)
+    } else {
+        None
+    }
+}

--- a/ostd/src/arch/arm/task/mod.rs
+++ b/ostd/src/arch/arm/task/mod.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The architecture support of context switch.
+
+use crate::task::TaskContextApi;
+
+core::arch::global_asm!(include_str!("switch.S"));
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct TaskContext {
+    regs: CalleeRegs,
+    lr: usize, // x30
+}
+
+impl TaskContext {
+    /// Creates a new `TaskContext`.
+    pub(crate) const fn new() -> Self {
+        TaskContext {
+            regs: CalleeRegs::new(),
+            lr: 0,
+        }
+    }
+}
+
+/// Callee-saved registers.
+#[repr(C)]
+#[derive(Clone, Debug)]
+struct CalleeRegs {
+    x19: u64,
+    x20: u64,
+    x21: u64,
+    x22: u64,
+    x23: u64,
+    x24: u64,
+    x25: u64,
+    x26: u64,
+    x27: u64,
+    x28: u64,
+    x29: u64,
+    sp: u64,
+}
+
+impl CalleeRegs {
+    /// Creates a new `CalleeRegs`.
+    pub(self) const fn new() -> Self {
+        CalleeRegs {
+            x19: 0,
+            x20: 0,
+            x21: 0,
+            x22: 0,
+            x23: 0,
+            x24: 0,
+            x25: 0,
+            x26: 0,
+            x27: 0,
+            x28: 0,
+            x29: 0,
+            sp: 0,
+        }
+    }
+}
+
+impl TaskContextApi for TaskContext {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.lr = ip;
+    }
+
+    fn set_stack_pointer(&mut self, sp: usize) {
+        self.regs.sp = sp as u64;
+    }
+}
+
+unsafe extern "C" {
+    pub(crate) unsafe fn context_switch(nxt: *const TaskContext, cur: *mut TaskContext);
+    pub(crate) unsafe fn first_context_switch(nxt: *const TaskContext);
+    pub(crate) unsafe fn kernel_task_entry_wrapper();
+}

--- a/ostd/src/arch/arm/task/switch.S
+++ b/ostd/src/arch/arm/task/switch.S
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+.text
+
+.global context_switch
+.type context_switch, @function
+context_switch: # (nxt: *const TaskContext, cur: *mut TaskContext)
+  stp x19, x20, [x1], #16
+  stp x21, x22, [x1], #16
+  stp x23, x24, [x1], #16
+  stp x25, x26, [x1], #16
+  stp x27, x28, [x1], #16
+  mov x2, sp
+  stp x29, x2, [x1], #16
+  str x30, [x1]
+  # fallthrough
+
+.global first_context_switch
+.type first_context_switch, @function
+first_context_switch: # (nxt: *const TaskContext)
+  ldp x19, x20, [x0], #16
+  ldp x21, x22, [x0], #16
+  ldp x23, x24, [x0], #16
+  ldp x25, x26, [x0], #16
+  ldp x27, x28, [x0], #16
+  ldp x29, x2, [x0], #16
+  mov sp, x2
+  ldr x30, [x0]
+
+  ret
+.size context_switch, .-context_switch
+.size first_context_switch, .-first_context_switch
+
+.global kernel_task_entry_wrapper
+.type kernel_task_entry_wrapper, @function
+kernel_task_entry_wrapper:
+  .cfi_startproc
+  .cfi_undefined 30 // mark return address as undefined to indicate end of call stack
+  bl kernel_task_entry
+  .cfi_endproc
+.size kernel_task_entry_wrapper, .-kernel_task_entry_wrapper

--- a/ostd/src/arch/arm/timer/mod.rs
+++ b/ostd/src/arch/arm/timer/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The timer support.
+
+use super::trap::TrapFrame;
+
+// TODO: Add ARM timer support and call this method.
+#[expect(dead_code)]
+fn timer_callback(trapframe: &TrapFrame) {
+    crate::timer::call_timer_callback_functions(trapframe);
+}

--- a/ostd/src/arch/arm/trap/mod.rs
+++ b/ostd/src/arch/arm/trap/mod.rs
@@ -8,6 +8,11 @@ mod trap;
 pub(super) use trap::RawUserContext;
 pub use trap::TrapFrame;
 
+use crate::arch::{
+    cpu::context::{CpuException, CpuTrap},
+    irq::{PSTATE_I, disable_local, enable_local},
+};
+
 /// Initializes interrupt handling on ARM.
 ///
 /// # Safety
@@ -19,5 +24,39 @@ pub(crate) unsafe fn init_on_cpu() {
     // SAFETY: The caller ensures the safety conditions.
     unsafe {
         trap::init_on_cpu();
+    }
+}
+
+/// Handle traps (only from kernel).
+// SAFETY: The name does not collide with other symbols.
+#[unsafe(no_mangle)]
+extern "C" fn trap_handler(f: &mut TrapFrame) {
+    fn enable_local_if(cond: bool) {
+        if cond {
+            enable_local();
+        }
+    }
+
+    fn disable_local_if(cond: bool) {
+        if cond {
+            disable_local();
+        }
+    }
+
+    // The IRQ state before trapping. We need to ensure that the IRQ state
+    // during exception handling is consistent with the state before the trap.
+    let was_irq_enabled = f.spsr & PSTATE_I == 0;
+
+    let trap = CpuTrap::new(f.trap_num);
+    match trap {
+        Some(CpuTrap::Exception(data_abort @ CpuException::DataAbort { address, .. })) => {
+            enable_local_if(was_irq_enabled);
+            crate::mm::fault::handle_user_page_fault(f, &data_abort, address);
+            disable_local_if(was_irq_enabled);
+        }
+        _ => panic!(
+            "Cannot handle kernel CPU exception: {:?}; trapframe: {:#?}",
+            trap, f
+        ),
     }
 }

--- a/ostd/src/arch/arm/trap/mod.rs
+++ b/ostd/src/arch/arm/trap/mod.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Handles trap.
+
+#[expect(clippy::module_inception)]
+mod trap;
+
+pub(super) use trap::RawUserContext;
+pub use trap::TrapFrame;
+
+/// Initializes interrupt handling on ARM.
+///
+/// # Safety
+///
+/// On the current CPU, this function must be called
+/// - only once and
+/// - before any trap can occur.
+pub(crate) unsafe fn init_on_cpu() {
+    // SAFETY: The caller ensures the safety conditions.
+    unsafe {
+        trap::init_on_cpu();
+    }
+}

--- a/ostd/src/arch/arm/trap/trap.S
+++ b/ostd/src/arch/arm/trap/trap.S
@@ -1,0 +1,175 @@
+/* SPDX-License-Identifier: MPL-2.0 OR MIT
+ *
+ * The original source code is from [trapframe-rs](https://github.com/rcore-os/trapframe-rs),
+ * which is released under the following license:
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2020 - 2024 Runji Wang
+ *
+ * We make the following new changes:
+ * * Adjust some symbol names.
+ * * Revise some comments.
+ *
+ * These changes are released under the following license:
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.text
+
+trap_common:
+    # x30 and x0 are saved in __vectors
+    # x0 is trap num now
+    # skip __reversed
+    str     x29, [sp, #-16]!
+    stp     x27, x28, [sp, #-16]!
+    stp     x25, x26, [sp, #-16]!
+    stp     x23, x24, [sp, #-16]!
+    stp     x21, x22, [sp, #-16]!
+    stp     x19, x20, [sp, #-16]!
+    stp     x17, x18, [sp, #-16]!
+    stp     x15, x16, [sp, #-16]!
+    stp     x13, x14, [sp, #-16]!
+    stp     x11, x12, [sp, #-16]!
+    stp     x9, x10, [sp, #-16]!
+    stp     x7, x8, [sp, #-16]!
+    stp     x5, x6, [sp, #-16]!
+    stp     x3, x4, [sp, #-16]!
+    stp     x1, x2, [sp, #-16]!
+
+    # skip tpidr and sp
+    add     sp, sp, #-16
+
+    # read spsr and elr
+    mrs     x2, spsr_el1
+    mrs     x1, elr_el1
+    stp     x1, x2, [sp, #-16]!
+
+    # save trap num
+    str     x0, [sp, #-16]!
+
+    # check source is 2
+    mov     x1, #0x3
+    and     x1, x1, x0
+    cmp     x1, #2
+    beq     _trap_from_user
+
+_trap_from_kernel:
+    # read tpidr and sp
+    mrs     x2, tpidr_el1
+    add     x1, sp, #38*8
+    stp     x1, x2, [sp, #32]
+
+    # go to rust
+    mov     x0, sp
+    bl      trap_handler
+
+    # load tpidr
+    ldr     x1, [sp, #40]
+    msr     tpidr_el1, x1
+
+    b       _trap_return
+
+_trap_from_user:
+    # read tpidr and sp
+    mrs     x2, tpidr_el0
+    mrs     x1, sp_el0
+    stp     x1, x2, [sp, #32]
+
+    # read sp
+    ldr     x2, [sp, #8]
+    mov     sp, x2
+
+    # load callee-saved registers
+    ldp     x19, x20, [sp], #16
+    ldp     x21, x22, [sp], #16
+    ldp     x23, x24, [sp], #16
+    ldp     x25, x26, [sp], #16
+    ldp     x27, x28, [sp], #16
+    ldp     x29, x30, [sp], #16
+
+    ret
+
+.macro HANDLER source kind
+    .balign 128
+    # sp is set to sp_el1 upon trap
+    stp     lr, x0, [sp, #-16]!
+    mov     x0, #\source
+    movk    x0, #\kind, lsl #16
+    b       trap_common
+.endm
+
+.balign 2048
+.global __vectors
+__vectors:
+    HANDLER 0 0
+    HANDLER 0 1
+    HANDLER 0 2
+    HANDLER 0 3
+    HANDLER 1 0
+    HANDLER 1 1
+    HANDLER 1 2
+    HANDLER 1 3
+    HANDLER 2 0
+    HANDLER 2 1
+    HANDLER 2 2
+    HANDLER 2 3
+    HANDLER 3 0
+    HANDLER 3 1
+    HANDLER 3 2
+    HANDLER 3 3
+
+.global run_user
+run_user: # (regs: &mut RawUserContext)
+    # x0 points to TrapFrame
+    # save callee-saved registers x19-x29
+    stp     x29, x30, [sp, #-16]!
+    stp     x27, x28, [sp, #-16]!
+    stp     x25, x26, [sp, #-16]!
+    stp     x23, x24, [sp, #-16]!
+    stp     x21, x22, [sp, #-16]!
+    stp     x19, x20, [sp, #-16]!
+
+    # save kernel sp to TrapFrame
+    mov     x1, sp
+    mov     sp, x0
+    str     x1, [sp, #8]
+
+    # load sp and tpidr
+    ldp     x1, x2, [sp, #32]
+    msr     sp_el0, x1
+    msr     tpidr_el0, x2
+
+_trap_return:
+    # sp points to TrapFrame
+    # skip trap num, don't restore
+    add     sp, sp, #16
+
+    # elr and spsr
+    ldp     x1, x2, [sp], #16
+    msr     elr_el1, x1
+    msr     spsr_el1, x2
+
+    # skip sp and tpidr
+    add     sp, sp, #16
+
+    # general purpose registers
+    ldp     x1, x2, [sp], #16
+    ldp     x3, x4, [sp], #16
+    ldp     x5, x6, [sp], #16
+    ldp     x7, x8, [sp], #16
+    ldp     x9, x10, [sp], #16
+    ldp     x11, x12, [sp], #16
+    ldp     x13, x14, [sp], #16
+    ldp     x15, x16, [sp], #16
+    ldp     x17, x18, [sp], #16
+    ldp     x19, x20, [sp], #16
+    ldp     x21, x22, [sp], #16
+    ldp     x23, x24, [sp], #16
+    ldp     x25, x26, [sp], #16
+    ldp     x27, x28, [sp], #16
+    ldr     x29, [sp], #16
+    ldp     lr, x0, [sp], #16
+
+    eret

--- a/ostd/src/arch/arm/trap/trap.rs
+++ b/ostd/src/arch/arm/trap/trap.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MPL-2.0 OR MIT
+//
+// The original source code is from [trapframe-rs](https://github.com/rcore-os/trapframe-rs),
+// which is released under the following license:
+//
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2020 - 2024 Runji Wang
+//
+// We make the following new changes:
+// * Implement the `trap_handler` of Asterinas.
+//
+// These changes are released under the following license:
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use core::arch::{asm, global_asm};
+
+use crate::{arch::cpu::context::GeneralRegs, irq::DisabledLocalIrqGuard, mm::fault::TrapFrameApi};
+
+/// Saved registers on a trap.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(in crate::arch) struct RawUserContext {
+    /// Trap num: Source and Kind
+    pub(in crate::arch) trap_num: usize,
+    /// Reserved for internal use
+    pub(in crate::arch) __reserved: usize,
+    /// Exception Link Register, elr_el1
+    pub(in crate::arch) elr: usize,
+    /// Saved Process Status Register, spsr_el1
+    pub(in crate::arch) spsr: usize,
+    /// Stack Pointer, sp_el0
+    pub(in crate::arch) sp: usize,
+    /// Software Thread ID Register, tpidr_el0
+    pub(in crate::arch) tpidr: usize,
+    /// General registers
+    /// Must be last in this struct
+    pub(in crate::arch) general: GeneralRegs,
+}
+
+global_asm!(include_str!("trap.S"));
+
+/// Initializes interrupt handling on ARM.
+///
+/// This function will:
+/// - Set `vbar_el1` to internal exception vector.
+///
+/// # Safety
+///
+/// On the current CPU, this function must be called
+/// - only once and
+/// - before any trap can occur.
+pub(super) unsafe fn init_on_cpu() {
+    // SAFETY: We believe that these assembly instructions correctly set up
+    // the trap handling for the current CPU without side effects.
+    unsafe {
+        // Set the exception vector address.
+        asm!("msr vbar_el1, {}", in(reg) __vectors as *const () as usize);
+    }
+}
+
+/// Trap frame of kernel interrupt
+///
+/// # Trap handler
+///
+/// You need to define a handler function like this:
+///
+/// ```no_run
+/// // SAFETY: The name does not collide with other symbols.
+/// #[unsafe(no_mangle)]
+/// pub extern "C" fn trap_handler(tf: &mut TrapFrame) {
+///     println!("TRAP! tf: {:#x?}", tf);
+/// }
+/// ```
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct TrapFrame {
+    /// Trap num: Source and Kind
+    pub trap_num: usize,
+    /// Reserved for internal use
+    pub __reserved: usize,
+    /// Exception Link Register, elr_el1
+    pub elr: usize,
+    /// Saved Process Status Register, spsr_el1
+    pub spsr: usize,
+    /// Stack Pointer, sp_el1
+    pub sp: usize,
+    /// Software Thread ID Register, tpidr_el1
+    pub tpidr: usize,
+    /// General registers
+    /// Must be last in this struct
+    pub general: GeneralRegs,
+}
+
+impl TrapFrameApi for TrapFrame {
+    fn set_instruction_pointer(&mut self, ip: usize) {
+        self.elr = ip;
+    }
+
+    fn instruction_pointer(&self) -> usize {
+        self.elr
+    }
+}
+
+impl RawUserContext {
+    /// Goes to user space with the context, and comes back when a trap occurs.
+    ///
+    /// On return, the context will be reset to the status before the trap.
+    /// Trap reason and error code will be placed at `trap_num`.
+    pub(in crate::arch) fn run(&mut self, guard: DisabledLocalIrqGuard) {
+        // Return to userspace with interrupts disabled. Otherwise, interrupts
+        // after switching `sp` will mess up the CPU state.
+        core::mem::forget(guard);
+
+        unsafe { run_user(self) };
+    }
+}
+
+unsafe extern "C" {
+    unsafe fn __vectors();
+    unsafe fn run_user(regs: &mut RawUserContext);
+}

--- a/ostd/src/boot/mod.rs
+++ b/ostd/src/boot/mod.rs
@@ -7,7 +7,11 @@
 //!  3. the routine booting the other processors in the SMP context.
 
 #![cfg_attr(
-    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    any(
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "aarch64"
+    ),
     expect(dead_code)
 )]
 

--- a/ostd/src/cpu/local/static_cpu_local.rs
+++ b/ostd/src/cpu/local/static_cpu_local.rs
@@ -3,7 +3,11 @@
 //! Statically-allocated CPU-local objects.
 
 #![cfg_attr(
-    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    any(
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "aarch64"
+    ),
     expect(dead_code)
 )]
 

--- a/ostd/src/io/io_mem/allocator.rs
+++ b/ostd/src/io/io_mem/allocator.rs
@@ -104,7 +104,10 @@ impl IoMemAllocatorBuilder {
     /// # Panics
     ///
     /// This function will panic if the specified range is not available.
-    #[cfg_attr(target_arch = "loongarch64", expect(unused))]
+    #[cfg_attr(
+        any(target_arch = "loongarch64", target_arch = "aarch64"),
+        expect(unused)
+    )]
     pub(crate) fn reserve(
         &self,
         range: Range<usize>,

--- a/ostd/src/io/io_mem/mod.rs
+++ b/ostd/src/io/io_mem/mod.rs
@@ -169,7 +169,10 @@ impl<SecuritySensitivity> IoMem<SecuritySensitivity> {
     }
 }
 
-#[cfg_attr(target_arch = "loongarch64", expect(unused))]
+#[cfg_attr(
+    any(target_arch = "loongarch64", target_arch = "aarch64"),
+    expect(unused)
+)]
 impl IoMem<Sensitive> {
     /// Reads a value of the `PodOnce` type at the specified offset using one
     /// non-tearing memory load.

--- a/ostd/src/io/mod.rs
+++ b/ostd/src/io/mod.rs
@@ -10,7 +10,10 @@
 pub(crate) mod io_mem;
 
 pub use self::io_mem::IoMem;
-#[cfg_attr(target_arch = "loongarch64", expect(unused_imports))]
+#[cfg_attr(
+    any(target_arch = "loongarch64", target_arch = "aarch64"),
+    expect(unused_imports)
+)]
 pub(crate) use self::io_mem::{IoMemAllocatorBuilder, Sensitive};
 
 cfg_select! {

--- a/ostd/src/irq/mod.rs
+++ b/ostd/src/irq/mod.rs
@@ -86,6 +86,7 @@ use crate::{
     cpu::PrivilegeLevel,
 };
 
+#[cfg_attr(target_arch = "aarch64", expect(dead_code))]
 pub(crate) fn call_irq_callback_functions(
     trap_frame: &TrapFrame,
     hw_irq_line: &HwIrqLine,

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -30,6 +30,7 @@ macro_rules! __log_prefix {
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86/mod.rs")]
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv/mod.rs")]
 #[cfg_attr(target_arch = "loongarch64", path = "arch/loongarch/mod.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "arch/arm/mod.rs")]
 pub mod arch;
 
 pub mod boot;

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -466,7 +466,7 @@ pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {
         max_paddr
     );
 
-    // In RISC-V, the boot page table has mapped the 512GB memory,
+    // In RISC-V and AArch64, the boot page table has mapped the 512GB memory,
     // so we don't need to add temporary linear mapping.
     // In LoongArch, the DWM0 has mapped the whole memory,
     // so we don't need to add temporary linear mapping.

--- a/ostd/src/mm/io/mod.rs
+++ b/ostd/src/mm/io/mod.rs
@@ -978,7 +978,8 @@ pub trait PodOnce: Pod {}
 #[cfg(any(
     target_arch = "x86_64",
     target_arch = "riscv64",
-    target_arch = "loongarch64"
+    target_arch = "loongarch64",
+    target_arch = "aarch64"
 ))]
 mod pod_once_impls {
     use super::PodOnce;

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -104,7 +104,7 @@ pub fn kernel_loaded_offset() -> usize {
 
 #[cfg(target_arch = "x86_64")]
 const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_8000_0000;
-#[cfg(target_arch = "riscv64")]
+#[cfg(any(target_arch = "riscv64", target_arch = "aarch64"))]
 const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_0000_0000;
 #[cfg(target_arch = "loongarch64")]
 const KERNEL_CODE_BASE_VADDR: usize = 0x9000_0000_0000_0000;

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -3,7 +3,11 @@
 //! Virtual memory (VM).
 
 #![cfg_attr(
-    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    any(
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "aarch64"
+    ),
     expect(unused_imports)
 )]
 

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![cfg_attr(
-    any(target_arch = "riscv64", target_arch = "loongarch64"),
+    any(
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "aarch64"
+    ),
     expect(dead_code)
 )]
 

--- a/ostd/src/power.rs
+++ b/ostd/src/power.rs
@@ -30,7 +30,8 @@ static RESTART_HANDLER: Once<fn(ExitCode)> = Once::new();
 /// so, calling this function outside of OSTD will never take effect. Currently, it happens in
 ///  - x86_64: Never;
 ///  - riscv64: Always;
-///  - loongarch64: Never.
+///  - loongarch64: Never;
+///  - aarch64: If a supported PSCI device tree node exists.
 pub fn inject_restart_handler(handler: fn(ExitCode)) {
     RESTART_HANDLER.call_once(|| handler);
 }
@@ -60,7 +61,8 @@ static POWEROFF_HANDLER: Once<fn(ExitCode)> = Once::new();
 /// so, calling this function outside of OSTD will never take effect. Currently, it happens in
 ///  - x86_64: If a QEMU hypervisor is detected;
 ///  - riscv64: Always;
-///  - loongarch64: Never.
+///  - loongarch64: Never;
+///  - aarch64: If a supported PSCI device tree node exists.
 pub fn inject_poweroff_handler(handler: fn(ExitCode)) {
     POWEROFF_HANDLER.call_once(|| handler);
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,4 +3,4 @@
 [toolchain]
 channel = "nightly-2026-07-21"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-targets = ["x86_64-unknown-none", "riscv64imac-unknown-none-elf", "loongarch64-unknown-none-softfloat"]
+targets = ["x86_64-unknown-none", "riscv64imac-unknown-none-elf", "loongarch64-unknown-none-softfloat", "aarch64-unknown-none-softfloat"]

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -18,6 +18,8 @@ let
       "x86_64-unknown-linux-gnu"
     else if target == "riscv64" then
       "riscv64-unknown-linux-gnu"
+    else if target == "aarch64" then
+      "aarch64-unknown-linux-gnu"
     else
       throw "Target arch ${target} not yet supported.";
 

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -117,6 +117,31 @@ if [ "$1" = "riscv" ]; then
     exit 0
 fi
 
+if [ "$1" = "aarch64" ]; then
+    QEMU_ARGS="\
+        -cpu cortex-a72 \
+        -machine virt,gic-version=3 \
+        -m ${MEM:-8G} \
+        -smp ${SMP:-1} \
+        --no-reboot \
+        -nographic \
+        -display none \
+        -monitor chardev:mux \
+        -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
+        -drive if=none,format=raw,id=x0,file=./test/initramfs/build/ext2.img \
+        -drive if=none,format=raw,id=x1,file=./test/initramfs/build/exfat.img \
+        -drive if=none,format=raw,id=x2,file=./test/initramfs/build/ltp_dev.img \
+        -device virtio-blk-device,drive=x2 \
+        -device virtio-blk-device,drive=x1 \
+        -device virtio-blk-device,drive=x0 \
+        -device virtio-keyboard-device \
+        -device virtio-serial-device \
+        $CONSOLE_ARGS \
+    "
+    echo $QEMU_ARGS
+    exit 0
+fi
+
 if [ "$1" = "tdx" ]; then
     TDX_OBJECT='{ "qom-type": "tdx-guest", "id": "tdx0", "sept-ve-disable": true, "quote-generation-socket": { "type": "vsock", "cid": "1", "port": "4050" } }'
     if [ "$INITRAMFS" = "off" ]; then


### PR DESCRIPTION
This is the "minimal" AArch64 support. Fixes #2241.

Although it is minimal, it contains everything necessary to run a busybox binary, but **excluding** extra drivers.

Here are some examples:
 1. FPU support is included. Otherwise, the busybox binary cannot be run.
 2. Fallible memory operations are implemented. While this is not strictly required, as a simple busybox binary may not trigger fallible memory in the kernel, doing so is reasonable for correctness purposes.

Also, there are some counterexamples.
 1. No input device drivers are implemented, so you cannot interact with the busybox shell.
 2. `virtio-console` is not supported because supporting it is not essential.

Why not include those? The main problem is that implementing an interrupt controller (e.g., GICv3 in AArch64) is relatively complex. So, I'm a little worried about bloating this PR too much.

Since we cannot input, how can we verify this PR? Unforunately, there may not be many ways, you can try:
```
make run_kernel TARGET_ARCH=aarch64 AUTO_TEST=boot CONSOLE=ttyS0
```

It will succeed:
```
[kernel] running /init as the init process
mount: mounting /dev/vda on /ext2 failed: No such file or directory
mount: mounting /dev/vdb on /exfat failed: No such file or directory
Successfully booted.
```

As an alternative, you can check out the [full branch](https://github.com/lrh2000/asterinas/tree/arm-v4), which provides access to a fully functional BusyBox shell (via `make run_kernel RELEASE=1 TARGET_ARCH=aarch64`).

### Naming conventions

"AArch64" is the official name for "ARM64", so I'm using "AArch64" throughout the codebase to indicate the 64-bit variant of ARM architectures. There is one exception: "ARM64" is already used in `README.md`, so I use it for consistency.

The directory name under `arch/` should omit the "64-bit" variant naming (e.g., `arch/x86` instead of `arch/x86-64`), so I will use `arch/arm`.

### Commit notes

1. "Add AArch64 boilerplate code" contains mostly code copied from other architectures with slight modifications (e.g., "RISC-V" changed to "ARM"). When in doubt, check the implementation in other architectures.
2. For background on some co-author commits, see https://github.com/asterinas/asterinas/pull/3270#issuecomment-4718792335. Other commits are created from scratch by me.