### PR TITLE
Implement `ksoftirqd`

### DIFF
--- a/kernel/core/comps/softirq/src/lib.rs
+++ b/kernel/core/comps/softirq/src/lib.rs
@@ -153,10 +153,12 @@ cpu_local_cell! {
 
 /// Processes pending softirqs.
 fn process_pending(irq_guard: DisabledLocalIrqGuard, irq_num: u8) -> DisabledLocalIrqGuard {
+    // Process the statistic for the (hardware) IRQ before checking the state of the softirqs.
+    process_statistic(irq_num);
+
     if !is_softirq_enabled() {
         return irq_guard;
     }
-    process_statistic(irq_num);
     process_all_pending(irq_guard)
 }
 

--- a/kernel/core/comps/softirq/src/lib.rs
+++ b/kernel/core/comps/softirq/src/lib.rs
@@ -1,28 +1,36 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Software interrupt.
+//
+// TODO: Move the `softirq` crate into `aster-core` as a subsystem.
+// The `softirq` crate relies on `aster-core` for spawning daemon kernel threads (`softirqd`).
+// After this refactoring,
+// the new `softirq` subsystem can further absorb the highly-related `softirqd` module.
+
 #![no_std]
 #![deny(unsafe_code)]
 
 extern crate alloc;
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, sync::Arc};
 use core::sync::atomic::{AtomicU8, Ordering};
 
 use aster_util::per_cpu_counter::PerCpuCounter;
 use component::{ComponentInitError, init_component};
 use ostd::{
-    cpu::CpuId,
-    cpu_local_cell,
+    cpu::{CpuId, PinCurrentCpu},
+    cpu_local, cpu_local_cell,
     irq::{
         DisabledLocalIrqGuard, disable_local, register_bottom_half_handler_l1,
         register_bottom_half_handler_l2,
     },
+    sync::{Waiter, Waker},
+    task::{Task, disable_preempt},
 };
 use spin::Once;
 
 use self::{
-    lock::is_softirq_enabled,
+    lock::{disable_local_bottom_half_with, is_softirq_enabled},
     stats::{IRQ_COUNTERS, NR_IRQ_LINES, process_statistic},
 };
 
@@ -145,10 +153,19 @@ fn init() -> Result<(), ComponentInitError> {
     Ok(())
 }
 
+#[cfg(ktest)]
+pub fn init_for_ktest() {
+    init().unwrap();
+}
+
 static ENABLED_MASK: AtomicU8 = AtomicU8::new(0);
 
 cpu_local_cell! {
     static PENDING_MASK: u8 = 0;
+}
+
+cpu_local! {
+    static DAEMON_WAKER: Once<Arc<Waker>> = Once::new();
 }
 
 /// Processes pending softirqs.
@@ -164,15 +181,20 @@ fn process_pending(irq_guard: DisabledLocalIrqGuard, irq_num: u8) -> DisabledLoc
 
 /// Processes all pending softirqs regardless of whether softirqs are disabled.
 ///
