### PR TITLE
Fix host/guest benchmark initramfs rebuild

### DIFF
--- a/test/initramfs/src/benchmark/bench_linux_and_aster.sh
+++ b/test/initramfs/src/benchmark/bench_linux_and_aster.sh
@@ -170,7 +170,7 @@ run_benchmark() {
             echo "Running benchmark ${benchmark} on Asterinas..."
             # Execute directly from array, redirect stderr to stdout, then tee
             "${asterinas_cmd_arr[@]}" 2>&1 | tee "${ASTER_OUTPUT}"
-            prepare_fs
+            prepare_fs "$benchmark"
             echo "Running benchmark ${benchmark} on Linux..."
             # Execute directly from array, redirect stderr to stdout, then tee
             "${linux_cmd_arr[@]}" 2>&1 | tee "${LINUX_OUTPUT}"
@@ -190,7 +190,8 @@ run_benchmark() {
                 "${asterinas_cmd_str}" \
                 "${linux_cmd_str}" \
                 "${ASTER_OUTPUT}" \
-                "${LINUX_OUTPUT}"
+                "${LINUX_OUTPUT}" \
+                "${benchmark}"
             ;;
         *)
             echo "Error: Unknown benchmark type '${run_mode}'" >&2

--- a/test/initramfs/src/benchmark/common/host_guest_bench_runner.sh
+++ b/test/initramfs/src/benchmark/common/host_guest_bench_runner.sh
@@ -9,6 +9,7 @@ ASTERINAS_GUEST_CMD=$2
 LINUX_GUEST_CMD=$3
 ASTERINAS_OUTPUT=$4
 LINUX_OUTPUT=$5
+BENCHMARK_NAME=$6
 # Message to monitor in the log file to determine whether the VM is ready
 # It should align with bench_runner.sh
 READY_MESSAGE="The VM is ready for the benchmark."
@@ -82,7 +83,7 @@ run_benchmark "${ASTERINAS_GUEST_CMD}" "${ASTERINAS_OUTPUT}" "/tmp/asterinas.log
 wait
 
 # Run the benchmark on the Linux VM
-prepare_fs
+prepare_fs "${BENCHMARK_NAME}"
 run_benchmark "${LINUX_GUEST_CMD}" "${LINUX_OUTPUT}" "/tmp/linux.log" "${READY_MESSAGE}"
 
 # Wait for the Linux QEMU process to exit

--- a/test/initramfs/src/benchmark/common/prepare_host.sh
+++ b/test/initramfs/src/benchmark/common/prepare_host.sh
@@ -40,6 +40,12 @@ prepare_libs() {
 
 # Prepare fs for Linux
 prepare_fs() {
+    local benchmark="$1"
+    if [[ -z "${benchmark}" ]]; then
+        echo "Error: benchmark name is required to prepare the Linux filesystem." >&2
+        return 1
+    fi
+
     # Disable unsupported ext2 features of Asterinas on Linux to ensure fairness
     mke2fs -F -O ^ext_attr -O ^resize_inode -O ^dir_index ${BENCHMARK_ROOT}/../../build/ext2.img
     make initramfs BENCHMARK=${benchmark}


### PR DESCRIPTION
Host/guest benchmarks rebuilt the Linux initramfs with an empty `BENCHMARK` because `$benchmark` was not available in the child runner process. This caused malformed Nix arguments and the `conformanceTestSuite` path error.