### PR TITLE
Check access permissions with one call

### DIFF
--- a/kernel/core/src/syscall/access.rs
+++ b/kernel/core/src/syscall/access.rs
@@ -54,12 +54,38 @@ bitflags! {
 }
 
 bitflags! {
+    /// The accessibility checks requested by the `access(2)` family.
+    ///
+    /// Do not confuse this type with [`crate::fs::file::AccessMode`],
+    /// which describes the read/write mode of an opened file.
     struct AccessMode: u32 {
         const R_OK = 0x4;
         const W_OK = 0x2;
         const X_OK = 0x1;
-        // We should ignore F_OK in bitflags.
+        // We should ignore `F_OK` in bitflags.
         // const F_OK = 0x0;
+    }
+}
+
+impl AccessMode {
+    /// Returns the permissions that the access mode requires.
+    ///
+    /// `F_OK` is represented by `AccessMode::empty()`,
+    /// which requires no permissions.
+    fn required_permission(&self) -> Permission {
+        let mut permission = Permission::empty();
+
+        if self.contains(Self::R_OK) {
+            permission |= Permission::MAY_READ;
+        }
+        if self.contains(Self::W_OK) {
+            permission |= Permission::MAY_WRITE;
+        }
+        if self.contains(Self::X_OK) {
+            permission |= Permission::MAY_EXEC;
+        }
+
+        permission
     }
 }
 
@@ -97,15 +123,13 @@ fn do_faccessat(
 
     let inode = path.inode();
 
-    // F_OK is represented by `AccessMode::empty()`, which does not perform permission checks.
-    if mode.contains(AccessMode::R_OK) {
-        inode.check_permission(Permission::MAY_READ)?;
-    }
-    if mode.contains(AccessMode::W_OK) {
-        inode.check_permission(Permission::MAY_WRITE)?;
-    }
-    if mode.contains(AccessMode::X_OK) {
-        inode.check_permission(Permission::MAY_EXEC)?;
+    // `F_OK` is represented by `AccessMode::empty()`.
+    // It only asks whether the file exists,
+    // which the successful path lookup above has already established.
+    // So we can skip the permission check, which is not free.
+    let permission = mode.required_permission();
+    if !permission.is_empty() {
+        inode.check_permission(permission)?;
     }
 
     Ok(SyscallReturn::Return(0))


### PR DESCRIPTION
`kernel/core/src/syscall/access.rs` contained the following code:

```rust
    // F_OK is represented by `AccessMode::empty()`, which does not perform permission checks.
    if mode.contains(AccessMode::R_OK) {
        inode.check_permission(Permission::MAY_READ)?;
    }
    if mode.contains(AccessMode::W_OK) {
        inode.check_permission(Permission::MAY_WRITE)?;
    }
    if mode.contains(AccessMode::X_OK) {
        inode.check_permission(Permission::MAY_EXEC)?;
    }
```

It is inefficient to invoke `check_permission` for each permission.
It should have converted `mode: AccessMode` to `perm: Permission` first,
and then called `check_permission` on this `perm` value.

This PR does exactly that.
`Inode::check_permission` is now called at most once per `access`/`faccessat`/`faccessat2`,
so the credential lookup and the `metadata()` query happen once
rather than up to three times.

The single combined check accepts and rejects exactly the same requests as the split checks:
`check_permission` selects its owner/group/other branch from the caller's credentials,
not from the requested permissions,
and evaluates the read, write, and exec bits independently within that branch.
The `DAC_OVERRIDE` path behaves the same way as well,
because it drops the read and write bits
and then answers the exec bit with the "at least one exec bit is set" rule,
regardless of which other bits are present.
`F_OK`, which is `AccessMode::empty()`, still skips the check entirely.

## Testing

- `make check` (rustfmt, clippy) passes.
- `make run_kernel AUTO_TEST=regression`: all regression tests pass.
- LTP `access02`, `access03`, `faccessat01`, `faccessat02`, `faccessat201`: pass.
  `access01`, `access04`, and `faccessat202` still fail,
  exactly as they do on the base commit;
  they are excluded from the LTP test list
  and cover the real-uid semantics of `access(2)`,
  which this kernel does not implement yet.