-/// The processing instructions will iterate for `SOFTIRQ_RUN_TIMES` times. If any softirq
-/// is raised during the iteration, it will be processed.
+/// This is called from the context of arbitrary tasks, meaning that we're processing softirqs using
+/// the time budget of another task. If not done carefully, this can cause fairness issues between
+/// the softirq workload and normal tasks.
+///
+/// To address this, we defer the work to a background daemon as soon as the maximum number of
+/// iterations is reached, or when the scheduler wants to preempt us.
 fn process_all_pending(mut irq_guard: DisabledLocalIrqGuard) -> DisabledLocalIrqGuard {
     const SOFTIRQ_RUN_TIMES: u8 = 5;
 
-    for _ in 0..SOFTIRQ_RUN_TIMES {
-        let mut action_mask = {
+    let mut run_time = 0;
+
+    loop {
+        let action_mask = {
             let pending_mask = PENDING_MASK.load();
-            PENDING_MASK.store(0);
             pending_mask & ENABLED_MASK.load(Ordering::Acquire)
         };
 
@@ -180,27 +202,111 @@ fn process_all_pending(mut irq_guard: DisabledLocalIrqGuard) -> DisabledLocalIrq
             break;
         }
 
+        // We will defer the remaining work in two cases:
+        // 1. if we are overloaded, i.e., there are still pending softirqs after `SOFTIRQ_RUN_TIMES`
+        //    iterations, or
+        // 2. if another task preempts us, where we will want to give it time to run to ensure
+        //    fairness.
+        if run_time >= SOFTIRQ_RUN_TIMES || Task::need_yield() {
+            // If this is `None`, the work will be processed when the daemon thread starts up.
+            if let Some(waker) = DAEMON_WAKER.get_with(&irq_guard).get() {
+                let _ = waker.wake_up();
+            }
+            break;
+        }
+        run_time += 1;
+
+        PENDING_MASK.store(0);
+
         drop(irq_guard);
 
-        while action_mask > 0 {
-            let action_id = u8::trailing_zeros(action_mask) as u8;
-
-            let softirq_line = SoftIrqLine::get(action_id);
-            softirq_line
-                .counter
-                .get()
-                .unwrap()
-                // No races because we are in IRQs.
-                .add_on_cpu(CpuId::current_racy(), 1);
-            softirq_line.callback.get().unwrap()();
-
-            action_mask &= action_mask - 1;
-        }
+        run_callbacks(action_mask);
 
         irq_guard = disable_local();
     }
 
-    // TODO: Wake up ksoftirqd if some softirqs are still pending.
-
     irq_guard
+}
+
+/// Runs a loop on the current CPU in a daemon kernel thread that processes softirqs.
+///
+/// This must be called on a kernel thread bound to a specific CPU. It should be called once on each
+/// CPU.
+///
+/// Usually, softirqs are processed in the bottom half of an IRQ handler. However, if the bottom
+/// half is overloaded or causing fairness issues, the work is deferred to a background kernel
+/// thread that runs this loop.
+pub fn daemon_loop_on_cpu() {
+    let (waiter, waker) = Waiter::new_pair();
+
+    // Disable preemption. We should process softirqs in atomic mode anyway.
+    let mut preempt_guard = disable_preempt();
+
+    // Register the daemon thread.
+    DAEMON_WAKER
+        .get_on_cpu(preempt_guard.current_cpu())
+        .call_once(|| waker);
+
+    // Before the daemon thread starts, some work may not have been processed in the bottom half.
+    let mut should_wait = false;
+
+    loop {
+        if should_wait {
+            drop(preempt_guard);
+            waiter.wait();
+            preempt_guard = disable_preempt();
+
+            should_wait = false;
+        }
+
+        let (action_mask, bottom_half_gurad) = {
+            let _irq_guard = disable_local();
+
+            let mut pending_mask = PENDING_MASK.load();
+            pending_mask &= ENABLED_MASK.load(Ordering::Acquire);
+
+            if pending_mask == 0 {
+                // There is nothing to do. Wait for some sofirqs to come in and be deferred to the
+                // daemon thread.
+                should_wait = true;
+                continue;
+            }
+
+            PENDING_MASK.store(0);
+
+            // Prevent reentrancy in softirq callbacks.
+            let bottom_half_guard = disable_local_bottom_half_with(&preempt_guard);
+
+            (pending_mask, bottom_half_guard)
+        };
+
+        run_callbacks(action_mask);
+
+        drop(bottom_half_gurad);
+
+        // Allow the scheduler to preempt us to ensure fairness.
+        if Task::need_yield() {
+            drop(preempt_guard);
+            Task::yield_now();
+            preempt_guard = disable_preempt();
+        }
+    }
+}
+
+fn run_callbacks(mut action_mask: u8) {
+    while action_mask > 0 {
+        let action_id = u8::trailing_zeros(action_mask) as u8;
+
+        let softirq_line = SoftIrqLine::get(action_id);
+        softirq_line
+            .counter
+            .get()
+            .unwrap()
+            // No races because we are either in IRQs or in a daemon thread that should have been
+            // bound to a specific CPU.
+            .add_on_cpu(CpuId::current_racy(), 1);
+        softirq_line.callback.get().unwrap()();
+
+        action_mask &= action_mask - 1;
+    }
 }

--- a/kernel/core/comps/softirq/src/lib.rs
+++ b/kernel/core/comps/softirq/src/lib.rs
@@ -11,7 +11,6 @@ use core::sync::atomic::{AtomicU8, Ordering};
 
 use aster_util::per_cpu_counter::PerCpuCounter;
 use component::{ComponentInitError, init_component};
-use lock::is_softirq_enabled;
 use ostd::{
     cpu::CpuId,
     cpu_local_cell,
@@ -21,19 +20,25 @@ use ostd::{
     },
 };
 use spin::Once;
-use stats::IRQ_COUNTERS;
-pub use stats::{
-    iter_irq_counts_across_all_cpus, iter_softirq_counts_across_all_cpus,
-    iter_softirq_counts_on_cpu,
+
+use self::{
+    lock::is_softirq_enabled,
+    stats::{IRQ_COUNTERS, NR_IRQ_LINES, process_statistic},
 };
+
 mod lock;
 pub mod softirq_id;
 mod stats;
 mod taskless;
-pub use lock::{BottomHalfDisabled, DisableLocalBottomHalfGuard};
-pub use taskless::Taskless;
 
-use crate::stats::{NR_IRQ_LINES, process_statistic};
+pub use self::{
+    lock::{BottomHalfDisabled, DisableLocalBottomHalfGuard},
+    stats::{
+        iter_irq_counts_across_all_cpus, iter_softirq_counts_across_all_cpus,
+        iter_softirq_counts_on_cpu,
+    },
+    taskless::Taskless,
+};
 
 /// A representation of a software interrupt (softirq) line.
 ///
@@ -52,15 +57,15 @@ use crate::stats::{NR_IRQ_LINES, process_statistic};
 /// # Example
 ///
 /// ```
-/// // Define an unused softirq id.
+/// // Define an unused softirq ID.
 /// const MY_SOFTIRQ_ID: u8 = 4;
-/// // Enable the softirq line of this id.
+/// // Enable the softirq line of this ID.
 /// SoftIrqLine::get(MY_SOFTIRQ_ID).enable(|| {
-///     // Define the action to take when the softirq with MY_SOFTIRQ_ID is raised
+///     // Define the action to take when the softirq with `MY_SOFTIRQ_ID` is raised
 ///     // ...
 /// });
 /// // Later on:
-/// SoftIrqLine::get(MY_SOFTIRQ_ID).raise(); // This will trigger the registered callback
+/// SoftIrqLine::get(MY_SOFTIRQ_ID).raise(); // This will trigger the registered callback.
 /// ```
 pub struct SoftIrqLine {
     id: u8,

--- a/kernel/core/comps/softirq/src/lock.rs
+++ b/kernel/core/comps/softirq/src/lock.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::marker::PhantomData;
+
 use ostd::{
     cpu_local_cell,
     irq::{InterruptLevel, disable_local},
@@ -21,9 +23,6 @@ cpu_local_cell! {
 pub(super) fn is_softirq_enabled() -> bool {
     DISABLE_SOFTIRQ_COUNT.load() == 0
 }
-
-/// A guardian that disables bottom half while holding a lock.
-pub enum BottomHalfDisabled {}
 
 /// A guard for disabled local softirqs.
 pub struct DisableLocalBottomHalfGuard {
@@ -74,6 +73,9 @@ impl GuardTransfer for DisableLocalBottomHalfGuard {
     }
 }
 
+/// A guardian that disables bottom half while holding a lock.
+pub enum BottomHalfDisabled {}
+
 impl SpinGuardian for BottomHalfDisabled {
     type Guard = DisableLocalBottomHalfGuard;
     type ReadGuard = DisableLocalBottomHalfGuard;
@@ -84,6 +86,30 @@ impl SpinGuardian for BottomHalfDisabled {
 
     fn guard() -> Self::Guard {
         disable_local_bottom_half()
+    }
+}
+
+/// A guard for disabled local softirqs when there is a pre-existing preempt guard.
+///
+/// Note the difference between this guard and [`DisableLocalBottomHalfGuard`]:
+/// the former keeps a reference to a [`DisabledPreemptGuard`] guard,
+/// while the latter _owns_ one.
+pub(super) struct DisableLocalBottomHalfGuardInPreempt<'a> {
+    phantom_data: PhantomData<&'a DisabledPreemptGuard>,
+}
+
+impl<'a> Drop for DisableLocalBottomHalfGuardInPreempt<'a> {
+    fn drop(&mut self) {
+        DISABLE_SOFTIRQ_COUNT.sub_assign(1);
+    }
+}
+
+pub(super) fn disable_local_bottom_half_with<'a>(
+    _preempt_guard: &'a DisabledPreemptGuard,
+) -> DisableLocalBottomHalfGuardInPreempt<'a> {
+    DISABLE_SOFTIRQ_COUNT.add_assign(1);
+    DisableLocalBottomHalfGuardInPreempt {
+        phantom_data: PhantomData,
     }
 }
 

--- a/kernel/core/src/init.rs
+++ b/kernel/core/src/init.rs
@@ -264,9 +264,7 @@ static INIT_PROCESS: Once<Arc<Process>> = Once::new();
 
 fn init_in_first_kthread(path_resolver: &PathResolver) {
     component::init_all(InitStage::Kthread, component::parse_metadata!()).unwrap();
-    // Work queue should be initialized before interrupt is enabled,
-    // in case any irq handler uses work queue as bottom half
-    crate::thread::work_queue::init_in_first_kthread();
+    crate::thread::init_in_first_kthread();
     crate::fs::init_in_first_kthread(path_resolver);
     crate::device::init_in_first_kthread();
     crate::net::init_in_first_kthread();

--- a/kernel/core/src/thread/mod.rs
+++ b/kernel/core/src/thread/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Posix thread implementation
+//! Thread implementation.
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -11,18 +11,20 @@ use ostd::{
     task::Task,
 };
 
+use self::stats::CONTEXT_SWITCH_COUNTER;
 use crate::{
     prelude::*,
     sched::{SchedAttr, SchedPolicy},
 };
-mod stats;
-use stats::CONTEXT_SWITCH_COUNTER;
-pub(crate) use stats::collect_context_switch_count;
+
 pub(crate) mod exception;
 pub(crate) mod kernel_thread;
 pub(crate) mod oops;
+mod stats;
 pub(crate) mod task;
 pub(crate) mod work_queue;
+
+pub(crate) use self::stats::collect_context_switch_count;
 
 pub(crate) type Tid = u32;
 
@@ -62,20 +64,23 @@ pub(super) fn init() {
     ostd::mm::fault::inject_user_page_fault_handler(exception::page_fault_handler);
 }
 
-/// A thread is a wrapper on top of task.
+/// A thread is a wrapper on top of a task.
 #[derive(Debug)]
 pub(crate) struct Thread {
-    // immutable part
-    /// Low-level info
+    // Immutable part:
+    //
+    /// Low-level task.
     task: Weak<Task>,
-    /// Data: Posix thread info/Kernel thread Info
+    /// POSIX thread information or kernel thread information.
     data: Box<dyn Send + Sync + Any>,
 
-    // mutable part
-    /// Thread status
+    // Mutable part:
+    //
+    /// Thread status.
     is_exited: AtomicBool,
-    /// Thread CPU affinity
+    /// Thread CPU affinity.
     cpu_affinity: AtomicCpuSet,
+    /// Thread scheduling attribute.
     sched_attr: SchedAttr,
 }
 

--- a/kernel/core/src/thread/mod.rs
+++ b/kernel/core/src/thread/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 pub(crate) mod exception;
 pub(crate) mod kernel_thread;
 pub(crate) mod oops;
+mod softirqd;
 mod stats;
 pub(crate) mod task;
 pub(crate) mod work_queue;
@@ -62,6 +63,11 @@ pub(super) fn init() {
     ostd::task::inject_pre_schedule_handler(pre_schedule_handler);
     ostd::task::inject_post_schedule_handler(post_schedule_handler);
     ostd::mm::fault::inject_user_page_fault_handler(exception::page_fault_handler);
+}
+
+pub(super) fn init_in_first_kthread() {
+    work_queue::init_in_first_kthread();
+    softirqd::init_in_first_kthread();
 }
 
 /// A thread is a wrapper on top of a task.

--- a/kernel/core/src/thread/softirqd.rs
+++ b/kernel/core/src/thread/softirqd.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use super::kernel_thread::ThreadOptions;
+
+pub(super) fn init_in_first_kthread() {
+    // Spawn softirq daemons on each CPU.
+    for cpu in ostd::cpu::all_cpus() {
+        ThreadOptions::new(aster_softirq::daemon_loop_on_cpu)
+            .cpu_affinity(cpu.into())
+            .spawn();
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use aster_softirq::SoftIrqLine;
+    use ostd::{irq::InterruptLevel, prelude::ktest, sync::Waiter};
+
+    const SOFTIRQ_ID: u8 = 7;
+
+    const MAX_NUM_SOFTIRQS: usize = 256;
+
+    /// The number of callbacks that we've processed in the bottom half.
+    static COUNTER_BH: AtomicUsize = AtomicUsize::new(0);
+
+    /// The number of callbacks that we've processed in the daemon thread.
+    static COUNTER_DAEMON: AtomicUsize = AtomicUsize::new(0);
+
+    /// The number of callbacks that we've processed.
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    #[ktest]
+    fn softirq_and_softirqd() {
+        aster_softirq::init_for_ktest();
+        super::init_in_first_kthread();
+
+        let (waiter, waker) = Waiter::new_pair();
+
+        let softirq_line = SoftIrqLine::get(SOFTIRQ_ID);
+
+        softirq_line.enable(move || {
+            if !InterruptLevel::current().is_task_context() {
+                COUNTER_BH.fetch_add(1, Ordering::Relaxed);
+            } else {
+                COUNTER_DAEMON.fetch_add(1, Ordering::Relaxed);
+            }
+            let _ = waker.wake_up();
+
+            if COUNTER.fetch_add(1, Ordering::Relaxed) + 1 < MAX_NUM_SOFTIRQS {
+                // Raise the same softirq again.
+                softirq_line.raise();
+            }
+        });
+
+        softirq_line.raise();
+
+        loop {
+            waiter.wait();
+
+            let counter_bh = COUNTER_BH.load(Ordering::Relaxed);
+            let counter_daemon = COUNTER_DAEMON.load(Ordering::Relaxed);
+
+            // There are at most `MAX_NUM_SOFTIRQS` softirqs.
+            let counter = counter_bh + counter_daemon;
+            assert!(counter <= MAX_NUM_SOFTIRQS);
+
+            if counter == MAX_NUM_SOFTIRQS {
+                // Since we're keeping the raise softirqs, we expect that most of the work will be
+                // processed by the daemon rather than by the bottom half.
+                assert!(counter_bh < counter_daemon);
+                break;
+            }
+        }
+    }
+}

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -88,6 +88,16 @@ impl Task {
         &self.ctx
     }
 
+    /// Returns whether we need to yield execution to another task.
+    ///
+    /// If the scheduler decides to preempt the current task in favor of
+    /// another (for example, if the current task has exhausted its runtime
+    /// budget or if the new task has a higher priority), this method will
+    /// return `true`.
+    pub fn need_yield() -> bool {
+        preempt::cpu_local::need_preempt()
+    }
+
     /// Yields execution so that another task may be scheduled.
     ///
     /// Note that this method cannot be simply named "yield" as the name is


### PR DESCRIPTION
softirqd plays a key role in ensuring fairness between softirq work and normal tasks.

Considering that we're receiving a large amount of packets from a network device, without softirqd, the following can happen:
```
hard interrupt
 - soft interrupt
   - process incoming packets
      - the receiver has been woken up

(the userspace receiver does not have the opportunity to run)

hard interrupt
 - soft interrupt
   - process incoming packets
      - the receiver has been woken up

(the userspace receiver does not have the opportunity to run)

hard interrupt
 - soft interrupt
   - process incoming packets
     - socket buffer overflows

(the userspace receiver does not have the opportunity to run)

hard interrupt
 - soft interrupt
   - process incoming packets
     - socket buffer overflows

(the userspace receiver does not have the opportunity to run)
```

With softirqd and a proper limit on the maximum number of packets that a soft interrupt can process (the limit has **not** been implemented in this PR), the following should happen:
```
hard interrupt
  - soft interrupt
    - process incoming packets (at most 64)
      - the receiver has been woken up
    - the remaining softirq work will be deferred

hard interrupt
  - no soft interrupt (deferred)

run the userspace receiver

run the softirqd
  - process incoming packets (at most 64)
    - the receiver has been woken up
  - the remaining softirq work will be deferred

hard interrupt
  - no soft interrupt (deferred)

run the userspace receiver

run the softirqd
  - process incoming packets (at most 64)
    - the receiver has been woken up
  - the remaining softirq work will be deferred

hard interrupt
  - no soft interrupt (deferred)
```