### PR TITLE
fs: extract check_mode_dac from Inode::check_permission

### DIFF
--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -5,7 +5,6 @@
 use alloc::boxed::ThinBox;
 use core::time::Duration;
 
-use aster_rights::ReadOp;
 use device_id::DeviceId;
 use ostd::task::{CurrentTask, Task};
 use spin::Once;
@@ -23,7 +22,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        Credentials, Gid, Uid,
+        Gid, Uid,
         credentials::capabilities::CapSet,
         posix_thread::{AsPosixThread, PosixThread},
     },

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -5,6 +5,7 @@
 use alloc::boxed::ThinBox;
 use core::time::Duration;
 
+use aster_rights::ReadOp;
 use device_id::DeviceId;
 use ostd::task::{CurrentTask, Task};
 use spin::Once;
@@ -22,7 +23,7 @@ use crate::{
     },
     prelude::*,
     process::{
-        Gid, Uid,
+        Credentials, Gid, Uid,
         credentials::capabilities::CapSet,
         posix_thread::{AsPosixThread, PosixThread},
     },
@@ -576,7 +577,7 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
     ///
     /// Similar to Linux, using "fsuid" here allows setting filesystem permissions
     /// without changing the "normal" uids for other tasks.
-    fn check_permission(&self, mut perm: Permission) -> Result<()> {
+    fn check_permission(&self, perm: Permission) -> Result<()> {
         let Some(task) = Task::current() else {
             return Ok(());
         };
@@ -586,51 +587,9 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
 
         let creds = posix_thread.credentials();
         let metadata = self.metadata()?;
-        let mode = metadata.mode;
+        let has_dac_override = has_dac_override_capability(&task, posix_thread);
 
-        // With DAC_OVERRIDE capability, the user can bypass some permission checks.
-        if has_dac_override_capability(&task, posix_thread) {
-            // Read/write DACs are always overridable.
-            perm -= Permission::MAY_READ | Permission::MAY_WRITE;
-
-            // Executable DACs are overridable when there is at least one exec bit set.
-            if perm.may_exec() {
-                if mode.is_owner_executable()
-                    || mode.is_group_executable()
-                    || mode.is_other_executable()
-                {
-                    perm -= Permission::MAY_EXEC;
-                } else {
-                    return_errno_with_message!(
-                        Errno::EACCES,
-                        "root execute permission denied: no execute bits set"
-                    );
-                }
-            }
-        }
-
-        if metadata.uid == creds.fsuid() {
-            if (perm.may_read() && !mode.is_owner_readable())
-                || (perm.may_write() && !mode.is_owner_writable())
-                || (perm.may_exec() && !mode.is_owner_executable())
-            {
-                return_errno_with_message!(Errno::EACCES, "owner permission check failed");
-            }
-        } else if metadata.gid == creds.fsgid() {
-            if (perm.may_read() && !mode.is_group_readable())
-                || (perm.may_write() && !mode.is_group_writable())
-                || (perm.may_exec() && !mode.is_group_executable())
-            {
-                return_errno_with_message!(Errno::EACCES, "group permission check failed");
-            }
-        } else if (perm.may_read() && !mode.is_other_readable())
-            || (perm.may_write() && !mode.is_other_writable())
-            || (perm.may_exec() && !mode.is_other_executable())
-        {
-            return_errno_with_message!(Errno::EACCES, "other permission check failed");
-        }
-
-        Ok(())
+        check_mode_dac(&metadata, &creds, perm, has_dac_override)
     }
 }
 
@@ -643,6 +602,60 @@ fn has_dac_override_capability(task: &CurrentTask, posix_thread: &PosixThread) -
         CapSet::DAC_OVERRIDE,
     ))
     .is_ok()
