### PR TITLE
Remove unnecessary `WaitQueue`s in devtmpfs and elsewhere

### DIFF
--- a/kernel/core/src/device/misc/tdxguest.rs
+++ b/kernel/core/src/device/misc/tdxguest.rs
@@ -45,7 +45,7 @@ use device_id::{DeviceId, MinorId};
 use ostd::{
     const_assert,
     mm::{FrameAllocOptions, HasPaddr, HasSize, USegment, VmIo, dma::DmaCoherent},
-    sync::{RwMutexWriteGuard, WaitQueue},
+    sync::{RwMutexWriteGuard, Waiter},
 };
 use spin::Once;
 use tdx_guest::{
@@ -266,14 +266,14 @@ pub(crate) fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
 
     // Poll for the quote to be ready.
     let status_ptr = field_ptr!(&header_ptr, TdxQuoteHdr, status);
-    let sleep_queue = WaitQueue::new();
+    let (sleep_waiter, _) = Waiter::new_pair();
     let sleep_duration = Duration::from_millis(100);
     loop {
         let status = status_ptr.read()?;
         if status != GET_QUOTE_IN_FLIGHT {
             break;
         }
-        let _ = sleep_queue.wait_until_or_timeout(|| -> Option<()> { None }, &sleep_duration);
+        let _ = sleep_waiter.wait_until_or_timeout(|| -> Option<()> { None }, &sleep_duration);
     }
 
     // Note: We cannot convert `DmaCoherent` to `USegment` here. When shared memory is converted back

--- a/kernel/core/src/device/misc/tdxguest.rs
+++ b/kernel/core/src/device/misc/tdxguest.rs
@@ -195,12 +195,7 @@ impl PerOpenFileOps for TdxGuestFile {
                         inblob_ptr.read()?
                     };
 
-                    let report = TDX_REPORT
-                        .get()
-                        .ok_or_else(|| {
-                            Error::with_message(Errno::ENODEV, "TDX report not initialized")
-                        })?
-                        .write();
+                    let report = tdx_report_or_err()?.write();
                     refresh_tdx_report_locked(&report, Some(inblob.as_bytes()))?;
                     let outblob_ptr = field_ptr!(&data_ptr, TdxReportRequest, tdx_report);
                     outblob_ptr.copy_from(&SafePtr::new(&*report, 0))?;
@@ -214,6 +209,12 @@ impl PerOpenFileOps for TdxGuestFile {
 }
 
 static TDX_REPORT: Once<RwMutex<USegment>> = Once::new();
+
+fn tdx_report_or_err() -> Result<&'static RwMutex<USegment>> {
+    TDX_REPORT
+        .get()
+        .ok_or_else(|| Error::with_message(Errno::ENODEV, "the TDX report is not initialized"))
+}
 
 /// Runtime Measurement Register (RTMR) index.
 ///
@@ -251,10 +252,7 @@ pub(crate) fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
     field_ptr!(&header_ptr, TdxQuoteHdr, in_len).write(&(size_of::<TdReport>() as u32))?;
     field_ptr!(&header_ptr, TdxQuoteHdr, out_len).write(&0u32)?;
 
-    let report = TDX_REPORT
-        .get()
-        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
-        .write();
+    let report = tdx_report_or_err()?.write();
     refresh_tdx_report_locked(&report, Some(inblob))?;
     payload_ptr.copy_from(&SafePtr::new(&*report, 0))?;
     drop(report);
