### PR TITLE
Send current status flags in virtio-fs `FUSE_READDIR`

### DIFF
--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -641,3 +641,257 @@ fn do_seek_util(offset: &Mutex<usize>, pos: SeekFrom, end: Option<usize>) -> Res
     *offset = new_offset;
     Ok(new_offset)
 }
+
+#[cfg(ktest)]
+mod tests {
+    use core::time::Duration;
+
+    use device_id::DeviceId;
+    use ostd::prelude::ktest;
+
+    use super::*;
+    use crate::{
+        fs::{
+            file::{InodeMode, StatusFlagsUpdate},
+            vfs::{
+                file_system::{FileSystem, FsEventSubscriberStats, SuperBlock},
+                inode::{Extension, Inode, Metadata},
+                path::{Mount, PerMountFlags},
+                registry::FsAndRoot,
+            },
+        },
+        process::{Gid, Uid},
+    };
+
+    /// A mock inode that records the `status_flags` its `readdir_at` receives.
+    struct MockInode {
+        received_flags: Mutex<Option<StatusFlags>>,
+        bound_fs: Mutex<Option<Weak<MockFs>>>,
+        extension: Extension,
+    }
+
+    impl MockInode {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                received_flags: Mutex::new(None),
+                bound_fs: Mutex::new(None),
+                extension: Extension::new(),
+            })
+        }
+
+        /// Binds the inode to its enclosing mock file system.
+        ///
+        /// The binding is weak so that the inode does not keep the file system
+        /// alive: the file system owns the root inode, and a strong back
+        /// reference would form a reference cycle.
+        fn bind_fs(&self, fs: Weak<MockFs>) {
+            *self.bound_fs.lock() = Some(fs);
+        }
+    }
+
+    impl FileOps for MockInode {
+        fn read_at(
+            &self,
+            _offset: usize,
+            _writer: &mut VmWriter,
+            _status_flags: StatusFlags,
+        ) -> Result<usize> {
+            return_errno_with_message!(Errno::EISDIR, "the mock inode is a directory");
+        }
+
+        fn write_at(
+            &self,
+            _offset: usize,
+            _reader: &mut VmReader,
+            _status_flags: StatusFlags,
+        ) -> Result<usize> {
+            return_errno_with_message!(Errno::EISDIR, "the mock inode is a directory");
+        }
+
+        fn readdir_at(
+            &self,
+            _offset: usize,
+            _visitor: &mut dyn DirentVisitor,
+            status_flags: StatusFlags,
+        ) -> Result<usize> {
+            *self.received_flags.lock() = Some(status_flags);
+            Ok(0)
+        }
+    }
+
+    impl Inode for MockInode {
+        fn size(&self) -> usize {
+            0
+        }
+
+        fn resize(&self, _new_size: usize) -> Result<()> {
+            Ok(())
+        }
+
+        fn metadata(&self) -> Result<Metadata> {
+            Ok(Metadata {
+                ino: 1,
+                size: 0,
+                optimal_block_size: PAGE_SIZE,
+                nr_sectors_allocated: 0,
+                last_access_at: Duration::ZERO,
+                last_modify_at: Duration::ZERO,
+                last_meta_change_at: Duration::ZERO,
+                type_: InodeType::Dir,
+                mode: InodeMode::from_bits_truncate(0o755),
+                nr_hard_links: 1,
+                uid: Uid::new_root(),
+                gid: Gid::new_root(),
+                container_dev_id: DeviceId::null(),
+                self_dev_id: None,
+                birth_at: None,
+            })
+        }
+
+        fn ino(&self) -> u64 {
+            1
+        }
+
+        fn type_(&self) -> InodeType {
+            InodeType::Dir
+        }
+
+        fn mode(&self) -> Result<InodeMode> {
+            Ok(InodeMode::from_bits_truncate(0o755))
+        }
+
+        fn set_mode(&self, _mode: InodeMode) -> Result<()> {
+            Ok(())
+        }
+
+        fn owner(&self) -> Result<Uid> {
+            Ok(Uid::new_root())
+        }
+
+        fn set_owner(&self, _uid: Uid) -> Result<()> {
+            Ok(())
+        }
+
+        fn group(&self) -> Result<Gid> {
+            Ok(Gid::new_root())
+        }
+
+        fn set_group(&self, _gid: Gid) -> Result<()> {
+            Ok(())
+        }
+
+        fn atime(&self) -> Duration {
+            Duration::ZERO
+        }
+
+        fn set_atime(&self, _time: Duration) {}
+
+        fn mtime(&self) -> Duration {
+            Duration::ZERO
+        }
+
+        fn set_mtime(&self, _time: Duration) {}
+
+        fn ctime(&self) -> Duration {
+            Duration::ZERO
+        }
+
+        fn set_ctime(&self, _time: Duration) {}
+
+        fn fs(&self) -> Arc<dyn FileSystem> {
+            // The VFS may consult `fs()` after the test body completes (e.g.,
+            // the fsnotify hooks in `FileCommon`'s drop), so the mock must be
+            // properly bound instead of panicking.
+            self.bound_fs
+                .lock()
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .expect("the mock file system is still alive")
+        }
+
+        fn extension(&self) -> &Extension {
+            &self.extension
+        }
+    }
+
+    /// A mock file system whose root inode is a [`MockInode`].
+    struct MockFs {
+        root: Arc<MockInode>,
+        sb: SuperBlock,
+        fs_event_subscriber_stats: FsEventSubscriberStats,
+    }
+
+    impl MockFs {
+        /// Arbitrary magic identifying the mock file system; spells "MOCK".
+        const MOCK_FS_MAGIC: u64 = 0x4d_4f_43_4b;
+
+        fn new(root: Arc<MockInode>) -> Arc<Self> {
+            Arc::new_cyclic(|weak| {
+                root.bind_fs(weak.clone());
+                Self {
+                    root,
+                    sb: SuperBlock::new(Self::MOCK_FS_MAGIC, PAGE_SIZE, 255, DeviceId::null()),
+                    fs_event_subscriber_stats: FsEventSubscriberStats::new(),
+                }
+            })
+        }
+    }
+
+    impl FileSystem for MockFs {
+        fn name(&self) -> &'static str {
+            "mockfs"
+        }
+
+        fn sync(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn root_inode(&self) -> Arc<dyn Inode> {
+            self.root.clone()
+        }
+
+        fn sb(&self) -> SuperBlock {
+            self.sb.clone()
+        }
+
+        fn fs_event_subscriber_stats(&self) -> &FsEventSubscriberStats {
+            &self.fs_event_subscriber_stats
+        }
+    }
+
+    /// Asserts that `InodeHandle::readdir` forwards the *current* per-open
+    /// status flags (i.e. post-`fcntl(F_SETFL)`) to `FileOps::readdir_at`.
+    ///
+    /// Regression test for issue #3536: previously `readdir_at` had no access
+    /// to the live flags, so filesystems like virtio-fs composed `FUSE_READDIR`
+    /// from flags captured at open time and could not observe post-`fcntl`
+    /// changes.
+    #[ktest]
+    fn readdir_receives_current_status_flags() {
+        let inode = MockInode::new();
+        let fs: Arc<dyn FileSystem> = MockFs::new(inode.clone());
+        let mount = Mount::new_detached(
+            FsAndRoot::new(fs),
+            PerMountFlags::empty(),
+            Weak::new(),
+            None,
+        )
+        .unwrap();
+        let handle = InodeHandle::new_unchecked_access(
+            Path::new_root(mount),
+            AccessMode::O_RDONLY,
+            StatusFlags::empty(),
+        )
+        .unwrap();
+
+        // Change the status flags through the same path `fcntl(F_SETFL)` uses.
+        handle
+            .common
+            .update_status_flags(&handle, StatusFlagsUpdate::set(StatusFlags::O_APPEND));
+
+        let mut visitor: Vec<String> = Vec::new();
+        handle.readdir(&mut visitor).unwrap();
+
+        assert_eq!(*inode.received_flags.lock(), Some(StatusFlags::O_APPEND));
+    }
+}

