### PR TITLE
Fix xAPIC ID extraction

### DIFF
--- a/ostd/src/arch/x86/kernel/apic/xapic.rs
+++ b/ostd/src/arch/x86/kernel/apic/xapic.rs
@@ -67,7 +67,9 @@ impl XApic {
 
 impl super::Apic for XApic {
     fn id(&self) -> u32 {
-        unsafe { self.io_mem.read_once(xapic::XAPIC_ID as usize) }
+        let raw: u32 = unsafe { self.io_mem.read_once(xapic::XAPIC_ID as usize) };
+        // Bits 31-24: APIC ID.
+        (raw >> 24) & 0xff
     }
 
     fn version(&self) -> u32 {


### PR DESCRIPTION
`XApic::id()` returns the raw 32-bit APIC_ID register value, but in xAPIC mode the APIC ID only lives in bits 24-31. `ApicId::from` later truncates it with `as u8`, keeping only the low 8 bits which are always zero, so every CPU ends up with ID 0.

Since every CPU gets ID 0, `send_ipi` always targets CPU 0, so the intended CPU never gets the TLB flush request and `sync_tlb_flush` waits forever.

Fix it by extracting bits 24-31, same as Linux's `flat_get_apic_id`:

```c
// arch/x86/kernel/apic/apic_flat_64.c
static u32 physflat_get_apic_id(u32 x)
{
	return (x >> 24) & 0xFF;
}
```
