### PR TITLE
Use `ctx.user_space()` and improve comments in `syscall/futex.rs`

### DIFF
--- a/kernel/core/src/syscall/futex.rs
+++ b/kernel/core/src/syscall/futex.rs
@@ -5,7 +5,6 @@ use core::time::Duration;
 use ostd::mm::VmIo;
 
 use crate::{
-    context::current_userspace,
     prelude::*,
     process::posix_thread::futex::{
         FutexFlags, FutexOp, FutexVisibility, futex_op_and_flags_from_u32, futex_requeue,
@@ -41,23 +40,21 @@ pub(super) fn sys_futex(
         }
 
         let timeout = {
-            let time_spec: timespec_t = current_userspace!().read_val(timeout_addr)?;
+            let time_spec: timespec_t = ctx.user_space().read_val(timeout_addr)?;
             Duration::try_from(time_spec)?
         };
 
         let is_real_time = futex_flags.contains(FutexFlags::FUTEX_CLOCK_REALTIME);
         if is_real_time && futex_op == FutexOp::FUTEX_WAIT {
-            // Ref: <https://github.com/torvalds/linux/commit/4fbf5d6837bf81fd7a27d771358f4ee6c4f243f8>
+            // Reference:
+            // <https://github.com/torvalds/linux/commit/4fbf5d6837bf81fd7a27d771358f4ee6c4f243f8>
             return_errno_with_message!(Errno::ENOSYS, "FUTEX_WAIT cannot use CLOCK_REALTIME");
         }
 
         let timeout = {
-            // From man(2) futex:
-            // for FUTEX_WAIT, timeout is interpreted as a relative value.
-            // This differs from other futex operations,
-            // where timeout is interpreted as an absolute value.
-            // To obtain the equivalent of FUTEX_WAIT with an absolute timeout,
-            // employ FUTEX_WAIT_BITSET with val3 specified as FUTEX_BITSET_MATCH_ANY.
+            // For `FUTEX_WAIT`, `timeout` is interpreted as a relative value. This differs from
+            // other futex operations, where `timeout` is interpreted as an absolute value.
+            // Reference: <https://www.man7.org/linux/man-pages/man2/FUTEX_WAIT.2const.html>
             if futex_op == FutexOp::FUTEX_WAIT {
                 Timeout::After(timeout)
             } else {
@@ -107,7 +104,7 @@ pub(super) fn sys_futex(
         }
         FutexOp::FUTEX_REQUEUE => {
             let max_nwakes = futex_val_to_max_count(futex_val);
-            // The `utime_addr` is used as the maximum number of requeues in this case.
+            // `utime_addr` is used as the maximum number of requeues in this case.
             // When `utime_addr` is 0 or negative, it means no requeues.
             let max_nrequeues = (utime_addr as i32).max(0) as usize;
             futex_requeue(
@@ -121,7 +118,6 @@ pub(super) fn sys_futex(
         }
         FutexOp::FUTEX_WAKE_OP => {
             let futex_val_2 = utime_addr as u32;
-
             futex_wake_op(
                 futex_addr,
                 futex_new_addr,
@@ -143,13 +139,13 @@ pub(super) fn sys_futex(
         _ => err,
     })?;
 
-    debug!("futex returns, tid= {} ", ctx.posix_thread.tid());
+    debug!("futex returns, tid = {}", ctx.posix_thread.tid());
     Ok(SyscallReturn::Return(res as _))
 }
 
 fn futex_val_to_max_count(futex_val: u32) -> usize {
-    // From gVisor/test/syscalls/linux/futex.cc:260: "The Linux kernel wakes one
-    // waiter even if val is 0 or negative." To be consistent with Linux, we set
-    // the max_count to 1 if it is 0 or negative.
+    // Linux wakes one waiter even if `futex_val` is 0 or negative. To be
+    // consistent with Linux, we set `max_count` to 1 if it is 0 or negative.
+    // Reference: <https://elixir.bootlin.com/linux/v7.2/source/kernel/futex/waitwake.c#L219>
     (futex_val as i32).max(1) as usize
 }


### PR DESCRIPTION
A few random cleanups in `syscall/futex.rs`:

 - Replace `current_userspace!()` with `ctx.user_space()` whenever possible. https://github.com/asterinas/asterinas/blob/6e4a5b0dfc8fb37400da6a199cb2bb0ce1507214/kernel/core/src/syscall/futex.rs#L44
 - Rewrite comments. https://github.com/asterinas/asterinas/blob/6e4a5b0dfc8fb37400da6a199cb2bb0ce1507214/kernel/core/src/syscall/futex.rs#L151-L153 (and several others)
 - Remove a blank line in `FUTEX_WAKE_OP` because all other futex operations do not have such a blank line. https://github.com/asterinas/asterinas/blob/6e4a5b0dfc8fb37400da6a199cb2bb0ce1507214/kernel/core/src/syscall/futex.rs#L123-L125