### PR TITLE
Drop `not same fs` errors from `fs_impls`

### DIFF
--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -196,9 +196,7 @@ impl Inode for Ext2Inode {
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        let old = old
-            .downcast_ref::<Ext2Inode>()
-            .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
+        let old = old.downcast_ref::<Ext2Inode>().unwrap();
         self.link(old, name)
     }
 

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -984,16 +984,11 @@ impl Inode for RamInode {
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        if !Arc::ptr_eq(&self.fs(), &old.fs()) {
-            return_errno_with_message!(Errno::EXDEV, "not same fs");
-        }
         if self.typ != InodeType::Dir {
             return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
         }
 
-        let old = old
-            .downcast_ref::<RamInode>()
-            .ok_or(Error::new(Errno::EXDEV))?;
+        let old = old.downcast_ref::<RamInode>().unwrap();
         if old.typ == InodeType::Dir {
             return_errno_with_message!(Errno::EPERM, "old is a dir");
         }

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -417,9 +417,7 @@ impl Inode for VirtioFsInode {
     }
 
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()> {
-        let old = old
-            .downcast_ref::<VirtioFsInode>()
-            .ok_or_else(|| Error::with_message(Errno::EXDEV, "not same fs"))?;
+        let old = old.downcast_ref::<VirtioFsInode>().unwrap();
 
         let fs = self.fs_ref();
         let request_attr_version = fs.session().snapshot_attr_version();


### PR DESCRIPTION
https://github.com/asterinas/asterinas/pull/3735 drops some `not same fs` errors in `rename()`.

I guess the remaining `not same fs` errors in `link()` can also be dropped.

They should have been checked here:
https://github.com/asterinas/asterinas/blob/36ae7fe1078842feb16c311fbbf22a527e9b0e28/kernel/core/src/fs/vfs/path/mod.rs#L674-L677

(Some directory checks may be redundant, but they are kept for consistency with the sounding methods. We can address this separately in the future.)