### PR TITLE
Add partition support for NVMe devices

### DIFF
--- a/kernel/core/comps/block/src/lib.rs
+++ b/kernel/core/comps/block/src/lib.rs
@@ -47,7 +47,9 @@ mod partition;
 mod prelude;
 pub mod request_queue;
 
-use ::device_id::DeviceId;
+use alloc::format;
+
+use ::device_id::{DeviceId, MinorId};
 use component::{ComponentInitError, init_component};
 pub use device_id::{EXTENDED_DEVICE_ID_ALLOCATOR, MajorIdOwner, acquire_major, allocate_major};
 use ostd::sync::Mutex;
@@ -60,6 +62,11 @@ use self::{
 
 pub const BLOCK_SIZE: usize = ostd::mm::PAGE_SIZE;
 pub const SECTOR_SIZE: usize = 512;
+
+/// The number of minor device numbers allocated for each whole-disk device,
+/// including the whole disk and its partitions. If a disk has more than
+/// 16 partitions, then allocate a device ID via `EXTENDED_DEVICE_ID_ALLOCATOR`.
+pub const DEVICE_MINORS: u32 = 16;
 
 pub trait BlockDevice: Send + Sync + Any + Debug {
     /// Enqueues a new `SubmittedBio` to the block device.
@@ -80,11 +87,64 @@ pub trait BlockDevice: Send + Sync + Any + Debug {
     }
 
     /// Sets the partitions of the block device.
-    fn set_partitions(&self, _infos: Vec<Option<PartitionInfo>>) {}
+    fn set_partitions(&self, _partitions: Vec<Arc<PartitionNode>>) {}
 
     /// Returns the partitions of the block device.
     fn partitions(&self) -> Option<Vec<Arc<dyn BlockDevice>>> {
         None
+    }
+
+    /// Updates the partitions of the block device with the parsed partition
+    /// information
+    fn update_partitions(&self, infos: Vec<Option<PartitionInfo>>) {
+        let Some(device) = lookup(self.id()) else {
+            return;
+        };
+
+        if let Some(old_partitions) = self.partitions() {
+            for partition in old_partitions {
+                let _ = unregister(partition.id());
+            }
+        }
+
+        let mut new_partitions = Vec::new();
+        for (index, info_opt) in infos.iter().enumerate() {
+            let Some(info) = info_opt else {
+                continue;
+            };
+
+            let index = index as u32 + 1;
+            let id = if index < DEVICE_MINORS {
+                DeviceId::new(
+                    self.id().major(),
+                    MinorId::new(self.id().minor().get() + index),
+                )
+            } else {
+                EXTENDED_DEVICE_ID_ALLOCATOR.get().unwrap().allocate()
+            };
+            let name = partition_name(self.name(), index);
+            let partition = Arc::new(PartitionNode::new(id, name, device.clone(), *info));
+            new_partitions.push(partition);
+        }
+
+        for partition in new_partitions.iter() {
+            let _ = register(partition.clone());
+        }
+
+        self.set_partitions(new_partitions);
+    }
+}
+
+/// Formats the name of a partition. We perform the naming similar to the
+/// Linux implementation: insert "p" between the disk name and the partition
+/// number when the disk name ends with a digit (`nvme0n1p1`), and append the
+/// number otherwise (`vda1`).
+/// Reference: <https://elixir.bootlin.com/linux/v7.2.2/source/block/partitions/core.c#L337>
+fn partition_name(disk_name: &str, partno: u32) -> String {
+    if disk_name.ends_with(|c: char| c.is_ascii_digit()) {
+        format!("{}p{}", disk_name, partno)
+    } else {
+        format!("{}{}", disk_name, partno)
     }
 }
 
@@ -170,7 +230,7 @@ pub fn scan_partitions() {
             continue;
         };
 
-        device.set_partitions(partition_info);
+        device.update_partitions(partition_info);
     }
 }
 

--- a/kernel/core/comps/block/src/lib.rs
+++ b/kernel/core/comps/block/src/lib.rs
@@ -47,13 +47,11 @@ mod partition;
 mod prelude;
 pub mod request_queue;
 
-use alloc::format;
-
-use ::device_id::{DeviceId, MinorId};
+use ::device_id::DeviceId;
 use component::{ComponentInitError, init_component};
 pub use device_id::{EXTENDED_DEVICE_ID_ALLOCATOR, MajorIdOwner, acquire_major, allocate_major};
 use ostd::sync::Mutex;
