### PR TITLE
Fix loop partition readiness before formatting

### DIFF
--- a/.github/workflows/publish_aster_nixos.yml
+++ b/.github/workflows/publish_aster_nixos.yml
@@ -96,7 +96,10 @@ jobs:
         with:
           image: asterinas/kernel-dev:0.18.1-20260901
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
+          # docker-run-action-fork joins these lines with ';' and runs them via
+          # `sh -c` without fail-fast settings, unlike a normal `run:` step.
           run: |
+            set -e
             export ASTER_BUILD_TIMESTAMP=`date '+%a %b %e %H:%M:%S %Z %Y'`
             make iso RELEASE=1 AUTO_INSTALL=false ARCH=${{ matrix.arch }}
             iso_path=$(realpath ./target/nixos/iso_image/iso/*.iso)

--- a/.github/workflows/test_nixos_full.yml
+++ b/.github/workflows/test_nixos_full.yml
@@ -25,6 +25,7 @@ on:
       - distro/**
       - tools/nixos/**
       - tools/github_workflows/filter_json_array_with_changed_files.sh
+      - tools/github_workflows/stress_installer_provisioning.sh
       - test/nixos/common/**
       - .github/workflows/test_nixos_full.yml
       # Paths of test suites, which trigger runs of the corresponding test suites.
@@ -196,3 +197,28 @@ jobs:
           run: |
             make nixos NIXOS_TEST_SUITE=${{ matrix.test.name }} NIXOS_DISK_SIZE_IN_MB=${{ matrix.test.disk_size }}
             make run_nixos NIXOS_TEST_SUITE=${{ matrix.test.name }} NIXOS_TEST_TIMEOUT=${{ matrix.test.test_timeout_minutes || 10 }}min
+
+  # Guard against the loop-partition readiness race (issue #3700).
+  stress-installer-provisioning:
+    name: Stress installer provisioning
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: endersonmenezes/free-disk-space@v3
+        with:
+          rm_cmd: "rmz"
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+      - uses: actions/checkout@v4
+      - name: Run the installer provisioning path 500 times
+        uses: maus007/docker-run-action-fork@v1
+        with:
+          image: asterinas/kernel-dev:0.18.1-20260901
+          options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
+          # docker-run-action-fork joins these lines with ';' and runs them via
+          # `sh -c` without fail-fast settings, unlike a normal `run:` step.
+          run: |
+            set -e
+            bash tools/github_workflows/stress_installer_provisioning.sh

--- a/.github/workflows/test_nixos_full.yml
+++ b/.github/workflows/test_nixos_full.yml
@@ -194,7 +194,10 @@ jobs:
         with:
           image: asterinas/kernel-dev:0.18.1-20260901
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
+          # docker-run-action-fork joins these lines with ';' and runs them via
+          # `sh -c` without fail-fast settings, unlike a normal `run:` step.
           run: |
+            set -e
             make nixos NIXOS_TEST_SUITE=${{ matrix.test.name }} NIXOS_DISK_SIZE_IN_MB=${{ matrix.test.disk_size }}
             make run_nixos NIXOS_TEST_SUITE=${{ matrix.test.name }} NIXOS_TEST_TIMEOUT=${{ matrix.test.test_timeout_minutes || 10 }}min
 

--- a/.github/workflows/test_nixos_minimal.yml
+++ b/.github/workflows/test_nixos_minimal.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           image: asterinas/kernel-dev:0.18.1-20260901
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
+          # docker-run-action-fork joins these lines with ';' and runs them via
+          # `sh -c` without fail-fast settings, unlike a normal `run:` step.
           run: |
+            set -e
             make nixos NIXOS_TEST_SUITE=hello NIXOS_DISK_SIZE_IN_MB=6144
             make run_nixos NIXOS_TEST_SUITE=hello

--- a/distro/aster_nixos_installer/templates/aster-nixos-install
+++ b/distro/aster_nixos_installer/templates/aster-nixos-install
@@ -73,6 +73,14 @@ if [[ -z "$DISK" ]]; then
     exit 1
 fi
 
+# Hold an exclusive BSD lock on the whole disk from before parted until both
+# partitions are mounted (https://systemd.io/BLOCK_DEVICE_LOCKING/). Without
+# it, udevd re-reads the partition table as soon as parted cli closes the disk,
+# the kernel drops and re-creates the partition devices, and mkfs races that
+# window with ENOENT/ENXIO.
+exec 9<"${DISK}"
+flock -x 9
+
 # Confirm dangerous operation if --force-format-disk is used
 if [[ "$FORCE_FORMAT_DISK" == true ]]; then
     echo "WARNING: You are about to FORMAT the disk: $DISK"
@@ -118,6 +126,10 @@ mkdir -p ${BUILD_DIR}/tmp
 chmod 1777 ${BUILD_DIR}/tmp
 mkdir -p ${BUILD_DIR}/etc/nixos
 mount -o umask=077,sync,dirsync "${BOOT_DEVICE}" ${BUILD_DIR}/boot
+
+# Both partitions are mounted, so a re-read would fail with EBUSY anyway;
+# release the lock so udevd can process the deferred events.
+exec 9<&-
 
 echo "${BUILD_DIR} is mounted successfully!"
 

--- a/tools/github_workflows/stress_installer_provisioning.sh
+++ b/tools/github_workflows/stress_installer_provisioning.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# Regression test for the loop-partition readiness race (issue #3700):
+# repeat the aster-nixos-install template's provisioning path
+# (losetup -> parted -> mkfs) on a fresh loop disk. The unlocked installer
+# failed within 24-240 iterations, so a single install cannot catch it.
+# A PATH shim replaces mount, so every run aborts right after
+# "mkfs finished" and one iteration costs well under a second instead of
+# a full nixos-install.
+
+set -Eeuo pipefail
+
+# Run 500 iterations (losetup -> parted -> mkfs) on a fresh loop disk
+STRESS_RUNS=500
+MOUNT_SHIM_EXIT=42
+
+trap 'echo "::error::Stress harness failed at line $LINENO" >&2; exit 2' ERR
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ASTERINAS_DIR=$(realpath "${SCRIPT_DIR}/../..")
+CONFIG_PATH="${ASTERINAS_DIR}/distro/etc_nixos/configuration.nix"
+# Nix substitutions are only used after the mount shim aborts the installer.
+INSTALLER="${ASTERINAS_DIR}/distro/aster_nixos_installer/templates/aster-nixos-install"
+
+stress_tmp=$(mktemp -d /tmp/installer-provisioning-stress.XXXXXX)
+stress_disk=""
+stress_image=""
+
+release_iteration() {
+    local absence_streak=0
+    local disk=$stress_disk
+    local _attempt
+
+    if [ -n "$disk" ]; then
+        losetup -d "$disk" || return 1
+        stress_disk=""
+        # Detach is asynchronous too: wait for stable node absence so the
+        # next iteration cannot reuse a loop device that is still dying.
+        for ((_attempt = 0; _attempt < 500; _attempt++)); do
+            if [ ! -e "${disk}p1" ] && [ ! -e "${disk}p2" ]; then
+                absence_streak=$((absence_streak + 1))
+                if [ "$absence_streak" -ge 5 ]; then
+                    break
+                fi
+            else
+                absence_streak=0
+            fi
+            sleep 0.01
+        done
+        if [ "$absence_streak" -lt 5 ]; then
+            return 1
+        fi
+    fi
+    rm -f "$stress_image"
+}
+
+cleanup_all() {
+    local status=$?
+    trap - EXIT
+    if ! release_iteration; then
+        echo "::error::Cannot release loop device $stress_disk" >&2
+        if [ "$status" -eq 0 ]; then status=2; fi
+    fi
+    if ! rm -rf "$stress_tmp"; then
+        if [ "$status" -eq 0 ]; then status=2; fi
+    fi
+    exit "$status"
+}
+trap cleanup_all EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Abort at mount to avoid running a full installation
+mkdir -p "$stress_tmp/shim"
+cat > "$stress_tmp/shim/mount" <<EOF
+#!/bin/sh
+exit $MOUNT_SHIM_EXIT
+EOF
+# Redirect temporary directories into $stress_tmp for cleanup, since the
+# installer exits before registering its own cleanup path
+chmod +x "$stress_tmp/shim/mount"
+cat > "$stress_tmp/shim/mktemp" <<EOF
+#!/usr/bin/env bash
+exec $(printf '%q -d %q' "$(command -v mktemp)" "$stress_tmp/build.XXXXXX")
+EOF
+chmod +x "$stress_tmp/shim/mktemp"
+
+echo "runs=$STRESS_RUNS installer=$(readlink -f "$INSTALLER")"
+
+for ((iteration = 1; iteration <= STRESS_RUNS; iteration++)); do
+    stress_image="$stress_tmp/disk-$iteration.img"
+    # Sparse image: the hard-coded partition layout needs >= 1GB of
+    # address space but only a few MB are ever written.
+    if ! truncate -s 1024M "$stress_image"; then
+        echo "iteration=$iteration operation=truncate failure=harness"
+        exit 2
+    fi
+    if ! stress_disk=$(losetup -fP --show "$stress_image"); then
+        echo "iteration=$iteration operation=losetup failure=harness"
+        exit 2
+    fi
+
+    status=0
+    output=$(PATH="$stress_tmp/shim:$PATH" \
+        bash "$INSTALLER" --config "$CONFIG_PATH" --disk "$stress_disk" 2>&1) || status=$?
+
+    if [ "$status" -ne "$MOUNT_SHIM_EXIT" ] ||
+        [[ "$output" != *"mkfs finished"* ]]; then
+        echo "iteration=$iteration disk=$stress_disk status=$status failure=provisioning"
+        printf '%s\n' "$output"
+        exit 1
+    fi
+
+    if ! release_iteration; then
+        echo "iteration=$iteration operation=loop-cleanup failure=harness"
+        exit 2
+    fi
+    if [ $((iteration % 50)) -eq 0 ]; then
+        echo "progress completed=$iteration"
+    fi
+done
+
+echo "Installer provisioning survived $STRESS_RUNS runs"


### PR DESCRIPTION
Fix the first part of https://github.com/asterinas/asterinas/issues/3700 (closes #3700)

We could close that issue once the PR merged.

### Issue

The minimal AsterNixOS test intermittently fails while creating the disk image:

```
mkfs.fat: unable to open /dev/loop0p1: No such file or directory
```

Example: https://github.com/asterinas/asterinas/actions/runs/32697071617/job/97341107357 (the visible 600-second QEMU login timeout is a downstream symptom; image creation had already failed).

### Root cause 

The installer assumed that once `parted` completed successfully, the loop device’s partition nodes were ready for `mkfs`. However, udev updates these nodes asynchronously. If `mkfs` runs too early, it may fail with `No such file or directory` because the node has not been created yet, or with `No such device or address` because the node exists but the partition behind it is not yet available.

### Fix 

systemd-udevd takes a flock on the whole disk before that re-read and skips it when the lock is held by someone else; this is the documented protocol for partitioning and formatting tools ([systemd docs/BLOCK_DEVICE_LOCKING.md](https://github.com/systemd/systemd/blob/main/docs/BLOCK_DEVICE_LOCKING.md)). The installer now holds an exclusive lock on the disk FD from before parted until both partitions are mounted.

`set -e` is needed here because docker-run-action-fork does not execute this block with the usual fail-fast shell settings. It converts the lines to a semicolon-separated command and runs them with sh -c inside the container. So make run_nixos  still runs against an incomplete disk image, which hided the actual mkfs error and convert it to the unrelated 600s QEMU timeout. I will update it with comment.

### Why not udevadm settle
 
`udevadm settle` is not a substitute. In this CI setup only /dev is bind-mounted into the container, and the device nodes belong to the host and are managed by the host's udevd, while a container-local udevadm settle looks for `/run/udev/control` and `/run/udev/queue` inside the container, finds neither, and returns 0 without waiting,

ref: https://github.com/systemd/systemd/blob/v255/src/udev/udevadm-settle.c#L200-L217

### How to verify

The race is hard to trigger on demand. A before/after stress run on the fork used the same harness and container image (`asterinas/kernel-dev:0.18.1-20260901`), with the same container setup as this CI job. With only the disk-locking patch reverted, the two baseline jobs failed at iterations 159 and 54 with `mkfs.fat: unable to open /dev/loop0p1: No such file or directory`. With the patch applied, 1000 fresh-disk partition-and-format iterations (2 jobs x 500) completed with zero failures: [CI run](https://github.com/chinrw/asterinas/actions/runs/34201163770).

The harness is [stress_installer_provisioning.sh](https://github.com/chinrw/asterinas/blob/40afad82a1a3f600f99cd576c74ed4843b4a385e/tools/github_workflows/stress_installer_provisioning.sh). This workflow will be triggered by `test_nixos_full` and will run in parallel.