@@ -296,10 +294,7 @@ pub(crate) fn tdx_get_quote(inblob: &[u8]) -> Result<Box<[u8]>> {
 /// should use [`get_tdx_mr_refresh`] instead, which combines the refresh and
 /// the register read atomically.
 pub(crate) fn refresh_tdx_report(inblob: Option<&[u8]>) -> Result<()> {
-    let report = TDX_REPORT
-        .get()
-        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
-        .write();
+    let report = tdx_report_or_err()?.write();
     refresh_tdx_report_locked(&report, inblob)
 }
 
@@ -313,10 +308,7 @@ pub(crate) const SHA384_DIGEST_SIZE: usize = 48;
 /// recent [`extend_tdx_mr`], use [`get_tdx_mr_refresh`] instead to obtain the
 /// current hardware value.
 pub(crate) fn get_tdx_mr(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
-    let report = TDX_REPORT
-        .get()
-        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
-        .read();
+    let report = tdx_report_or_err()?.read();
 
     let mut blob = [0u8; SHA384_DIGEST_SIZE];
     report
@@ -336,10 +328,7 @@ pub(crate) fn get_tdx_mr(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]
 /// value. If no extend has occurred and the cached report is still current,
 /// the cheaper [`get_tdx_mr`] can be used instead.
 pub(crate) fn get_tdx_mr_refresh(reg: MeasurementReg) -> Result<[u8; SHA384_DIGEST_SIZE]> {
-    let report = TDX_REPORT
-        .get()
-        .ok_or_else(|| Error::with_message(Errno::ENODEV, "TDX report not initialized"))?
-        .write();
+    let report = tdx_report_or_err()?.write();
 
     refresh_tdx_report_locked(&report, None)?;
 

--- a/kernel/core/src/device/mod.rs
+++ b/kernel/core/src/device/mod.rs
@@ -27,9 +27,7 @@ pub(crate) trait Device: Send + Sync + 'static {
     fn id(&self) -> DeviceId;
 
     /// Returns the metadata that specifies a device inode to be created in devtmpfs, if any.
-    fn devtmpfs_meta(&self) -> Option<DevtmpfsNodeMeta> {
-        None
-    }
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsNodeMeta>;
 
     /// Opens the device, returning a file-like object that the userspace can interact with by
     /// doing I/O.

--- a/kernel/core/src/device/pty/driver.rs
+++ b/kernel/core/src/device/pty/driver.rs
@@ -10,7 +10,7 @@ use crate::{
         },
     },
     events::IoEvents,
-    fs::file::PerOpenFileOps,
+    fs::{devtmpfs::DevtmpfsNodeMeta, file::PerOpenFileOps},
     prelude::*,
     process::signal::Pollee,
     util::{
@@ -113,6 +113,10 @@ impl PtyDriver {
 impl TtyDriver for PtyDriver {
     // Reference: <https://elixir.bootlin.com/linux/v6.17/source/include/uapi/linux/major.h#L147>.
     const DEVICE_MAJOR_ID: u32 = 136;
+
+    fn devtmpfs_meta(&self, _index: u32) -> Option<DevtmpfsNodeMeta> {
+        None
+    }
 
     fn open(tty: Arc<Tty<Self>>) -> Result<Box<dyn PerOpenFileOps>> {
         Ok(Box::new(PtySlaveFile::new(tty)?))

--- a/kernel/core/src/device/tty/device.rs
+++ b/kernel/core/src/device/tty/device.rs
@@ -80,6 +80,9 @@ pub(crate) struct SystemConsole {
     inner: Arc<dyn Device>,
 }
 
+/// The device ID of `/dev/console`.
+pub(crate) const CONSOLE_DEVICE_ID: DeviceId = DeviceId::new(MajorId::new(5), MinorId::new(1));
+
 impl SystemConsole {
     /// Returns the singleton instance of the console device.
     pub(crate) fn singleton() -> &'static Arc<SystemConsole> {
@@ -117,7 +120,7 @@ impl Device for SystemConsole {
     }
 
     fn id(&self) -> DeviceId {
-        super::console_device_id()
+        CONSOLE_DEVICE_ID
     }
 
     fn devtmpfs_meta(&self) -> Option<DevtmpfsNodeMeta> {

--- a/kernel/core/src/device/tty/driver.rs
+++ b/kernel/core/src/device/tty/driver.rs
@@ -20,9 +20,7 @@ pub(crate) trait TtyDriver: Send + Sync + 'static {
     const DEVICE_MAJOR_ID: u32;
 
     /// Returns the metadata that specifies a TTY device inode to be created in devtmpfs, if any.
-    fn devtmpfs_meta(&self, _index: u32) -> Option<DevtmpfsNodeMeta> {
-        None
-    }
+    fn devtmpfs_meta(&self, _index: u32) -> Option<DevtmpfsNodeMeta>;
 
     /// Opens the TTY.
     ///

--- a/kernel/core/src/device/tty/mod.rs
+++ b/kernel/core/src/device/tty/mod.rs
@@ -30,6 +30,7 @@ mod serial;
 pub(super) mod termio;
 mod vt;
 
+pub(crate) use device::CONSOLE_DEVICE_ID;
 pub(super) use driver::TtyDriver;
 pub(super) use flags::TtyFlags;
 
@@ -40,10 +41,6 @@ pub(super) fn init_in_first_process() -> Result<()> {
     vt::init_in_first_process()?;
 
     Ok(())
-}
-
-pub(crate) fn console_device_id() -> DeviceId {
-    DeviceId::new(MajorId::new(5), MinorId::new(1))
 }
 
 const IO_CAPACITY: usize = 4096;

--- a/kernel/core/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/ptmx.rs
@@ -8,6 +8,7 @@ use super::{BLOCK_SIZE, DevPts, PTMX_INO};
 use crate::{
     device::{Device, DeviceType},
     fs::{
+        devtmpfs::DevtmpfsNodeMeta,
         file::{AccessMode, InodeMode, InodeType, PerOpenFileOps, StatusFlags, mkmod},
         vfs::{
             file_system::{FileSystem, SuperBlock},
@@ -177,6 +178,10 @@ impl Device for Inner {
 
     fn id(&self) -> DeviceId {
         DeviceId::new(MajorId::new(PTMX_MAJOR_NUM), MinorId::new(PTMX_MINOR_NUM))
+    }
+
+    fn devtmpfs_meta(&self) -> Option<DevtmpfsNodeMeta> {
+        None
     }
 
     fn open(&self) -> Result<Box<dyn PerOpenFileOps>> {

--- a/kernel/core/src/fs/fs_impls/devtmpfs/mod.rs
+++ b/kernel/core/src/fs/fs_impls/devtmpfs/mod.rs
@@ -31,7 +31,7 @@ pub(super) fn init() {
 }
 
 pub(super) fn init_in_first_kthread() {
-    worker::init();
+    worker::init_in_first_kthread();
 }
 
 #[cfg(ktest)]
@@ -67,6 +67,7 @@ mod tests {
         )
     }
 
+    #[track_caller]
     fn assert_missing(path: &str) {
         match tree::lookup_path(path) {
             Err(error) => assert_eq!(error.error(), Errno::ENOENT),

--- a/kernel/core/src/fs/fs_impls/devtmpfs/tree.rs
+++ b/kernel/core/src/fs/fs_impls/devtmpfs/tree.rs
@@ -17,7 +17,7 @@ use crate::{
         vfs::{
             file_system::FileSystem,
             inode::{Inode, MknodType},
-            path,
+            path::{self, SplitPath},
         },
     },
     prelude::*,
@@ -38,19 +38,26 @@ pub(crate) struct DevtmpfsNodeMeta {
     mode: InodeMode,
 }
 
+/// An error returned by [`DevtmpfsNodeMeta::new`] and [`DevtmpfsNodeMeta::with_mode`].
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct InvalidDevtmpfsPath;
+
 impl DevtmpfsNodeMeta {
     /// Creates the metadata for a devtmpfs node with the default mode (`u+rw`).
     ///
     /// `path` must be a non-empty, relative, well-formed path. For example,
     /// `a/b/c` is valid, whereas `/`, `/abc`, `a//b`, and `a/b/` are invalid.
-    pub(crate) fn new(path: impl Into<Cow<'static, str>>) -> Result<Self> {
+    pub(crate) fn new(path: impl Into<Cow<'static, str>>) -> Result<Self, InvalidDevtmpfsPath> {
         Self::with_mode(path, mkmod!(u+rw))
     }
 
     /// Creates the metadata for a devtmpfs node with the specified mode.
     ///
     /// The path follows the same requirements as [`Self::new`].
-    pub(crate) fn with_mode(path: impl Into<Cow<'static, str>>, mode: InodeMode) -> Result<Self> {
+    pub(crate) fn with_mode(
+        path: impl Into<Cow<'static, str>>,
+        mode: InodeMode,
+    ) -> Result<Self, InvalidDevtmpfsPath> {
         let path = path.into();
         if path.is_empty()
             || path.starts_with('/')
@@ -58,7 +65,7 @@ impl DevtmpfsNodeMeta {
                 .split('/')
                 .any(|component| component.is_empty() || path::is_dot_or_dotdot(component))
         {
-            return_errno_with_message!(Errno::EINVAL, "the device path is invalid");
+            return Err(InvalidDevtmpfsPath);
         }
         Ok(Self { path, mode })
     }
@@ -94,13 +101,13 @@ impl DevtmpfsNode {
 }
 
 pub(super) fn create_node(node: &DevtmpfsNode) -> Result<()> {
-    let (parent_path, node_name) = split_parent_and_basename(node.meta.path()).unwrap();
+    let (parent_path, node_name) = node.meta.path().split_dirname_and_basename().unwrap();
     let parent_inode = lookup_or_create_path(parent_path)?;
     create_device_node(parent_inode.as_ref(), node_name, node)
 }
 
 pub(super) fn delete_node(node: &DevtmpfsNode) -> Result<()> {
-    let (parent_path, node_name) = split_parent_and_basename(node.meta.path()).unwrap();
+    let (parent_path, node_name) = node.meta.path().split_dirname_and_basename().unwrap();
     let parent_inode = lookup_path(parent_path)?;
     let parent_ram_inode = parent_inode.downcast_ref::<RamInode>().unwrap();
 
@@ -164,7 +171,7 @@ fn create_device_node(parent_inode: &dyn Inode, name: &str, node: &DevtmpfsNode)
 fn remove_empty_parent_dirs(path: &str) {
     let mut path = path;
 
-    while let Some((parent_path, name)) = split_parent_and_basename(path) {
+    while let Ok((parent_path, name)) = path.split_dirname_and_basename() {
         let parent_inode = match lookup_path(parent_path) {
             Ok(inode) => inode,
             Err(_) => break,
@@ -189,15 +196,4 @@ fn matches_device(inode: &RamInode, node: &DevtmpfsNode) -> bool {
     };
 
     inode.type_() == expected_type && inode.metadata().unwrap().self_dev_id == Some(node.device_id)
-}
-
-fn split_parent_and_basename(path: &str) -> Option<(&str, &str)> {
-    if path.is_empty() {
-        return None;
-    }
-
-    path.rsplit_once('/').map_or_else(
-        || Some(("", path)),
-        |(parent, basename)| (!basename.is_empty()).then_some((parent, basename)),
-    )
 }

--- a/kernel/core/src/fs/fs_impls/devtmpfs/worker.rs
+++ b/kernel/core/src/fs/fs_impls/devtmpfs/worker.rs
@@ -26,7 +26,7 @@ pub(crate) fn delete_node(node: DevtmpfsNode) -> Result<()> {
     submit(Request::DeleteNode(node))
 }
 
-pub(super) fn init() {
+pub(super) fn init_in_first_kthread() {
     ThreadOptions::new(devtmpfsd).spawn();
 }
 

--- a/kernel/core/src/fs/fs_impls/devtmpfs/worker.rs
+++ b/kernel/core/src/fs/fs_impls/devtmpfs/worker.rs
@@ -2,7 +2,7 @@
 
 //! Request queue and kernel thread for serialized devtmpfs node operations.
 
-use ostd::sync::WaitQueue;
+use ostd::sync::{Waiter, Waker};
 use spin::Once;
 
 use super::{DevtmpfsNode, tree};
@@ -31,59 +31,65 @@ pub(super) fn init() {
 }
 
 fn submit(request: Request) -> Result<()> {
-    let request = Arc::new(PendingRequest::new(request));
-    let queue = request_queue();
-    queue.requests.lock().push_back(request.clone());
-    queue.wait_queue.wake_one();
+    let (waiter, waker) = Waiter::new_pair();
+    let request = Arc::new(PendingRequest::new(request, waker));
 
-    request
-        .wait_queue
-        .wait_until(|| request.result.lock().take())
+    REQUEST_QUEUE.requests.lock().push_back(request.clone());
+    if let Some(waker) = REQUEST_QUEUE.waker.get() {
+        waker.wake_up();
+    } else {
+        // `devtmpfsd` will check the requests after initializing the waker.
+    }
+
+    waiter.wait();
+
+    // `result` is guaranteed to be available after `waiter.wait()`.
+    *request.result.get().unwrap()
 }
 
 fn devtmpfsd() {
-    let queue = request_queue();
+    let (waiter, waker) = Waiter::new_pair();
+
+    REQUEST_QUEUE.waker.call_once(|| waker);
 
     loop {
-        let request = queue
-            .wait_queue
-            .wait_until(|| queue.requests.lock().pop_front());
+        let request = REQUEST_QUEUE.requests.lock().pop_front();
+        let Some(request) = request else {
+            waiter.wait();
+            continue;
+        };
+
         let result = match &request.request {
             Request::CreateNode(node) => tree::create_node(node),
             Request::DeleteNode(node) => tree::delete_node(node),
         };
-
-        *request.result.lock() = Some(result);
-        request.wait_queue.wake_all();
+        request.result.call_once(|| result);
+        request.waker.wake_up();
     }
-}
-
-fn request_queue() -> &'static RequestQueue {
-    static REQUEST_QUEUE: Once<RequestQueue> = Once::new();
-
-    REQUEST_QUEUE.call_once(|| RequestQueue {
-        requests: SpinLock::new(VecDeque::new()),
-        wait_queue: WaitQueue::new(),
-    })
 }
 
 struct RequestQueue {
     requests: SpinLock<VecDeque<Arc<PendingRequest>>>,
-    wait_queue: WaitQueue,
+    waker: Once<Arc<Waker>>,
 }
+
+static REQUEST_QUEUE: RequestQueue = RequestQueue {
+    requests: SpinLock::new(VecDeque::new()),
+    waker: Once::new(),
+};
 
 struct PendingRequest {
     request: Request,
-    result: Mutex<Option<Result<()>>>,
-    wait_queue: WaitQueue,
+    result: Once<Result<()>>,
+    waker: Arc<Waker>,
 }
 
 impl PendingRequest {
-    fn new(request: Request) -> Self {
+    fn new(request: Request, waker: Arc<Waker>) -> Self {
         Self {
             request,
-            result: Mutex::new(None),
-            wait_queue: WaitQueue::new(),
+            result: Once::new(),
+            waker,
         }
     }
 }

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -151,10 +151,12 @@ pub(in crate::fs::fs_impls) struct RamInode {
     /// Reference to fs
     fs: Weak<RamFs>,
     /// Device ID.
+    ///
     /// Detached inodes such as `memfd` store it directly
     /// because they do not have a valid fs reference.
     container_dev_id: DeviceId,
     /// Hard linkability.
+    ///
     /// All inodes except temporary files are set to linkable
     /// Linkability of temporary files is specified via [`RamInode::create_tmpfile`]
     hard_linkability: HardLinkability,
@@ -783,13 +785,12 @@ impl RamInode {
 
         let mut self_dir = self.inner.as_direntry().unwrap().write();
         let (idx, target) = self_dir.get_entry(name).ok_or(Error::new(Errno::ENOENT))?;
-        if !predicate(&target) {
-            return Ok(false);
-        }
         if target.typ == InodeType::Dir {
             return_errno_with_message!(Errno::EISDIR, "unlink on dir");
         }
-
+        if !predicate(&target) {
+            return Ok(false);
+        }
         self_dir.remove_entry(idx);
         drop(self_dir);
 
@@ -893,9 +894,7 @@ impl RamInode {
             InodeType::SymLink => RamInode::new_symlink(&fs, mode, uid, gid, to_be_revalidated),
             InodeType::Socket => RamInode::new_socket(&fs, mode, uid, gid, to_be_revalidated),
             InodeType::Dir => RamInode::new_dir(&fs, mode, uid, gid, &self.this, to_be_revalidated),
-            _ => {
-                panic!("unsupported inode type");
-            }
+            _ => panic!("unsupported inode type"),
         };
 
         let mut self_dir = self_dir.upgrade();

--- a/kernel/core/src/fs/fs_impls/tmpfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/tmpfs/fs.rs
@@ -62,7 +62,6 @@ impl TmpFs {
 fn default_max_blocks() -> usize {
     crate::vm::mem_total() / PAGE_SIZE / 2
 }
-
 fn default_max_inodes() -> usize {
     crate::vm::mem_total() / PAGE_SIZE / 2
 }

--- a/kernel/core/src/fs/initramfs.rs
+++ b/kernel/core/src/fs/initramfs.rs
@@ -86,7 +86,7 @@ fn ensure_dev_console(path_resolver: &PathResolver) -> Result<()> {
             dev_path.mknod(
                 "console",
                 mkmod!(u+rw),
-                MknodType::CharDevice(tty::console_device_id().as_encoded_u64()),
+                MknodType::CharDevice(tty::CONSOLE_DEVICE_ID.as_encoded_u64()),
             )?;
             Ok(())
         }

--- a/kernel/core/src/init.rs
+++ b/kernel/core/src/init.rs
@@ -2,6 +2,8 @@
 
 //! Kernel initialization.
 
+use core::sync::atomic::{AtomicU8, Ordering};
+
 use aster_cmdline::INIT_PROC_ARGS;
 use component::InitStage;
 use ostd::{cpu::CpuId, util::id_set::Id};
@@ -162,13 +164,14 @@ struct BootInit {
     init_path: Option<(Path, &'static str)>,
 }
 
+#[repr(u8)]
 enum BootSource {
-    Initramfs,
-    Rootfs,
+    Initramfs = 0,
+    Rootfs = 1,
 }
 
 pub(crate) fn booted_from_rootfs() -> bool {
-    matches!(BOOT_SOURCE.get(), Some(BootSource::Rootfs))
+    BOOT_SOURCE.load(Ordering::Relaxed) == BootSource::Rootfs as u8
 }
 
 impl BootInit {
@@ -195,7 +198,7 @@ impl BootInit {
 
 fn prepare_boot_init(mut path_resolver: PathResolver) -> BootInit {
     if let Ok(init_path) = initramfs::find_init(&path_resolver) {
-        BOOT_SOURCE.call_once(|| BootSource::Initramfs);
+        BOOT_SOURCE.store(BootSource::Initramfs as u8, Ordering::Relaxed);
         return BootInit {
             path_resolver,
             init_path: Some(init_path),
@@ -205,7 +208,7 @@ fn prepare_boot_init(mut path_resolver: PathResolver) -> BootInit {
     rootfs::switch_to_rootfs(&mut path_resolver)
         .expect("neither an initramfs init nor a usable root filesystem was available");
     let init_path = rootfs::find_init(&path_resolver).expect("failed to resolve rootfs init path");
-    BOOT_SOURCE.call_once(|| BootSource::Rootfs);
+    BOOT_SOURCE.store(BootSource::Rootfs as u8, Ordering::Relaxed);
     BootInit {
         path_resolver,
         init_path,
@@ -276,4 +279,4 @@ fn print_banner() {
     println!("{}", logo_ascii_art::get_gradient_color_version());
 }
 
-static BOOT_SOURCE: Once<BootSource> = Once::new();
+static BOOT_SOURCE: AtomicU8 = AtomicU8::new(BootSource::Initramfs as u8);

--- a/kernel/core/src/thread/work_queue/worker_pool.rs
+++ b/kernel/core/src/thread/work_queue/worker_pool.rs
@@ -9,7 +9,7 @@ use core::{
 
 use ostd::{
     cpu::{CpuId, CpuSet},
-    sync::WaitQueue,
+    sync::{WaitQueue, Waiter},
     task::Task,
 };
 
@@ -257,7 +257,7 @@ impl Monitor {
     }
 
     fn run_monitor_loop(self: &Arc<Self>) {
-        let sleep_queue = WaitQueue::new();
+        let (sleep_waiter, _) = Waiter::new_pair();
         let sleep_duration = Duration::from_millis(100);
         loop {
             let worker_pool = self.worker_pool.upgrade();
@@ -268,7 +268,7 @@ impl Monitor {
             for local_pool in worker_pool.local_pools.iter() {
                 local_pool.set_heartbeat(false);
             }
-            let _ = sleep_queue.wait_until_or_timeout(|| -> Option<()> { None }, &sleep_duration);
+            let _ = sleep_waiter.wait_until_or_timeout(|| -> Option<()> { None }, &sleep_duration);
         }
     }
 }

--- a/kernel/libs/device-id/src/lib.rs
+++ b/kernel/libs/device-id/src/lib.rs
@@ -20,7 +20,7 @@ pub struct DeviceId(u32);
 
 impl DeviceId {
     /// Creates a device ID from the major device number and the minor device number.
-    pub fn new(major: MajorId, minor: MinorId) -> Self {
+    pub const fn new(major: MajorId, minor: MinorId) -> Self {
         Self(((major.get() as u32) << 20) | minor.get())
     }
 


### PR DESCRIPTION
I don't think there's any need to use `WaitQueue` in the devtmpfs implementation. There is only one waiter, so it's not a queue. The purpose of a queue is to enable multiple people to wait for the same thing, which is not the case here.

Additionally, I'm unsure what the point is of making `devtmpfs_meta` have a default implementation. In our codebase, it seems rather useless since we don't have many implementations that use the default. I'd prefer to keep the benefit of explicitness until it's clearer that flexibility outweighs it.

There are some other cleanups in the second commit. Hopefully it won't be too hard to parse..

---

cc @taosue Could you please help check the changes here?