### PR TITLE
Limit page-cache reads to the file size in ramfs and exfat

### DIFF
--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -650,7 +650,12 @@ impl ExfatInode {
             let end = file_size.min(offset + writer.avail());
             (start, end - start)
         };
-        inner.page_cache.read(read_off, writer)?;
+        if read_len > 0 {
+            let mut limited_writer = writer.clone_exclusive();
+            limited_writer.limit(read_len);
+            inner.page_cache.read(read_off, &mut limited_writer)?;
+            writer.skip(read_len);
+        }
 
         inner.upgrade().update_atime()?;
         Ok(read_len)

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -1008,7 +1008,12 @@ impl FileOps for RamInode {
                     let end = file_size.min(offset + writer.avail());
                     (start, end - start)
                 };
-                page_cache.lock().read(offset, writer)?;
+                if read_len > 0 {
+                    let mut limited_writer = writer.clone_exclusive();
+                    limited_writer.limit(read_len);
+                    page_cache.lock().read(offset, &mut limited_writer)?;
+                    writer.skip(read_len);
+                }
                 read_len
             }
             _ => return_errno_with_message!(Errno::EISDIR, "read is not supported"),

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -1002,16 +1002,16 @@ impl FileOps for RamInode {
     ) -> Result<usize> {
         let read_len = match &self.inner {
             Inner::File(page_cache) => {
-                let (offset, read_len) = {
-                    let file_size = self.size();
-                    let start = file_size.min(offset);
-                    let end = file_size.min(offset + writer.avail());
-                    (start, end - start)
-                };
+                // Lock before reading the size or the `resize` may shrink the cache
+                let page_cache = page_cache.lock();
+                let file_size = self.size();
+                let offset = file_size.min(offset);
+                let end = file_size.min(offset + writer.avail());
+                let read_len = end - offset;
                 if read_len > 0 {
                     let mut limited_writer = writer.clone_exclusive();
                     limited_writer.limit(read_len);
-                    page_cache.lock().read(offset, &mut limited_writer)?;
+                    page_cache.read(offset, &mut limited_writer)?;
                     writer.skip(read_len);
                 }
                 read_len

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -10,6 +10,7 @@ SUBDIRS := \
 	overlayfs \
 	procfs \
 	pseudofs \
+	read_eof \
 	rename \
 	statx \
 	symlink \

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -11,6 +11,7 @@ SUBDIRS := \
 	procfs \
 	pseudofs \
 	read_eof \
+	read_truncate_race \
 	rename \
 	statx \
 	symlink \

--- a/test/initramfs/src/regression/fs/read_eof/Makefile
+++ b/test/initramfs/src/regression/fs/read_eof/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+EXTRA_C_FLAGS := -static -lpthread
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/read_eof/read_eof.c
+++ b/test/initramfs/src/regression/fs/read_eof/read_eof.c
@@ -1,0 +1,237 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define FILE_NAME "aster_read_eof"
+#define CONTENT "hi"
+#define CONTENT_LEN (sizeof(CONTENT) - 1)
+#define BUF_SIZE 64
+#define SENTINEL 0xAA
+#define READV_BUF_SIZE 8192
+#define READV_ROUNDS 20000
+/* Use extra writers to increase the chance of cross-CPU placement. */
+#define NR_WRITERS 8
+
+/* Mount points of the file systems whose reads go through the page cache. */
+static const char *const DIRS[] = { "/tmp", "/ext2", "/exfat" };
+#define NR_DIRS (sizeof(DIRS) / sizeof(DIRS[0]))
+
+static int fds[NR_DIRS];
+
+/* Returns 1 if `buf[from..BUF_SIZE)` still holds the sentinel. */
+static int tail_untouched(const unsigned char *buf, size_t from)
+{
+	for (size_t i = from; i < BUF_SIZE; i++) {
+		if (buf[i] != SENTINEL) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+FN_SETUP(create_files)
+{
+	char path[64];
+	struct stat st;
+
+	for (size_t i = 0; i < NR_DIRS; i++) {
+		if (stat(DIRS[i], &st) < 0) {
+			fds[i] = -1;
+			continue;
+		}
+
+		CHECK(snprintf(path, sizeof(path), "%s/" FILE_NAME, DIRS[i]));
+		unlink(path);
+
+		fds[i] = CHECK(open(path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+		CHECK_WITH(write(fds[i], CONTENT, CONTENT_LEN),
+			   _ret == CONTENT_LEN);
+	}
+}
+END_SETUP()
+
+FN_TEST(pread_across_eof_leaves_tail_untouched)
+{
+	unsigned char buf[BUF_SIZE];
+
+	for (size_t i = 0; i < NR_DIRS; i++) {
+		if (fds[i] < 0) {
+			continue;
+		}
+		fprintf(stderr, "%s: on %s\n", __func__, DIRS[i]);
+
+		memset(buf, SENTINEL, sizeof(buf));
+		TEST_RES(pread(fds[i], buf, sizeof(buf), 1),
+			 _ret == CONTENT_LEN - 1);
+		TEST_RES(tail_untouched(buf, CONTENT_LEN - 1), _ret == 1);
+	}
+}
+END_TEST()
+
+FN_TEST(pread_at_eof_leaves_buffer_untouched)
+{
+	unsigned char buf[BUF_SIZE];
+
+	for (size_t i = 0; i < NR_DIRS; i++) {
+		if (fds[i] < 0) {
+			continue;
+		}
+		fprintf(stderr, "%s: on %s\n", __func__, DIRS[i]);
+
+		memset(buf, SENTINEL, sizeof(buf));
+		TEST_RES(pread(fds[i], buf, sizeof(buf), CONTENT_LEN),
+			 _ret == 0);
+		TEST_RES(tail_untouched(buf, 0), _ret == 1);
+	}
+}
+END_TEST()
+
+FN_TEST(read_across_eof_leaves_tail_untouched)
+{
+	unsigned char buf[BUF_SIZE];
+
+	for (size_t i = 0; i < NR_DIRS; i++) {
+		if (fds[i] < 0) {
+			continue;
+		}
+		fprintf(stderr, "%s: on %s\n", __func__, DIRS[i]);
+
+		memset(buf, SENTINEL, sizeof(buf));
+		TEST_SUCC(lseek(fds[i], 1, SEEK_SET));
+		TEST_RES(read(fds[i], buf, sizeof(buf)),
+			 _ret == CONTENT_LEN - 1);
+		TEST_RES(tail_untouched(buf, CONTENT_LEN - 1), _ret == 1);
+	}
+}
+END_TEST()
+
+static _Atomic int stop_requested;
+static _Atomic int writer_cpus[NR_WRITERS];
+
+static int current_cpu(void)
+{
+	unsigned int cpu;
+
+	CHECK(syscall(SYS_getcpu, &cpu, NULL, NULL));
+	return cpu;
+}
+
+/* Keep the file smaller than iov[0], so an append after a short read
+ * must not place data in iov[1].
+ */
+static void *append_and_truncate(void *arg)
+{
+	int fd = fds[0];
+
+	*(_Atomic int *)arg = current_cpu();
+	while (!stop_requested) {
+		CHECK_WITH(pwrite(fd, "!", 1, CONTENT_LEN), _ret == 1);
+		CHECK(ftruncate(fd, CONTENT_LEN));
+	}
+
+	return NULL;
+}
+
+static void start_writers(pthread_t *threads)
+{
+	for (int i = 0; i < NR_WRITERS; i++) {
+		writer_cpus[i] = -1;
+		CHECK_WITH(pthread_create(&threads[i], NULL,
+					  append_and_truncate, &writer_cpus[i]),
+			   _ret == 0);
+	}
+	for (int i = 0; i < NR_WRITERS; i++) {
+		while (writer_cpus[i] < 0)
+			sched_yield();
+	}
+}
+
+/* Must run before the test returns, cleanup closes the fd under the writers. */
+static void stop_writers(pthread_t *threads)
+{
+	stop_requested = 1;
+	for (int i = 0; i < NR_WRITERS; i++) {
+		CHECK_WITH(pthread_join(threads[i], NULL), _ret == 0);
+	}
+}
+
+static long count_split_reads(int fd)
+{
+	/* Larger than the one cached page, so the pre-fix whole-page copy
+	 * leaves space in iov[0] and stops before iov[1].
+	 */
+	static unsigned char first[READV_BUF_SIZE];
+	static unsigned char second[1];
+	struct iovec iov[2] = {
+		{ .iov_base = first, .iov_len = sizeof(first) },
+		{ .iov_base = second, .iov_len = sizeof(second) },
+	};
+	long split = 0;
+
+	for (long i = 0; i < READV_ROUNDS; i++) {
+		memset(first, SENTINEL, sizeof(first));
+		second[0] = SENTINEL;
+		ssize_t ret = CHECK(preadv(fd, iov, 2, 0));
+		int bad = second[0] != SENTINEL || ret > CONTENT_LEN + 1;
+		for (ssize_t j = 0; j < ret && j < READV_BUF_SIZE; j++) {
+			if (first[j] == SENTINEL)
+				bad = 1;
+		}
+		if (bad)
+			split++;
+	}
+
+	return split;
+}
+
+FN_TEST(preadv_fills_iovecs_in_order)
+{
+	/* A short first iovec must stop the read even if an append follows. */
+	int fd = fds[0];
+	SKIP_TEST_IF(fd < 0);
+	SKIP_TEST_IF(sysconf(_SC_NPROCESSORS_ONLN) < 2);
+
+	pthread_t threads[NR_WRITERS];
+	start_writers(threads);
+
+	/* This placement check assumes threads do not migrate between CPUs. */
+	int reader_cpu = current_cpu();
+	int all_on_reader_cpu = 1;
+	for (int i = 0; i < NR_WRITERS; i++) {
+		if (writer_cpus[i] != reader_cpu)
+			all_on_reader_cpu = 0;
+	}
+	if (all_on_reader_cpu)
+		stop_writers(threads);
+	SKIP_TEST_IF(all_on_reader_cpu);
+
+	TEST_RES(count_split_reads(fd), _ret == 0);
+	stop_writers(threads);
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	char path[64];
+
+	for (size_t i = 0; i < NR_DIRS; i++) {
+		if (fds[i] < 0) {
+			continue;
+		}
+
+		CHECK(close(fds[i]));
+		CHECK(snprintf(path, sizeof(path), "%s/" FILE_NAME, DIRS[i]));
+		CHECK(unlink(path));
+	}
+}
+END_SETUP()

--- a/test/initramfs/src/regression/fs/read_truncate_race/Makefile
+++ b/test/initramfs/src/regression/fs/read_truncate_race/Makefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
+EXTRA_C_FLAGS := -static -lpthread
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/read_truncate_race/read_truncate_race.c
+++ b/test/initramfs/src/regression/fs/read_truncate_race/read_truncate_race.c
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+/*
+ * A read that races with a truncate or an extending write may be short, but it
+ * must never report bytes it did not copy. The reader fills its buffer with a
+ * sentinel before every `pread()`; the file only ever holds 'x', so a sentinel
+ * byte inside `[0, ret)` is a byte the kernel counted but never wrote.
+ */
+
+#define FILE_PATH "/tmp/aster_read_truncate_race"
+#define LEN 8192
+#define ROUNDS 20000
+#define SENTINEL 0xAA
+/* Use extra writers to increase the chance of cross-CPU placement. */
+#define NR_WRITERS 8
+
+static int fd;
+static char data[LEN];
+static _Atomic int stop_requested;
+static _Atomic int writer_cpus[NR_WRITERS];
+
+static int current_cpu(void)
+{
+	unsigned int cpu;
+
+	CHECK(syscall(SYS_getcpu, &cpu, NULL, NULL));
+	return cpu;
+}
+
+/* Alternates the file between empty and LEN bytes of 'x'. */
+static void *truncate_and_rewrite(void *arg)
+{
+	*(_Atomic int *)arg = current_cpu();
+	while (!stop_requested) {
+		CHECK(ftruncate(fd, 0));
+		CHECK_WITH(pwrite(fd, data, LEN, 0), _ret == LEN);
+	}
+
+	return NULL;
+}
+
+static void start_writers(pthread_t *threads)
+{
+	for (int i = 0; i < NR_WRITERS; i++) {
+		writer_cpus[i] = -1;
+		CHECK_WITH(pthread_create(&threads[i], NULL,
+					  truncate_and_rewrite,
+					  &writer_cpus[i]),
+			   _ret == 0);
+	}
+	for (int i = 0; i < NR_WRITERS; i++) {
+		while (writer_cpus[i] < 0)
+			sched_yield();
+	}
+}
+
+/* Must run before the test returns, cleanup closes the fd under the writers. */
+static void stop_writers(pthread_t *threads)
+{
+	stop_requested = 1;
+	for (int i = 0; i < NR_WRITERS; i++) {
+		CHECK_WITH(pthread_join(threads[i], NULL), _ret == 0);
+	}
+}
+
+/* Returns how many of ROUNDS reads reported bytes that were never written. */
+static long count_unwritten_reads(void)
+{
+	static unsigned char buf[LEN];
+	long unwritten = 0;
+
+	for (long i = 0; i < ROUNDS; i++) {
+		memset(buf, SENTINEL, LEN);
+		ssize_t ret = CHECK(pread(fd, buf, LEN, 0));
+		for (ssize_t j = 0; j < ret; j++) {
+			if (buf[j] == SENTINEL) {
+				unwritten++;
+				break;
+			}
+		}
+	}
+
+	return unwritten;
+}
+
+FN_SETUP(create_file)
+{
+	memset(data, 'x', LEN);
+	fd = CHECK(open(FILE_PATH, O_RDWR | O_CREAT | O_TRUNC, 0600));
+	CHECK_WITH(pwrite(fd, data, LEN, 0), _ret == LEN);
+}
+END_SETUP()
+
+FN_TEST(read_never_reports_unwritten_bytes)
+{
+	SKIP_TEST_IF(sysconf(_SC_NPROCESSORS_ONLN) < 2);
+
+	pthread_t threads[NR_WRITERS];
+	start_writers(threads);
+
+	/* This placement check assumes threads do not migrate between CPUs. */
+	int reader_cpu = current_cpu();
+	int all_on_reader_cpu = 1;
+	for (int i = 0; i < NR_WRITERS; i++) {
+		if (writer_cpus[i] != reader_cpu)
+			all_on_reader_cpu = 0;
+	}
+	if (all_on_reader_cpu)
+		stop_writers(threads);
+	SKIP_TEST_IF(all_on_reader_cpu);
+
+	TEST_RES(count_unwritten_reads(), _ret == 0);
+	stop_writers(threads);
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(fd));
+	CHECK(unlink(FILE_PATH));
+}
+END_SETUP()

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -148,6 +148,8 @@ echo "All mount bind file test passed."
 ./pseudofs/pseudo_inode
 ./pseudofs/pseudo_mount
 
+./read_eof/read_eof
+
 ./rename/same_inode
 
 ./statx/btime

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -149,6 +149,7 @@ echo "All mount bind file test passed."
 ./pseudofs/pseudo_mount
 
 ./read_eof/read_eof
+./read_truncate_race/read_truncate_race
 
 ./rename/same_inode
 


### PR DESCRIPTION
### Problem

`RamInode::read_at` and `ExfatInode::read_at` compute how many bytes are
readable (`min(file_size, offset + avail) - min(file_size, offset)`) but then
hand the caller's *unlimited* writer to `PageCache::read`. The page cache's
size is block-aligned, so it can hold bytes beyond the file size, and
`Vmo::read` copies up to that size. A read that reaches EOF therefore writes
past the byte count it returns:

```
file "hi" (2 bytes), 64-byte buffer pre-filled with 0xAA
                              Linux 7.1.9 (tmpfs)         Asterinas (ramfs, exfat)
pread(off=1, len=64)          ret=1, buf[1..64) intact    ret=1, buf[1..64) zeroed
pread(off=EOF, len=64)        ret=0, buffer intact        ret=0, all 64 bytes zeroed
```

`read(2)` promises that only the returned number of bytes is stored; a caller
that keeps other data after the read position in the same buffer, or that
uses the return value to know what changed, is corrupted silently.

### Fix

Follow the behavior of virtiofs, which skips the page-cache read when nothing
is readable, otherwise read through `writer.clone_exclusive()` limited to
`read_len` and then `writer.skip(read_len)`. The caller's writer is advanced by
exactly the bytes read and keeps its real remaining space, which `do_sys_readv`
relies on to stop at EOF.

### Test

`test/initramfs/src/regression/fs/read_eof/read_eof.c` writes a 2-byte file on
`/tmp`, `/ext2` and `/exfat`, then checks with `pread` across EOF, `pread` at
EOF and `read` across EOF that every byte past the returned count still holds
the sentinel. Fails on unpatched kernels for `/tmp` and `/exfat` (6 failing
checks), passes with the fix and on Linux.

### Misc

Perhaps we need to follow the idea of https://github.com/asterinas/asterinas/issues/711#issuecomment-2016319390 to prevent similar issue in the future.

This issue was found by https://github.com/specula-org/Specula :)