### PR TITLE
Remove duplicate ramfs code

### DIFF
--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -783,6 +783,14 @@ impl RamInode {
             return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
         }
 
+        self.unlink_impl(name, predicate)
+    }
+
+    fn unlink_impl<F>(&self, name: &str, predicate: F) -> Result<bool>
+    where
+        F: FnOnce(&Self) -> bool,
+    {
+        // When we got the lock, the directory may have been modified by another thread.
         let mut self_dir = self.inner.as_direntry().unwrap().write();
         let (idx, target) = self_dir.get_entry(name).ok_or(Error::new(Errno::ENOENT))?;
         if target.typ == InodeType::Dir {
@@ -830,10 +838,18 @@ impl RamInode {
         }
 
         let target = self.find(name)?;
+        self.rmdir_impl(name, &target, predicate)
+    }
+
+    fn rmdir_impl<F>(&self, name: &str, target: &Self, predicate: F) -> Result<bool>
+    where
+        F: FnOnce(&Self) -> bool,
+    {
         if target.typ != InodeType::Dir {
             return_errno_with_message!(Errno::ENOTDIR, "rmdir on not dir");
         }
 
+        // When we got the lock, the directory may have been modified by another thread.
         let (mut self_dir, target_dir) = write_lock_two_direntries_by_ino(
             (self.ino, self.inner.as_direntry().unwrap()),
             (target.ino, target.inner.as_direntry().unwrap()),
@@ -844,10 +860,10 @@ impl RamInode {
         let Some((idx, current)) = self_dir.get_entry(name) else {
             return_errno!(Errno::ENOENT);
         };
-        if !Arc::ptr_eq(&current, &target) {
+        if !core::ptr::eq(&*current, target) {
             return_errno!(Errno::ENOENT);
         }
-        if !predicate(&target) {
+        if !predicate(target) {
             return Ok(false);
         }
         self_dir.remove_entry(idx);
@@ -1229,65 +1245,15 @@ impl Inode for RamInode {
 
     fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         let target = child.downcast_ref::<RamInode>().unwrap();
-        if target.typ == InodeType::Dir {
-            return_errno_with_message!(Errno::EISDIR, "unlink on dir");
-        }
-
-        // When we got the lock, the dir may have been modified by another thread
-        let mut self_dir = self.inner.as_direntry().unwrap().write();
-        let (idx, new_target) = self_dir.get_entry(name).ok_or(Error::new(Errno::ENOENT))?;
-        if new_target.ino != target.ino {
+        if !self.unlink_impl(name, |entry| entry.ino == target.ino)? {
             return_errno!(Errno::ENOENT);
         }
-        self_dir.remove_entry(idx);
-        drop(self_dir);
-
-        let now = now();
-        let mut self_meta = self.metadata.lock();
-        self_meta.dec_size();
-        self_meta.set_mtime(now);
-        self_meta.set_ctime(now);
-        drop(self_meta);
-        let mut target_meta = target.metadata.lock();
-        target_meta.dec_nlinks();
-        target_meta.set_ctime(now);
-
         Ok(())
     }
 
     fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
         let target = child.downcast_ref::<RamInode>().unwrap();
-        if target.typ != InodeType::Dir {
-            return_errno_with_message!(Errno::ENOTDIR, "rmdir on not dir");
-        }
-
-        // When we got the lock, the dir may have been modified by another thread
-        let (mut self_dir, target_dir) = write_lock_two_direntries_by_ino(
-            (self.ino, self.inner.as_direntry().unwrap()),
-            (target.ino, target.inner.as_direntry().unwrap()),
-        );
-        if !target_dir.is_empty_children() {
-            return_errno_with_message!(Errno::ENOTEMPTY, "dir not empty");
-        }
-        let (idx, new_target) = self_dir.get_entry(name).ok_or(Error::new(Errno::ENOENT))?;
-        if new_target.ino != target.ino {
-            return_errno!(Errno::ENOENT);
-        }
-        self_dir.remove_entry(idx);
-        drop(self_dir);
-        drop(target_dir);
-
-        let now = now();
-        let mut self_meta = self.metadata.lock();
-        self_meta.dec_size();
-        self_meta.dec_nlinks();
-        self_meta.set_mtime(now);
-        self_meta.set_ctime(now);
-        drop(self_meta);
-        let mut target_meta = target.metadata.lock();
-        target_meta.dec_nlinks();
-        target_meta.dec_nlinks();
-
+        self.rmdir_impl(name, target, |_| true)?;
         Ok(())
     }
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
@@ -82,6 +82,10 @@ impl PerOpenFileOps for VirtioFsDir {
         Ok(())
     }
 
+    fn is_offset_aware(&self) -> bool {
+        true
+    }
+
     fn sync(&self, mode: SyncMode) -> Result<()> {
         self.inode.sync(mode)?;
 
@@ -97,9 +101,5 @@ impl PerOpenFileOps for VirtioFsDir {
         )?;
 
         Ok(())
-    }
-
-    fn is_offset_aware(&self) -> bool {
-        true
     }
 }

--- a/kernel/core/src/fs/fs_impls/virtiofs/file.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/file.rs
@@ -146,6 +146,18 @@ impl PerOpenFileOps for VirtioFsFile {
         Ok(())
     }
 
+    fn is_offset_aware(&self) -> bool {
+        true
+    }
+
+    fn seek_end(&self) -> Result<Option<usize>> {
+        // The cached inode size may be stale. Refreshing attributes here keeps
+        // `SEEK_END` consistent with the latest file size on the server.
+        self.inode.revalidate_attr(Some(self.open_handle.fh()))?;
+
+        Ok(Some(self.inode.size()))
+    }
+
     fn sync(&self, mode: SyncMode) -> Result<()> {
         self.inode.sync(mode)?;
 
@@ -161,18 +173,6 @@ impl PerOpenFileOps for VirtioFsFile {
         )?;
 
         Ok(())
-    }
-
-    fn is_offset_aware(&self) -> bool {
-        true
-    }
-
-    fn seek_end(&self) -> Result<Option<usize>> {
-        // The cached inode size may be stale. Refreshing attributes here keeps
-        // `SEEK_END` consistent with the latest file size on the server.
-        self.inode.revalidate_attr(Some(self.open_handle.fh()))?;
-
-        Ok(Some(self.inode.size()))
     }
 }
 


### PR DESCRIPTION
I think we can try to de-duplicate code in `rmdir_if` and `rmdir` / `unlink_if` and `unlink`.

For `rmdir`:
https://github.com/asterinas/asterinas/blob/c8935f97b1c857ebf2756467ae09b388a759baa1/kernel/core/src/fs/fs_impls/ramfs/fs.rs#L833-L866
https://github.com/asterinas/asterinas/blob/c8935f97b1c857ebf2756467ae09b388a759baa1/kernel/core/src/fs/fs_impls/ramfs/fs.rs#L1260-L1289

We can use:
```rust
    fn rmdir(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
        let target = child.downcast_ref::<RamInode>().unwrap();
        self.rmdir_impl(name, target, |_| true)?;
        Ok(())
    }
```

For `unlink`:
https://github.com/asterinas/asterinas/blob/c8935f97b1c857ebf2756467ae09b388a759baa1/kernel/core/src/fs/fs_impls/ramfs/fs.rs#L786-L805
https://github.com/asterinas/asterinas/blob/c8935f97b1c857ebf2756467ae09b388a759baa1/kernel/core/src/fs/fs_impls/ramfs/fs.rs#L1232-L1253

It is roughly equivalent:
```rust
    fn unlink(&self, name: &str, child: &Arc<dyn Inode>) -> Result<()> {
        let target = child.downcast_ref::<RamInode>().unwrap();
        if !self.unlink_impl(name, |entry| entry.ino == target.ino)? {
            return_errno!(Errno::ENOENT);
        }
        Ok(())
    }
```
Note, however, that it is not strictly equivalent. There is a minor difference: `EISDIR` is returned when checking the new target instead of the old one. However, I think this is fine. 

(Returning `ENOENT` when races happen is likely incorrect, though that's outside the scope of this PR.)

---

Additionally, sort `PerOpenFileOps` methods so that they're consistent with the trait definition.