### PR TITLE
Skip invalid I/O APIC entries from the MADT

### DIFF
--- a/ostd/src/arch/x86/irq/chip/ioapic.rs
+++ b/ostd/src/arch/x86/irq/chip/ioapic.rs
@@ -6,6 +6,7 @@ use crate::{
     Error, Result, info,
     io::{IoMem, IoMemAllocatorBuilder, Sensitive},
     irq::IrqLine,
+    mm::HasPaddr,
 };
 
 /// I/O Advanced Programmable Interrupt Controller (APIC).
@@ -30,9 +31,37 @@ impl IoApic {
         base_address: usize,
         base_interrupt: u32,
         io_mem_builder: &IoMemAllocatorBuilder,
-    ) -> Self {
+    ) -> Option<Self> {
+        // SAFETY: The safety is upheld by the caller.
         let mut access = unsafe { IoApicAccess::new(base_address, io_mem_builder) };
+
+        // SAFETY: IOAPICID is safe to read.
+        let reg_id = unsafe { access.read(IoApicAccess::IOAPICID) };
+        // SAFETY: IOAPICVER is safe to read.
+        let reg_ver = unsafe { access.read(IoApicAccess::IOAPICVER) };
+        // SAFETY: IOAPICARB is safe to read.
+        let reg_arb = unsafe { access.read(IoApicAccess::IOAPICARB) };
+        if reg_id == u32::MAX && reg_ver == u32::MAX && reg_arb == u32::MAX {
+            crate::warn!(
+                "IOAPIC {:#x} registers return all ones, skipping",
+                base_address
+            );
+            return None;
+        }
+
         let max_redirection_entry = access.max_redirection_entry();
+        if base_interrupt
+            .checked_add(max_redirection_entry as u32)
+            .is_none()
+        {
+            crate::warn!(
+                "IOAPIC {:#x} GSI range overflows ({}+{}), skipping",
+                base_address,
+                base_interrupt,
+                max_redirection_entry
+            );
+            return None;
+        }
 
         info!(
             "IOAPIC found at {:#x}, ID {}, version {}, interrupt base {}, interrupt count {}",
@@ -54,7 +83,7 @@ impl IoApic {
             ioapic.disable(index).unwrap();
         }
 
-        ioapic
+        Some(ioapic)
     }
 
     /// Enables an entry.
@@ -140,6 +169,16 @@ impl IoApic {
     pub(super) fn interrupt_base(&self) -> u32 {
         self.interrupt_base
     }
+
+    /// Returns the last number of the global system interrupts controlled by the I/O APIC.
+    pub(super) fn interrupt_end(&self) -> u32 {
+        self.interrupt_base + self.max_redirection_entry as u32
+    }
+
+    /// Returns the base address of the I/O APIC.
+    pub(super) fn address(&self) -> usize {
+        self.access.io_mem.paddr()
+    }
 }
 
 struct IoApicAccess {
@@ -159,9 +198,11 @@ impl IoApicAccess {
     const MMIO_SIZE: usize = crate::mm::PAGE_SIZE;
 
     /// IOAPIC ID.
-    const IOAPICID: u8 = 0x00;
+    pub(self) const IOAPICID: u8 = 0x00;
     /// IOAPIC Version.
-    const IOAPICVER: u8 = 0x01;
+    pub(self) const IOAPICVER: u8 = 0x01;
+    /// IOAPIC Arbitration.
+    pub(self) const IOAPICARB: u8 = 0x02;
     /// Redirection Table.
     pub(self) const IOREDTBL: u8 = 0x10;
 

--- a/ostd/src/arch/x86/irq/chip/mod.rs
+++ b/ostd/src/arch/x86/irq/chip/mod.rs
@@ -177,7 +177,7 @@ pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
         pic::init_and_disable();
     }
 
-    let mut io_apics = Vec::with_capacity(2);
+    let mut io_apics: Vec<IoApic> = Vec::with_capacity(2);
     let mut isa_overrides = Vec::new();
 
     const BUS_ISA: u8 = 0; // "0 Constant, meaning ISA".
@@ -185,15 +185,55 @@ pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
     for madt_entry in madt_table.get().entries() {
         match madt_entry {
             MadtEntry::IoApic(madt_io_apic) => {
-                // SAFETY: We trust the ACPI tables (as well as the MADTs in them), from which the
-                // base address is obtained, so it is a valid I/O APIC base address.
-                let io_apic = unsafe {
+                let address = madt_io_apic.io_apic_address as usize;
+                let interrupt_base = madt_io_apic.global_system_interrupt_base;
+
+                // ACPI tables may contain buggy MADT entries. We perform checks similar to those in
+                // the Linux implementation to identify and skip these entries.
+                // Reference: <https://elixir.bootlin.com/linux/v7.2.2/source/arch/x86/kernel/apic/io_apic.c#L2672>
+
+                if address == 0 {
+                    crate::warn!("IOAPIC address is invalid (zero), skipping");
+                    continue;
+                }
+                if io_apics
+                    .iter()
+                    .any(|existing| existing.address() == address)
+                {
+                    crate::warn!(
+                        "IOAPIC address {:#x} duplicates an existing one, skipping",
+                        address
+                    );
+                    continue;
+                }
+
+                // SAFETY: The base address is non-zero and is obtained from the MADTs. Therefore,
+                // it is a valid I/O APIC base address for `IoApic::new`, which performs further
+                // checks and rejects entries whose registers return all ones.
+                let Some(io_apic) = (unsafe {
                     IoApic::new(
                         madt_io_apic.io_apic_address as usize,
                         madt_io_apic.global_system_interrupt_base,
                         io_mem_builder,
                     )
+                }) else {
+                    continue;
                 };
+
+                let interrupt_end = io_apic.interrupt_end();
+                if io_apics.iter().any(|existing| {
+                    interrupt_base <= existing.interrupt_end()
+                        && interrupt_end >= existing.interrupt_base()
+                }) {
+                    crate::warn!(
+                        "IOAPIC {:#x} GSI range [{}-{}] conflicts with an existing IOAPIC, skipping",
+                        address,
+                        interrupt_base,
+                        interrupt_end
+                    );
+                    continue;
+                }
+
                 io_apics.push(io_apic);
             }
             MadtEntry::InterruptSourceOverride(madt_isa_override)


### PR DESCRIPTION
The MADTs may contain invalid I/O APIC entries. On a Hygon 3450M machine, `IOAPIC[2]` at `0xfec01000` returns all ones in its registers. Linux detects this and logs "I/O APIC 0xfec01000 registers return all ones, skipping!" during boot.

Linux's `mp_register_ioapic()` rejects zero and duplicate addresses, skips entries whose registers return all ones via `bad_ioapic_register()`, and rejects entries whose GSI range conflicts with an already registered I/O APIC. Asterinas previously trusted every MADT entry and initialized all of them, so the boot stalled on that machine.

Fix it by rejecting entries whose registers return all ones, following `bad_ioapic_register()`, and also add the other checks from `mp_register_ioapic()` (zero and duplicate addresses, GSI range conflicts):

```c
// arch/x86/kernel/apic/io_apic.c
static int bad_ioapic_register(int idx)
{
	union IO_APIC_reg_00 reg_00;
	union IO_APIC_reg_01 reg_01;
	union IO_APIC_reg_02 reg_02;

	reg_00.raw = io_apic_read(idx, 0);
	reg_01.raw = io_apic_read(idx, 1);
	reg_02.raw = io_apic_read(idx, 2);

	if (reg_00.raw == -1 && reg_01.raw == -1 && reg_02.raw == -1) {
		pr_warn("I/O APIC 0x%x registers return all ones, skipping!\n",
			mpc_ioapic_addr(idx));
		return 1;
	}

	return 0;
}
```

```c
// arch/x86/kernel/apic/io_apic.c (mp_register_ioapic)
	entries = io_apic_get_redir_entries(idx);
	gsi_end = gsi_base + entries - 1;
	for_each_ioapic(ioapic) {
		gsi_cfg = mp_ioapic_gsi_routing(ioapic);
		if ((gsi_base >= gsi_cfg->gsi_base &&
		     gsi_base <= gsi_cfg->gsi_end) ||
		    (gsi_end >= gsi_cfg->gsi_base &&
		     gsi_end <= gsi_cfg->gsi_end)) {
			pr_warn("GSI range [%u-%u] for new IOAPIC conflicts with GSI[%u-%u]\n",
				gsi_base, gsi_end, gsi_cfg->gsi_base, gsi_cfg->gsi_end);
			clear_fixmap(FIX_IO_APIC_BASE_0 + idx);
			return -ENOSPC;
		}
	}
```
