### PR TITLE
Skip the early console when no serial port is present

### DIFF
--- a/ostd/src/arch/x86/serial.rs
+++ b/ostd/src/arch/x86/serial.rs
@@ -46,6 +46,34 @@ impl SerialAccess {
             }
         }
     }
+
+    /// Detects whether a UART is present at the legacy COM1 serial port.
+    ///
+    /// Reference: <https://elixir.bootlin.com/linux/v7.2.2/source/drivers/tty/serial/8250/8250_port.c#L1094>
+    fn probe(&mut self) -> bool {
+        // A real UART echoes values written to its interrupt enable register, while
+        // an unbacked port reads 0xFF or 0x00 on every access. We perform the
+        // existence check by checking if the register works as expected.
+
+        // Some UARTs (e.g., the TL 16C754B) only allow IER[7:4] to be modified when
+        // an EFR bit is set, so only the low four bits are tested.
+        const IER_ALL_INTR: u8 = 0x0F;
+
+        let saved_ier = self.read(Ns16550aRegister::IntEnOrDivisorHi);
+
+        let is_ok1 = {
+            self.write(Ns16550aRegister::IntEnOrDivisorHi, 0x00);
+            self.read(Ns16550aRegister::IntEnOrDivisorHi) & IER_ALL_INTR == 0
+        };
+        let is_ok2 = {
+            self.write(Ns16550aRegister::IntEnOrDivisorHi, IER_ALL_INTR);
+            self.read(Ns16550aRegister::IntEnOrDivisorHi) & IER_ALL_INTR == IER_ALL_INTR
+        };
+
+        self.write(Ns16550aRegister::IntEnOrDivisorHi, saved_ier);
+
+        is_ok1 && is_ok2
+    }
 }
 
 impl Ns16550aAccess for SerialAccess {
@@ -75,23 +103,32 @@ impl Ns16550aAccess for SerialAccess {
 }
 
 /// Initializes the serial port.
-pub(crate) fn init(early_cmdline: &EarlyCmdline) {
+///
+/// # Safety
+///
+/// This function should be called only once.
+pub(crate) unsafe fn init(early_cmdline: &EarlyCmdline) {
     if !early_cmdline.has_early_console {
         return;
     }
 
-    // TODO: Add existence check for COM1.
-    SERIAL_PORT.call_once(|| {
-        // SAFETY:
-        // 1. The legacy COM1 serial port at 0x3F8 can be disabled via the command line. If it is
-        //    enabled, it is assumed to exist and be accessible via the I/O registers.
-        //    (FIXME: This needs to be confirmed by checking the ACPI table or using more specific
-        //    kernel parameters to obtain early information for building the early console.)
-        // 2. `reserve_io_port_range` guarantees exclusive ownership of the I/O registers.
-        let access = unsafe { SerialAccess::new(0x3F8) };
-        let mut serial = Ns16550aUart::new(access);
-        serial.init();
-        SpinLock::new(serial)
-    });
+    // SAFETY:
+    // 1. The legacy COM1 serial port at 0x3F8 can be disabled via the command line.
+    //    (FIXME: This needs to be confirmed by checking the ACPI table or using more specific
+    //    kernel parameters to obtain early information for building the early console.)
+    // 2. `reserve_io_port_range` guarantees exclusive ownership of the I/O registers.
+    let mut access = unsafe { SerialAccess::new(0x3F8) };
+    if !access.probe() {
+        // The `IoPort`s in the access are backed by statically reserved ranges,
+        // but dropping the access would recycle these ranges through the port
+        // allocator, which is not initialized yet at this point.
+        core::mem::forget(access);
+        return;
+    }
+
+    let mut serial = Ns16550aUart::new(access);
+    serial.init();
+
+    SERIAL_PORT.call_once(|| SpinLock::new(serial));
 }
 reserve_io_port_range!(0x3F8..0x400);

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -88,7 +88,8 @@ unsafe fn init() {
     #[cfg(target_arch = "x86_64")]
     arch::if_tdx_enabled!({
     } else {
-        arch::serial::init(&early_cmdline);
+        // SAFETY: This function is called only once on the BSP.
+        unsafe { arch::serial::init(&early_cmdline) };
     });
     #[cfg(not(target_arch = "x86_64"))]
     arch::serial::init(&early_cmdline);
@@ -122,7 +123,8 @@ unsafe fn init() {
 
     #[cfg(target_arch = "x86_64")]
     arch::if_tdx_enabled!({
-        arch::serial::init(&early_cmdline);
+        // SAFETY: This function is called only once on the BSP.
+        unsafe { arch::serial::init(&early_cmdline) };
     });
 
     smp::init();


### PR DESCRIPTION
On some machines that do not have a COM1 serial port reading 0x3F8 returns 0xFF, so the data-ready bit is always set and `flush()` never returns. `early_print` is unaffected because it only sends. Disabling `earlycon` avoids the hang, but this actually reveals two underlying issues: the serial port is never checked for existence, and `flush()`/`send()` have no timeout.

This adds the existence check in `serial::init`, following Linux's `autoconfig` (`drivers/tty/serial/8250/8250_port.c`): write 0x00 and then 0x0f to the interrupt enable register and verify both are read back. The check is a `SerialAccess::probe` method, so the access is constructed exactly once in `init`; when no UART is present, the early console is skipped entirely.

Since the access is no longer constructed inside `call_once`, `init` is marked `unsafe` with an at-most-once requirement, like other initialization routines. When the probe fails, the access is forgotten so that its destructors never run: its ports are backed by statically reserved ranges, and dropping it would recycle these ranges through the port allocator, which is not initialized yet at this point.

A timeout for `flush()` would probably belong to a redesign of these interfaces rather than this PR, so I left it out.