-pub use partition::{PartitionInfo, PartitionNode};
+pub use partition::{PartitionInfo, PartitionManager, PartitionNode};
 
 use self::{
     bio::{BioEnqueueError, SubmittedBio},
@@ -86,65 +84,13 @@ pub trait BlockDevice: Send + Sync + Any + Debug {
         false
     }
 
-    /// Sets the partitions of the block device.
-    fn set_partitions(&self, _partitions: Vec<Arc<PartitionNode>>) {}
-
-    /// Returns the partitions of the block device.
-    fn partitions(&self) -> Option<Vec<Arc<dyn BlockDevice>>> {
+    /// Returns the partition manager of the block device.
+    ///
+    /// Whole-disk devices return their manager, which owns the device's
+    /// partitions. Partition devices and devices without partition support
+    /// return `None`.
+    fn partition_manager(&self) -> Option<&PartitionManager> {
         None
-    }
-
-    /// Updates the partitions of the block device with the parsed partition
-    /// information
-    fn update_partitions(&self, infos: Vec<Option<PartitionInfo>>) {
-        let Some(device) = lookup(self.id()) else {
-            return;
-        };
-
-        if let Some(old_partitions) = self.partitions() {
-            for partition in old_partitions {
-                let _ = unregister(partition.id());
-            }
-        }
-
-        let mut new_partitions = Vec::new();
-        for (index, info_opt) in infos.iter().enumerate() {
-            let Some(info) = info_opt else {
-                continue;
-            };
-
-            let index = index as u32 + 1;
-            let id = if index < DEVICE_MINORS {
-                DeviceId::new(
-                    self.id().major(),
-                    MinorId::new(self.id().minor().get() + index),
-                )
-            } else {
-                EXTENDED_DEVICE_ID_ALLOCATOR.get().unwrap().allocate()
-            };
-            let name = partition_name(self.name(), index);
-            let partition = Arc::new(PartitionNode::new(id, name, device.clone(), *info));
-            new_partitions.push(partition);
-        }
-
-        for partition in new_partitions.iter() {
-            let _ = register(partition.clone());
-        }
-
-        self.set_partitions(new_partitions);
-    }
-}
-
-/// Formats the name of a partition. We perform the naming similar to the
-/// Linux implementation: insert "p" between the disk name and the partition
-/// number when the disk name ends with a digit (`nvme0n1p1`), and append the
-/// number otherwise (`vda1`).
-/// Reference: <https://elixir.bootlin.com/linux/v7.2.2/source/block/partitions/core.c#L337>
-fn partition_name(disk_name: &str, partno: u32) -> String {
-    if disk_name.ends_with(|c: char| c.is_ascii_digit()) {
-        format!("{}p{}", disk_name, partno)
-    } else {
-        format!("{}{}", disk_name, partno)
     }
 }
 
@@ -226,11 +172,15 @@ pub fn scan_partitions() {
             continue;
         }
 
-        let Some(partition_info) = partition::parse(&device) else {
+        let Some(partition_manager) = device.partition_manager() else {
             continue;
         };
 
-        device.update_partitions(partition_info);
+        let Some(partition_infos) = partition::parse(&device) else {
+            continue;
+        };
+
+        partition_manager.update(&device, partition_infos);
     }
 }
 

--- a/kernel/core/comps/block/src/partition.rs
+++ b/kernel/core/comps/block/src/partition.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use device_id::DeviceId;
-use ostd::mm::VmIo;
+use alloc::format;
+
+use device_id::{DeviceId, MinorId};
+use ostd::{mm::VmIo, sync::Mutex};
 use ostd_pod::Pod;
 
 use crate::{
-    BlockDevice, BlockDeviceMeta, SECTOR_SIZE,
+    BlockDevice, BlockDeviceMeta, DEVICE_MINORS, EXTENDED_DEVICE_ID_ALLOCATOR, SECTOR_SIZE,
     bio::{BioEnqueueError, SubmittedBio},
     prelude::*,
+    register, unregister,
 };
 
 /// Represents a partition entry.
@@ -287,5 +290,93 @@ impl PartitionNode {
             device,
             info,
         }
