### PR TITLE
Drop InodeHandle fields in lifetime-safe order

### DIFF
--- a/kernel/core/src/device/pty/master.rs
+++ b/kernel/core/src/device/pty/master.rs
@@ -245,10 +245,9 @@ impl PerOpenFileOps for PtyMaster {
 
 impl Drop for PtyMaster {
     fn drop(&mut self) {
-        if let Some(devpts) = self.ptmx.devpts() {
-            let index = self.slave.index();
-            devpts.remove_slave(index);
-        }
+        let devpts = self.ptmx.devpts().unwrap();
+        let index = self.slave.index();
+        devpts.remove_slave(index);
 
         self.slave_flags().set_other_closed();
         self.slave.notify_hup();

--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -26,12 +26,19 @@ use crate::{
 };
 
 pub(crate) struct InodeHandle {
-    common: FileCommon,
     /// `open_file` is similar to the `file_private` field in Linux's `file` structure. If
     /// `open_file` is `Some(_)`, typical file operations including `read`, `write`, `poll`,
     /// and `ioctl` will be provided by the per-open file object instead of `path`.
     open_file: Option<Box<dyn PerOpenFileOps>>,
     offset: Mutex<usize>,
+    /// Path and common states of the handle.
+    //
+    // This field is placed last so that its `Path` keeps the corresponding filesystem alive
+    // while `open_file` is dropped, because releasing `open_file` may access that filesystem.
+    //
+    // Struct fields are dropped in declaration order.
+    // Reference: <https://doc.rust-lang.org/reference/destructors.html>.
+    common: FileCommon,
 }
 
 impl InodeHandle {
@@ -69,9 +76,9 @@ impl InodeHandle {
         };
 
         Ok(Self {
-            common: FileCommon::new(path, access_mode, status_flags),
             open_file,
             offset: Mutex::new(0),
+            common: FileCommon::new(path, access_mode, status_flags),
         })
     }
 


### PR DESCRIPTION
## Changes
- Move `InodeHandle::common` to the last field.

## Motivation
Struct fields are dropped in declaration order. See https://doc.rust-lang.org/reference/destructors.html for details.

`FileCommon` holds a `Path`, which keeps the corresponding filesystem alive while `open_file` is being dropped. This is necessary because releasing a per-open file object may still access the filesystem (e.g., sync or clean up).

This centralizes the lifetime handling for deferred cleanup paths such as virtiofs and PTY-related file objects.

## Context

This follows the same lifetime concern discussed in:

- [PR #3659 discussion](https://github.com/asterinas/asterinas/pull/3659#discussion_r3679669828)
- [PR #3747 discussion](https://github.com/asterinas/asterinas/pull/3747#discussion_r3840403018)