### PR TITLE
Add udp benchmark to github workflow

### DIFF
--- a/.github/workflows/benchmark_x86.yml
+++ b/.github/workflows/benchmark_x86.yml
@@ -75,6 +75,8 @@ jobs:
           - lmbench/tcp_virtio_lat
           - lmbench/udp_virtio_lat
           - iperf3/tcp_virtio_bw
+          - iperf3/udp_virtio_bw_rx
+          - iperf3/udp_virtio_bw_tx
           # Scheduler-related benchmarks
           - hackbench/group8_smp1
           # FIXME: hackbench panics on multi-core settings now.

--- a/.github/workflows/benchmark_x86_tdx.yml
+++ b/.github/workflows/benchmark_x86_tdx.yml
@@ -76,6 +76,8 @@ jobs:
           - lmbench/tcp_virtio_lat
           - lmbench/udp_virtio_lat
           - iperf3/tcp_virtio_bw
+          - iperf3/udp_virtio_bw_rx
+          - iperf3/udp_virtio_bw_tx
           # Scheduler-related benchmarks
           - hackbench/group8_smp1
           # FIXME: hackbench panics on multi-core settings now.


### PR DESCRIPTION
Add the two benchmarks in #3727 to GitHub workflow files. Otherwise it cannot be scheduled to run.