### PR TITLE
Pass the resolved inode to `Inode::unlink` and `Inode::rmdir`

### DIFF
--- a/kernel/core/src/fs/fs_impls/cgroupfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/cgroupfs/inode.rs
@@ -9,7 +9,6 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Extension, Inode, Metadata, RevalidationPolicy},
-            path::{is_dot, is_dotdot},
         },
     },
     prelude::*,
@@ -88,14 +87,7 @@ impl Inode for CgroupInode {
         CgroupFs::singleton().clone()
     }
 
-    fn rmdir(&self, name: &str) -> Result<()> {
-        if is_dot(name) {
-            return_errno_with_message!(Errno::EINVAL, "rmdir on .");
-        }
-        if is_dotdot(name) {
-            return_errno_with_message!(Errno::ENOTEMPTY, "rmdir on ..");
-        }
-
+    fn rmdir(&self, name: &str, _child: &Arc<dyn Inode>) -> Result<()> {
         let SysTreeNodeKind::Branch(branch_node) = self.node_kind() else {
             return_errno_with_message!(Errno::ENOTDIR, "the current node is not a branch node");
         };

--- a/kernel/core/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/mod.rs
@@ -320,7 +320,7 @@ impl Inode for RootInode {
         Err(Error::new(Errno::EPERM))
     }
 
-    fn unlink(&self, name: &str) -> Result<()> {
+    fn unlink(&self, name: &str, _child: &Arc<dyn Inode>) -> Result<()> {
         match name {
             "." | ".." => {
                 return_errno_with_message!(Errno::EISDIR, "the devpts directory cannot be unlinked")
@@ -335,7 +335,7 @@ impl Inode for RootInode {
         }
     }
 
-    fn rmdir(&self, name: &str) -> Result<()> {
+    fn rmdir(&self, _name: &str, _child: &Arc<dyn Inode>) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/core/src/fs/fs_impls/devtmpfs/mod.rs
+++ b/kernel/core/src/fs/fs_impls/devtmpfs/mod.rs
@@ -145,7 +145,7 @@ mod tests {
 
         let inode = root.lookup(path).unwrap();
         assert!(!to_be_revalidated(inode.as_ref()));
-        root.unlink(path).unwrap();
+        root.unlink(path, &inode).unwrap();
     }
 
     #[ktest]

--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -35,7 +35,6 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Extension, FileOps, Inode, Metadata, MknodType, RenameMode, SymbolicLink},
-            path::{is_dot, is_dot_or_dotdot, is_dotdot},
         },
     },
     prelude::*,
@@ -1286,7 +1285,7 @@ impl ExfatInode {
     /// Delete the file contents if delete_content is set.
     fn delete_inode(
         &self,
-        inode: Arc<ExfatInode>,
+        inode: &ExfatInode,
         delete_contents: bool,
         fs_guard: &MutexGuard<()>,
     ) -> Result<()> {
@@ -1598,21 +1597,11 @@ impl Inode for ExfatInode {
         return_errno_with_message!(Errno::EINVAL, "unsupported operation")
     }
 
-    fn unlink(&self, name: &str) -> Result<()> {
-        if !self.inner.read().inode_type.is_directory() {
-            return_errno!(Errno::ENOTDIR)
-        }
-        if name.len() > MAX_NAME_LENGTH {
-            return_errno!(Errno::ENAMETOOLONG)
-        }
-        if is_dot_or_dotdot(name) {
-            return_errno!(Errno::EISDIR)
-        }
-
+    fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();
 
-        let inode = self.inner.read().lookup_by_name(name, true, &fs_guard)?;
+        let inode = child.downcast_ref::<ExfatInode>().unwrap();
 
         // FIXME: we need to step by following line to avoid deadlock.
         if inode.type_() != InodeType::File {
@@ -1629,24 +1618,11 @@ impl Inode for ExfatInode {
         Ok(())
     }
 
-    fn rmdir(&self, name: &str) -> Result<()> {
-        if !self.inner.read().inode_type.is_directory() {
-            return_errno!(Errno::ENOTDIR)
-        }
-        if is_dot(name) {
-            return_errno_with_message!(Errno::EINVAL, "rmdir on .")
-        }
-        if is_dotdot(name) {
-            return_errno_with_message!(Errno::ENOTEMPTY, "rmdir on ..")
-        }
-        if name.len() > MAX_NAME_LENGTH {
-            return_errno!(Errno::ENAMETOOLONG)
-        }
-
+    fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         let fs = self.inner.read().fs();
         let fs_guard = fs.lock();
 
-        let inode = self.inner.read().lookup_by_name(name, true, &fs_guard)?;
+        let inode = child.downcast_ref::<ExfatInode>().unwrap();
 
         if inode.inner.read().inode_type != InodeType::Dir {
             return_errno!(Errno::ENOTDIR)
@@ -1736,7 +1712,7 @@ impl Inode for ExfatInode {
         }
 
         // All checks are done here. This is a valid rename and it needs to modify the metadata.
-        self.delete_inode(old_inode.clone(), false, &fs_guard)?;
+        self.delete_inode(&old_inode, false, &fs_guard)?;
         // Create the new dentries.
         let new_inode =
             new_dir_inode.add_entry(new_name, old_inode.type_(), old_inode.mode()?, &fs_guard)?;
@@ -1748,7 +1724,7 @@ impl Inode for ExfatInode {
         let _ = fs.insert_inode(old_inode.clone());
         // Remove the exist 'new_name' file.
         if let Some(exist_inode) = replaced_inode {
-            new_dir_inode.delete_inode(exist_inode, true, &fs_guard)?;
+            new_dir_inode.delete_inode(&exist_inode, true, &fs_guard)?;
         }
         // Update the times.
         self.inner.write().update_atime_mtime_and_ctime()?;

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -200,12 +200,14 @@ impl Inode for Ext2Inode {
         self.link(old, name)
     }
 
-    fn unlink(&self, name: &str) -> Result<()> {
-        self.unlink(name)
+    fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
+        let child = child.downcast_ref::<Ext2Inode>().unwrap();
+        self.unlink(name, child)
     }
 
-    fn rmdir(&self, name: &str) -> Result<()> {
-        self.rmdir(name)
+    fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
+        let child = child.downcast_ref::<Ext2Inode>().unwrap();
+        self.rmdir(name, child)
     }
 
     fn rename(

--- a/kernel/core/src/fs/fs_impls/ext2/inode/dir/mod.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/dir/mod.rs
@@ -63,14 +63,9 @@ impl Inode {
     }
 
     /// Removes an empty sub-directory.
-    pub(in ext2) fn rmdir(&self, name: &str) -> Result<()> {
-        let entry_info = {
-            let parent_inner = self.inner.read();
-            parent_inner.find_entry_info(name)?
-        };
+    pub(in ext2) fn rmdir(&self, name: &str, child: &Inode) -> Result<()> {
         let fs = self.fs()?;
-        let child = fs.read_inode(entry_info.ino)?;
-        let lock_targets = [self, child.as_ref()];
+        let lock_targets = [self, child];
 
         // The `DirDentry.children` lock in the VFS layer keeps the parent
         // directory entry stable during this operation, so we only need to
@@ -89,11 +84,14 @@ impl Inode {
         child_inner.dec_link_count(2);
 
         if child_inner.link_count() == 0 {
-            child_inner.write_back_inode_desc(&fs, entry_info.ino)?;
-            let _ = fs.remove_inode(entry_info.ino);
+            child_inner.write_back_inode_desc(&fs, child.ino())?;
+            let _ = fs.remove_inode(child.ino());
         }
 
         let parent_inner = guards.inner_mut(self.ino());
+
+        let entry_info = parent_inner.find_entry_info(name)?;
+        debug_assert_eq!(entry_info.ino, child.ino);
 
         parent_inner.delete_entry(&entry_info)?;
         parent_inner.dec_link_count(1);
@@ -196,19 +194,14 @@ impl Inode {
     }
 
     /// Removes a non-directory entry from this directory.
-    pub(in ext2) fn unlink(&self, name: &str) -> Result<()> {
-        let entry_info = {
-            let parent_inner = self.inner.read();
-            parent_inner.find_entry_info(name)?
-        };
+    pub(in ext2) fn unlink(&self, name: &str, child: &Inode) -> Result<()> {
         let fs = self.fs()?;
-        let child = fs.read_inode(entry_info.ino)?;
 
         // The `DirDentry.children` lock in the VFS layer keeps the parent
         // directory entry stable during this operation, so we only need to
         // lock all related inodes in order, without rechecking the lookup
         // result.
-        let lock_targets = [self, child.as_ref()];
+        let lock_targets = [self, child];
         let mut guards = MultiInodeInnerGuards::lock(&lock_targets);
 
         let child_inner = guards.inner_mut(child.ino());
@@ -217,6 +210,10 @@ impl Inode {
         }
 
         let parent_inner = guards.inner_mut(self.ino());
+
+        let entry_info = parent_inner.find_entry_info(name)?;
+        debug_assert_eq!(entry_info.ino, child.ino);
+
         parent_inner.delete_entry(&entry_info)?;
         parent_inner.set_mtime_ctime(utils::now());
 
@@ -225,8 +222,8 @@ impl Inode {
         child_inner.set_ctime(utils::now());
         child_inner.dec_link_count(1);
         if child_inner.link_count() == 0 {
-            child_inner.write_back_inode_desc(&fs, entry_info.ino)?;
-            let _ = fs.remove_inode(entry_info.ino);
+            child_inner.write_back_inode_desc(&fs, child.ino())?;
+            let _ = fs.remove_inode(child.ino());
         }
         Ok(())
     }
@@ -797,7 +794,7 @@ mod test {
         old.write_direct_at(0, &mut payload_reader).unwrap();
 
         let free_blocks_before = f.ext2.super_block().free_blocks_count();
-        root.unlink("old").unwrap();
+        root.unlink("old", old.as_ref()).unwrap();
         assert_errno!(f.ext2.read_inode(old_ino), Errno::ESTALE);
         assert!(
             f.ext2

--- a/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
@@ -276,7 +276,9 @@ impl OverlayInode {
         if is_whiteout {
             // Delete the whiteout file first then create the new file
             // or the new opaque directory.
-            upper.unlink(&whiteout_name(name))?;
+            let whiteout_name = whiteout_name(name);
+            let whiteout = upper.lookup(&whiteout_name)?;
+            upper.unlink(&whiteout_name, &whiteout)?;
 
             if type_ == InodeType::Dir {
                 upper_is_opaque = true;
@@ -379,10 +381,9 @@ impl OverlayInode {
 
     /// Deletes the target file by creating a "whiteout" file from the upper layer.
     /// The corresponding parent directories will be created also if they do not exist.
-    pub(crate) fn unlink(&self, name: &str) -> Result<()> {
+    pub(crate) fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         // TODO: Hold the upper lock from here to avoid race condition
-        let inode = self.lookup(name)?;
-        let target = inode.downcast_ref::<OverlayInode>().unwrap();
+        let target = child.downcast_ref::<OverlayInode>().unwrap();
         if target.type_() == InodeType::Dir {
             return_errno!(Errno::EISDIR);
         }
@@ -396,8 +397,8 @@ impl OverlayInode {
 
         let upper = upper_guard.as_ref().unwrap();
         let target_has_valid_lower = target.has_valid_lower();
-        if target.has_valid_upper() {
-            upper.unlink(name)?;
+        if let Some(upper_child) = target.upper() {
+            upper.unlink(name, &upper_child)?;
         } else {
             assert!(target_has_valid_lower);
         }
@@ -417,10 +418,9 @@ impl OverlayInode {
 
     /// Deletes the target directory by creating an "opaque" directory from the upper layer.
     /// The corresponding parent directories will be created also if they do not exist.
-    pub(crate) fn rmdir(&self, name: &str) -> Result<()> {
+    pub(crate) fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         // TODO: Hold the upper lock from here to avoid race condition
-        let inode = self.lookup(name)?;
-        let target = inode.downcast_ref::<OverlayInode>().unwrap();
+        let target = child.downcast_ref::<OverlayInode>().unwrap();
         if target.type_() != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
         }
@@ -443,11 +443,14 @@ impl OverlayInode {
 
             for whiteout in target_visitor.iter().skip(2) {
                 assert!(whiteout.starts_with(WHITEOUT_PREFIX));
-                target_upper.unlink(whiteout)?;
+                let whiteout_inode = target_upper.lookup(whiteout)?;
+                target_upper.unlink(whiteout, &whiteout_inode)?;
             }
         }
 
-        upper.rmdir(name)?;
+        if let Some(upper_child) = target.upper() {
+            upper.rmdir(name, &upper_child)?;
+        }
 
         let whiteout = upper.create(&whiteout_name(name), InodeType::File, mkmod!(a+r, u+w))?;
         // FIXME: Align the whiteout xattr behavior with Linux
@@ -1015,8 +1018,8 @@ impl Inode for OverlayInode {
         status_flags: StatusFlags,
     ) -> Option<Result<Box<dyn PerOpenFileOps>>>;
     fn link(&self, old: &Arc<dyn Inode>, name: &str) -> Result<()>;
-    fn unlink(&self, name: &str) -> Result<()>;
-    fn rmdir(&self, name: &str) -> Result<()>;
+    fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()>;
+    fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()>;
     fn lookup(&self, name: &str) -> Result<Arc<dyn Inode>>;
     fn rename(
         &self,
@@ -1479,7 +1482,8 @@ mod tests {
             panic!();
         };
         assert_eq!(e.error(), Errno::EEXIST);
-        root.unlink("f1").unwrap();
+        let f1 = root.lookup("f1").unwrap();
+        root.unlink("f1", &f1).unwrap();
 
         root.create("f1", InodeType::File, mode).unwrap();
     }
@@ -1496,10 +1500,12 @@ mod tests {
         assert_eq!(e.error(), Errno::EEXIST);
 
         let d1 = root.lookup("d1").unwrap();
-        d1.unlink("f11").unwrap();
-        d1.unlink("f12").unwrap();
+        let f11 = d1.lookup("f11").unwrap();
+        d1.unlink("f11", &f11).unwrap();
+        let f12 = d1.lookup("f12").unwrap();
+        d1.unlink("f12", &f12).unwrap();
 
-        root.rmdir("d1").unwrap();
+        root.rmdir("d1", &d1).unwrap();
         let d1 = root.create("d1", InodeType::Dir, mode).unwrap();
         d1.create("f11", InodeType::File, mode).unwrap();
     }

--- a/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
@@ -199,11 +199,11 @@ impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
         Err(Error::new(Errno::EPERM))
     }
 
-    fn unlink(&self, _name: &str) -> Result<()> {
+    fn unlink(&self, _name: &str, _child: &Arc<dyn Inode>) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 
-    fn rmdir(&self, _name: &str) -> Result<()> {
+    fn rmdir(&self, _name: &str, _child: &Arc<dyn Inode>) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -1227,13 +1227,67 @@ impl Inode for RamInode {
         Ok(())
     }
 
-    fn unlink(&self, name: &str) -> Result<()> {
-        self.unlink_if(name, |_| true)?;
+    fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
+        let target = child.downcast_ref::<RamInode>().unwrap();
+        if target.typ == InodeType::Dir {
+            return_errno_with_message!(Errno::EISDIR, "unlink on dir");
+        }
+
+        // When we got the lock, the dir may have been modified by another thread
+        let mut self_dir = self.inner.as_direntry().unwrap().write();
+        let (idx, new_target) = self_dir.get_entry(name).ok_or(Error::new(Errno::ENOENT))?;
+        if new_target.ino != target.ino {
+            return_errno!(Errno::ENOENT);
+        }
+        self_dir.remove_entry(idx);
+        drop(self_dir);
+
+        let now = now();
+        let mut self_meta = self.metadata.lock();
+        self_meta.dec_size();
+        self_meta.set_mtime(now);
+        self_meta.set_ctime(now);
+        drop(self_meta);
+        let mut target_meta = target.metadata.lock();
+        target_meta.dec_nlinks();
+        target_meta.set_ctime(now);
+
         Ok(())
     }
 
-    fn rmdir(&self, name: &str) -> Result<()> {
-        self.rmdir_if(name, |_| true)?;
+    fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
+        let target = child.downcast_ref::<RamInode>().unwrap();
+        if target.typ != InodeType::Dir {
+            return_errno_with_message!(Errno::ENOTDIR, "rmdir on not dir");
+        }
+
+        // When we got the lock, the dir may have been modified by another thread
+        let (mut self_dir, target_dir) = write_lock_two_direntries_by_ino(
+            (self.ino, self.inner.as_direntry().unwrap()),
+            (target.ino, target.inner.as_direntry().unwrap()),
+        );
+        if !target_dir.is_empty_children() {
+            return_errno_with_message!(Errno::ENOTEMPTY, "dir not empty");
+        }
+        let (idx, new_target) = self_dir.get_entry(name).ok_or(Error::new(Errno::ENOENT))?;
+        if new_target.ino != target.ino {
+            return_errno!(Errno::ENOENT);
+        }
+        self_dir.remove_entry(idx);
+        drop(self_dir);
+        drop(target_dir);
+
+        let now = now();
+        let mut self_meta = self.metadata.lock();
+        self_meta.dec_size();
+        self_meta.dec_nlinks();
+        self_meta.set_mtime(now);
+        self_meta.set_ctime(now);
+        drop(self_meta);
+        let mut target_meta = target.metadata.lock();
+        target_meta.dec_nlinks();
+        target_meta.dec_nlinks();
+
         Ok(())
     }
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -184,16 +184,6 @@ impl VirtioFsInode {
         Ok(())
     }
 
-    fn lookup_child_inode(&self, name: &str) -> Result<Arc<VirtioFsInode>> {
-        let fs = self.fs_ref();
-        let request_attr_version = fs.session().snapshot_attr_version();
-        let lookup_reply = fs
-            .session()
-            .do_fuse_op(self.nodeid(), LookupOperation::new(name))?;
-
-        fs.lookup_inode_from_cache(lookup_reply, request_attr_version)
-    }
-
     fn type_(&self) -> InodeType {
         self.type_
     }
@@ -434,9 +424,9 @@ impl Inode for VirtioFsInode {
         Ok(())
     }
 
-    fn unlink(&self, name: &str) -> Result<()> {
+    fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         let fs = self.fs_ref();
-        let child = self.lookup_child_inode(name)?;
+        let child = child.downcast_ref::<VirtioFsInode>().unwrap();
 
         fs.session()
             .do_fuse_op(self.nodeid(), UnlinkOperation::new(name))?;
@@ -447,9 +437,9 @@ impl Inode for VirtioFsInode {
         Ok(())
     }
 
-    fn rmdir(&self, name: &str) -> Result<()> {
+    fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         let fs = self.fs_ref();
-        let child = self.lookup_child_inode(name)?;
+        let child = child.downcast_ref::<VirtioFsInode>().unwrap();
 
         fs.session()
             .do_fuse_op(self.nodeid(), RmdirOperation::new(name))?;

--- a/kernel/core/src/fs/utils/systree_inode.rs
+++ b/kernel/core/src/fs/utils/systree_inode.rs
@@ -536,11 +536,11 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         Err(Error::new(Errno::EPERM))
     }
 
-    default fn unlink(&self, _name: &str) -> Result<()> {
+    default fn unlink(&self, _name: &str, _child: &Arc<dyn Inode>) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 
-    default fn rmdir(&self, _name: &str) -> Result<()> {
+    default fn rmdir(&self, _name: &str, _child: &Arc<dyn Inode>) -> Result<()> {
         Err(Error::new(Errno::EPERM))
     }
 

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -442,11 +442,11 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
         Err(Error::new(Errno::ENOTDIR))
     }
 
-    fn unlink(&self, name: &str) -> Result<()> {
+    fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))
     }
 
-    fn rmdir(&self, name: &str) -> Result<()> {
+    fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         Err(Error::new(Errno::ENOTDIR))
     }
 

--- a/kernel/core/src/fs/vfs/path/dentry.rs
+++ b/kernel/core/src/fs/vfs/path/dentry.rs
@@ -661,7 +661,8 @@ impl DirDentry<'_> {
         }
 
         let dir_inode = self.inode();
-        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.unlink(name))?;
+        let child_inode =
+            self.remove_child(name, |dir_inode, name, child| dir_inode.unlink(name, child))?;
 
         let nlinks = child_inode.metadata()?.nr_hard_links;
         fs::vfs::notify::on_link_count(&child_inode);
@@ -694,7 +695,8 @@ impl DirDentry<'_> {
         }
 
         let dir_inode = self.inode();
-        let child_inode = self.remove_child(name, |dir_inode, name| dir_inode.rmdir(name))?;
+        let child_inode =
+            self.remove_child(name, |dir_inode, name, child| dir_inode.rmdir(name, child))?;
 
         let nlinks = child_inode.metadata()?.nr_hard_links;
         if nlinks == 0 {
@@ -719,7 +721,7 @@ impl DirDentry<'_> {
     fn remove_child(
         &self,
         name: &str,
-        remove_child_fn: impl FnOnce(&dyn Inode, &str) -> Result<()>,
+        remove_child_fn: impl FnOnce(&dyn Inode, &str, &Arc<dyn Inode>) -> Result<()>,
     ) -> Result<Arc<dyn Inode>> {
         let dir_inode = self.inode();
         let mut children = self.children.upread();
@@ -750,7 +752,7 @@ impl DirDentry<'_> {
             None => dir_inode.lookup(name)?,
         };
 
-        remove_child_fn(dir_inode.as_ref(), name)?;
+        remove_child_fn(dir_inode.as_ref(), name, &child_inode)?;
         if cached_child.is_some() {
             children.upgrade().delete(name);
         }


### PR DESCRIPTION
Like #3735, in fact, when we perform `unlink` and `rmdir` at the VFS layer, we have already resolved the target inode, so passing it directly to the filesystem layer can avoid an additional lookup. This approach is also more consistent with Linux.