### PR TITLE
Clear IOPL in RFLAGS before returning to user space

### DIFF
--- a/kernel/core/src/arch/x86/cpu.rs
+++ b/kernel/core/src/arch/x86/cpu.rs
@@ -6,7 +6,10 @@ use core::{arch::x86_64::CpuidResult, ffi::CStr, fmt, str};
 use ostd::{
     arch::{
         cpu::{
-            context::{CpuException, PageFaultErrorCode, RawPageFaultInfo, UserContext},
+            context::{
+                CpuException, PageFaultErrorCode, RawPageFaultInfo, USER_MODIFIABLE_RFLAGS,
+                UserContext,
+            },
             cpuid::cpuid,
         },
         tsc_freq,
@@ -16,11 +19,18 @@ use ostd::{
     sync::SpinLock,
     task::DisabledPreemptGuard,
 };
+use x86_64::registers::rflags::RFlags;
 
 use crate::{
     cpu::LinuxAbi,
     vm::{perms::VmPerms, vmar::PageFaultInfo},
 };
+
+// RFLAGS bits that Linux restores from a user signal frame.
+//
+// Reference: <https://elixir.bootlin.com/linux/v7.1/source/arch/x86/include/asm/sighandling.h#L11-L14>.
+const SIGRETURN_RFLAGS_MASK: usize =
+    USER_MODIFIABLE_RFLAGS & !(RFlags::NESTED_TASK.bits() as usize);
 
 impl LinuxAbi for UserContext {
     fn syscall_num(&self) -> usize {
@@ -106,7 +116,6 @@ macro_rules! copy_gp_regs {
         $dst.r14 = $src.r14;
         $dst.r15 = $src.r15;
         $dst.rip = $src.rip;
-        $dst.rflags = $src.rflags;
     };
 }
 
@@ -114,11 +123,15 @@ impl SigContext {
     pub(crate) fn copy_user_regs_to(&self, dst: &mut UserContext) {
         let gp_regs = dst.general_regs_mut();
         copy_gp_regs!(self, gp_regs);
+        dst.set_rflags(
+            (dst.rflags() & !SIGRETURN_RFLAGS_MASK) | (self.rflags & SIGRETURN_RFLAGS_MASK),
+        );
     }
 
     pub(crate) fn copy_user_regs_from(&mut self, src: &UserContext) {
         let gp_regs = src.general_regs();
         copy_gp_regs!(gp_regs, self);
+        self.rflags = src.rflags();
 
         // TODO: Fill exception information in `SigContext`.
     }

--- a/kernel/core/src/arch/x86/ptrace.rs
+++ b/kernel/core/src/arch/x86/ptrace.rs
@@ -6,7 +6,7 @@ use core::ops::Range;
 
 use ostd::{
     arch::{
-        cpu::context::{FsBase, GeneralRegs, GsBase},
+        cpu::context::{FsBase, GeneralRegs, GsBase, UserContext},
         trap::{USER_CS_VALUE, USER_SS_VALUE},
     },
     mm::MAX_USERSPACE_VADDR,
@@ -59,16 +59,21 @@ impl CUserRegsStruct {
     ///
     /// `orig_rax` is left at zero. Callers needing the syscall-entry
     /// value should assign it from `ThreadLocal::orig_syscall_ret`.
-    pub(crate) fn from_regs(general_regs: &GeneralRegs, fs_base: FsBase, gs_base: GsBase) -> Self {
+    pub(crate) fn from_regs(user_context: &UserContext, fs_base: FsBase, gs_base: GsBase) -> Self {
         let mut out = Self::default();
         let bytes = out.as_mut_bytes();
         for rule in REG_RULES {
             let value = match rule.policy {
                 Policy::Fixed(val) => val,
-                _ => (rule.get.unwrap())(general_regs),
+                _ => (rule.get.unwrap())(user_context.general_regs()),
             };
             write_word(bytes, rule.offset, value);
         }
+        write_word(
+            bytes,
+            core::mem::offset_of!(CUserRegsStruct, rflags),
+            user_context.rflags(),
+        );
         write_word(
             bytes,
             core::mem::offset_of!(CUserRegsStruct, fsbase),
@@ -92,16 +97,19 @@ impl CUserRegsStruct {
     /// Returns `EIO` on any invalid value.
     pub(crate) fn apply_to(
         &self,
-        general_regs: &mut GeneralRegs,
+        user_context: &mut UserContext,
         fs_base: &mut FsBase,
         gs_base: &mut GsBase,
     ) -> Result<()> {
         let bytes = self.as_bytes();
-        let mut new_general_regs = *general_regs;
+
+        let mut new_general_regs = *user_context.general_regs();
         for rule in REG_RULES {
             let value = read_word(bytes, rule.offset);
             rule.apply(&mut new_general_regs, value)?;
         }
+
+        let rflags = read_word(bytes, core::mem::offset_of!(CUserRegsStruct, rflags));
 
         let fsbase = read_word(bytes, core::mem::offset_of!(CUserRegsStruct, fsbase));
         if !is_user_addr(fsbase) {
@@ -113,7 +121,8 @@ impl CUserRegsStruct {
             return_errno_with_message!(Errno::EIO, "invalid register value");
         }
 
-        *general_regs = new_general_regs;
+        *user_context.general_regs_mut() = new_general_regs;
+        user_context.set_rflags(rflags);
         *fs_base = FsBase::new(fsbase);
         *gs_base = GsBase::new(gsbase);
         Ok(())
@@ -122,13 +131,16 @@ impl CUserRegsStruct {
 
 /// Reads one word from the x86-64 USER area at `offset`.
 pub(crate) fn read_user_word(
-    general_regs: &GeneralRegs,
+    user_context: &UserContext,
     fs_base: FsBase,
     gs_base: GsBase,
     orig_rax: usize,
     offset: usize,
 ) -> Result<usize> {
     check_user_offset(offset)?;
+    if offset == core::mem::offset_of!(CUserRegsStruct, rflags) {
+        return Ok(user_context.rflags());
+    }
     if offset == core::mem::offset_of!(CUserRegsStruct, fsbase) {
         return Ok(fs_base.addr());
     }
@@ -157,13 +169,13 @@ pub(crate) fn read_user_word(
         RegRule::for_offset(offset).expect("offset has been validated by `check_user_offset`");
     Ok(match rule.policy {
         Policy::Fixed(value) => value,
-        _ => (rule.get.unwrap())(general_regs),
+        _ => (rule.get.unwrap())(user_context.general_regs()),
     })
 }
 
 /// Writes one word to the x86-64 USER area at `offset`.
 pub(crate) fn write_user_word(
-    general_regs: &mut GeneralRegs,
+    user_context: &mut UserContext,
     fs_base: &mut FsBase,
     gs_base: &mut GsBase,
     orig_rax: &mut usize,
@@ -171,6 +183,10 @@ pub(crate) fn write_user_word(
     value: usize,
 ) -> Result<()> {
     check_user_offset(offset)?;
+    if offset == core::mem::offset_of!(CUserRegsStruct, rflags) {
+        user_context.set_rflags(value);
+        return Ok(());
+    }
     if offset == core::mem::offset_of!(CUserRegsStruct, fsbase) {
         if !is_user_addr(value) {
             return_errno_with_message!(Errno::EIO, "invalid register value");
@@ -198,17 +214,17 @@ pub(crate) fn write_user_word(
 
     let rule =
         RegRule::for_offset(offset).expect("offset has been validated by `check_user_offset`");
-    rule.apply(general_regs, value)
+    rule.apply(user_context.general_regs_mut(), value)
 }
 
 /// Enables x86-64 single-step execution by setting the trap flag.
-pub(crate) fn enable_single_step(regs: &mut GeneralRegs) {
-    regs.rflags |= RFlags::TRAP_FLAG.bits() as usize;
+pub(crate) fn enable_single_step(user_context: &mut UserContext) {
+    user_context.set_rflags(user_context.rflags() | RFlags::TRAP_FLAG.bits() as usize);
 }
 
 /// Disables x86-64 single-step execution by clearing the trap flag.
-pub(crate) fn disable_single_step(regs: &mut GeneralRegs) {
-    regs.rflags &= !(RFlags::TRAP_FLAG.bits() as usize);
+pub(crate) fn disable_single_step(user_context: &mut UserContext) {
+    user_context.set_rflags(user_context.rflags() & !(RFlags::TRAP_FLAG.bits() as usize));
 }
 
 // =====================================================================
@@ -256,13 +272,6 @@ const REG_RULES: &[RegRule] = &[
         |r, v| r.rip = v,
         Policy::SetIf(is_user_addr),
     ),
-    // Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/arch/x86/kernel/ptrace.c#L369>
-    RegRule::rw(
-        off!(rflags),
-        |r| r.rflags,
-        |r, v| r.rflags = v,
-        Policy::SetBitsTruncate(USER_MODIFIABLE_RFLAGS_MASK),
-    ),
     // Asterinas does not run 32-bit user code,
     // so the segment selectors are always at fixed values.
     RegRule::fixed(off!(cs), USER_CS_VALUE),
@@ -274,7 +283,7 @@ const REG_RULES: &[RegRule] = &[
 ];
 
 const _: () = {
-    assert!((REG_RULES.len() + 3) * size_of::<usize>() == size_of::<CUserRegsStruct>());
+    assert!((REG_RULES.len() + 4) * size_of::<usize>() == size_of::<CUserRegsStruct>());
 };
 
 /// One rule for a single register inside `CUserRegsStruct`.
@@ -332,10 +341,6 @@ impl RegRule {
                 }
                 (self.set.unwrap())(regs, value);
             }
-            Policy::SetBitsTruncate(mask) => {
-                let current = (self.get.unwrap())(regs);
-                (self.set.unwrap())(regs, (current & !mask) | (value & mask));
-            }
             Policy::Fixed(expected) => {
                 if value != expected {
                     return_errno_with_message!(Errno::EIO, "invalid fixed register value");
@@ -353,8 +358,6 @@ enum Policy {
     Set,
     /// Set only if the predicate accepts the value.
     SetIf(fn(usize) -> bool),
-    /// Replace only the bits in the mask, preserve the rest.
-    SetBitsTruncate(usize),
     /// The field is fixed at the expected value.
     Fixed(usize),
 }
@@ -362,21 +365,6 @@ enum Policy {
 const fn is_user_addr(v: usize) -> bool {
     v < MAX_USERSPACE_VADDR
 }
-
-/// RFLAGS bits the user may modify via ptrace.
-//
-// Reference: <https://elixir.bootlin.com/linux/v6.16.5/source/arch/x86/kernel/ptrace.c#L241>.
-const USER_MODIFIABLE_RFLAGS_MASK: usize = (RFlags::CARRY_FLAG.bits()
-    | RFlags::PARITY_FLAG.bits()
-    | RFlags::AUXILIARY_CARRY_FLAG.bits()
-    | RFlags::ZERO_FLAG.bits()
-    | RFlags::SIGN_FLAG.bits()
-    | RFlags::TRAP_FLAG.bits()
-    | RFlags::DIRECTION_FLAG.bits()
-    | RFlags::OVERFLOW_FLAG.bits()
-    | RFlags::RESUME_FLAG.bits()
-    | RFlags::ALIGNMENT_CHECK.bits()
-    | RFlags::NESTED_TASK.bits()) as usize;
 
 /// Checks whether the given offset is valid in `struct user`.
 //

--- a/kernel/core/src/process/execve.rs
+++ b/kernel/core/src/process/execve.rs
@@ -4,7 +4,7 @@ use aster_rights::ReadWriteOp;
 #[cfg(target_arch = "x86_64")]
 use ostd::arch::cpu::context::{FsBase, GsBase};
 use ostd::{
-    arch::cpu::context::{FpuContext, GeneralRegs, UserContext},
+    arch::cpu::context::{FpuContext, UserContext},
     mm::VmIo,
     sync::Waiter,
     user::UserContextApi,
@@ -325,16 +325,15 @@ fn set_cpu_context(
     // Reset FPU context.
     supp.fpu().set(FpuContext::new());
 
-    // Reset general-purpose registers.
-    *user_context.general_regs_mut() = GeneralRegs::default();
     // Clear the TLS pointer.
     #[cfg(target_arch = "x86_64")]
     {
         supp.fs_base().set(FsBase::default());
         supp.gs_base().set(GsBase::default());
     }
-    #[cfg(not(target_arch = "x86_64"))]
-    user_context.set_tls_pointer(0);
+
+    // Reset the user register context.
+    *user_context = UserContext::default();
 
     // Set the new instruction pointer to the ELF entry point.
     user_context.set_instruction_pointer(elf_load_info.entry_point as _);

--- a/kernel/core/src/process/posix_thread/ptrace/mod.rs
+++ b/kernel/core/src/process/posix_thread/ptrace/mod.rs
@@ -5,7 +5,7 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_arch = "x86_64")]
-use ostd::arch::cpu::context::{FsBase, GeneralRegs, GsBase};
+use ostd::arch::cpu::context::{FsBase, GsBase};
 use ostd::{arch::cpu::context::UserContext, sync::Waiter};
 
 use super::{AsPosixThread, PosixThread};
@@ -377,8 +377,8 @@ impl TraceeStatus {
         state.tracer = Weak::new();
         #[cfg(target_arch = "x86_64")]
         {
-            if let Some(regs) = state.general_regs.as_mut() {
-                arch_ptrace::disable_single_step(regs);
+            if let Some(user_context) = state.user_context.as_mut() {
+                arch_ptrace::disable_single_step(user_context);
             }
         }
         state.is_tracing_syscall = false;
@@ -490,7 +490,7 @@ impl TraceeStatus {
             let supp = ctx.thread_local.supp_user_context();
             state.fs_base = Some(supp.fs_base().get());
             state.gs_base = Some(supp.gs_base().get());
-            state.general_regs = Some(*user_ctx.general_regs());
+            state.user_context = Some(user_ctx.clone());
             state.set_orig_syscall_ret(ctx.thread_local.orig_syscall_ret());
         }
         self.is_stopped.store(true, Ordering::Relaxed);
@@ -518,7 +518,7 @@ impl TraceeStatus {
             state.event = None;
             #[cfg(target_arch = "x86_64")]
             {
-                state.general_regs = None;
+                state.user_context = None;
                 state.fs_base = None;
                 state.gs_base = None;
                 state.clear_orig_syscall_ret();
@@ -534,8 +534,7 @@ impl TraceeStatus {
 
         #[cfg(target_arch = "x86_64")]
         {
-            let general_regs = state.general_regs.take().unwrap();
-            *user_ctx.general_regs_mut() = general_regs;
+            *user_ctx = state.user_context.take().unwrap();
             let supp = ctx.thread_local.supp_user_context();
             supp.fs_base().set(state.fs_base.take().unwrap());
             supp.gs_base().set(state.gs_base.take().unwrap());
@@ -603,11 +602,11 @@ impl TraceeStatus {
 
         #[cfg(target_arch = "x86_64")]
         {
-            let regs = state.general_regs.as_mut().unwrap();
+            let user_context = state.user_context.as_mut().unwrap();
             if matches!(request, PtraceContRequest::SingleStep(_)) {
-                arch_ptrace::enable_single_step(regs);
+                arch_ptrace::enable_single_step(user_context);
             } else {
-                arch_ptrace::disable_single_step(regs);
+                arch_ptrace::disable_single_step(user_context);
             }
         }
 
@@ -624,10 +623,10 @@ impl TraceeStatus {
         let state = self.state.lock();
         self.check_ptrace_stopped(&state)?;
 
-        let general_regs = state.general_regs.as_ref().unwrap();
+        let user_context = state.user_context.as_ref().unwrap();
         let fs_base = state.fs_base.unwrap();
         let gs_base = state.gs_base.unwrap();
-        let mut regs = arch_ptrace::CUserRegsStruct::from_regs(general_regs, fs_base, gs_base);
+        let mut regs = arch_ptrace::CUserRegsStruct::from_regs(user_context, fs_base, gs_base);
         regs.orig_rax = state.orig_syscall_ret;
         Ok(regs)
     }
@@ -639,13 +638,13 @@ impl TraceeStatus {
         self.check_ptrace_stopped(&state)?;
 
         let TraceeState {
-            general_regs,
+            user_context,
             fs_base,
             gs_base,
             ..
         } = &mut *state;
         regs.apply_to(
-            general_regs.as_mut().unwrap(),
+            user_context.as_mut().unwrap(),
             fs_base.as_mut().unwrap(),
             gs_base.as_mut().unwrap(),
         )?;
@@ -659,11 +658,11 @@ impl TraceeStatus {
         // Hold the lock first to avoid race conditions.
         let state = self.state.lock();
         self.check_ptrace_stopped(&state)?;
-        let general_regs = state.general_regs.as_ref().unwrap();
+        let user_context = state.user_context.as_ref().unwrap();
         let fs_base = state.fs_base.unwrap();
         let gs_base = state.gs_base.unwrap();
         arch_ptrace::read_user_word(
-            general_regs,
+            user_context,
             fs_base,
             gs_base,
             state.orig_syscall_ret,
@@ -678,13 +677,13 @@ impl TraceeStatus {
         self.check_ptrace_stopped(&state)?;
         let mut orig_syscall_ret = state.orig_syscall_ret;
         let TraceeState {
-            general_regs,
+            user_context,
             fs_base,
             gs_base,
             ..
         } = &mut *state;
         arch_ptrace::write_user_word(
-            general_regs.as_mut().unwrap(),
+            user_context.as_mut().unwrap(),
             fs_base.as_mut().unwrap(),
             gs_base.as_mut().unwrap(),
             &mut orig_syscall_ret,
@@ -769,9 +768,9 @@ struct TraceeState {
     options: PtraceOptions,
     /// Whether the tracee should stop at the next syscall enter or exit.
     is_tracing_syscall: bool,
-    /// The general-purpose registers of the tracee at the time of ptrace-stop.
+    /// The user register context of the tracee at the time of ptrace-stop.
     #[cfg(target_arch = "x86_64")]
-    general_regs: Option<GeneralRegs>,
+    user_context: Option<UserContext>,
     /// The FS base of the tracee at the time of ptrace-stop.
     #[cfg(target_arch = "x86_64")]
     fs_base: Option<FsBase>,
@@ -793,7 +792,7 @@ impl TraceeState {
             options: PtraceOptions::empty(),
             is_tracing_syscall: false,
             #[cfg(target_arch = "x86_64")]
-            general_regs: None,
+            user_context: None,
             #[cfg(target_arch = "x86_64")]
             fs_base: None,
             #[cfg(target_arch = "x86_64")]

--- a/kernel/core/src/process/signal/mod.rs
+++ b/kernel/core/src/process/signal/mod.rs
@@ -471,7 +471,7 @@ pub(crate) fn handle_user_signal(
         target_arch = "x86_64" => {
             // Clear the DF flag. This is to conform to x86-64 calling conventions.
             const X86_RFLAGS_DF: usize = 1 << 10; // Bit 10 is the DF flag.
-            user_ctx.general_regs_mut().rflags &= !X86_RFLAGS_DF;
+            user_ctx.set_rflags(user_ctx.rflags() & !X86_RFLAGS_DF);
         }
         _ => {},
     }

--- a/ostd/src/arch/loongarch/cpu/context.rs
+++ b/ostd/src/arch/loongarch/cpu/context.rs
@@ -107,29 +107,33 @@ impl Default for UserContext {
 }
 
 impl UserContext {
+    // Methods shared across all architectures (i.e., general registers and exceptions).
+
     /// Returns a reference to the general registers.
     pub fn general_regs(&self) -> &GeneralRegs {
         &self.user_context.general
     }
 
-    /// Returns a mutable reference to the general registers
+    /// Returns a mutable reference to the general registers.
     pub fn general_regs_mut(&mut self) -> &mut GeneralRegs {
         &mut self.user_context.general
     }
 
-    /// Returns the trap information.
+    /// Takes the CPU exception out.
     pub fn take_exception(&mut self) -> Option<CpuExceptionInfo> {
         self.cpu_exception_info.take()
     }
 
-    /// Sets the thread-local storage pointer.
-    pub fn set_tls_pointer(&mut self, tls: usize) {
-        self.set_tp(tls)
-    }
+    // Architecture-specific methods.
 
-    /// Gets the thread-local storage pointer.
+    /// Gets the value of the thread-local storage pointer.
     pub fn tls_pointer(&self) -> usize {
         self.tp()
+    }
+
+    /// Sets the value of the thread-local storage pointer.
+    pub fn set_tls_pointer(&mut self, tls: usize) {
+        self.set_tp(tls)
     }
 
     /// Enables floating-point unit.

--- a/ostd/src/arch/riscv/cpu/context.rs
+++ b/ostd/src/arch/riscv/cpu/context.rs
@@ -146,12 +146,14 @@ pub enum FaultInstruction {
 }
 
 impl UserContext {
+    // Methods shared across all architectures (i.e., general registers and exceptions).
+
     /// Returns a reference to the general registers.
     pub fn general_regs(&self) -> &GeneralRegs {
         &self.user_context.general
     }
 
-    /// Returns a mutable reference to the general registers
+    /// Returns a mutable reference to the general registers.
     pub fn general_regs_mut(&mut self) -> &mut GeneralRegs {
         &mut self.user_context.general
     }
@@ -161,14 +163,16 @@ impl UserContext {
         self.exception.take()
     }
 
-    /// Sets the thread-local storage pointer.
-    pub fn set_tls_pointer(&mut self, tls: usize) {
-        self.set_tp(tls)
-    }
+    // Architecture-specific methods.
 
-    /// Gets the thread-local storage pointer.
+    /// Gets the value of the thread-local storage pointer.
     pub fn tls_pointer(&self) -> usize {
         self.tp()
+    }
+
+    /// Sets the value of the thread-local storage pointer.
+    pub fn set_tls_pointer(&mut self, tls: usize) {
+        self.set_tp(tls)
     }
 }
 

--- a/ostd/src/arch/x86/cpu/context/mod.rs
+++ b/ostd/src/arch/x86/cpu/context/mod.rs
@@ -35,12 +35,52 @@ cfg_select! {
     }
 }
 
+/// RFLAGS bits that non-privileged code may modify.
+///
+/// This is the union of the flags that Linux allows `ptrace` and `rt_sigreturn`
+/// to modify. Because the set allowed by `rt_sigreturn` is a strict subset of
+/// the `ptrace` set (it excludes `NT`), this is effectively the set of flags
+/// that `ptrace` may modify.
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/arch/x86/include/asm/sighandling.h#L11-L14>.
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/arch/x86/kernel/ptrace.c#L158-L163>.
+pub const USER_MODIFIABLE_RFLAGS: usize = (RFlags::CARRY_FLAG.bits()
+    | RFlags::PARITY_FLAG.bits()
+    | RFlags::AUXILIARY_CARRY_FLAG.bits()
+    | RFlags::ZERO_FLAG.bits()
+    | RFlags::SIGN_FLAG.bits()
+    | RFlags::TRAP_FLAG.bits()
+    | RFlags::DIRECTION_FLAG.bits()
+    | RFlags::OVERFLOW_FLAG.bits()
+    | RFlags::RESUME_FLAG.bits()
+    | RFlags::ALIGNMENT_CHECK.bits()
+    | RFlags::NESTED_TASK.bits()) as usize;
+
 /// Userspace CPU context, including general-purpose registers and exception information.
 #[repr(C)]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct UserContext {
     user_context: RawUserContext,
     exception: Option<CpuException>,
+}
+
+impl Default for UserContext {
+    fn default() -> Self {
+        // RFLAGS bit 1 is reserved, and Linux always sets it to 1 on x86.
+        // Set the interrupt flag to enable the reception of external interrupts in user mode.
+        // Set the ID flag to indicate that the CPU supports the CPUID instruction.
+        const USER_MODE_INITIAL_RFLAGS: usize =
+            (1 << 1) | (RFlags::INTERRUPT_FLAG.bits() | RFlags::ID.bits()) as usize;
+
+        Self {
+            user_context: RawUserContext {
+                general: GeneralRegs::default(),
+                rflags: USER_MODE_INITIAL_RFLAGS,
+                trap_num: 0,
+                error_code: 0,
+            },
+            exception: None,
+        }
+    }
 }
 
 /// General registers.
@@ -65,7 +105,6 @@ pub struct GeneralRegs {
     pub r14: usize,
     pub r15: usize,
     pub rip: usize,
-    pub rflags: usize,
 }
 
 /// The user-mode FS base register.
@@ -286,12 +325,14 @@ impl CpuException {
 pub struct SelectorErrorCode(usize);
 
 impl UserContext {
+    // Methods shared across all architectures (i.e., general registers and exceptions).
+
     /// Returns a reference to the general registers.
     pub fn general_regs(&self) -> &GeneralRegs {
         &self.user_context.general
     }
 
-    /// Returns a mutable reference to the general registers
+    /// Returns a mutable reference to the general registers.
     pub fn general_regs_mut(&mut self) -> &mut GeneralRegs {
         &mut self.user_context.general
     }
@@ -300,14 +341,26 @@ impl UserContext {
     pub fn take_exception(&mut self) -> Option<CpuException> {
         self.exception.take()
     }
+
+    // Architecture-specific methods.
+
+    /// Gets the value of the RFLAGS register.
+    pub fn rflags(&self) -> usize {
+        self.user_context.rflags
+    }
+
+    /// Sets the value of the RFLAGS register.
+    ///
+    /// We only allow the setting or clearing of the bits in [`USER_MODIFIABLE_RFLAGS`].
+    /// Any other bits will be ignored and will remain unchanged.
+    pub fn set_rflags(&mut self, rflags: usize) {
+        self.user_context.rflags = (self.user_context.rflags & !USER_MODIFIABLE_RFLAGS)
+            | (rflags & USER_MODIFIABLE_RFLAGS);
+    }
 }
 
 impl UserContextApiInternal for UserContext {
     fn execute<T: UserModeHooks>(&mut self, hooks: &T) -> ReturnReason {
-        // Set the interrupt flag to enable the reception of external interrupts in user mode.
-        // Set the ID flag to indicate that the CPU supports the CPUID instruction.
-        self.user_context.general.rflags |= (RFlags::INTERRUPT_FLAG | RFlags::ID).bits() as usize;
-
         const SYSCALL_TRAPNUM: usize = 0x100;
 
         // Return when it is syscall or cpu exception type is Fault or Trap.
@@ -382,7 +435,7 @@ impl UserContextApiInternal for UserContext {
             error_code: self.user_context.error_code,
             rip: self.user_context.general.rip,
             cs: 0,
-            rflags: self.user_context.general.rflags,
+            rflags: self.user_context.rflags,
             rsp: self.user_context.general.rsp,
             ss: 0,
         }
@@ -519,8 +572,7 @@ cpu_context_impl_getter_setter!(
     [r13, set_r13],
     [r14, set_r14],
     [r15, set_r15],
-    [rip, set_rip],
-    [rflags, set_rflags]
+    [rip, set_rip]
 );
 
 /// The FPU context of user task.

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -141,6 +141,7 @@ pub(crate) unsafe fn init_on_cpu() {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct RawUserContext {
     pub(super) general: GeneralRegs,
+    pub(super) rflags: usize,
     pub(super) trap_num: usize,
     pub(super) error_code: usize,
 }


### PR DESCRIPTION
Fixes #3781.

Clear the IOPL bits in the RFLAGS register every time before returning to userspace.

Additionally, the handling of the INTERRUPT_FLAG/ID/IOPL bits in RFLAGS has been consolidated to occur right before `self.user_context.run`, rather than at the entry point of `UserContext::execute`. This change is necessary because `UserContext::execute` is not re-executed every time control returns from userspace to the kernel—it's only re-executed when a kernel event occurs (e.g., upon receiving a signal). However, we need to guarantee that these RFLAGS bits are cleared every single time before entering userspace, regardless of whether `UserContext::execute` itself is re-executed.