--- a/kernel/core/src/fs/file/inode_handle.rs
+++ b/kernel/core/src/fs/file/inode_handle.rs
@@ -139,7 +139,7 @@ impl InodeHandle {
             self.path().inode().as_ref()
         };
         let mut offset = self.offset.lock();
-        let read_cnt = file_ops.readdir_at(*offset, visitor)?;
+        let read_cnt = file_ops.readdir_at(*offset, visitor, self.status_flags())?;
         *offset += read_cnt;
         Ok(read_cnt)
     }

--- a/kernel/core/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/mod.rs
@@ -194,7 +194,12 @@ impl FileOps for RootInode {
         Err(Error::new(Errno::EISDIR))
     }
 
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
         let try_readdir = |offset: &mut usize, visitor: &mut dyn DirentVisitor| -> Result<()> {
             // Read the 3 special entries.
             if *offset == 0 {

--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -1366,7 +1366,12 @@ impl FileOps for ExfatInode {
         }
     }
 
-    fn readdir_at(&self, dir_cnt: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    fn readdir_at(
+        &self,
+        dir_cnt: usize,
+        visitor: &mut dyn DirentVisitor,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
         let inner = self.inner.upread();
 
         if dir_cnt >= (inner.num_sub_inodes + 2) as usize {

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -59,7 +59,12 @@ impl FileOps for Ext2Inode {
         }
     }
 
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
         self.readdir_at(offset, visitor)
     }
 }

--- a/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
@@ -158,7 +158,9 @@ impl OverlayFs {
     /// Validates that work is empty.
     fn validate_work_empty(work: &Path) -> Result<()> {
         let mut counter = DirentCounter::new();
-        let _ = work.inode().readdir_at(0, &mut counter);
+        let _ = work
+            .inode()
+            .readdir_at(0, &mut counter, StatusFlags::empty());
         if counter.count() > 0 {
             return_errno_with_message!(Errno::EINVAL, "workdir must be empty");
         }
@@ -381,12 +383,13 @@ impl OverlayInode {
         &self,
         offset: usize,
         visitor: &mut dyn DirentVisitor,
+        status_flags: StatusFlags,
     ) -> Result<usize> {
         if self.type_ != InodeType::Dir {
             return_errno!(Errno::ENOTDIR);
         }
 
-        let overlay_dir_visitor = self.readdir_inner(offset)?;
+        let overlay_dir_visitor = self.readdir_inner(offset, status_flags)?;
 
         let mut last_visited_offset: Option<usize> = None;
         for (entry_offset, (name, ino, type_)) in overlay_dir_visitor.as_merged_view() {
@@ -464,7 +467,7 @@ impl OverlayInode {
         let upper_guard = self.upper.lock();
         let upper = upper_guard.as_ref().unwrap();
 
-        let visitor = target.readdir_inner(0)?;
+        let visitor = target.readdir_inner(0, StatusFlags::empty())?;
         if visitor.visited_files() > 0 {
             return_errno!(Errno::ENOTEMPTY);
         }
@@ -474,7 +477,7 @@ impl OverlayInode {
             let target_upper = target.upper().unwrap();
 
             let mut target_visitor = Vec::<String>::new();
-            target_upper.readdir_at(0, &mut target_visitor)?;
+            target_upper.readdir_at(0, &mut target_visitor, StatusFlags::empty())?;
 
             for whiteout in target_visitor.iter().skip(2) {
                 assert!(whiteout.starts_with(WHITEOUT_PREFIX));
@@ -786,7 +789,7 @@ impl OverlayInode {
         Ok(Some(child_ovl_inode))
     }
 
-    fn readdir_inner(&self, offset: usize) -> Result<OverlayDirVisitor> {
+    fn readdir_inner(&self, offset: usize, status_flags: StatusFlags) -> Result<OverlayDirVisitor> {
         let mut overlay_visitor = OverlayDirVisitor::new();
         let (mut layer_idx, fs_offset) = UniqueNoGenerator::parse_unique_offset(offset);
         overlay_visitor.set_cur_layer(layer_idx);
@@ -804,7 +807,7 @@ impl OverlayInode {
                 };
 
                 if let Some(cur_inode) = cur_inode {
-                    cur_inode.readdir_at(0, &mut overlay_visitor)?;
+                    cur_inode.readdir_at(0, &mut overlay_visitor, status_flags)?;
                 }
             }
 
@@ -815,7 +818,7 @@ impl OverlayInode {
         if layer_idx == 0 {
             if let Some(upper) = self.upper() {
                 debug_assert!(upper.type_() == InodeType::Dir);
-                upper.readdir_at(fs_offset, &mut overlay_visitor)?;
+                upper.readdir_at(fs_offset, &mut overlay_visitor, status_flags)?;
             }
 
             layer_idx += 1;
@@ -825,13 +828,13 @@ impl OverlayInode {
         if !self.is_opaque_dir() && layer_idx > 0 && layer_idx as usize <= self.lowers.len() {
             // TODO: Figure out how to check the opaque directories within lower layers.
             let first_lower = &self.lowers[layer_idx as usize - 1];
-            first_lower.readdir_at(fs_offset, &mut overlay_visitor)?;
+            first_lower.readdir_at(fs_offset, &mut overlay_visitor, status_flags)?;
 
             layer_idx += 1;
             overlay_visitor.set_cur_layer(layer_idx);
 
             for lower in self.lowers.iter().skip(layer_idx as usize - 1) {
-                lower.readdir_at(0, &mut overlay_visitor)?;
+                lower.readdir_at(0, &mut overlay_visitor, status_flags)?;
 
                 layer_idx += 1;
                 overlay_visitor.set_cur_layer(layer_idx);
@@ -1009,7 +1012,12 @@ impl FileOps for OverlayInode {
         reader: &mut VmReader,
         status_flags: StatusFlags,
     ) -> Result<usize>;
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize>;
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        status_flags: StatusFlags,
+    ) -> Result<usize>;
 }
 
 #[inherit_methods(from = "self")]
@@ -1490,7 +1498,9 @@ mod tests {
         assert_eq!(d1.type_(), InodeType::Dir);
         let mut d1_fnames = Vec::<String>::new();
         // No assumption on the return value
-        let _ = d1.readdir_at(0, &mut d1_fnames).unwrap();
+        let _ = d1
+            .readdir_at(0, &mut d1_fnames, StatusFlags::empty())
+            .unwrap();
         assert_eq!(d1_fnames, [".", "..", "f11", "f12"]);
     }
 
@@ -1596,7 +1606,9 @@ mod tests {
         let mut offset = 0usize;
         loop {
             let mut batch = Vec::<String>::new();
-            let read_cnt = root_inode.readdir_at(offset, &mut batch).unwrap();
+            let read_cnt = root_inode
+                .readdir_at(offset, &mut batch, StatusFlags::empty())
+                .unwrap();
             all_names.extend(batch);
             if read_cnt == 0 {
                 break;

--- a/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
@@ -114,7 +114,12 @@ impl<D: ProcDirOps + 'static> FileOps for ProcDir<D> {
         Err(Error::new(Errno::EISDIR))
     }
 
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
         /// Returns the always-present `.` and `..` entries for a procfs directory.
         fn special_entries<D: ProcDirOps + 'static>(
             dir: &ProcDir<D>,

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -1058,7 +1058,12 @@ impl FileOps for RamInode {
         Ok(written_len)
     }
 
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
         if self.typ != InodeType::Dir {
             return_errno_with_message!(Errno::ENOTDIR, "self is not dir");
         }

--- a/kernel/core/src/fs/fs_impls/sysfs/test.rs
+++ b/kernel/core/src/fs/fs_impls/sysfs/test.rs
@@ -467,7 +467,7 @@ fn readdir_leaf() {
     let mut offset = 0;
     loop {
         // Pass offset as usize
-        let result = leaf1_inode.readdir_at(offset, &mut visitor);
+        let result = leaf1_inode.readdir_at(offset, &mut visitor, StatusFlags::empty());
         match result {
             Ok(next_offset) => {
                 if next_offset == offset || next_offset == 0 {

--- a/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
@@ -56,16 +56,19 @@ impl FileOps for VirtioFsDir {
         return_errno_with_message!(Errno::EISDIR, "the inode is a directory");
     }
 
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
-        // FIXME: `readdir_at` should pass current status flags to the
-        // server, while `FileOps` interface currently does not expose them,
-        // so `FUSE_READDIR` uses the flags captured at open time.
-        self.inode.readdir(
-            self.open_handle.fh(),
-            offset,
-            self.open_handle.file_flags(),
-            visitor,
-        )
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        status_flags: StatusFlags,
+    ) -> Result<usize> {
+        // Compose the request flags from the *current* per-open status flags
+        // (which may have changed via `fcntl`) rather than the flags captured
+        // at `FUSE_OPENDIR` time. The access mode is immutable post-open, so
+        // it is still taken from the server-issued handle.
+        let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();
+        self.inode
+            .readdir(self.open_handle.fh(), offset, file_flags, visitor)
     }
 }
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/dir.rs
@@ -66,7 +66,7 @@ impl FileOps for VirtioFsDir {
         // (which may have changed via `fcntl`) rather than the flags captured
         // at `FUSE_OPENDIR` time. The access mode is immutable post-open, so
         // it is still taken from the server-issued handle.
-        let file_flags = self.open_handle.access_mode() as u32 | status_flags.bits();
+        let file_flags = self.open_handle.file_flags_with(status_flags);
         self.inode
             .readdir(self.open_handle.fh(), offset, file_flags, visitor)
     }

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -587,7 +587,12 @@ impl FileOps for VirtioFsInode {
         )
     }
 
-    fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        status_flags: StatusFlags,
+    ) -> Result<usize> {
         let fs = self.fs_ref();
         let open_out = fs
             .session()
@@ -612,10 +617,13 @@ impl FileOps for VirtioFsInode {
 
         // FIXME: `readdir_at` exposes the delta-based interface, while
         // FUSE readdir offsets are opaque continuation cookies.
-        // FIXME: `readdir_at` should pass current status flags to the
-        // filesystem backend. The `FileOps` interface currently does not
-        // expose them, so `FUSE_READDIR` uses the transient handle flags.
-        self.readdir(dir_handle.fh(), offset, dir_handle.file_flags(), visitor)
+        // The transient handle has no owning file description, so the request
+        // carries the caller's live `status_flags` (e.g. from an internal
+        // lookup) composed with the transient `O_RDONLY` access mode. The VFS
+        // readdir path uses `VirtioFsDir` instead, which holds a real per-open
+        // handle.
+        let file_flags = AccessMode::O_RDONLY as u32 | status_flags.bits();
+        self.readdir(dir_handle.fh(), offset, file_flags, visitor)
     }
 }
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -619,10 +619,10 @@ impl FileOps for VirtioFsInode {
         // FUSE readdir offsets are opaque continuation cookies.
         // The transient handle has no owning file description, so the request
         // carries the caller's live `status_flags` (e.g. from an internal
-        // lookup) composed with the transient `O_RDONLY` access mode. The VFS
-        // readdir path uses `VirtioFsDir` instead, which holds a real per-open
-        // handle.
-        let file_flags = AccessMode::O_RDONLY as u32 | status_flags.bits();
+        // lookup) composed with the transient handle's `O_RDONLY` access
+        // mode. The VFS readdir path uses `VirtioFsDir` instead, which holds
+        // a real per-open handle.
+        let file_flags = dir_handle.file_flags_with(status_flags);
         self.readdir(dir_handle.fh(), offset, file_flags, visitor)
     }
 }

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/page_cache.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/page_cache.rs
@@ -28,10 +28,12 @@ impl PageCacheBackend for VirtioFsInode {
         let session = self.fs_ref().session().clone();
         let cache_page = locked_page.deref().clone();
         let data_buf = FuseReplyBuf::new_map(Segment::from(cache_page.clone()).into())?;
-        // FIXME: Page-cache I/O should use the current `InodeHandle` status
-        // flags instead of the flags captured in the cached FUSE handle. The
-        // page-cache backend currently receives only the inode, so it cannot
-        // observe per-open status flag changes.
+        // The page-cache backend is inode-scoped and asynchronous: at I/O time
+        // no specific `InodeHandle` is in context, and the handle used here may
+        // be a reused live handle or a transient one. Its own open flags are
+        // therefore the well-defined flag source. `O_APPEND`/`O_NONBLOCK` do
+        // not apply to explicit-offset page I/O, and `O_DIRECT` bypasses the
+        // page cache, so the captured `handle.file_flags()` are correct here.
         let read_req = ReadReq::new(
             handle.fh(),
             page_offset(idx)? as u64,
@@ -115,10 +117,12 @@ impl PageCacheBackend for VirtioFsInode {
         let nodeid = self.nodeid();
         let session = fs.session().clone();
         let complete_page = page.clone();
-        // FIXME: Page-cache I/O should use the current `InodeHandle` status
-        // flags instead of the flags captured in the cached FUSE handle. The
-        // page-cache backend currently receives only the inode, so it cannot
-        // observe per-open status flag changes.
+        // The page-cache backend is inode-scoped and asynchronous: at I/O time
+        // no specific `InodeHandle` is in context, and the handle used here may
+        // be a reused live handle or a transient one. Its own open flags are
+        // therefore the well-defined flag source. `O_APPEND`/`O_NONBLOCK` do
+        // not apply to explicit-offset page I/O, and `O_DIRECT` bypasses the
+        // page cache, so the captured `handle.file_flags()` are correct here.
         let write_req = WriteReq::new(
             handle.fh(),
             page_start as u64,

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/page_cache.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/page_cache.rs
@@ -16,6 +16,13 @@ use crate::{
     vm::page_cache::{CachePageExt, LockedCachePage, PageCacheBackend},
 };
 
+// The page-cache backend is inode-scoped and asynchronous: at I/O time no
+// specific `InodeHandle` is in context, and the handle used here may be a
+// reused live handle or a transient one. Its own open flags are therefore
+// the well-defined flag source. `O_APPEND`/`O_NONBLOCK` do not apply to
+// explicit-offset page I/O, and `O_DIRECT` bypasses the page cache, so the
+// captured `handle.file_flags()` are correct for both readback and writeback
+// below.
 impl PageCacheBackend for VirtioFsInode {
     fn read_page_async(
         &self,
@@ -28,12 +35,6 @@ impl PageCacheBackend for VirtioFsInode {
         let session = self.fs_ref().session().clone();
         let cache_page = locked_page.deref().clone();
         let data_buf = FuseReplyBuf::new_map(Segment::from(cache_page.clone()).into())?;
-        // The page-cache backend is inode-scoped and asynchronous: at I/O time
-        // no specific `InodeHandle` is in context, and the handle used here may
-        // be a reused live handle or a transient one. Its own open flags are
-        // therefore the well-defined flag source. `O_APPEND`/`O_NONBLOCK` do
-        // not apply to explicit-offset page I/O, and `O_DIRECT` bypasses the
-        // page cache, so the captured `handle.file_flags()` are correct here.
         let read_req = ReadReq::new(
             handle.fh(),
             page_offset(idx)? as u64,
@@ -117,12 +118,9 @@ impl PageCacheBackend for VirtioFsInode {
         let nodeid = self.nodeid();
         let session = fs.session().clone();
         let complete_page = page.clone();
-        // The page-cache backend is inode-scoped and asynchronous: at I/O time
-        // no specific `InodeHandle` is in context, and the handle used here may
-        // be a reused live handle or a transient one. Its own open flags are
-        // therefore the well-defined flag source. `O_APPEND`/`O_NONBLOCK` do
-        // not apply to explicit-offset page I/O, and `O_DIRECT` bypasses the
-        // page cache, so the captured `handle.file_flags()` are correct here.
+        // The captured `handle.file_flags()` are used for the same reason as
+        // in `read_page_async`; see the rationale above the `PageCacheBackend`
+        // impl.
         let write_req = WriteReq::new(
             handle.fh(),
             page_start as u64,

--- a/kernel/core/src/fs/fs_impls/virtiofs/open_handle.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/open_handle.rs
@@ -71,9 +71,10 @@ impl Drop for VirtioFsOpenHandle {
         let fs = self.fs.clone();
         let nodeid = self.nodeid;
         let fh = self.fh;
-        // FIXME: `FUSE_RELEASE` should use the current status flags from the
-        // owning file description. `VirtioFsOpenHandle` can outlive that
-        // context, so release currently uses the flags captured at open time.
+        // `FUSE_RELEASE` uses the flags captured at open time. A handle can be
+        // shared across file descriptions or opened transiently (see
+        // `OpenHandles`), so a single owning description's current flags are
+        // not well-defined; the captured flags are the consistent choice.
         let file_flags = self.file_flags();
         let release_options = self.release_options;
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/open_handle.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/open_handle.rs
@@ -50,9 +50,22 @@ impl VirtioFsOpenHandle {
         self.fh
     }
 
-    /// Returns the composite file flags (access mode | status flags).
+    /// Returns the composite file flags (access mode | captured status flags)
+    /// recorded when this handle was opened.
     pub(super) fn file_flags(&self) -> u32 {
-        self.access_mode as u32 | self.status_flags.bits()
+        self.file_flags_with(self.status_flags)
+    }
+
+    /// Returns the composite file flags (access mode | status flags) for a
+    /// request issued through this handle with the given `status_flags`.
+    ///
+    /// The access mode is immutable after open, so it is always taken from
+    /// this server-issued handle. `status_flags` are per-file-description and
+    /// can change via `fcntl` after open, so callers pass the *current* value
+    /// (e.g. from `InodeHandle::readdir`) rather than the flags captured at
+    /// open time.
+    pub(super) fn file_flags_with(&self, status_flags: StatusFlags) -> u32 {
+        self.access_mode as u32 | status_flags.bits()
     }
 
     /// Returns the access mode.
@@ -152,5 +165,51 @@ impl OpenHandles {
         });
 
         found
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use aster_fuse::ops::release::{ReleaseFlags, ReleaseKind};
+    use ostd::prelude::ktest;
+
+    use super::*;
+
+    /// Builds a handle whose open-time flag capture is empty, so a test can
+    /// tell captured flags apart from live flags passed at request time.
+    fn handle_with_empty_capture() -> Arc<VirtioFsOpenHandle> {
+        VirtioFsOpenHandle::new(
+            FuseFileHandle::new(1),
+            FuseNodeId::new(1),
+            AccessMode::O_RDONLY,
+            StatusFlags::empty(),
+            FuseOpenFlags::empty(),
+            Weak::new(),
+            ReleaseOptions::new(ReleaseKind::Directory, ReleaseFlags::empty()),
+        )
+    }
+
+    #[ktest]
+    fn file_flags_with_composes_live_flags_not_open_time_capture() {
+        let handle = handle_with_empty_capture();
+
+        // The capture recorded at open time is empty...
+        assert_eq!(handle.file_flags(), AccessMode::O_RDONLY as u32);
+
+        // ...so any extra bits in the composed value must come from the live
+        // flags passed in, i.e. from the issuing file description. Regression
+        // guard for issue #3536: requests such as `FUSE_READDIR` must carry
+        // the current per-open flags, not the open-time capture.
+        let live_flags = StatusFlags::O_APPEND | StatusFlags::O_NONBLOCK;
+        assert_eq!(
+            handle.file_flags_with(live_flags),
+            AccessMode::O_RDONLY as u32 | live_flags.bits()
+        );
+
+        // Dropping the handle would submit a `FUSE_RELEASE` work item to the
+        // global work queue, which is not initialized in the ktest
+        // environment. Leak the handle instead; the release is a no-op here
+        // anyway since the handle is not connected to a live virtio-fs session.
+        core::mem::forget(handle);
     }
 }

--- a/kernel/core/src/fs/utils/dirent_visitor.rs
+++ b/kernel/core/src/fs/utils/dirent_visitor.rs
@@ -25,7 +25,7 @@ pub(crate) trait DirentVisitor {
     /// ```no_run
     /// let mut all_dirents = Vec::new();
     /// let dir_inode = todo!("create an inode");
-    /// dir_inode.readdir_at(0, &mut all_dirents).unwrap();
+    /// dir_inode.readdir_at(0, &mut all_dirents, StatusFlags::empty()).unwrap();
     /// ```
     fn visit(&mut self, name: &str, ino: u64, type_: InodeType, offset: usize) -> Result<()>;
 }

--- a/kernel/core/src/fs/utils/systree_inode.rs
+++ b/kernel/core/src/fs/utils/systree_inode.rs
@@ -347,7 +347,12 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> FileOps for KInode {
         Ok(len)
     }
 
-    default fn readdir_at(&self, offset: usize, visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    default fn readdir_at(
+        &self,
+        offset: usize,
+        visitor: &mut dyn DirentVisitor,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
         // Why interpreting the `offset` argument as an inode number?
         //
         // It may take multiple `getdents` system calls

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -355,7 +355,16 @@ pub(crate) trait FileOps {
     ) -> Result<usize>;
 
     /// Reads directory entries from the given offset.
-    fn readdir_at(&self, _offset: usize, _visitor: &mut dyn DirentVisitor) -> Result<usize> {
+    ///
+    /// `status_flags` are the live per-open status flags of the calling file
+    /// description, so filesystems that propagate flags to a server (e.g.
+    /// virtio-fs `FUSE_READDIR`) can observe post-`fcntl` changes.
+    fn readdir_at(
+        &self,
+        _offset: usize,
+        _visitor: &mut dyn DirentVisitor,
+        _status_flags: StatusFlags,
+    ) -> Result<usize> {
         return_errno_with_message!(Errno::ENOTDIR, "readdir is not supported");
     }
 }


### PR DESCRIPTION
Refs #3536 (readdir sub-task), part of #3343.

## Summary

`FileOps::readdir_at` did not receive the per-open status flags, so virtio-fs
composed `FUSE_READDIR` from the flags captured at open time and could not
observe post-`fcntl` changes. This PR widens `readdir_at` to carry the live
`StatusFlags` (mirroring `read_at`/`write_at`), threads them from
`InodeHandle::readdir`, and composes the virtio-fs request from the current
flags.

## Changes

- `FileOps::readdir_at` gains a `status_flags: StatusFlags` parameter; all
  implementors (devpts, exfat, ext2, overlayfs, procfs, ramfs, sysfs/systree,
  virtio-fs) and the VFS call site are updated.
- `VirtioFsOpenHandle::file_flags_with` composes a request's flags from the
  handle's access mode and the caller's status flags. `VirtioFsDir::readdir_at`
  uses it with the live flags instead of the ones captured at `FUSE_OPENDIR`
  time; the access mode stays handle-sourced since it is immutable post-open.
- The transient `VirtioFsInode::readdir_at` path (no owning file description)
  composes `O_RDONLY | status_flags`.
- Scope: this resolves the `readdir_at` requirement of #3536. Its other
  requirement — letting the page-cache read/writeback paths observe the current
  per-open flags — is untouched, and the FIXMEs in `inode/page_cache.rs` and
  `open_handle.rs` still mark it. Those paths are reached through the VM
  page-cache layer, which receives only the inode and is driven by page faults
  and writeback, so they need the design decision the issue leaves open rather
  than the same mechanical change. `file_flags_with` is where the composition
  would move once the flags can get there.

## Test

- New ktest `readdir_receives_current_status_flags` asserts that
  `InodeHandle::readdir` forwards the current (post-`F_SETFL`) status flags to
  `FileOps::readdir_at`, using a mock inode that records the received flags.
- New ktest `file_flags_with_composes_live_flags_not_open_time_capture`
  asserts that `VirtioFsOpenHandle::file_flags_with` composes the request flags
  from the live flags passed in, not the open-time capture.
- Both ktests pass with `cargo osdk test <name>`, and the workspace clippy
  checks (including the `--ktests` pass) pass locally.
- CI is green on this head, including `basic-test (ktest)`, the regression and
  boot suites, the three conformance suites and `xfstests`.

## Demonstration

The changed value is observable at the server, and a server can act on it.

To see it, a virtiofsd backend was instrumented in two places:

1. its `readdir()` prints the `flags` field of every `FUSE_READDIR` it
   receives. `FUSE_READDIR` reuses `struct fuse_read_in`, whose `flags` field
   is the one this PR fills differently;
2. its `readdir()` hides every entry whose name starts with `beta` when
   `O_NONBLOCK` is set in that field. Stock virtiofsd ignores the field, so
   this stands in for a server that acts on it.

A guest program mounts the `aster-virtiofs` tag, lists the directory, sets
`O_NONBLOCK` with `fcntl(F_SETFL)`, and lists it again. Both trees were run
with the same backend, the same initramfs and the same program.

On upstream/main, the second listing re-issues `FUSE_READDIR` (so nothing is
served from a cache) but still carries the flags captured at open time:

```
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=0 size=4096 flags=0x0
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=2147483647 size=4096 flags=0x0
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=0 size=4096 flags=0x0
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=2147483647 size=4096 flags=0x0
```

```
listing after fcntl(F_SETFL):
  entry: .
  entry: ..
  entry: alpha.txt
  entry: beta.txt
  entry: gamma.txt
before: .;..;alpha.txt;beta.txt;gamma.txt;
after:  .;..;alpha.txt;beta.txt;gamma.txt;
VERDICT: the listing did not change
```

On this branch, the first listing is unchanged (`flags=0x0`, the same control),
and the second listing carries the live `O_NONBLOCK`:

```
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=0 size=4096 flags=0x0
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=2147483647 size=4096 flags=0x0
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=0 size=4096 flags=0x800 [O_NONBLOCK]
SCENARIO FUSE_READDIR nodeid=1 fh=14 offset=2147483647 size=4096 flags=0x800 [O_NONBLOCK]
```

```
listing after fcntl(F_SETFL):
  entry: .
  entry: ..
  entry: alpha.txt
  entry: gamma.txt
before: .;..;alpha.txt;beta.txt;gamma.txt;
after:  .;..;alpha.txt;gamma.txt;
VERDICT: the listing changed
```

The two listings differ in content, not only in the log: the entry the backend
hid for `O_NONBLOCK` is gone from the second one.

## Notes for reviewers

- `FUSE_READDIR` reuses `ReadReq`'s `flags` field, so this changes which value
  is placed there, not the wire format. Linux fills that field from
  `file->f_flags` in `fuse_readdir_uncached()` and `fuse_readdir_cached()`
  (`fs/fuse/readdir.c`), so the value sent here now matches the kernel.
- The public-trait widening touches 8 filesystems; the mechanical per-FS
  updates are identical in shape (one extra ignored parameter).
- There is no automated test at the wire level, and there cannot be one
  against the current CI backend: `virtiofsd` accepts the field but does not
  act on it for `READDIR`, so a stock server produces an identical reply
  either way. The ktests above are what CI can assert; the Demonstration
  section is what a server that does act on the field would see.
