### PR TITLE
Implement cyclic PID and TID allocation

### DIFF
--- a/kernel/core/src/fs/fs_impls/cgroupfs/controller/pids.rs
+++ b/kernel/core/src/fs/fs_impls/cgroupfs/controller/pids.rs
@@ -8,7 +8,7 @@ use aster_util::printer::VmPrinter;
 use ostd::mm::{VmReader, VmWriter};
 
 use super::TryChargeError;
-use crate::{process::posix_thread::PID_MAX, util::ReadCString};
+use crate::{process::pid_table::PID_MAX, util::ReadCString};
 
 /// A sub-controller responsible for PID resource management in the cgroup subsystem.
 ///
@@ -111,7 +111,7 @@ impl super::SubControl for PidsController {
                 let value = if value == "max" {
                     u32::MAX
                 } else if let Ok(value) = value.parse::<u32>() {
-                    if value >= PID_MAX {
+                    if value > PID_MAX {
                         return Err(Error::InvalidOperation);
                     }
                     value

--- a/kernel/core/src/fs/fs_impls/procfs/loadavg.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/loadavg.rs
@@ -14,7 +14,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::posix_thread,
+    process::pid_table,
     sched::{self, loadavg::get_loadavg},
 };
 
@@ -44,7 +44,7 @@ impl ProcFileOps for LoadAvgFileOps {
             avg[2],
             nr_running,
             nr_queued,
-            posix_thread::last_tid(),
+            pid_table::last_tid(),
         )?;
 
         Ok(printer.bytes_written())

--- a/kernel/core/src/fs/fs_impls/procfs/pid/task/mod.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/pid/task/mod.rs
@@ -25,7 +25,7 @@ use crate::{
         vfs::inode::{Inode, RevalidationPolicy},
     },
     prelude::*,
-    process::{Process, pid_table, pid_table::PidEntry, posix_thread::AsPosixThread},
+    process::{Process, pid_table::PidEntry, posix_thread::AsPosixThread},
     thread::{Thread, Tid},
 };
 
@@ -198,35 +198,15 @@ impl ProcDirOps for TaskDirOps {
             return_errno_with_message!(Errno::ENOENT, "the name is not a valid TID");
         };
 
-        // Note: After a PID-number recycling mechanism is introduced, there may be a race here:
-        // - If a PID number is recycled as soon as its `PidEntry` is removed from the `PidTable`,
-        //   then before the `PidTable` lock is acquired below, the current inode’s `PidEntry` may
-        //   already have been removed and replaced with a new entry using the same PID number.
-        //   In that case, it is possible that the main thread of the `Process` obtained here has not
-        //   yet been deleted, causing `contains_tid` to return true even though we have actually
-        //   retrieved the wrong `PidEntry`.
-        // - If the PID number is not recycled until the `PidEntry` is dropped, then this race does not arise.
-        //
-        // TODO: Revisit and handle this potential race as appropriate once PID-number recycling is implemented.
         let Some(process) = self.process() else {
             return_errno_with_message!(Errno::ESRCH, "the process does not exist");
         };
 
-        // Lock order: PID table -> tasks of process
-
-        let pid_table = pid_table::pid_table_mut();
-
-        let contains_tid = process
-            .tasks()
-            .lock()
-            .as_slice()
-            .iter()
-            .any(|task| task.as_posix_thread().unwrap().tid() == tid);
-        if !contains_tid {
-            return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
-        }
-
-        let Some(pid_entry) = pid_table.get_entry(tid) else {
+        let pid_entry = process.tasks().lock().as_slice().iter().find_map(|task| {
+            let posix_thread = task.as_posix_thread().unwrap();
+            (posix_thread.tid() == tid).then(|| posix_thread.pid_entry())
+        });
+        let Some(pid_entry) = pid_entry else {
             return_errno_with_message!(Errno::ENOENT, "the thread does not exist");
         };
 

--- a/kernel/core/src/fs/fs_impls/procfs/sys/kernel/pid_max.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/sys/kernel/pid_max.rs
@@ -9,7 +9,7 @@ use crate::{
         vfs::inode::Inode,
     },
     prelude::*,
-    process::posix_thread::PID_MAX,
+    process::pid_table::PID_MAX,
 };
 
 /// Represents the inode at `/proc/sys/kernel/pid_max`.

--- a/kernel/core/src/process/clone.rs
+++ b/kernel/core/src/process/clone.rs
@@ -11,7 +11,8 @@ use ostd::{
 };
 
 use super::{
-    Credentials, Pid, Process, pid_table,
+    Credentials, Pid, Process,
+    pid_table::{self, PidReservation},
     posix_thread::{AsPosixThread, PosixThreadBuilder},
     rlimit::ResourceLimits,
     signal::{constants::SIGCHLD, sig_disposition::SigDispositions, sig_num::SigNum},
@@ -28,7 +29,7 @@ use crate::{
     process::{
         NsProxy, UserNamespace,
         pid_file::PidFile,
-        posix_thread::{PosixThread, ThreadLocal, allocate_posix_tid},
+        posix_thread::{PosixThread, ThreadLocal},
         stats::PROCESS_CREATION_COUNTER,
     },
     sched::Nice,
@@ -436,7 +437,9 @@ fn clone_child_task(
     // Inherit the thread name.
     let thread_name = *posix_thread.thread_name().lock();
 
-    let child_tid = allocate_posix_tid();
+    let reservation = pid_table::reserve_tid()?;
+    let child_tid = reservation.tid();
+    let child_pid_entry = reservation.pid_entry();
     let child_task = {
         let credentials = {
             let credentials = ctx.posix_thread.credentials();
@@ -444,7 +447,7 @@ fn clone_child_task(
         };
 
         let mut thread_builder = PosixThreadBuilder::new(
-            child_tid,
+            child_pid_entry,
             thread_name,
             child_user_ctx,
             credentials,
@@ -471,19 +474,18 @@ fn clone_child_task(
         thread_builder.build()
     };
 
-    process
-        .tasks()
-        .lock()
-        .insert(child_task.clone())
-        .map_err(|_| {
-            Error::with_message(
-                Errno::EINTR,
-                "the process has exited or has already executed a new program",
-            )
-        })?;
+    // Lock order: PID table -> tasks of process
+    let mut pid_table = pid_table::pid_table_mut();
+    let mut tasks = process.tasks().lock();
+    tasks.insert(child_task.clone()).map_err(|_| {
+        Error::with_message(
+            Errno::EINTR,
+            "the process has exited or has already executed a new program",
+        )
+    })?;
 
     let child_thread = child_task.as_thread().unwrap();
-    pid_table::pid_table_mut().insert_thread(child_tid, child_thread);
+    reservation.commit_thread(&mut pid_table, child_thread);
 
     Ok(child_task)
 }
@@ -565,7 +567,9 @@ fn clone_child_process(
     // Inherit the parent's OOM score adjustment
     let child_oom_score_adj = process.oom_score_adj().load(Ordering::Relaxed);
 
-    let child_tid = allocate_posix_tid();
+    let reservation = pid_table::reserve_tid()?;
+    let child_tid = reservation.tid();
+    let child_pid_entry = reservation.pid_entry();
 
     let child = {
         let child_vmar_arc = child_vmar.clone_arc();
@@ -580,7 +584,7 @@ fn clone_child_process(
             };
 
             PosixThreadBuilder::new(
-                child_tid,
+                child_pid_entry,
                 child_thread_name,
                 child_user_ctx,
                 credentials,
@@ -627,7 +631,7 @@ fn clone_child_process(
     };
 
     // Sets parent process and group for child process.
-    set_parent_and_group(clone_flags, process, &child);
+    set_parent_and_group(clone_flags, process, &child, reservation);
 
     Ok(child)
 }
@@ -857,7 +861,12 @@ fn create_child_process(
     child_proc
 }
 
-fn set_parent_and_group(clone_flags: CloneFlags, parent: &Arc<Process>, child: &Arc<Process>) {
+fn set_parent_and_group(
+    clone_flags: CloneFlags,
+    parent: &Arc<Process>,
+    child: &Arc<Process>,
+    reservation: PidReservation,
+) {
     loop {
         let real_parent = clone_parent(clone_flags, parent);
 
@@ -900,8 +909,8 @@ fn set_parent_and_group(clone_flags: CloneFlags, parent: &Arc<Process>, child: &
         // Put the child process in the parent's `children` field
         children_mut.insert(child.pid(), child.clone());
 
-        // Put the child process in the global table
-        pid_table.insert_process(child.pid(), child);
+        // Put the child process in the global table and commit its reserved PID.
+        reservation.commit_process(&mut pid_table, child);
 
         return;
     }

--- a/kernel/core/src/process/execve.rs
+++ b/kernel/core/src/process/execve.rs
@@ -300,7 +300,8 @@ fn make_current_main_thread(ctx: &Context) {
     assert!(core::ptr::eq(ctx.task, tasks.as_slice()[1].as_ref()));
 
     tasks.swap_main();
-    ctx.posix_thread.set_main(pid);
+    let main_pid_entry = pid_table.get_entry(pid).unwrap();
+    ctx.posix_thread.set_main(main_pid_entry);
 
     if let Some(tracer_tracees) = tracer_tracees.as_mut()
         && let Some(tracee) = tracer_tracees.remove(&old_tid)

--- a/kernel/core/src/process/pid_table.rs
+++ b/kernel/core/src/process/pid_table.rs
@@ -8,8 +8,11 @@
 //! the need for separate per-type lookup tables.
 
 use alloc::collections::btree_map::Entry;
+use core::sync::atomic::{AtomicU32, Ordering};
 
-use super::{Pgid, Pid, Process, ProcessGroup, Session, Sid};
+use sparse_id_alloc::CyclicIdAlloc;
+
+use super::{INIT_PROCESS_PID, Pgid, Pid, Process, ProcessGroup, Session, Sid};
 use crate::{
     prelude::*,
     process::posix_thread::AsPosixThread,
@@ -18,12 +21,29 @@ use crate::{
 
 static PID_TABLE: Mutex<PidTable> = Mutex::new(PidTable::new());
 
+/// The PID allocation wrap value.
+///
+/// This matches Linux's `PID_MAX_LIMIT` on 64-bit architectures.
+/// Reference: <https://elixir.bootlin.com/linux/v6.16/source/include/linux/threads.h#L34>.
+// FIXME: This value cannot yet be modified by the user by writing to
+// `/proc/sys/kernel/pid_max`.
+pub(crate) const PID_MAX: u32 = 4 * 1024 * 1024;
+
+/// The lowest TID that may be reused after the allocator wraps.
+///
+/// Linux reserves the lower 300 PIDs after the initial allocation pass.
+/// Reference: <https://elixir.bootlin.com/linux/v6.16/source/include/linux/pid.h#L48>.
+const PID_RECYCLE_MIN: Tid = 300;
+
+static LAST_ALLOCATED_TID: AtomicU32 = AtomicU32::new(0);
+
 /// The unified PID table.
 ///
 /// Combines the process, process-group, session, and thread tables into a
 /// single structure.
 pub(crate) struct PidTable {
     entries: BTreeMap<u32, Arc<PidEntry>>,
+    tid_allocator: CyclicIdAlloc,
     process_count: usize,
 }
 
@@ -31,76 +51,136 @@ impl PidTable {
     const fn new() -> Self {
         Self {
             entries: BTreeMap::new(),
+            tid_allocator: CyclicIdAlloc::new(INIT_PROCESS_PID, PID_RECYCLE_MIN, PID_MAX - 1),
             process_count: 0,
         }
     }
 
-    /// Returns the entry for the given ID, or creates a new one if absent.
-    fn get_or_create_entry(&mut self, id: u32) -> &Arc<PidEntry> {
-        self.entries
-            .entry(id)
-            .or_insert_with(|| Arc::new(PidEntry::new()))
+    /// Returns the allocated entry for an associated process group or session.
+    ///
+    /// ID zero is used by the bootstrap process group and session but is never
+    /// handed out by the TID allocator.
+    fn associated_entry(&mut self, id: u32) -> &Arc<PidEntry> {
+        if id == 0 {
+            return self
+                .entries
+                .entry(id)
+                .or_insert_with(|| Arc::new(PidEntry::new(id, false)));
+        }
+
+        let entry = self
+            .entries
+            .get(&id)
+            .expect("a nonzero associated ID must already be allocated");
+        debug_assert!(!entry.lock().is_reserved());
+        entry
+    }
+
+    /// Reserves a new TID and creates an invisible [`PidEntry`] for it.
+    fn reserve_tid(&mut self) -> Result<PidReservation> {
+        let tid = self
+            .tid_allocator
+            .alloc()
+            .ok_or_else(|| Error::with_message(Errno::EAGAIN, "the PID space is exhausted"))?;
+        let entry = Arc::new(PidEntry::new(tid, true));
+        let old_entry = self.entries.insert(tid, entry.clone());
+        debug_assert!(old_entry.is_none());
+        LAST_ALLOCATED_TID.store(tid, Ordering::Relaxed);
+
+        Ok(PidReservation {
+            tid,
+            entry,
+            active: true,
+        })
+    }
+
+    /// Commits a reserved TID as a non-main thread.
+    fn commit_thread(&mut self, reservation: &PidReservation, thread: &Arc<Thread>) {
+        debug_assert_eq!(reservation.tid, thread.as_posix_thread().unwrap().tid());
+        let entry = self.entries.get(&reservation.tid).unwrap();
+        debug_assert!(Arc::ptr_eq(entry, &reservation.entry));
+
+        let mut entry = entry.lock();
+        entry.commit_reservation();
+        debug_assert!(!entry.has_live_process());
+        entry.set_thread(thread);
+    }
+
+    /// Commits a reserved TID as a process and its main thread.
+    fn commit_process(&mut self, reservation: &PidReservation, process: &Arc<Process>) {
+        debug_assert_eq!(reservation.tid, process.pid());
+        let entry = self.entries.get(&reservation.tid).unwrap();
+        debug_assert!(Arc::ptr_eq(entry, &reservation.entry));
+
+        self.process_count += 1;
+        let mut entry = entry.lock();
+        entry.commit_reservation();
+        entry.set_process(process);
+        entry.set_thread(&process.main_thread());
+    }
+
+    /// Cancels a reservation that was not committed.
+    fn cancel_reservation(&mut self, reservation: &PidReservation) {
+        let entry = self.entries.get(&reservation.tid).unwrap();
+        debug_assert!(Arc::ptr_eq(entry, &reservation.entry));
+        debug_assert!(entry.lock().is_reserved());
+
+        self.entries.remove(&reservation.tid);
+        self.tid_allocator.free(reservation.tid);
+    }
+
+    /// Removes an empty PID entry and returns its number to the allocator.
+    fn remove_entry_if_empty(&mut self, id: Tid) {
+        let should_remove = self
+            .entries
+            .get(&id)
+            .is_some_and(|entry| entry.lock().is_empty());
+        if should_remove {
+            self.entries.remove(&id);
+            if id != 0 {
+                self.tid_allocator.free(id);
+            }
+        }
     }
 
     // ---- Thread operations ----
-
-    /// Inserts a non-main thread into the table.
-    ///
-    /// This method requires the target entry not to track a process. A
-    /// process's main thread must be inserted with [`Self::insert_process`].
-    pub(super) fn insert_thread(&mut self, tid: Tid, thread: &Arc<Thread>) {
-        debug_assert_eq!(tid, thread.as_posix_thread().unwrap().tid());
-
-        let mut entry = self.get_or_create_entry(tid).lock();
-        debug_assert!(!entry.has_live_process());
-
-        entry.set_thread(thread);
-    }
 
     /// Removes a non-main thread from the table.
     ///
     /// This method requires the target entry not to track a process. A
     /// process's main thread must be removed with [`Self::remove_process`].
     pub(super) fn remove_thread(&mut self, tid: Tid) {
-        let Entry::Occupied(map_entry) = self.entries.entry(tid) else {
-            return;
-        };
+        {
+            let Entry::Occupied(map_entry) = self.entries.entry(tid) else {
+                return;
+            };
 
-        let should_remove = {
             let mut pid_entry = map_entry.get().lock();
             debug_assert!(!pid_entry.has_live_process());
 
             pid_entry.clear_thread();
-            // Drop the locked PID entry before removing the B-tree entry.
-            pid_entry.is_empty()
-        };
-
-        if should_remove {
-            map_entry.remove();
         }
+        self.remove_entry_if_empty(tid);
     }
 
     /// Removes a non-main thread from the table and returns it.
     ///
     /// This method requires the target entry not to track a process.
     pub(super) fn take_thread(&mut self, tid: Tid) -> Option<Arc<Thread>> {
-        let Entry::Occupied(map_entry) = self.entries.entry(tid) else {
-            return None;
-        };
+        let thread = {
+            let Entry::Occupied(map_entry) = self.entries.entry(tid) else {
+                return None;
+            };
 
-        let (thread, should_remove) = {
             let mut pid_entry = map_entry.get().lock();
             debug_assert!(!pid_entry.has_live_process());
 
             let thread = pid_entry.thread()?;
             pid_entry.clear_thread();
-            // Drop the locked PID entry before removing the B-tree entry.
-            (thread, pid_entry.is_empty())
+            thread
         };
 
-        if should_remove {
-            map_entry.remove();
-        }
+        self.remove_entry_if_empty(tid);
 
         Some(thread)
     }
@@ -109,7 +189,7 @@ impl PidTable {
     pub(super) fn replace_thread(&mut self, tid: Tid, thread: &Arc<Thread>) {
         debug_assert_eq!(tid, thread.as_posix_thread().unwrap().tid());
 
-        let entry = self.get_or_create_entry(tid);
+        let entry = self.entries.get(&tid).unwrap();
         entry.lock().replace_thread(thread);
     }
 
@@ -129,28 +209,17 @@ impl PidTable {
 
     // ---- Process operations ----
 
-    /// Inserts a process and its main thread into the table.
-    pub(super) fn insert_process(&mut self, pid: Pid, process: &Arc<Process>) {
-        // `set_process` will assert the process slot is empty.
-        self.process_count += 1;
-
-        let entry = self.get_or_create_entry(pid);
-        let mut entry = entry.lock();
-        entry.set_process(process);
-        entry.set_thread(&process.main_thread());
-    }
-
     /// Removes a process and its main thread from the table.
     //
     // TODO: Add an active reclamation mechanism for dentries corresponding to `PidEntry`
     // in the procfs `DentryCache`, so that invalid dentries can be released as promptly
     // as possible.
     pub(super) fn remove_process(&mut self, pid: Pid) {
-        let Entry::Occupied(map_entry) = self.entries.entry(pid) else {
-            return;
-        };
+        {
+            let Entry::Occupied(map_entry) = self.entries.entry(pid) else {
+                return;
+            };
 
-        let should_remove = {
             let mut pid_entry = map_entry.get().lock();
 
             // `clear_process` will assert the process slot is not empty.
@@ -158,13 +227,8 @@ impl PidTable {
 
             pid_entry.clear_process();
             pid_entry.clear_thread();
-            // Drop the locked PID entry before removing the B-tree entry.
-            pid_entry.is_empty()
-        };
-
-        if should_remove {
-            map_entry.remove();
         }
+        self.remove_entry_if_empty(pid);
     }
 
     /// Gets a process by a PID.
@@ -190,26 +254,21 @@ impl PidTable {
 
     /// Inserts a process group into the table.
     pub(super) fn insert_process_group(&mut self, pgid: Pgid, group: &Arc<ProcessGroup>) {
-        let entry = self.get_or_create_entry(pgid);
+        let entry = self.associated_entry(pgid);
         entry.lock().set_process_group(group);
     }
 
     /// Removes a process group from the table.
     pub(super) fn remove_process_group(&mut self, pgid: Pgid) {
-        let Entry::Occupied(map_entry) = self.entries.entry(pgid) else {
-            return;
-        };
+        {
+            let Entry::Occupied(map_entry) = self.entries.entry(pgid) else {
+                return;
+            };
 
-        let should_remove = {
             let mut pid_entry = map_entry.get().lock();
             pid_entry.clear_process_group();
-            // Drop the locked PID entry before removing the B-tree entry.
-            pid_entry.is_empty()
-        };
-
-        if should_remove {
-            map_entry.remove();
         }
+        self.remove_entry_if_empty(pgid);
     }
 
     /// Gets a process group by a PGID.
@@ -230,32 +289,82 @@ impl PidTable {
 
     /// Inserts a session into the table.
     pub(super) fn insert_session(&mut self, sid: Sid, session: &Arc<Session>) {
-        let entry = self.get_or_create_entry(sid);
+        let entry = self.associated_entry(sid);
         entry.lock().set_session(session);
     }
 
     /// Removes a session from the table.
     pub(super) fn remove_session(&mut self, sid: Sid) {
-        let Entry::Occupied(map_entry) = self.entries.entry(sid) else {
-            return;
-        };
+        {
+            let Entry::Occupied(map_entry) = self.entries.entry(sid) else {
+                return;
+            };
 
-        let should_remove = {
             let mut pid_entry = map_entry.get().lock();
             pid_entry.clear_session();
-            // Drop the locked PID entry before removing the B-tree entry.
-            pid_entry.is_empty()
-        };
+        }
+        self.remove_entry_if_empty(sid);
+    }
 
-        if should_remove {
-            map_entry.remove();
+    /// Returns the visible entry for the given numeric identifier.
+    pub(crate) fn get_entry(&self, id: u32) -> Option<Arc<PidEntry>> {
+        self.entries
+            .get(&id)
+            .filter(|entry| !entry.lock().is_reserved())
+            .cloned()
+    }
+}
+
+/// A TID reserved for a process or thread that is still being constructed.
+///
+/// The reservation is invisible to PID lookups. Dropping it before it is
+/// committed returns the number to the allocator.
+pub(super) struct PidReservation {
+    tid: Tid,
+    entry: Arc<PidEntry>,
+    active: bool,
+}
+
+impl PidReservation {
+    /// Returns the reserved TID.
+    pub(super) fn tid(&self) -> Tid {
+        self.tid
+    }
+
+    /// Returns the stable PID entry associated with the reservation.
+    pub(super) fn pid_entry(&self) -> Arc<PidEntry> {
+        self.entry.clone()
+    }
+
+    /// Commits the reservation as a non-main thread while the caller holds the PID table.
+    pub(super) fn commit_thread(mut self, pid_table: &mut PidTable, thread: &Arc<Thread>) {
+        pid_table.commit_thread(&self, thread);
+        self.active = false;
+    }
+
+    /// Commits the reservation as a process while the caller holds the PID table.
+    pub(super) fn commit_process(mut self, pid_table: &mut PidTable, process: &Arc<Process>) {
+        pid_table.commit_process(&self, process);
+        self.active = false;
+    }
+}
+
+impl Drop for PidReservation {
+    fn drop(&mut self) {
+        if self.active {
+            pid_table_mut().cancel_reservation(self);
         }
     }
+}
 
-    /// Returns the entry for the given numeric identifier.
-    pub(crate) fn get_entry(&self, id: u32) -> Option<Arc<PidEntry>> {
-        self.entries.get(&id).cloned()
-    }
+/// Reserves a new TID from the global PID table.
+pub(super) fn reserve_tid() -> Result<PidReservation> {
+    pid_table_mut().reserve_tid()
+}
+
+/// Returns the most recently reserved TID.
+pub(crate) fn last_tid() -> Tid {
+    LAST_ALLOCATED_TID.load(Ordering::Relaxed)
 }
 
 /// An entry in the unified PID table.
@@ -278,10 +387,12 @@ impl PidTable {
 /// there will never be a `PidEntry` in the [`PidTable`] that is associated with
 /// a [`Process`], but at some intermediate moment has only an associated [`Thread`].
 pub(crate) struct PidEntry {
+    id: Tid,
     inner: Mutex<PidEntryInner>,
 }
 
 struct PidEntryInner {
+    reserved: bool,
     thread: Weak<Thread>,
     process: Weak<Process>,
     process_group: Weak<ProcessGroup>,
@@ -302,11 +413,17 @@ pub(crate) enum PidEntryType {
 }
 
 impl PidEntry {
-    /// Creates a new empty `PidEntry`.
-    fn new() -> Self {
+    /// Creates a new PID entry.
+    fn new(id: Tid, reserved: bool) -> Self {
         Self {
-            inner: Mutex::new(PidEntryInner::new()),
+            id,
+            inner: Mutex::new(PidEntryInner::new(reserved)),
         }
+    }
+
+    /// Returns the numeric identifier represented by this entry.
+    pub(super) fn id(&self) -> Tid {
+        self.id
     }
 
     /// Locks and returns access to the entry internals.
@@ -362,13 +479,25 @@ impl PidEntry {
 
 impl PidEntryInner {
     /// Creates a new empty `PidEntryInner`.
-    fn new() -> Self {
+    fn new(reserved: bool) -> Self {
         Self {
+            reserved,
             thread: Weak::new(),
             process: Weak::new(),
             process_group: Weak::new(),
             session: Weak::new(),
         }
+    }
+
+    /// Marks a reserved entry as ready to expose its associated object.
+    fn commit_reservation(&mut self) {
+        debug_assert!(self.reserved);
+        self.reserved = false;
+    }
+
+    /// Returns whether this entry is reserved for an object under construction.
+    fn is_reserved(&self) -> bool {
+        self.reserved
     }
 
     /// Sets the thread reference.
@@ -462,7 +591,8 @@ impl PidEntryInner {
 
     /// Returns `true` if the entry no longer tracks any live object.
     fn is_empty(&self) -> bool {
-        !self.has_live_thread()
+        !self.reserved
+            && !self.has_live_thread()
             && !self.has_live_process()
             && !self.has_live_process_group()
             && !self.has_live_session()

--- a/kernel/core/src/process/posix_thread/builder.rs
+++ b/kernel/core/src/process/posix_thread/builder.rs
@@ -18,11 +18,12 @@ use crate::{
     prelude::*,
     process::{
         Credentials, NsProxy, Process, UserNamespace,
+        pid_table::PidEntry,
         posix_thread::{ThreadName, thread_local::SuppUserContext},
         signal::{sig_mask::AtomicSigMask, sig_queues::SigQueues},
     },
     sched::{Nice, SchedPolicy},
-    thread::{Thread, Tid, task},
+    thread::{Thread, task},
     time::{TimerManager, clocks::ProfClock},
     vm::vmar::VmarHandle,
 };
@@ -30,7 +31,7 @@ use crate::{
 /// The builder to build a POSIX thread
 pub(crate) struct PosixThreadBuilder {
     // The essential part
-    tid: Tid,
+    pid_entry: Arc<PidEntry>,
     thread_name: ThreadName,
     user_ctx: Box<UserContext>,
     process: Weak<Process>,
@@ -53,14 +54,14 @@ pub(crate) struct PosixThreadBuilder {
 
 impl PosixThreadBuilder {
     pub(crate) fn new(
-        tid: Tid,
+        pid_entry: Arc<PidEntry>,
         thread_name: ThreadName,
         user_ctx: Box<UserContext>,
         credentials: Credentials,
         vmar: VmarHandle,
     ) -> Self {
         Self {
-            tid,
+            pid_entry,
             thread_name,
             user_ctx,
             process: Weak::new(),
@@ -150,7 +151,7 @@ impl PosixThreadBuilder {
 
     pub(crate) fn build(self) -> Arc<Task> {
         let Self {
-            tid,
+            pid_entry,
             user_ctx,
             process,
             credentials,
@@ -187,7 +188,8 @@ impl PosixThreadBuilder {
                 PosixThread {
                     process,
                     task: weak_task.clone(),
-                    tid: AtomicU32::new(tid),
+                    tid: AtomicU32::new(pid_entry.id()),
+                    pid_entry: Mutex::new(pid_entry),
                     name: Mutex::new(thread_name),
                     credentials,
                     fs: RwMutex::new(fs.clone()),

--- a/kernel/core/src/process/posix_thread/mod.rs
+++ b/kernel/core/src/process/posix_thread/mod.rs
@@ -19,8 +19,9 @@ use crate::{
     fs::{file::file_table::FileTable, thread_info::ThreadFsInfo},
     prelude::*,
     process::{
-        ExitCode, Pid,
+        ExitCode,
         namespace::nsproxy::NsProxy,
+        pid_table::PidEntry,
         posix_thread::ptrace::TraceeStatus,
         signal::{PauseReason, PollHandle, sig_mask::SigMask},
     },
@@ -54,6 +55,8 @@ pub(crate) struct PosixThread {
 
     // Mutable part
     tid: AtomicU32,
+    /// The identity represented by `tid`, independent of numeric ID reuse.
+    pid_entry: Mutex<Arc<PidEntry>>,
 
     name: Mutex<ThreadName>,
 
@@ -122,11 +125,23 @@ impl PosixThread {
         self.tid.load(Ordering::Relaxed)
     }
 
+    /// Returns the stable PID entry for this thread.
+    ///
+    /// A caller that also compares [`Self::tid`] must hold the process task-set
+    /// lock to exclude the identity change performed by [`Self::set_main`].
+    pub(crate) fn pid_entry(&self) -> Arc<PidEntry> {
+        self.pid_entry.lock().clone()
+    }
+
     /// Sets the thread as the main thread by changing its thread ID.
-    pub(super) fn set_main(&self, pid: Pid) {
+    ///
+    /// The caller must hold both the PID table and the process task-set lock.
+    pub(super) fn set_main(&self, pid_entry: Arc<PidEntry>) {
+        let pid = pid_entry.id();
         debug_assert_eq!(pid, self.process.upgrade().unwrap().pid());
         debug_assert_ne!(pid, self.tid.load(Ordering::Relaxed));
 
+        *self.pid_entry.lock() = pid_entry;
         self.tid.store(pid, Ordering::Relaxed);
     }
 
@@ -404,38 +419,6 @@ pub(crate) fn derive_thread_name(exec_path: &str) -> ThreadName {
 
     ThreadName::from_str_truncated(path)
 }
-
-/// The TID of the first POSIX thread (i.e., the main thread of the init process).
-pub(crate) const FIRST_POSIX_TID: Tid = 1;
-
-static POSIX_TID_ALLOCATOR: AtomicU32 = AtomicU32::new(FIRST_POSIX_TID);
-
-/// Allocates a new TID for the new POSIX thread.
-pub(crate) fn allocate_posix_tid() -> Tid {
-    let tid = POSIX_TID_ALLOCATOR.fetch_add(1, Ordering::Relaxed);
-    if tid >= PID_MAX {
-        // When the kernel's next PID value reaches `PID_MAX`,
-        // it should wrap back to a minimum PID value.
-        // PIDs with a value of `PID_MAX` or larger should not be allocated.
-        // Reference: <https://docs.kernel.org/admin-guide/sysctl/kernel.html#pid-max>.
-        //
-        // FIXME: Currently, we cannot determine which PID is recycled,
-        // so we are unable to allocate smaller PIDs.
-        warn!("the allocated ID is greater than the maximum allowed PID");
-    }
-    tid
-}
-
-/// Returns the last allocated TID.
-pub(crate) fn last_tid() -> Tid {
-    POSIX_TID_ALLOCATOR.load(Ordering::Relaxed) - 1
-}
-
-/// The maximum allowed process ID.
-//
-// FIXME: The current value is chosen arbitrarily.
-// This value can be modified by the user by writing to `/proc/sys/kernel/pid_max`.
-pub(crate) const PID_MAX: u32 = u32::MAX / 2;
 
 /// The sleeping state of a thread.
 #[derive(Clone, Copy, Debug)]

--- a/kernel/core/src/process/process/init_proc.rs
+++ b/kernel/core/src/process/process/init_proc.rs
@@ -12,14 +12,14 @@ use crate::{
     },
     prelude::*,
     process::{
-        Credentials, ProcessVm, ShebangScriptPath, UndetectedExecutable, UserNamespace, pid_table,
-        posix_thread::{PosixThreadBuilder, allocate_posix_tid, derive_thread_name},
+        Credentials, ProcessVm, ShebangScriptPath, UndetectedExecutable, UserNamespace,
+        pid_table::{self, PidEntry, PidReservation},
+        posix_thread::{PosixThreadBuilder, derive_thread_name},
         program_loader::ProgramToLoad,
         rlimit::new_resource_limits_for_init,
         signal::sig_disposition::SigDispositions,
     },
     sched::Nice,
-    thread::Tid,
     vm::vmar::VmarHandle,
 };
 
@@ -30,7 +30,7 @@ pub(crate) fn spawn_init_process(
     argv: Vec<CString>,
     envp: Vec<CString>,
 ) -> Result<Arc<Process>> {
-    let process = create_init_process(path_resolver, executable_path, argv, envp)?;
+    let (process, reservation) = create_init_process(path_resolver, executable_path, argv, envp)?;
 
     // Linux starts the init process without placing it in a process group or session.
     // It joins one only after userspace first calls `setsid()`.
@@ -39,7 +39,7 @@ pub(crate) fn spawn_init_process(
     // a session. The init process is therefore placed in a bootstrap process group
     // and session with PGID and SID set to zero. This preserves the same user-visible
     // behavior.
-    set_bootstrap_session_and_group(&process);
+    set_bootstrap_session_and_group(&process, reservation);
 
     process.run();
 
@@ -51,10 +51,12 @@ fn create_init_process(
     executable_path: Path,
     argv: Vec<CString>,
     envp: Vec<CString>,
-) -> Result<Arc<Process>> {
+) -> Result<(Arc<Process>, PidReservation)> {
     let fs = ThreadFsInfo::new(path_resolver);
 
-    let pid = allocate_posix_tid();
+    let reservation = pid_table::reserve_tid()?;
+    let pid = reservation.tid();
+    let pid_entry = reservation.pid_entry();
     let vmar = VmarHandle::new(ProcessVm::new(executable_path.clone()));
     let resource_limits = new_resource_limits_for_init();
     let nice = Nice::default();
@@ -72,13 +74,13 @@ fn create_init_process(
         user_ns,
     );
 
-    let init_task = create_init_task(pid, &init_proc, fs, vmar, executable_path, argv, envp)?;
+    let init_task = create_init_task(pid_entry, &init_proc, fs, vmar, executable_path, argv, envp)?;
     init_proc.tasks().lock().insert(init_task).unwrap();
 
-    Ok(init_proc)
+    Ok((init_proc, reservation))
 }
 
-fn set_bootstrap_session_and_group(process: &Arc<Process>) {
+fn set_bootstrap_session_and_group(process: &Arc<Process>, reservation: PidReservation) {
     // Locking order: PID table -> process group
     let mut pid_table = pid_table::pid_table_mut();
 
@@ -88,13 +90,13 @@ fn set_bootstrap_session_and_group(process: &Arc<Process>) {
     pid_table.insert_process_group(process_group.pgid(), &process_group);
     *process.process_group.lock() = Some(process_group);
 
-    // Add the new process to the global table
-    pid_table.insert_process(process.pid(), process);
+    // Add the new process to the global table and commit its reserved PID.
+    reservation.commit_process(&mut pid_table, process);
 }
 
 /// Creates the init task from the given executable path.
 fn create_init_task(
-    tid: Tid,
+    pid_entry: Arc<PidEntry>,
     process: &Arc<Process>,
     fs: ThreadFsInfo,
     vmar: VmarHandle,
@@ -125,9 +127,14 @@ fn create_init_task(
 
     let thread_name = derive_thread_name(&executable_abs_path);
 
-    let thread_builder =
-        PosixThreadBuilder::new(tid, thread_name, Box::new(user_ctx), credentials, vmar)
-            .process(Arc::downgrade(process))
-            .fs(Arc::new(fs));
+    let thread_builder = PosixThreadBuilder::new(
+        pid_entry,
+        thread_name,
+        Box::new(user_ctx),
+        credentials,
+        vmar,
+    )
+    .process(Arc::downgrade(process))
+    .fs(Arc::new(fs));
     Ok(thread_builder.build())
 }

--- a/kernel/core/src/process/process/mod.rs
+++ b/kernel/core/src/process/process/mod.rs
@@ -10,7 +10,7 @@ use ostd::timer::Jiffies;
 use self::timer_manager::PosixTimerManager;
 use super::{
     pid_table::{self, PidTable},
-    posix_thread::{AsPosixThread, FIRST_POSIX_TID},
+    posix_thread::AsPosixThread,
     process_vm::ProcessVmarGuard,
     rlimit::ResourceLimits,
     signal::{
@@ -58,7 +58,7 @@ pub(crate) use terminal::Terminal;
 pub(crate) type Pid = u32;
 
 /// The PID of the init process.
-pub(crate) const INIT_PROCESS_PID: Pid = FIRST_POSIX_TID;
+pub(crate) const INIT_PROCESS_PID: Pid = 1;
 
 define_atomic_version_of_integer_like_type!(Pid, {
     /// Atomic [`Pid`].

--- a/kernel/core/src/thread/task.rs
+++ b/kernel/core/src/thread/task.rs
@@ -15,7 +15,8 @@ use crate::{
     cpu::LinuxAbi,
     prelude::*,
     process::{
-        posix_thread::{AsPosixThread, FIRST_POSIX_TID, ThreadLocal, ptrace::PtraceStopResult},
+        INIT_PROCESS_PID,
+        posix_thread::{AsPosixThread, ThreadLocal, ptrace::PtraceStopResult},
         signal::{HandlePendingSignal, PauseReason, handle_pending_signal},
     },
     syscall::handle_syscall,
@@ -64,7 +65,7 @@ pub(crate) fn create_new_user_task(
         };
 
         // The startup method is only executed when the first user thread starts up.
-        if ctx.posix_thread.tid() == FIRST_POSIX_TID {
+        if ctx.posix_thread.tid() == INIT_PROCESS_PID {
             crate::init::on_first_process_startup(&ctx);
         }
 

--- a/kernel/libs/sparse-id-alloc/src/lib.rs
+++ b/kernel/libs/sparse-id-alloc/src/lib.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! A sparse u32 ID allocator over a configurable range.
+//! Sparse u32 ID allocators over configurable ranges.
 //!
-//! The [`SparseIdAlloc`] type allocates the smallest available ID in an
-//! inclusive `u32` range and supports returning IDs later.
+//! [`SparseIdAlloc`] allocates the smallest available ID in a range.
+//! [`CyclicIdAlloc`] advances a cursor and only reuses lower IDs after wrapping.
 
 #![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]
@@ -47,38 +47,7 @@ impl SparseIdAlloc {
     ///
     /// Returns `None` when every ID in `[min, max]` is in use.
     pub fn alloc(&mut self) -> Option<u32> {
-        let first = self
-            .allocated_runs
-            .first_key_value()
-            .map(|(&start, &end)| (start, end));
-
-        match first {
-            // The range's lowest IDs are allocated; the smallest free ID
-            // is just past the first run (unless the range is exhausted).
-            Some((start, end)) if start == self.min => {
-                if end == self.max {
-                    return None;
-                }
-
-                let id = end + 1;
-                let new_end = id
-                    .checked_add(1)
-                    .and_then(|next_start| self.allocated_runs.remove(&next_start))
-                    .unwrap_or(id);
-                *self.allocated_runs.get_mut(&start).unwrap() = new_end;
-                Some(id)
-            }
-            // `min` itself is free.
-            _ => {
-                let id = self.min;
-                let end = id
-                    .checked_add(1)
-                    .and_then(|next_start| self.allocated_runs.remove(&next_start))
-                    .unwrap_or(id);
-                self.allocated_runs.insert(id, end);
-                Some(id)
-            }
-        }
+        self.alloc_at_or_after(self.min)
     }
 
     /// Releases the given ID.
@@ -106,11 +75,135 @@ impl SparseIdAlloc {
             self.allocated_runs.insert(id + 1, end);
         }
     }
+
+    /// Allocates the smallest available ID greater than or equal to `start`.
+    fn alloc_at_or_after(&mut self, start: u32) -> Option<u32> {
+        let start = start.max(self.min);
+        if start > self.max {
+            return None;
+        }
+
+        let previous = self
+            .allocated_runs
+            .range(..=start)
+            .next_back()
+            .map(|(&run_start, &run_end)| (run_start, run_end));
+        let id = match previous {
+            Some((_, run_end)) if start <= run_end => run_end.checked_add(1)?,
+            _ => start,
+        };
+        if id > self.max {
+            return None;
+        }
+
+        self.mark_allocated(id, previous);
+        Some(id)
+    }
+
+    /// Marks an available ID as allocated and merges adjacent allocated runs.
+    fn mark_allocated(&mut self, id: u32, previous: Option<(u32, u32)>) {
+        debug_assert!(previous.is_none_or(|(_, end)| id > end));
+
+        let previous_start = previous
+            .filter(|&(_, end)| end.checked_add(1) == Some(id))
+            .map(|(start, _)| start);
+        let next = id
+            .checked_add(1)
+            .and_then(|next_id| self.allocated_runs.remove_entry(&next_id));
+
+        match (previous_start, next) {
+            (Some(start), Some((_, end))) => {
+                *self.allocated_runs.get_mut(&start).unwrap() = end;
+            }
+            (Some(start), None) => {
+                *self.allocated_runs.get_mut(&start).unwrap() = id;
+            }
+            (None, Some((_, end))) => {
+                self.allocated_runs.insert(id, end);
+            }
+            (None, None) => {
+                self.allocated_runs.insert(id, id);
+            }
+        }
+    }
+}
+
+/// A sparse allocator that searches for free IDs from a moving cursor.
+///
+/// IDs are first allocated from `initial_min` upwards. Once the cursor passes
+/// `recycle_min`, a search that reaches `max` wraps back to `recycle_min`, so IDs
+/// below that value are reserved after the initial allocation pass.
+///
+/// This follows the allocation policy of Linux's `idr_alloc_cyclic`.
+/// Reference: <https://github.com/torvalds/linux/blob/v6.16/lib/idr.c#L96-L136>.
+#[derive(Clone, Debug)]
+pub struct CyclicIdAlloc {
+    allocated: SparseIdAlloc,
+    initial_min: u32,
+    recycle_min: u32,
+    next: u64,
+}
+
+impl CyclicIdAlloc {
+    /// Creates an allocator over the inclusive range `[initial_min, max]`.
+    ///
+    /// After the initial allocation pass, searches wrap to `recycle_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `initial_min <= recycle_min <= max`.
+    pub const fn new(initial_min: u32, recycle_min: u32, max: u32) -> Self {
+        assert!(
+            initial_min <= recycle_min,
+            "initial_min must be <= recycle_min"
+        );
+        assert!(recycle_min <= max, "recycle_min must be <= max");
+        Self {
+            allocated: SparseIdAlloc::new(initial_min, max),
+            initial_min,
+            recycle_min,
+            next: initial_min as u64,
+        }
+    }
+
+    /// Allocates the next available ID, wrapping after reaching the maximum.
+    ///
+    /// Returns `None` when every reusable ID is allocated.
+    pub fn alloc(&mut self) -> Option<u32> {
+        let wrap_min = if self.next > u64::from(self.recycle_min) {
+            self.recycle_min
+        } else {
+            self.initial_min
+        };
+
+        let next_id = u32::try_from(self.next)
+            .ok()
+            .and_then(|next| self.allocated.alloc_at_or_after(next));
+        let id = match next_id {
+            Some(id) => id,
+            None if self.next > u64::from(wrap_min) => {
+                self.allocated.alloc_at_or_after(wrap_min)?
+            }
+            None => return None,
+        };
+
+        self.next = u64::from(id) + 1;
+        Some(id)
+    }
+
+    /// Releases an allocated ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the ID is not currently allocated.
+    pub fn free(&mut self, id: u32) {
+        self.allocated.free(id);
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use super::SparseIdAlloc;
+    use super::{CyclicIdAlloc, SparseIdAlloc};
 
     #[test]
     fn sparse_alloc_is_monotonic_from_min() {
@@ -176,5 +269,52 @@ mod test {
         let id = a.alloc().unwrap();
         a.free(id);
         a.free(id);
+    }
+
+    #[test]
+    fn cyclic_alloc_reserves_low_ids_after_first_pass() {
+        let mut a = CyclicIdAlloc::new(1, 3, 5);
+        assert_eq!(a.alloc(), Some(1));
+        assert_eq!(a.alloc(), Some(2));
+        a.free(1);
+
+        assert_eq!(a.alloc(), Some(3));
+        assert_eq!(a.alloc(), Some(4));
+        assert_eq!(a.alloc(), Some(5));
+        assert_eq!(a.alloc(), None);
+    }
+
+    #[test]
+    fn cyclic_alloc_wraps_to_recycle_min() {
+        let mut a = CyclicIdAlloc::new(1, 3, 5);
+        for expected in 1..=5 {
+            assert_eq!(a.alloc(), Some(expected));
+        }
+
+        a.free(4);
+        a.free(2);
+        assert_eq!(a.alloc(), Some(4));
+        assert_eq!(a.alloc(), None);
+    }
+
+    #[test]
+    fn cyclic_alloc_reuses_gaps_after_the_cursor() {
+        let mut a = CyclicIdAlloc::new(1, 1, 5);
+        for expected in 1..=4 {
+            assert_eq!(a.alloc(), Some(expected));
+        }
+
+        a.free(2);
+        assert_eq!(a.alloc(), Some(5));
+        assert_eq!(a.alloc(), Some(2));
+    }
+
+    #[test]
+    fn cyclic_alloc_supports_u32_max() {
+        let mut a = CyclicIdAlloc::new(u32::MAX, u32::MAX, u32::MAX);
+        assert_eq!(a.alloc(), Some(u32::MAX));
+        assert_eq!(a.alloc(), None);
+        a.free(u32::MAX);
+        assert_eq!(a.alloc(), Some(u32::MAX));
     }
 }

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1816,7 +1816,7 @@ wait01
 wait02
 
 # wait401
-# wait402
+wait402
 # wait403
 
 # waitpid01

--- a/test/initramfs/src/regression/process/pid_reuse.c
+++ b/test/initramfs/src/regression/process/pid_reuse.c
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <linux/sched.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#ifdef __asterinas__
+
+#define PID_MAX_PATH "/proc/sys/kernel/pid_max"
+#define LOADAVG_PATH "/proc/loadavg"
+
+#define EXPECTED_PID_MAX (4 * 1024 * 1024)
+#define PID_RECYCLE_MIN 300
+
+struct pid_wrap_observation {
+	pid_t before;
+	pid_t after;
+};
+
+static int read_pid_max(pid_t *pid_max)
+{
+	FILE *file = fopen(PID_MAX_PATH, "r");
+	if (file == NULL)
+		return -1;
+
+	int scanned = fscanf(file, "%d", pid_max);
+	int saved_errno = errno;
+	if (fclose(file) < 0)
+		return -1;
+
+	if (scanned != 1) {
+		errno = saved_errno != 0 ? saved_errno : EIO;
+		return -1;
+	}
+
+	errno = 0;
+	return 0;
+}
+
+static int read_last_pid(pid_t *last_pid)
+{
+	FILE *file = fopen(LOADAVG_PATH, "r");
+	if (file == NULL)
+		return -1;
+
+	int scanned = fscanf(file, "%*s %*s %*s %*s %d", last_pid);
+	int saved_errno = errno;
+	if (fclose(file) < 0)
+		return -1;
+
+	if (scanned != 1) {
+		errno = saved_errno != 0 ? saved_errno : EIO;
+		return -1;
+	}
+
+	errno = 0;
+	return 0;
+}
+
+static int advance_pid_cursor(uint32_t allocation_count)
+{
+	struct clone_args args = {
+		.flags = CLONE_FILES | CLONE_FS | CLONE_PARENT_SETTID |
+			 CLONE_SIGHAND | CLONE_THREAD | CLONE_VM,
+		.parent_tid = 1,
+	};
+
+	/*
+	 * Failing CLONE_PARENT_SETTID after reserving a TID advances the cyclic
+	 * cursor without creating millions of live threads. The failed reservation
+	 * is returned to the allocator, so the test does not consume the PID space.
+	 */
+	for (uint32_t allocation = 0; allocation < allocation_count;
+	     allocation++) {
+		if (syscall(SYS_clone3, &args, sizeof(args)) != -1) {
+			errno = EIO;
+			return -1;
+		}
+		if (errno != EFAULT)
+			return -1;
+	}
+
+	errno = 0;
+	return 0;
+}
+
+static int observe_pid_cursor_wrap(pid_t pid_max, pid_t initial_last_pid,
+				   struct pid_wrap_observation *observation)
+{
+	uint32_t allocation_count = pid_max - initial_last_pid - 1;
+	if (advance_pid_cursor(allocation_count) != 0)
+		return -1;
+
+	pid_t last_pid;
+	if (read_last_pid(&last_pid) != 0)
+		return -1;
+	if (last_pid <= 0 || last_pid >= pid_max) {
+		errno = ERANGE;
+		return -1;
+	}
+
+	if (last_pid < initial_last_pid) {
+		if (advance_pid_cursor(1) != 0)
+			return -1;
+
+		pid_t next_pid;
+		if (read_last_pid(&next_pid) != 0)
+			return -1;
+		if (next_pid <= last_pid || next_pid >= pid_max) {
+			errno = ERANGE;
+			return -1;
+		}
+
+		observation->before = initial_last_pid;
+		observation->after = last_pid;
+		errno = 0;
+		return 0;
+	}
+
+	/*
+	 * Concurrent allocations may have moved the cursor, so use the observed
+	 * value rather than requiring it to equal pid_max - 1. This second advance
+	 * is normally a single allocation and is sufficient to cross pid_max.
+	 */
+	allocation_count = pid_max - last_pid;
+	if (advance_pid_cursor(allocation_count) != 0)
+		return -1;
+
+	pid_t wrapped_pid;
+	if (read_last_pid(&wrapped_pid) != 0)
+		return -1;
+	if (wrapped_pid < PID_RECYCLE_MIN || wrapped_pid >= last_pid) {
+		errno = ERANGE;
+		return -1;
+	}
+
+	observation->before = last_pid;
+	observation->after = wrapped_pid;
+	errno = 0;
+	return 0;
+}
+
+#endif /* __asterinas__ */
+
+FN_TEST(pid_is_reused_after_allocation_wraps)
+{
+#ifndef __asterinas__
+	SKIP_TEST_IF(1);
+#else
+	pid_t pid_max;
+	pid_t last_pid;
+	struct pid_wrap_observation observation;
+
+	int read_result = TEST_RES(read_pid_max(&pid_max),
+				   _ret == 0 && pid_max == EXPECTED_PID_MAX);
+	if (read_result != 0 || pid_max != EXPECTED_PID_MAX)
+		goto out;
+
+	read_result = TEST_RES(read_last_pid(&last_pid),
+			       _ret == 0 && last_pid > 0 && last_pid < pid_max);
+	if (read_result != 0 || last_pid <= 0 || last_pid >= pid_max)
+		goto out;
+
+	if (TEST_SUCC(observe_pid_cursor_wrap(pid_max, last_pid,
+					      &observation)) != 0)
+		goto out;
+	pid_t wrapped_pid =
+		TEST_RES(observation.after, observation.before < pid_max &&
+						    _ret >= PID_RECYCLE_MIN &&
+						    _ret < observation.before);
+	if (wrapped_pid < PID_RECYCLE_MIN || wrapped_pid >= observation.before)
+		goto out;
+
+	pid_t child_pid = TEST_SUCC(fork());
+	if (child_pid == 0)
+		_exit(EXIT_SUCCESS);
+	if (child_pid < 0)
+		goto out;
+
+	TEST_RES(child_pid,
+		 child_pid >= PID_RECYCLE_MIN && child_pid < pid_max);
+
+	int status;
+	TEST_RES(waitpid(child_pid, &status, 0),
+		 _ret == child_pid && WIFEXITED(status) &&
+			 WEXITSTATUS(status) == EXIT_SUCCESS);
+
+out:
+#endif /* __asterinas__ */
+}
+END_TEST()

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -77,4 +77,5 @@ fi
 ./job_control
 ./pidfd
 ./pidfd_getfd
+./pid_reuse
 ./wait4


### PR DESCRIPTION
The previous allocator only advanced monotonically and did not model Linux's bounded PID allocation behavior. Once the allocation cursor reached the PID limit, identifiers could not be reused correctly. This affected the behavior expected by LTP `wait402`, which exercises process wait operations with PIDs outside the valid allocation range.

## Implementation

- Add `CyclicIdAlloc`, a range-bounded allocator that follows Linux's cyclic allocation policy and starts reusing identifiers from PID 300 after the initial allocation pass.
- Reserve a PID/TID before constructing a process or thread, and commit the reservation only after the object is published in the PID table. Return uncommitted reservations to the allocator when process or thread creation fails.
- Store stable `PidEntry` references in POSIX threads so PID/TID lookups remain correct when numeric identifiers are recycled.
- Update `/proc/loadavg` to report the most recently allocated TID and adjust related procfs and cgroup PID-limit handling.