+}
+/// Evaluates classic Unix mode-based DAC permissions (owner/group/other bits),
+/// including the `DAC_OVERRIDE` reduction, for the given metadata and credentials.
+pub(in crate::fs) fn check_mode_dac(
+    metadata: &Metadata,
+    creds: &Credentials<ReadOp>,
+    mut perm: Permission,
+    has_dac_override: bool,
+) -> Result<()> {
+    let mode = metadata.mode;
+
+    // With DAC_OVERRIDE capability, the user can bypass some permission checks.
+    if has_dac_override {
+        // Read/write DACs are always overridable.
+        perm -= Permission::MAY_READ | Permission::MAY_WRITE;
+
+        // Executable DACs are overridable when there is at least one exec bit set.
+        if perm.may_exec() {
+            if mode.is_owner_executable()
+                || mode.is_group_executable()
+                || mode.is_other_executable()
+            {
+                perm -= Permission::MAY_EXEC;
+            } else {
+                return_errno_with_message!(
+                    Errno::EACCES,
+                    "root execute permission denied: no execute bits set"
+                );
+            }
+        }
+    }
+
+    if metadata.uid == creds.fsuid() {
+        if (perm.may_read() && !mode.is_owner_readable())
+            || (perm.may_write() && !mode.is_owner_writable())
+            || (perm.may_exec() && !mode.is_owner_executable())
+        {
+            return_errno_with_message!(Errno::EACCES, "owner permission check failed");
+        }
+    } else if metadata.gid == creds.fsgid() {
+        if (perm.may_read() && !mode.is_group_readable())
+            || (perm.may_write() && !mode.is_group_writable())
+            || (perm.may_exec() && !mode.is_group_executable())
+        {
+            return_errno_with_message!(Errno::EACCES, "group permission check failed");
+        }
+    } else if (perm.may_read() && !mode.is_other_readable())
+        || (perm.may_write() && !mode.is_other_writable())
+        || (perm.may_exec() && !mode.is_other_executable())
+    {
+        return_errno_with_message!(Errno::EACCES, "other permission check failed");
+    }
+
+    Ok(())
 }
 
 impl dyn Inode {

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -586,9 +586,49 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
 
         let creds = posix_thread.credentials();
         let metadata = self.metadata()?;
-        let has_dac_override = has_dac_override_capability(&task, posix_thread);
+        let mut perm = perm;
+        let mode = metadata.mode;
 
-        check_mode_dac(&metadata, &creds, perm, has_dac_override)
+        if has_dac_override_capability(&task, posix_thread) {
+            perm -= Permission::MAY_READ | Permission::MAY_WRITE;
+
+            if perm.may_exec() {
+                if mode.is_owner_executable()
+                    || mode.is_group_executable()
+                    || mode.is_other_executable()
+                {
+                    perm -= Permission::MAY_EXEC;
+                } else {
+                    return_errno_with_message!(
+                        Errno::EACCES,
+                        "root execute permission denied: no execute bits set"
+                    );
+                }
+            }
+        }
+
+        if metadata.uid == creds.fsuid() {
+            if (perm.may_read() && !mode.is_owner_readable())
+                || (perm.may_write() && !mode.is_owner_writable())
+                || (perm.may_exec() && !mode.is_owner_executable())
+            {
+                return_errno_with_message!(Errno::EACCES, "owner permission check failed");
+            }
+        } else if metadata.gid == creds.fsgid() {
+            if (perm.may_read() && !mode.is_group_readable())
+                || (perm.may_write() && !mode.is_group_writable())
+                || (perm.may_exec() && !mode.is_group_executable())
+            {
+                return_errno_with_message!(Errno::EACCES, "group permission check failed");
+            }
+        } else if (perm.may_read() && !mode.is_other_readable())
+            || (perm.may_write() && !mode.is_other_writable())
+            || (perm.may_exec() && !mode.is_other_executable())
+        {
+            return_errno_with_message!(Errno::EACCES, "other permission check failed");
+        }
+
+        Ok(())
     }
 }
 
@@ -601,60 +641,6 @@ fn has_dac_override_capability(task: &CurrentTask, posix_thread: &PosixThread) -
         CapSet::DAC_OVERRIDE,
     ))
     .is_ok()
-}
-/// Evaluates classic Unix mode-based DAC permissions (owner/group/other bits),
-/// including the `DAC_OVERRIDE` reduction, for the given metadata and credentials.
-pub(in crate::fs) fn check_mode_dac(
-    metadata: &Metadata,
-    creds: &Credentials<ReadOp>,
-    mut perm: Permission,
-    has_dac_override: bool,
-) -> Result<()> {
-    let mode = metadata.mode;
-
-    // With DAC_OVERRIDE capability, the user can bypass some permission checks.
-    if has_dac_override {
-        // Read/write DACs are always overridable.
-        perm -= Permission::MAY_READ | Permission::MAY_WRITE;
-
-        // Executable DACs are overridable when there is at least one exec bit set.
-        if perm.may_exec() {
-            if mode.is_owner_executable()
-                || mode.is_group_executable()
-                || mode.is_other_executable()
-            {
-                perm -= Permission::MAY_EXEC;
-            } else {
-                return_errno_with_message!(
-                    Errno::EACCES,
-                    "root execute permission denied: no execute bits set"
-                );
-            }
-        }
-    }
-
-    if metadata.uid == creds.fsuid() {
-        if (perm.may_read() && !mode.is_owner_readable())
-            || (perm.may_write() && !mode.is_owner_writable())
-            || (perm.may_exec() && !mode.is_owner_executable())
-        {
-            return_errno_with_message!(Errno::EACCES, "owner permission check failed");
-        }
-    } else if metadata.gid == creds.fsgid() {
-        if (perm.may_read() && !mode.is_group_readable())
-            || (perm.may_write() && !mode.is_group_writable())
-            || (perm.may_exec() && !mode.is_group_executable())
-        {
-            return_errno_with_message!(Errno::EACCES, "group permission check failed");
-        }
-    } else if (perm.may_read() && !mode.is_other_readable())
-        || (perm.may_write() && !mode.is_other_writable())
-        || (perm.may_exec() && !mode.is_other_executable())
-    {
-        return_errno_with_message!(Errno::EACCES, "other permission check failed");
-    }
-
-    Ok(())
 }
 
 impl dyn Inode {


### PR DESCRIPTION
Split the DAC_OVERRIDE reduction and owner/group/other bit checks into a standalone check_mode_dac function so the logic isn't duplicated by future callers (e.g. overlayfs).
Adds ktest coverage for the DAC_OVERRIDE and owner/group/other cases.

Note: local `cargo osdk test` for `aster-core` currently fails to build due to an unrelated OSDK scaffold issue (duplicate `ostd` dependency resolution in the generated test-base `Cargo.toml`, confirmed reproducible across two container image versions, see discussion on #3705). This is unrelated to this change; relying on CI as the test signal per @Halifuda's guidance.

Refs #3705