### PR TITLE
Mark all infallible VMAR methods as infallible

### DIFF
--- a/kernel/core/src/process/clone.rs
+++ b/kernel/core/src/process/clone.rs
@@ -503,7 +503,7 @@ fn clone_child_process(
     let clone_flags = clone_args.flags;
 
     // Clone the virtual memory space
-    let child_vmar = clone_vmar(thread_local.vmar().borrow().as_ref().unwrap(), clone_flags)?;
+    let child_vmar = clone_vmar(thread_local.vmar().borrow().as_ref().unwrap(), clone_flags);
 
     // Clone the user context
     #[cfg_attr(target_arch = "x86_64", expect(unused_mut))]
@@ -669,13 +669,13 @@ fn clone_parent_settid(
     Ok(())
 }
 
-fn clone_vmar(parent_vmar: &VmarHandle, clone_flags: CloneFlags) -> Result<VmarHandle> {
+fn clone_vmar(parent_vmar: &VmarHandle, clone_flags: CloneFlags) -> VmarHandle {
     // If CLONE_VM is set, the child and parent share the same VMAR.
     // Otherwise, the child has a copy of the parent's VMAR.
     if clone_flags.contains(CloneFlags::CLONE_VM) {
-        Ok(parent_vmar.clone_handle())
+        parent_vmar.clone_handle()
     } else {
-        Ok(Vmar::fork_from(parent_vmar)?)
+        Vmar::fork_from(parent_vmar)
     }
 }
 

--- a/kernel/core/src/process/process_vm/heap.rs
+++ b/kernel/core/src/process/process_vm/heap.rs
@@ -142,8 +142,7 @@ impl Heap {
         // `mmap`, or `munmap`. Like Linux, shrinking removes every mapping in the released
         // tail regardless of those boundaries.
         if new_size < old_size {
-            vmar.remove_mapping(new_heap_end_aligned..current_heap_end_aligned)
-                .map_err(|_| current_heap_end)?;
+            vmar.remove_mapping(new_heap_end_aligned..current_heap_end_aligned);
         } else {
             let expansion_size = new_size - old_size;
             let expansion_start = heap_start + old_size;

--- a/kernel/core/src/process/process_vm/heap.rs
+++ b/kernel/core/src/process/process_vm/heap.rs
@@ -77,7 +77,6 @@ impl Heap {
         let vmar_map_options = {
             let perms = VmPerms::READ | VmPerms::WRITE;
             vmar.new_map(PAGE_SIZE, perms)
-                .unwrap()
                 .offset(VmarMapOffset::FixedNoReplace(heap_start))
         };
         vmar_map_options.build()?;
@@ -156,7 +155,6 @@ impl Heap {
             let vmar_map_options = {
                 let perms = VmPerms::READ | VmPerms::WRITE;
                 vmar.new_map(expansion_size, perms)
-                    .map_err(|_| current_heap_end)?
                     .offset(VmarMapOffset::FixedNoReplace(expansion_start))
             };
             vmar_map_options.build().map_err(|_| current_heap_end)?;

--- a/kernel/core/src/process/process_vm/init_stack/mod.rs
+++ b/kernel/core/src/process/process_vm/init_stack/mod.rs
@@ -188,7 +188,7 @@ impl InitStack {
             let perms = VmPerms::READ | VmPerms::WRITE;
             let map_addr = self.initial_top - self.max_size;
             debug_assert!(map_addr.is_multiple_of(PAGE_SIZE));
-            vmar.new_map(self.max_size, perms)?
+            vmar.new_map(self.max_size, perms)
                 .offset(VmarMapOffset::FixedNoReplace(map_addr))
                 .vmo(vmo.clone())
         };

--- a/kernel/core/src/process/process_vm/mod.rs
+++ b/kernel/core/src/process/process_vm/mod.rs
@@ -84,7 +84,7 @@ pub(crate) struct ProcessVm {
 
 impl ProcessVm {
     /// Creates a new `ProcessVm` without mapping anything.
-    pub fn new(executable_path: Path) -> Self {
+    pub(crate) fn new(executable_path: Path) -> Self {
         Self {
             init_stack: InitStack::new(),
             heap: Heap::new_uninitialized(),

--- a/kernel/core/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/core/src/process/program_loader/elf/load_elf.rs
@@ -313,7 +313,7 @@ fn map_segment_vmos(
 
         // After acquiring a suitable range, we can remove the mapping and then
         // map each segment at the desired address.
-        vmar.remove_mapping(aligned_range.clone())?;
+        vmar.remove_mapping(aligned_range.clone());
 
         let start_offset = elf_va_range.start - elf_va_range_aligned.start;
         let end_offset = elf_va_range_aligned.end - elf_va_range.end;
@@ -340,7 +340,7 @@ fn map_segment_vmos(
 
         // After acquiring a suitable range, we can remove the mapping and then
         // map each segment at the desired address.
-        vmar.remove_mapping(elf_va_range_aligned.clone())?;
+        vmar.remove_mapping(elf_va_range_aligned.clone());
 
         elf_va_range.clone()
     };

--- a/kernel/core/src/process/program_loader/elf/load_elf.rs
+++ b/kernel/core/src/process/program_loader/elf/load_elf.rs
@@ -292,7 +292,7 @@ fn map_segment_vmos(
             if VMAR_CAP_ADDR - offset < map_size {
                 return_errno_with_message!(Errno::ENOMEM, "the mapping address is too large");
             }
-            vmar.new_map(map_size, VmPerms::empty())?
+            vmar.new_map(map_size, VmPerms::empty())
                 .align(align)
                 .offset(VmarMapOffset::FixedNoReplace(offset))
         } else {
@@ -307,7 +307,7 @@ fn map_segment_vmos(
             // Reference: <https://elixir.bootlin.com/linux/v6.16.9/source/fs/binfmt_elf.c#L1293>
             heap_base = Some(PIE_BASE_ADDR);
 
-            vmar.new_map(map_size, VmPerms::empty())?.align(align)
+            vmar.new_map(map_size, VmPerms::empty()).align(align)
         };
         let aligned_range = vmar_map_options.build().map(|addr| addr..addr + map_size)?;
 
@@ -334,7 +334,7 @@ fn map_segment_vmos(
             elf_va_range.start.align_down(PAGE_SIZE)..elf_va_range.end.align_up(PAGE_SIZE);
         let map_size = elf_va_range_aligned.len();
 
-        vmar.new_map(map_size, VmPerms::empty())?
+        vmar.new_map(map_size, VmPerms::empty())
             .offset(VmarMapOffset::FixedNoReplace(elf_va_range_aligned.start))
             .build()?;
 
@@ -421,7 +421,7 @@ fn map_segment_vmo(
 
     if segment_size != 0 {
         let vm_map_options = vmar
-            .new_map(segment_size, perms)?
+            .new_map(segment_size, perms)
             .mappable(elf_file)?
             .vmo_offset(segment_offset)
             .offset(VmarMapOffset::FixedReplace(offset))
@@ -448,7 +448,7 @@ fn map_segment_vmo(
     let anonymous_map_size = total_map_size - segment_size;
     if anonymous_map_size > 0 {
         let anonymous_map_options = vmar
-            .new_map(anonymous_map_size, perms)?
+            .new_map(anonymous_map_size, perms)
             .offset(VmarMapOffset::FixedReplace(offset + segment_size));
         anonymous_map_options.build()?;
     }
@@ -499,7 +499,6 @@ fn map_vdso_to_vmar(vmar: &Vmar) -> Option<Vaddr> {
 
     let options = vmar
         .new_map(VDSO_VMO_LAYOUT.size, VmPerms::empty())
-        .unwrap()
         .vmo(vdso_vmo);
 
     let vdso_vmo_base = options.build().unwrap();

--- a/kernel/core/src/syscall/mmap.rs
+++ b/kernel/core/src/syscall/mmap.rs
@@ -76,7 +76,7 @@ fn do_sys_mmap(
     let user_space = ctx.user_space();
     let vmar = user_space.vmar();
     let vm_map_options = {
-        let mut options = vmar.new_map(len, vm_perms)?;
+        let mut options = vmar.new_map(len, vm_perms);
 
         if option.flags().is_fixed() {
             if option.flags().contains(MMapFlags::MAP_FIXED_NOREPLACE) {

--- a/kernel/core/src/syscall/munmap.rs
+++ b/kernel/core/src/syscall/munmap.rs
@@ -21,7 +21,7 @@ pub(super) fn sys_munmap(addr: Vaddr, len: usize, ctx: &Context) -> Result<Sysca
 
     let user_space = ctx.user_space();
     let vmar = user_space.vmar();
-    vmar.remove_mapping(addr_range)?;
+    vmar.remove_mapping(addr_range);
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/core/src/thread/kernel_thread.rs
+++ b/kernel/core/src/thread/kernel_thread.rs
@@ -162,7 +162,6 @@ mod tests {
         let vmo = VmoOptions::new(map_size).alloc().unwrap();
         assert_eq!(
             vmar.new_map(map_size, VmPerms::READ | VmPerms::WRITE)
-                .unwrap()
                 .offset(VmarMapOffset::FixedNoReplace(map_addr))
                 .vmo(vmo)
                 .build()

--- a/kernel/core/src/vm/vmar/vmar_impls/fork.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/fork.rs
@@ -15,7 +15,7 @@ use crate::{prelude::*, process::ProcessVm, vm::vmar::VmarHandle};
 impl Vmar {
     /// Creates a new VMAR whose content is inherited from another
     /// using copy-on-write (COW) technique.
-    pub(crate) fn fork_from(vmar: &Self) -> Result<VmarHandle> {
+    pub(crate) fn fork_from(vmar: &Self) -> VmarHandle {
         // Obtain the heap lock and hold it for the entire method to avoid race conditions.
         let heap_guard = vmar.process_vm.heap().lock();
 
@@ -67,7 +67,7 @@ impl Vmar {
             }
         }
 
-        Ok(new_vmar)
+        new_vmar
     }
 }
 

--- a/kernel/core/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/map.rs
@@ -291,7 +291,7 @@ impl<'a> VmarMapOptions<'a> {
                     map_to_addr,
                     map_size,
                     &mut rss_delta,
-                )?;
+                );
                 map_to_addr
             }
             VmarMapOffset::FixedNoReplace(map_to_addr) => {

--- a/kernel/core/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/map.rs
@@ -33,7 +33,6 @@ impl Vmar {
     ///     .vmar()
     ///     // Create a read-only mapping spanning four pages
     ///     .new_map(PAGE_SIZE * 4, VmPerms::READ)
-    ///     .unwrap()
     ///     // Provide an optional offset for the mapping inside the VMAR
     ///     .offset(VmarMapOffset::FixedNoReplace(target_vaddr))
     ///     // Specify an optional binding VMO
@@ -48,8 +47,8 @@ impl Vmar {
     /// ```
     ///
     /// For more details on the available options, see [`VmarMapOptions`].
-    pub(crate) fn new_map(&self, size: usize, perms: VmPerms) -> Result<VmarMapOptions<'_>> {
-        Ok(VmarMapOptions::new(self, size, perms))
+    pub(crate) fn new_map(&self, size: usize, perms: VmPerms) -> VmarMapOptions<'_> {
+        VmarMapOptions::new(self, size, perms)
     }
 }
 

--- a/kernel/core/src/vm/vmar/vmar_impls/map.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/map.rs
@@ -395,7 +395,7 @@ impl<'a> VmarMapOptions<'a> {
         }
         debug_assert!(self.vmo_offset.is_multiple_of(self.align));
         if !self.vmo_offset.is_multiple_of(self.align) {
-            return_errno_with_message!(Errno::EINVAL, "invalid vmo offset");
+            return_errno_with_message!(Errno::EINVAL, "invalid VMO offset");
         }
         match self.offset {
             VmarMapOffset::FixedReplace(offset)
@@ -407,11 +407,9 @@ impl<'a> VmarMapOptions<'a> {
                 }
             }
             #[cfg(target_arch = "x86_64")]
-            VmarMapOffset::Map32Bit(offset_opt) => {
-                let Some(offset) = offset_opt else {
-                    return Ok(());
-                };
-
+            VmarMapOffset::Map32Bit(None) => (),
+            #[cfg(target_arch = "x86_64")]
+            VmarMapOffset::Map32Bit(Some(offset)) => {
                 debug_assert!(offset.is_multiple_of(self.align));
                 if !offset.is_multiple_of(self.align) {
                     return_errno_with_message!(Errno::EINVAL, "invalid offset");

--- a/kernel/core/src/vm/vmar/vmar_impls/mod.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/mod.rs
@@ -380,8 +380,9 @@ impl VmarInner {
         offset: Vaddr,
         size: usize,
         rss_delta: &mut RssDelta,
-    ) -> Result<Range<Vaddr>> {
+    ) -> Range<Vaddr> {
         let range = offset..offset + size;
+
         let mut mappings_to_remove = Vec::new();
         for vm_mapping in self.vm_mappings.find(&range) {
             mappings_to_remove.push(vm_mapping.map_to_addr());
@@ -410,7 +411,7 @@ impl VmarInner {
             rss_delta.add(taken.rss_type(), -(taken.unmap(&vmar.vm_space) as isize));
         }
 
-        Ok(offset..(offset + size))
+        range
     }
 
     /// Allocates a free region for mapping, searching from high address to low address.
@@ -526,7 +527,7 @@ impl VmarInner {
                 map_addr + new_size,
                 old_size - new_size,
                 rss_delta,
-            )?;
+            );
             return Ok(());
         }
 

--- a/kernel/core/src/vm/vmar/vmar_impls/remap.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/remap.rs
@@ -122,7 +122,7 @@ impl Vmar {
                 old_addr + new_size,
                 old_size - new_size,
                 &mut rss_delta,
-            )?;
+            );
             (new_size, old_addr..old_addr + new_size)
         } else {
             (old_size, old_addr..old_addr + old_size)
@@ -143,7 +143,8 @@ impl Vmar {
                     "remap: the new range overlaps with the old one"
                 );
             }
-            inner.alloc_free_region_exact_truncate(self, new_addr, new_size, &mut rss_delta)?
+
+            inner.alloc_free_region_exact_truncate(self, new_addr, new_size, &mut rss_delta)
         } else {
             // Fast path: expand the old mapping in place to the new size.
             // Skip when `action` is `RemapOldMappingAction::Keep` since we must

--- a/kernel/core/src/vm/vmar/vmar_impls/unmap.rs
+++ b/kernel/core/src/vm/vmar/vmar_impls/unmap.rs
@@ -41,14 +41,13 @@ impl Vmar {
     ///
     /// Mappings may fall partially within the range; only the overlapped
     /// portions of the mappings are unmapped.
-    pub(crate) fn remove_mapping(&self, range: Range<usize>) -> Result<()> {
+    pub(crate) fn remove_mapping(&self, range: Range<usize>) {
         debug_assert!(range.start.is_multiple_of(PAGE_SIZE));
         debug_assert!(range.end.is_multiple_of(PAGE_SIZE));
 
         let mut inner = self.inner.write();
         let mut rss_delta = RssDelta::new(self);
-        inner.alloc_free_region_exact_truncate(self, range.start, range.len(), &mut rss_delta)?;
-        Ok(())
+        inner.alloc_free_region_exact_truncate(self, range.start, range.len(), &mut rss_delta);
     }
 
     /// Discards all pages in the mappings that fall within the specified


### PR DESCRIPTION
https://github.com/asterinas/asterinas/pull/3716#pullrequestreview-4945881387

There seem to be many infallible methods that return `Ok`. Therefore, the exact purpose is unclear.

I think we can remove `Ok()` from the return type, which makes some code cleaner.

Also, while doing this, I found `check_perms` are being skipped in the `Map32Bit(None)`, and I don't believe it is on purpose. So I fix it as well.