+    }
+}
+
+/// Manages the partitions of a whole-disk block device.
+///
+/// The manager owns the device's current partition list and the lock that
+/// serializes partition replacement.
+#[derive(Debug)]
+pub struct PartitionManager {
+    inner: Mutex<Option<Vec<Arc<PartitionNode>>>>,
+}
+
+impl Default for PartitionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartitionManager {
+    /// Creates an empty partition manager.
+    pub const fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Returns the managed partitions.
+    pub fn partitions(&self) -> Option<Vec<Arc<dyn BlockDevice>>> {
+        self.inner.lock().as_ref().map(|partitions| {
+            partitions
+                .iter()
+                .map(|partition| partition.clone() as Arc<dyn BlockDevice>)
+                .collect()
+        })
+    }
+
+    /// Replaces the managed partitions with the parsed partition information.
+    pub(super) fn update(&self, device: &Arc<dyn BlockDevice>, infos: Vec<Option<PartitionInfo>>) {
+        // Lock order: partition lock -> `DEVICE_REGISTRY`
+
+        let mut partitions = self.inner.lock();
+
+        if let Some(old_partitions) = partitions.take() {
+            for partition in old_partitions {
+                let _ = unregister(partition.id());
+            }
+        }
+
+        let mut new_partitions = Vec::new();
+        for (index, info_opt) in infos.iter().enumerate() {
+            let Some(info) = info_opt else {
+                continue;
+            };
+
+            let index = index as u32 + 1;
+            let id = if index < DEVICE_MINORS {
+                DeviceId::new(
+                    device.id().major(),
+                    MinorId::new(device.id().minor().get() + index),
+                )
+            } else {
+                EXTENDED_DEVICE_ID_ALLOCATOR.get().unwrap().allocate()
+            };
+            let name = partition_name(device.name(), index);
+            let partition = Arc::new(PartitionNode::new(id, name, device.clone(), *info));
+            new_partitions.push(partition);
+        }
+
+        for partition in new_partitions.iter() {
+            let _ = register(partition.clone());
+        }
+
+        *partitions = Some(new_partitions);
+    }
+}
+
+/// Formats the name of a partition.
+///
+/// We perform the naming similar to the Linux implementation: insert "p" between
+/// the disk name and the partition number when the disk name ends with a digit
+/// (`nvme0n1p1`), and append the number otherwise (`vda1`).
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.2.2/source/block/partitions/core.c#L337>
+fn partition_name(disk_name: &str, partno: u32) -> String {
+    if disk_name.ends_with(|c: char| c.is_ascii_digit()) {
+        format!("{}p{}", disk_name, partno)
+    } else {
+        format!("{}{}", disk_name, partno)
     }
 }

--- a/kernel/core/comps/nvme/src/device/block_device.rs
+++ b/kernel/core/comps/nvme/src/device/block_device.rs
@@ -22,12 +22,12 @@ use core::{
 };
 
 use aster_block::{
-    BlockDeviceMeta, SECTOR_SIZE,
+    BlockDeviceMeta, PartitionNode, SECTOR_SIZE,
     bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio, bio_segment_pool_init},
     request_queue::{BioRequest, BioRequestSingleQueue},
 };
 use aster_util::safe_ptr::SafePtr;
