### PR TITLE
Add a devenv development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ cachix.list
 
 # temporary configuration file for NixOS tests
 distro/etc_nixos/_config_for_test.nix
+
+# devenv local state and per-user overrides
+.devenv*
+devenv.local.nix
+devenv.local.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,119 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1787350801,
+        "narHash": "sha256-gEOKc1EhkbrUj7JTjxwlNyh42vu89lpiyP33ubx/NCw=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "5844e78c960ab73bb92e131bc2902b39b9ee52dd",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "linux-vdso": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755760623,
+        "narHash": "sha256-Zimwr72fbR694fO7sdYrMK4SDp4w03UHW/QtmJyiP+Q=",
+        "owner": "asterinas",
+        "repo": "linux_vdso",
+        "rev": "74898350d406d6cd8988531ad737380a8e2cdbf4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "asterinas",
+        "repo": "linux_vdso",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1787002832,
+        "narHash": "sha256-DGkHh88/7YLVGZ7HzSVN4YmUmR+wGKudIp6H9UsUNT0=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "ee3d58d53cfcddfc0ae6fc7f04f4fe2a0c7cf0ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-multiverse": {
+      "locked": {
+        "lastModified": 1787432830,
+        "narHash": "sha256-4qXD9govwRkbfP8CEYDqfDGFWEefCbBMc7/ZUMK4FS0=",
+        "owner": "fzakaria",
+        "repo": "nixpkgs-multiverse",
+        "rev": "83a703cda645262d46f27b10a5392baf15355ec4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fzakaria",
+        "repo": "nixpkgs-multiverse",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786858016,
+        "narHash": "sha256-Vczr2zxD0orq6N2QQe5uqOGF7TRDcQJRRuAcsdHr4kg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "54ba4bcec4043e72a4006d825e0d7aff5562008f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "linux-vdso": "linux-vdso",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-multiverse": "nixpkgs-multiverse",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787454509,
+        "narHash": "sha256-r4LDUF+zmJnkftvCVkCrUhSJazsf6EVJF+V2l4/MYbI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f60c1b57ff805a46b5175c76fc981fb4f81efbcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,136 @@
+{
+  inputs,
+  lib,
+  multiverse,
+  pkgs,
+  ...
+}:
+
+let
+  python = pkgs.python3.withPackages (pythonPackages: [
+    pythonPackages.pyyaml
+    pythonPackages.yq
+  ]);
+
+  pinnedTypos = pkgs.writeShellScriptBin "typos" ''
+    # The historical binary uses an older glibc. Host-injected libraries may
+    # come from the current system and are not ABI-compatible with it.
+    unset LD_PRELOAD
+    exec ${multiverse.typos."1.39.0"}/bin/typos "$@"
+  '';
+
+  pinnedPackages = [
+    multiverse.qemu."10.2.1"
+    multiverse.cargo-expand."1.0.122"
+    multiverse.cargo-udeps."0.1.61"
+    multiverse.lychee."0.24.2"
+    multiverse.mdbook-mermaid."0.17.0"
+    multiverse.mdbook."0.5.2"
+    pinnedTypos
+  ];
+
+  commonPackages = with pkgs; [
+    bash
+    cachix
+    cargo-binutils
+    clang
+    clang-tools
+    cpio
+    curl
+    dosfstools
+    e2fsprogs
+    exfatprogs
+    file
+    gcc
+    gdb
+    git
+    gnumake
+    jq
+    mtools
+    nix
+    nixfmt-rfc-style
+    parted
+    pkg-config
+    python
+    socat
+    strace
+    unzip
+    wget
+    xorriso
+    zip
+  ];
+
+  linuxPackages = with pkgs; [
+    bridge-utils
+    cpuid
+    grub2
+    iproute2
+    iptables
+    nettools
+    openssh
+    virtiofsd
+  ];
+in
+{
+  languages.rust = {
+    enable = true;
+    toolchainFile = ./rust-toolchain.toml;
+
+    # Match the existing rustup-based container instead of injecting a host
+    # linker into kernel and bare-metal target builds.
+    clangLinker.enable = false;
+    lsp.package = pkgs.rust-analyzer;
+  };
+
+  packages = commonPackages ++ pinnedPackages ++ lib.optionals pkgs.stdenv.isLinux linuxPackages;
+
+  env = {
+    VDSO_LIBRARY_DIR = inputs.linux-vdso;
+  };
+
+  scripts = {
+    sctrace = {
+      description = "Trace a command and check its system calls against SCML rules";
+      exec = ''
+        exec "$DEVENV_ROOT/tools/sctrace.sh" "$@"
+      '';
+    };
+
+    asterinas-env-check = {
+      description = "Check the essential Asterinas development tools";
+      exec = ''
+        set -eu
+
+        rustc --version
+        cargo --version
+        rust-objcopy --version | head -n 1
+        qemu-system-x86_64 --version | head -n 1
+        qemu-system-riscv64 --version | head -n 1
+        qemu-system-loongarch64 --version | head -n 1
+        grub-mkrescue --version
+        yq --version
+        nixfmt --version
+        typos --version
+        test -f "$VDSO_LIBRARY_DIR/vdso_x86_64.so"
+      '';
+    };
+  };
+
+  tasks = {
+    "asterinas:test" = {
+      description = "Run user-mode Rust tests";
+      exec = "make test";
+    };
+
+    "asterinas:check" = {
+      description = "Run the repository checks";
+      exec = "make check";
+    };
+  };
+
+  enterShell = ''
+    export PATH="$DEVENV_ROOT/target/bin:$PATH"
+    ASTER_SCML="$(find "$DEVENV_ROOT/book/src/kernel/linux-compatibility" -name '*.scml' -print | tr '\n' ' ')"
+    export ASTER_SCML
+  '';
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,15 @@
+require_version: true
+
+inputs:
+  rust-overlay:
+    url: github:oxalica/rust-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  nixpkgs-multiverse:
+    url: github:fzakaria/nixpkgs-multiverse
+  linux-vdso:
+    # `devenv.lock` records the full revision. Keep it at the Docker image's
+    # `7489835` revision when updating this input.
+    url: github:asterinas/linux_vdso
+    flake: false


### PR DESCRIPTION
## Summary

- add a native devenv configuration for Asterinas development
- follow the repository's pinned Rust toolchain and provide the core build, test, and documentation tools
- use nixpkgs-multiverse for Docker-aligned historical tool versions, including QEMU 10.2.1
- expose environment checks and common repository tasks

## Validation

- `devenv shell -- asterinas-env-check`
- `devenv --no-tui tasks run asterinas:test`
- `devenv shell -- make kernel`

The kernel build produced `target/osdk/asterinas-osdk-bin.iso` successfully.

## Draft limitations

- `make run_kernel` has not been validated because the Docker image's custom OVMF layout is not provided yet
- the environment currently uses nixpkgs GRUB 2.12 rather than the Asterinas GRUB fork, so specialized boot protocols remain to be verified
- Docker remains necessary for prebuilt gVisor tests and other specialized integration suites
