### PR TITLE
Revert the temporary fix since dev containers are updated

### DIFF
--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -47,12 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # TODO: Remove this step after the next release includes Clang in the dev images.
-      - name: Install Clang temporarily
-        run: |
-          apt-get update
-          apt-get install -y clang
-
       - name: Run OSDK tests
         uses: ./.github/actions/test
         with:


### PR DESCRIPTION
#3736 Added this workaround to let CI pass. Now the dev images include clang and has been published. This workaround isn't necessary now.