-use device_id::DeviceId;
+use device_id::{DeviceId, MinorId};
 use ostd::{
     debug, error, info,
     mm::{HasDaddr, HasSize, PAGE_SIZE, dma::DmaStream},
@@ -67,6 +67,7 @@ pub struct NvmeBlockDevice {
     queue: BioRequestSingleQueue,
     name: String,
     id: DeviceId,
+    partitions: SpinLock<Option<Vec<Arc<PartitionNode>>>>,
 }
 
 static NR_NVME_DEVICE: AtomicU32 = AtomicU32::new(0);
@@ -80,7 +81,7 @@ impl NvmeBlockDevice {
         let id = {
             // Use the allocated major ID for the NVMe device
             let major_id = NVME_BLOCK_MAJOR_ID.get().unwrap().get();
-            DeviceId::new(major_id, device_id::MinorId::new(index))
+            DeviceId::new(major_id, MinorId::new(index * aster_block::DEVICE_MINORS))
         };
 
         let block_device = Arc::new(Self {
@@ -88,6 +89,7 @@ impl NvmeBlockDevice {
             queue: BioRequestSingleQueue::new(),
             name,
             id,
+            partitions: SpinLock::new(None),
         });
 
         block_device
@@ -135,6 +137,20 @@ impl aster_block::BlockDevice for NvmeBlockDevice {
 
     fn id(&self) -> DeviceId {
         self.id
+    }
+
+    fn partitions(&self) -> Option<Vec<Arc<dyn aster_block::BlockDevice>>> {
+        let partitions = self.partitions.lock();
+        let devices = partitions
+            .as_ref()?
+            .iter()
+            .map(|p| p.clone() as Arc<dyn aster_block::BlockDevice>)
+            .collect();
+        Some(devices)
+    }
+
+    fn set_partitions(&self, partitions: Vec<Arc<PartitionNode>>) {
+        *self.partitions.lock() = Some(partitions);
     }
 }
 

--- a/kernel/core/comps/nvme/src/device/block_device.rs
+++ b/kernel/core/comps/nvme/src/device/block_device.rs
@@ -22,7 +22,7 @@ use core::{
 };
 
 use aster_block::{
-    BlockDeviceMeta, PartitionNode, SECTOR_SIZE,
+    BlockDeviceMeta, PartitionManager, SECTOR_SIZE,
     bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio, bio_segment_pool_init},
     request_queue::{BioRequest, BioRequestSingleQueue},
 };
@@ -67,7 +67,7 @@ pub struct NvmeBlockDevice {
     queue: BioRequestSingleQueue,
     name: String,
     id: DeviceId,
-    partitions: SpinLock<Option<Vec<Arc<PartitionNode>>>>,
+    partition_manager: PartitionManager,
 }
 
 static NR_NVME_DEVICE: AtomicU32 = AtomicU32::new(0);
@@ -89,7 +89,7 @@ impl NvmeBlockDevice {
             queue: BioRequestSingleQueue::new(),
             name,
             id,
-            partitions: SpinLock::new(None),
+            partition_manager: PartitionManager::new(),
         });
 
         block_device
@@ -139,18 +139,8 @@ impl aster_block::BlockDevice for NvmeBlockDevice {
         self.id
     }
 
-    fn partitions(&self) -> Option<Vec<Arc<dyn aster_block::BlockDevice>>> {
-        let partitions = self.partitions.lock();
-        let devices = partitions
-            .as_ref()?
-            .iter()
-            .map(|p| p.clone() as Arc<dyn aster_block::BlockDevice>)
-            .collect();
-        Some(devices)
-    }
-
-    fn set_partitions(&self, partitions: Vec<Arc<PartitionNode>>) {
-        *self.partitions.lock() = Some(partitions);
+    fn partition_manager(&self) -> Option<&PartitionManager> {
+        Some(&self.partition_manager)
     }
 }
 

--- a/kernel/core/comps/virtio/src/device/block/device.rs
+++ b/kernel/core/comps/virtio/src/device/block/device.rs
@@ -1,20 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{
-    boxed::Box,
-    collections::BTreeMap,
-    format,
-    string::String,
-    sync::{Arc, Weak},
-    vec::Vec,
-};
+use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use core::{
     fmt::Debug,
     sync::atomic::{AtomicU32, Ordering},
 };
 
 use aster_block::{
-    BlockDeviceMeta, EXTENDED_DEVICE_ID_ALLOCATOR, PartitionInfo, PartitionNode,
+    BlockDeviceMeta, PartitionNode,
     bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio, bio_segment_pool_init},
     request_queue::{BioRequest, BioRequestSingleQueue},
 };
@@ -39,11 +32,6 @@ use crate::{
     transport::{ConfigManager, DeviceTransport},
 };
 
-/// The number of minor device numbers allocated for each virtio disk,
-/// including the whole disk and its partitions. If a disk has more than
-/// 16 partitions, then allocate a device ID via `EXTENDED_DEVICE_ID_ALLOCATOR`.
-const VIRTIO_DEVICE_MINORS: u32 = 16;
-
 /// The number of virtio block devices, used to assign minor device numbers.
 static NR_BLOCK_DEVICE: AtomicU32 = AtomicU32::new(0);
 
