### PR TITLE
Fix Redis cross-compilation on ARM64 builders

### DIFF
--- a/test/initramfs/nix/benchmark/default.nix
+++ b/test/initramfs/nix/benchmark/default.nix
@@ -7,10 +7,13 @@
   lmbench = callPackage ./lmbench.nix { };
   memcached = pkgsHostTarget.memcached;
   nginx = pkgsHostTarget.nginx;
-  redis =
-    (pkgsHostTarget.redis.overrideAttrs (_: { doCheck = false; })).override {
-      withSystemd = false;
-    };
+  redis = (pkgsHostTarget.redis.overrideAttrs (old: {
+    doCheck = false;
+    makeFlags = (old.makeFlags or [ ]) ++ [
+      "CC=${pkgsHostTarget.stdenv.cc.targetPrefix}cc"
+      "LD=${pkgsHostTarget.stdenv.cc.targetPrefix}cc"
+    ];
+  })).override { withSystemd = false; };
   schbench = callPackage ./schbench.nix { };
   sqlite-speedtest1 = callPackage ./sqlite-speedtest1.nix { };
   sysbench = if hostPlatform.isx86_64 then pkgsHostTarget.sysbench else null;

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -51,7 +51,11 @@ in rec {
     CPPFLAGS = "-fcommon -fpermissive";
   });
   lmbench = pkgs.callPackage ./benchmark/lmbench.nix { };
-  redis = (pkgs.redis.overrideAttrs (_: { doCheck = false; })).override {
-    withSystemd = false;
-  };
+  redis = (pkgs.redis.overrideAttrs (old: {
+    doCheck = false;
+    makeFlags = (old.makeFlags or [ ]) ++ [
+      "CC=${pkgs.stdenv.cc.targetPrefix}cc"
+      "LD=${pkgs.stdenv.cc.targetPrefix}cc"
+    ];
+  })).override { withSystemd = false; };
 }


### PR DESCRIPTION
After Nix channel aligned in PR #3773, Redis was upgraded from 7.2 to 8.8. Redis 8.8 builds its test modules as part of the default build, but the module Makefile hardcodes gcc, causing cross-compilation of the x86_64 package to fail on ARM64 builders because the target-prefixed compiler is used instead. See [CI job #99852608550](https://github.com/asterinas/asterinas/actions/runs/33502158230/job/99852608550). This PR passes the target CC and LD compiler through makeFlags to fix the build.