@@ -55,7 +43,6 @@ pub struct BlockDevice {
     id: DeviceId,
     name: String,
     partitions: SpinLock<Option<Vec<Arc<PartitionNode>>>>,
-    weak_self: Weak<Self>,
 }
 
 impl BlockDevice {
@@ -88,11 +75,11 @@ impl BlockDevice {
         let index = NR_BLOCK_DEVICE.fetch_add(1, Ordering::Relaxed);
         let id = DeviceId::new(
             VIRTIO_BLOCK_MAJOR_ID.get().unwrap().get(),
-            MinorId::new(index * VIRTIO_DEVICE_MINORS),
+            MinorId::new(index * aster_block::DEVICE_MINORS),
         );
         let name = Self::formatted_device_name(index);
 
-        let block_device = Arc::new_cyclic(|weak_self| BlockDevice {
+        let block_device = Arc::new(BlockDevice {
             device,
             // Each bio request includes an additional 1 request and 1 response descriptor,
             // therefore this upper bound is set to (QUEUE_SIZE - 2).
@@ -102,7 +89,6 @@ impl BlockDevice {
             id,
             name,
             partitions: SpinLock::new(None),
-            weak_self: weak_self.clone(),
         });
 
         aster_block::register(block_device).unwrap();
@@ -149,40 +135,6 @@ impl aster_block::BlockDevice for BlockDevice {
         self.id
     }
 
-    fn set_partitions(&self, infos: Vec<Option<PartitionInfo>>) {
-        let mut partitions = self.partitions.lock();
-        if let Some(old_partitions) = partitions.take() {
-            for partition in old_partitions {
-                let _ = aster_block::unregister(partition.id());
-            }
-        }
-
-        let mut new_partitions = Vec::new();
-        for (index, info_opt) in infos.iter().enumerate() {
-            let Some(info) = info_opt else {
-                continue;
-            };
-
-            let index = index as u32 + 1;
-            let id = if index < VIRTIO_DEVICE_MINORS {
-                DeviceId::new(self.id.major(), MinorId::new(self.id.minor().get() + index))
-            } else {
-                EXTENDED_DEVICE_ID_ALLOCATOR.get().unwrap().allocate()
-            };
-            let name = format!("{}{}", self.name(), index);
-            let device = self.weak_self.upgrade().unwrap();
-
-            let partition = Arc::new(PartitionNode::new(id, name, device, *info));
-            new_partitions.push(partition);
-        }
-
-        for partition in new_partitions.iter() {
-            let _ = aster_block::register(partition.clone());
-        }
-
-        *partitions = Some(new_partitions);
-    }
-
     fn partitions(&self) -> Option<Vec<Arc<dyn aster_block::BlockDevice>>> {
         let partitions = self.partitions.lock();
         let devices = partitions
@@ -191,6 +143,10 @@ impl aster_block::BlockDevice for BlockDevice {
             .map(|p| p.clone() as Arc<dyn aster_block::BlockDevice>)
             .collect();
         Some(devices)
+    }
+
+    fn set_partitions(&self, partitions: Vec<Arc<PartitionNode>>) {
+        *self.partitions.lock() = Some(partitions);
     }
 }
 

--- a/kernel/core/comps/virtio/src/device/block/device.rs
+++ b/kernel/core/comps/virtio/src/device/block/device.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use aster_block::{
-    BlockDeviceMeta, PartitionNode,
+    BlockDeviceMeta, PartitionManager,
     bio::{BioEnqueueError, BioStatus, BioType, SubmittedBio, bio_segment_pool_init},
     request_queue::{BioRequest, BioRequestSingleQueue},
 };
@@ -42,7 +42,7 @@ pub struct BlockDevice {
     queue: BioRequestSingleQueue,
     id: DeviceId,
     name: String,
-    partitions: SpinLock<Option<Vec<Arc<PartitionNode>>>>,
+    partition_manager: PartitionManager,
 }
 
 impl BlockDevice {
@@ -88,7 +88,7 @@ impl BlockDevice {
             ),
             id,
             name,
-            partitions: SpinLock::new(None),
+            partition_manager: PartitionManager::new(),
         });
 
         aster_block::register(block_device).unwrap();
@@ -135,18 +135,8 @@ impl aster_block::BlockDevice for BlockDevice {
         self.id
     }
 
-    fn partitions(&self) -> Option<Vec<Arc<dyn aster_block::BlockDevice>>> {
-        let partitions = self.partitions.lock();
-        let devices = partitions
-            .as_ref()?
-            .iter()
-            .map(|p| p.clone() as Arc<dyn aster_block::BlockDevice>)
-            .collect();
-        Some(devices)
-    }
-
-    fn set_partitions(&self, partitions: Vec<Arc<PartitionNode>>) {
-        *self.partitions.lock() = Some(partitions);
+    fn partition_manager(&self) -> Option<&PartitionManager> {
+        Some(&self.partition_manager)
     }
 }
 


### PR DESCRIPTION
I've been trying to boot the full NixOS image on the laptops I used in #3757. On real hardware there is no virtio-blk, and the NVMe driver never registers partition devices, so a rootfs on a partitioned disk can't be mounted.

The change is straightforward: the virtio-blk driver had its own partition registration code, and I moved it into the block layer as a default `update_partitions`. I also renamed the old `set_partitions` to `update_partitions`, since it replaces the whole partition table, and added a `partition_name` helper so a disk like `nvme0n1` gets `nvme0n1p1` for its first partition instead of `nvme0n11`.

With this, the full NixOS image boots into the graphical environment on my laptops, and I can interact with it using the built-in keyboard.
