### PR TITLE
Support and fix various broadcast behavior in TCP and UDP sockets

### DIFF
--- a/kernel/core/src/net/route/mod.rs
+++ b/kernel/core/src/net/route/mod.rs
@@ -240,8 +240,8 @@ pub(super) fn lookup_local_iface(address: IpAddress) -> Result<Arc<Iface>> {
 
     // Linux doesn't check the route type when adding a new route to the local table,
     // so we need to verify that the route type is local when an entry is found.
-    // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv4/devinet.c#L161>.
-    if type_ != RouteType::Local {
+    // Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/net/inet_sock.h#L441-L451>.
+    if type_ != RouteType::Local && type_ != RouteType::Broadcast {
         return_errno_with_message!(
             Errno::EADDRNOTAVAIL,
             "the address is not available from the local machine"

--- a/kernel/core/src/net/socket/ip/datagram/bound.rs
+++ b/kernel/core/src/net/socket/ip/datagram/bound.rs
@@ -41,7 +41,7 @@ impl datagram_common::Bound for BoundDatagram {
     type Endpoint = IpEndpoint;
 
     fn local_endpoint(&self) -> Self::Endpoint {
-        self.bound_socket.local_endpoint().unwrap()
+        self.bound_socket.local_endpoint()
     }
 
     fn remote_endpoint(&self) -> Option<&Self::Endpoint> {

--- a/kernel/core/src/net/socket/ip/stream/connected.rs
+++ b/kernel/core/src/net/socket/ip/stream/connected.rs
@@ -133,7 +133,7 @@ impl ConnectedStream {
     }
 
     pub(super) fn local_endpoint(&self) -> IpEndpoint {
-        self.tcp_conn.local_endpoint().unwrap()
+        self.tcp_conn.local_endpoint()
     }
 
     pub(super) fn remote_endpoint(&self) -> IpEndpoint {

--- a/kernel/core/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/core/src/net/socket/ip/stream/connecting.rs
@@ -90,7 +90,7 @@ impl ConnectingStream {
     }
 
     pub(super) fn local_endpoint(&self) -> IpEndpoint {
-        self.tcp_conn.local_endpoint().unwrap()
+        self.tcp_conn.local_endpoint()
     }
 
     pub(super) fn remote_endpoint(&self) -> IpEndpoint {

--- a/kernel/core/src/net/socket/ip/stream/init.rs
+++ b/kernel/core/src/net/socket/ip/stream/init.rs
@@ -15,6 +15,7 @@ use crate::{
     events::IoEvents,
     net::{
         iface::BoundTcpPort,
+        route::is_broadcast_endpoint,
         socket::{
             ip::{
                 addr::IpAddressFamily,
@@ -146,6 +147,15 @@ impl InitStream {
         );
 
         let remote_endpoint = map_unspecified_to_localhost(*remote_endpoint);
+        if is_broadcast_endpoint(&remote_endpoint) {
+            return Err((
+                Error::with_message(
+                    Errno::ENETUNREACH,
+                    "TCP sockets cannot connect to broadcast addresses",
+                ),
+                self,
+            ));
+        }
         let route_endpoint = if is_ipv4_mapped_localhost {
             IpEndpoint::new(Ipv6Address::LOCALHOST.into(), remote_endpoint.port)
         } else {

--- a/kernel/core/src/net/socket/ip/stream/listen.rs
+++ b/kernel/core/src/net/socket/ip/stream/listen.rs
@@ -48,7 +48,7 @@ impl ListenStream {
     }
 
     pub(super) fn local_endpoint(&self) -> IpEndpoint {
-        self.tcp_listener.local_endpoint().unwrap()
+        self.tcp_listener.local_endpoint()
     }
 
     pub(super) fn iface(&self) -> &Arc<Iface> {

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -27,9 +27,10 @@ use super::{
     time::get_network_timestamp,
 };
 use crate::{
-    device::AnyNetworkDevice,
+    device::{AnyNetworkDevice, WithDevice},
     errors::BindError,
     ext::Ext,
+    iface::ScheduleNextPoll,
     packet::{FreshTxPacket, LinkLayer, NetworkLayer, RxPacket, TxPacket},
     socket::{TcpListenerBg, UdpSocketBg},
     socket_table::SocketTable,
@@ -241,7 +242,17 @@ impl<E: Ext> IfaceCommon<E> {
 }
 
 impl<E: Ext> IfaceCommon<E> {
-    pub(super) fn poll(&self, device: &mut dyn AnyNetworkDevice, phy: &dyn PollPhy) -> Option<u64> {
+    pub(super) fn poll<D: WithDevice>(&self, driver: &D, phy: &dyn PollPhy) {
+        driver.with(|device| self.do_poll_and_notify(device, phy));
+    }
+
+    fn do_poll_and_notify(&self, device: &mut dyn AnyNetworkDevice, phy: &dyn PollPhy) {
+        let next_poll = self.do_poll(device, phy);
+        device.notify_poll_end();
+        self.sched_poll.schedule_next_poll(next_poll);
+    }
+
+    fn do_poll(&self, device: &mut dyn AnyNetworkDevice, phy: &dyn PollPhy) -> Option<u64> {
         let mut interface = self.interface();
         interface.context_mut().now = get_network_timestamp();
 

--- a/kernel/libs/aster-bigtcp/src/iface/common.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/common.rs
@@ -335,6 +335,29 @@ impl<E: Ext> BoundPort<E> {
     }
 }
 
+impl<E: Ext> BoundTcpPort<E> {
+    /// Ensures that the bound address is a unicast address.
+    ///
+    /// The bound address will be converted to a unicast address belonging to the local interface if
+    /// it is a broadcast address.
+    pub(crate) fn ensure_unicast(&mut self, interface: &PollableIface<E>) {
+        let new_addr = interface.map_broadcast_to_local(self.addr);
+        if new_addr == self.addr {
+            return;
+        }
+
+        // Lock order: `interface` -> `used_ports`
+        let iface_common = self.0.iface.common();
+        let mut used_ports = iface_common.used_ports.lock();
+
+        let can_reuse = self.can_reuse.load(Ordering::Relaxed);
+
+        used_ports.acquire(new_addr, self.port, can_reuse, self.protocol);
+        used_ports.release(self.addr, self.port, can_reuse, self.protocol);
+        self.0.addr = new_addr;
+    }
+}
+
 impl<E: Ext> Drop for BoundPort<E> {
     fn drop(&mut self) {
         self.iface.common().release_port(
@@ -503,6 +526,26 @@ impl PortTable {
         // to see if any can be reused instead of directly returning `None`.
 
         None
+    }
+
+    fn acquire(&mut self, addr: IpAddress, port: u16, can_reuse: bool, protocol: PortProtocol) {
+        let key = PortKey {
+            addr: NormalizedAddress::from(addr),
+            port,
+            protocol,
+        };
+        match self.used_ports.entry(key) {
+            Entry::Occupied(mut occupied) => {
+                let port_state = occupied.get_mut();
+                port_state.nsocket += 1;
+                if can_reuse {
+                    port_state.nreuse += 1;
+                }
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(PortState::new(can_reuse));
+            }
+        }
     }
 
     fn release(&mut self, addr: IpAddress, port: u16, can_reuse: bool, protocol: PortProtocol) {

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ether.rs
@@ -16,7 +16,7 @@ use crate::{
     device::{AnyNetworkDevice, WithDevice, new_interface},
     ext::Ext,
     iface::{
-        Iface, InterfaceFlags, InterfaceName, ScheduleNextPoll,
+        Iface, InterfaceFlags, InterfaceName,
         common::{IfaceCommon, InterfaceType, PhyProcessResult, PollPhy, TxPacketWithDst},
         iface::internal::IfaceInternal,
         time::get_network_timestamp,
@@ -81,11 +81,7 @@ impl<D: WithDevice + 'static, E: Ext> Iface<E> for EtherIface<D, E> {
     }
 
     fn poll(&self) {
-        self.driver.with(|device| {
-            let next_poll = self.common.poll(device, self);
-            device.notify_poll_end();
-            self.common.sched_poll().schedule_next_poll(next_poll);
-        });
+        self.common.poll(&self.driver, self);
     }
 
     fn mtu(&self) -> usize {

--- a/kernel/libs/aster-bigtcp/src/iface/phy/ip.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/phy/ip.rs
@@ -11,7 +11,7 @@ use crate::{
     device::{AnyNetworkDevice, WithDevice, new_interface},
     ext::Ext,
     iface::{
-        Iface, InterfaceName, ScheduleNextPoll,
+        Iface, InterfaceName,
         common::{
             IfaceCommon, InterfaceFlags, InterfaceType, PhyProcessResult, PollPhy, TxPacketWithDst,
         },
@@ -70,11 +70,7 @@ impl<D: WithDevice + 'static, E: Ext> Iface<E> for IpIface<D, E> {
     }
 
     fn poll(&self) {
-        self.driver.with(|device| {
-            let next_poll = self.common.poll(device, self);
-            device.notify_poll_end();
-            self.common.sched_poll().schedule_next_poll(next_poll);
-        });
+        self.common.poll(&self.driver, self);
     }
 
     fn mtu(&self) -> usize {

--- a/kernel/libs/aster-bigtcp/src/iface/poll.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll.rs
@@ -6,8 +6,8 @@ use ostd::mm::{Infallible, VmReader};
 use smoltcp::{
     storage::SliceLike,
     wire::{
-        IPV4_HEADER_LEN, IPV4_MIN_MTU, Icmpv4DstUnreachable, IpProtocol, IpRepr, Ipv4Address,
-        Ipv4Repr, TcpControl, TcpRepr, UDP_HEADER_LEN, UdpRepr,
+        IPV4_HEADER_LEN, IPV4_MIN_MTU, Icmpv4DstUnreachable, IpAddress, IpProtocol, IpRepr,
+        Ipv4Address, Ipv4Repr, TcpControl, TcpRepr, UDP_HEADER_LEN, UdpRepr,
     },
 };
 
@@ -105,12 +105,12 @@ impl<E: Ext> PollContext<'_, E> {
         let checksum_caps = self.iface.context().checksum_caps();
         let (packet, ip_repr) = ip::parse(packet, ip_version, checksum_caps.ipv4.rx())?;
 
-        if !ip_repr.inner.dst_addr().is_broadcast()
-            && !self
-                .iface
-                .context()
-                .is_unicast_local(ip_repr.inner.dst_addr())
-        {
+        let can_process = {
+            let cx = self.iface.context();
+            let dst_addr = ip_repr.inner.dst_addr();
+            cx.is_broadcast(&dst_addr) || cx.is_unicast_local(dst_addr)
+        };
+        if !can_process {
             return self.generate_icmp_unreachable(
                 phy,
                 &ip_repr.inner,
@@ -140,7 +140,9 @@ impl<E: Ext> PollContext<'_, E> {
         // TCP connections can only be established between unicast addresses. Ignore the packet if
         // this is not the case. See
         // <https://datatracker.ietf.org/doc/html/rfc9293#section-3.9.2.3>.
-        if !ip_repr.src_addr().is_unicast() || !ip_repr.dst_addr().is_unicast() {
+        if !self.iface.context().is_unicast(ip_repr.src_addr())
+            || !self.iface.context().is_unicast(ip_repr.dst_addr())
+        {
             return None;
         }
 
@@ -296,6 +298,7 @@ impl<E: Ext> PollContext<'_, E> {
         udp_payload: PacketSlice<'_>,
     ) -> bool {
         let mut processed = false;
+        let is_unicast = self.iface.context().is_unicast(ip_repr.dst_addr());
 
         for socket in self.sockets.udp_socket_iter() {
             if !socket.can_process(udp_repr.dst_port) {
@@ -308,7 +311,7 @@ impl<E: Ext> PollContext<'_, E> {
                 udp_repr,
                 udp_payload.clone(),
             );
-            if processed && ip_repr.dst_addr().is_unicast() {
+            if processed && is_unicast {
                 break;
             }
         }
@@ -323,7 +326,13 @@ impl<E: Ext> PollContext<'_, E> {
         mut ip_buffer: VmReader<'_, Infallible>,
         reason: Icmpv4DstUnreachable,
     ) -> Option<TxPacketWithDst> {
-        if !ip_repr.src_addr().is_unicast() || !ip_repr.dst_addr().is_unicast() {
+        // "An ICMP error message MUST NOT be sent as the result of receiving [..] a datagram
+        // destined to an IP broadcast or IP multicast address, or [..] a datagram whose source
+        // address does not define a single host."
+        // Reference: <https://datatracker.ietf.org/doc/html/rfc1122#page-39>.
+        if !self.iface.context().is_unicast(ip_repr.src_addr())
+            || !self.iface.context().is_unicast(ip_repr.dst_addr())
+        {
             return None;
         }
 
@@ -411,10 +420,13 @@ impl<E: Ext> PollContext<'_, E> {
         let packet = udp::emit(packet, ip_repr, udp_repr, checksum_caps.udp.tx());
         let packet = ip::emit(packet, ip_repr, checksum_caps.ipv4.tx());
 
-        Some(TxPacketWithDst {
-            packet,
-            dst_addr: ip_repr.dst_addr(),
-        })
+        let mut dst_addr = ip_repr.dst_addr();
+        if !self.iface.context().is_unicast(dst_addr) {
+            // Force the link layer to emit a broadcast link-layer address.
+            dst_addr = IpAddress::Ipv4(Ipv4Address::BROADCAST);
+        }
+
+        Some(TxPacketWithDst { packet, dst_addr })
     }
 
     fn copy_payload(phy: &dyn PollPhy, payload: &[u8]) -> Option<TxPacket<ApplicationLayer>> {
@@ -571,11 +583,10 @@ impl<E: Ext> PollContext<'_, E> {
                 let iface = PollableIfaceMut::new(cx, pending);
                 let mut this = PollContext::new(iface, self.sockets, &mut actions);
 
-                if ip_repr.dst_addr().is_broadcast()
-                    || !this.iface.context().is_unicast_local(ip_repr.dst_addr())
-                {
+                let is_broadcast = this.iface.context().is_broadcast(&ip_repr.dst_addr());
+                if is_broadcast || !this.iface.context().is_unicast_local(ip_repr.dst_addr()) {
                     tx_packet = this.emit_udp(phy, ip_repr, udp_repr, udp_payload);
-                    if !ip_repr.dst_addr().is_broadcast() {
+                    if !is_broadcast {
                         return;
                     }
                 }

--- a/kernel/libs/aster-bigtcp/src/iface/poll.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll.rs
@@ -6,8 +6,8 @@ use ostd::mm::{Infallible, VmReader};
 use smoltcp::{
     storage::SliceLike,
     wire::{
-        IPV4_HEADER_LEN, IPV4_MIN_MTU, Icmpv4DstUnreachable, IpAddress, IpProtocol, IpRepr,
-        Ipv4Address, Ipv4Repr, TcpControl, TcpRepr, UDP_HEADER_LEN, UdpRepr,
+        IPV4_HEADER_LEN, IPV4_MIN_MTU, Icmpv4DstUnreachable, IpProtocol, IpRepr, Ipv4Address,
+        Ipv4Repr, TcpControl, TcpRepr, UDP_HEADER_LEN, UdpRepr,
     },
 };
 
@@ -24,6 +24,7 @@ use super::{
 use crate::{
     device::{AnyNetworkDevice, NetError},
     ext::Ext,
+    iface::poll_iface::IsUnicast,
     packet::{ApplicationLayer, NetworkLayer, RxPacket, TransportLayer, TxPacket},
     socket::{TcpConnectionBg, TcpProcessResult},
     socket_table::{ConnectionKey, ListenerKey, SocketTable},
@@ -105,7 +106,10 @@ impl<E: Ext> PollContext<'_, E> {
         let (packet, ip_repr) = ip::parse(packet, ip_version, checksum_caps.ipv4.rx())?;
 
         if !ip_repr.inner.dst_addr().is_broadcast()
-            && !self.is_unicast_local(ip_repr.inner.dst_addr())
+            && !self
+                .iface
+                .context()
+                .is_unicast_local(ip_repr.inner.dst_addr())
         {
             return self.generate_icmp_unreachable(
                 phy,
@@ -157,7 +161,7 @@ impl<E: Ext> PollContext<'_, E> {
         let (mut ip_repr, mut tcp_repr) = self.process_tcp(ip_repr, tcp_repr, payload)?;
 
         loop {
-            if !self.is_unicast_local(ip_repr.dst_addr()) {
+            if !self.iface.context().is_unicast_local(ip_repr.dst_addr()) {
                 return Some((ip_repr, tcp_repr));
             }
 
@@ -323,7 +327,7 @@ impl<E: Ext> PollContext<'_, E> {
             return None;
         }
 
-        if self.is_unicast_local(ip_repr.src_addr()) {
+        if self.iface.context().is_unicast_local(ip_repr.src_addr()) {
             // In this case, the generating ICMP message will have a local IP address as the
             // destination. However, since we don't have the ability to handle ICMP messages, we'll
             // just skip the generation.
@@ -428,26 +432,6 @@ impl<E: Ext> PollContext<'_, E> {
 
         Some(builder.build())
     }
-
-    /// Returns whether the destination address is handled locally by this interface.
-    ///
-    /// Note: "local" means that the IP address belongs to the local interface, not to be confused
-    /// with the localhost IP (127.0.0.1).
-    fn is_unicast_local(&self, dst_addr: IpAddress) -> bool {
-        match dst_addr {
-            IpAddress::Ipv4(dst_addr) => self.iface.context().ipv4_addr().is_some_and(|addr| {
-                // All IPv4 loopback addresses are handled by the same loopback interface.
-                // Treating them as local allows direct socket delivery without traversing the
-                // device queues.
-                addr == dst_addr || (addr.is_loopback() && dst_addr.is_loopback())
-            }),
-            IpAddress::Ipv6(dst_addr) => self
-                .iface
-                .context()
-                .ipv6_addr()
-                .is_some_and(|addr| addr == dst_addr),
-        }
-    }
 }
 
 impl<E: Ext> PollContext<'_, E> {
@@ -500,7 +484,7 @@ impl<E: Ext> PollContext<'_, E> {
                 TcpConnectionBg::dispatch(&socket, &mut self.iface, |iface, ip_repr, tcp_repr| {
                     let mut this = PollContext::new(iface, self.sockets, self.actions);
 
-                    if !this.is_unicast_local(ip_repr.dst_addr()) {
+                    if !this.iface.context().is_unicast_local(ip_repr.dst_addr()) {
                         tx_packet = this.emit_tcp(phy, ip_repr, tcp_repr);
                         return None;
                     }
@@ -540,7 +524,9 @@ impl<E: Ext> PollContext<'_, E> {
                         tx_packet = self.emit_tcp(phy, &ip_repr, &tcp_repr);
                     }
                 }
-                (None, Some((ip_repr, tcp_repr))) if !self.is_unicast_local(ip_repr.dst_addr()) => {
+                (None, Some((ip_repr, tcp_repr)))
+                    if !self.iface.context().is_unicast_local(ip_repr.dst_addr()) =>
+                {
                     tx_packet = self.emit_tcp(phy, &ip_repr, &tcp_repr);
                 }
                 (None, Some((ip_repr, tcp_repr))) => {
@@ -585,7 +571,9 @@ impl<E: Ext> PollContext<'_, E> {
                 let iface = PollableIfaceMut::new(cx, pending);
                 let mut this = PollContext::new(iface, self.sockets, &mut actions);
 
-                if ip_repr.dst_addr().is_broadcast() || !this.is_unicast_local(ip_repr.dst_addr()) {
+                if ip_repr.dst_addr().is_broadcast()
+                    || !this.iface.context().is_unicast_local(ip_repr.dst_addr())
+                {
                     tx_packet = this.emit_udp(phy, ip_repr, udp_repr, udp_payload);
                     if !ip_repr.dst_addr().is_broadcast() {
                         return;

--- a/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
@@ -88,6 +88,30 @@ impl<E: Ext> PollableIface<E> {
     ) -> NeedIfacePoll {
         self.pending_conns.update_next_poll_at_ms(socket, poll_at)
     }
+
+    /// Maps an address to the local unicast address if it is a broadcast address.
+    ///
+    /// For example, if the interface is configured with the address `10.0.2.15/24`, this method
+    ///  - will return `10.0.2.15` for `10.0.2.255`, and
+    ///  - will return the original address for `10.0.2.15` and `10.0.2.16`.
+    ///
+    /// Note: "local" means that the IP address belongs to the local interface, not to be confused
+    /// with the localhost IP (`127.0.0.1`).
+    pub(crate) fn map_broadcast_to_local(
+        &self,
+        addr: smoltcp::wire::IpAddress,
+    ) -> smoltcp::wire::IpAddress {
+        use smoltcp::wire::IpAddress;
+
+        if let IpAddress::Ipv4(addr_v4) = addr
+            && let Some(cidr_v4) = self.ipv4_cidr()
+            && cidr_v4.broadcast() == Some(addr_v4)
+        {
+            return IpAddress::Ipv4(cidr_v4.address());
+        }
+
+        addr
+    }
 }
 
 /// A mutable reference to a [`PollableIface`].
@@ -317,14 +341,32 @@ impl<E: Ext> PendingConnSet<E> {
 
 /// An extension trait for an interface context.
 pub(super) trait IsUnicast {
-    /// Returns whether the destination address is handled locally by this interface.
+    /// Returns whether the destination address is a unicast address of an interface.
+    ///
+    /// For example, if the interface is configured with the address `10.0.2.15/24`, this method
+    ///  - will return true for `10.0.2.15` and `10.0.2.254`, and
+    ///  - will return false for `10.0.2.255` and `255.255.255.255`.
+    ///
+    /// Note: This excludes broadcast addresses, link-local broadcast addresses, and multicast
+    /// addresses.
+    fn is_unicast(&self, dst_addr: smoltcp::wire::IpAddress) -> bool;
+
+    /// Returns whether the destination address is a local unicast address of an interface.
+    ///
+    /// For example, if the interface is configured with the address `10.0.2.15/24`, this method
+    ///  - will return true for `10.0.2.15`, and
+    ///  - will return false for `10.0.2.14`, `10.0.2.255`, and `255.255.255.255`.
     ///
     /// Note: "local" means that the IP address belongs to the local interface, not to be confused
-    /// with the localhost IP (127.0.0.1).
+    /// with the localhost IP (`127.0.0.1`).
     fn is_unicast_local(&self, dst_addr: smoltcp::wire::IpAddress) -> bool;
 }
 
 impl IsUnicast for smoltcp::iface::Context {
+    fn is_unicast(&self, dst_addr: smoltcp::wire::IpAddress) -> bool {
+        !self.is_broadcast(&dst_addr) && !dst_addr.is_multicast()
+    }
+
     fn is_unicast_local(&self, dst_addr: smoltcp::wire::IpAddress) -> bool {
         use smoltcp::wire::IpAddress;
 

--- a/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
+++ b/kernel/libs/aster-bigtcp/src/iface/poll_iface.rs
@@ -314,3 +314,28 @@ impl<E: Ext> PendingConnSet<E> {
             .map(|first| first.0.poll_key().next_poll_at_ms.load(Ordering::Relaxed))
     }
 }
+
+/// An extension trait for an interface context.
+pub(super) trait IsUnicast {
+    /// Returns whether the destination address is handled locally by this interface.
+    ///
+    /// Note: "local" means that the IP address belongs to the local interface, not to be confused
+    /// with the localhost IP (127.0.0.1).
+    fn is_unicast_local(&self, dst_addr: smoltcp::wire::IpAddress) -> bool;
+}
+
+impl IsUnicast for smoltcp::iface::Context {
+    fn is_unicast_local(&self, dst_addr: smoltcp::wire::IpAddress) -> bool {
+        use smoltcp::wire::IpAddress;
+
+        match dst_addr {
+            IpAddress::Ipv4(dst_addr) => self.ipv4_addr().is_some_and(|addr| {
+                // All IPv4 loopback addresses are handled by the same loopback interface.
+                // Treating them as local allows direct socket delivery without traversing the
+                // device queues.
+                addr == dst_addr || (addr.is_loopback() && dst_addr.is_loopback())
+            }),
+            IpAddress::Ipv6(dst_addr) => self.ipv6_addr().is_some_and(|addr| addr == dst_addr),
+        }
+    }
+}

--- a/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/common.rs
@@ -93,8 +93,8 @@ impl<T: Inner<E>, E: Ext> Socket<T, E> {
         self.0.observer.call_once(|| new_observer);
     }
 
-    pub fn local_endpoint(&self) -> Option<IpEndpoint> {
-        Some(self.0.bound.endpoint())
+    pub fn local_endpoint(&self) -> IpEndpoint {
+        self.0.bound.endpoint()
     }
 
     pub fn iface(&self) -> &Arc<dyn Iface<E>> {

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_conn.rs
@@ -294,20 +294,25 @@ impl<E: Ext> TcpConnection<E> {
     ///
     /// Polling the iface is _always_ required after this method succeeds.
     pub fn new_connect(
-        bound: BoundTcpPort<E>,
+        mut bound: BoundTcpPort<E>,
         remote_endpoint: IpEndpoint,
         option: &RawTcpOption,
         observer: E::TcpEventObserver,
     ) -> Result<Self, (BoundTcpPort<E>, ConnectError)> {
-        let local_endpoint = bound.endpoint();
-
         let iface = bound.iface().clone();
-        // We have to lock `interface` before locking `sockets`
-        // to avoid dead lock due to inconsistent lock orders.
-        let mut interface = iface.common().interface();
-        let mut sockets = iface.common().sockets();
 
-        let connection_key = ConnectionKey::from((local_endpoint, remote_endpoint));
+        let mut interface = iface.common().interface();
+
+        // A TCP socket can initially be bound to a broadcast address; however, when connecting
+        // later, its address will fall back to a unicast address.
+        let connection_key = {
+            bound.ensure_unicast(&interface);
+            let local_endpoint = bound.endpoint();
+            ConnectionKey::from((local_endpoint, remote_endpoint))
+        };
+
+        // Lock order: `interface` -> `sockets`
+        let mut sockets = iface.common().sockets();
 
         if sockets.lookup_connection(&connection_key).is_some() {
             return Err((bound, ConnectError::AddressInUse));

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
@@ -163,7 +163,7 @@ impl<E: Ext> TcpListener<E> {
         };
 
         // The lock on `connecting`/`connected` cannot be locked after locking `self`, otherwise we
-        // might get a deadlock. due to inconsistent lock order problems.
+        // might get a deadlock due to inconsistent lock order problems.
         connecting.values().for_each(|socket| socket.reset());
         connected.iter().for_each(|socket| socket.reset());
     }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/udp.rs
@@ -53,11 +53,11 @@ impl<E: Ext> UdpSocketBg<E> {
         udp_repr: &UdpRepr,
         udp_payload: PacketSlice<'_>,
     ) -> bool {
-        let mut socket = self.inner.socket.lock();
-
-        if !socket.accepts(cx, ip_repr, udp_repr) {
+        if !self.accepts(ip_repr, udp_repr) {
             return false;
         }
+
+        let mut socket = self.inner.socket.lock();
 
         socket.process(
             cx,
@@ -70,6 +70,15 @@ impl<E: Ext> UdpSocketBg<E> {
         self.notify_events(SocketEvents::CAN_RECV);
 
         true
+    }
+
+    fn accepts(&self, ip_repr: &IpRepr, udp_repr: &UdpRepr) -> bool {
+        // This must be stricter than `RawUdpSocket::accepts` so that `RawUdpSocket::process` is
+        // guaranteed to work correctly if this method returns true.
+        //
+        // `RawUdpSocket::accepts` accepts all incoming broadcast and multicast packets, which is not
+        // what we want.
+        ip_repr.dst_addr() == *self.bound.addr() && udp_repr.dst_port == self.bound.port()
     }
 
     /// Tries to generate an outgoing packet and dispatches the generated packet.
@@ -110,7 +119,16 @@ impl<E: Ext> UdpSocket<E> {
         bound: BoundUdpPort<E>,
         observer: E::UdpEventObserver,
     ) -> Result<Self, (BoundUdpPort<E>, smoltcp::socket::udp::BindError)> {
-        let local_endpoint = bound.endpoint();
+        let local_endpoint = {
+            let mut endpoint = bound.endpoint();
+
+            // This is the address used to send packets. Source addresses can never be the broadcast
+            // address, even if it is the address that the socket binds to.
+            let interface = bound.iface().common().interface();
+            endpoint.addr = interface.map_broadcast_to_local(endpoint.addr);
+
+            endpoint
+        };
 
         let socket = {
             let mut socket = new_udp_socket();

--- a/test/initramfs/src/regression/network/broadcast_complex.c
+++ b/test/initramfs/src/regression/network/broadcast_complex.c
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <sys/socket.h>
+#include <netinet/ip.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+static struct sockaddr_in broadcast_port1; // 127.255.255.255:12345
+static struct sockaddr_in broadcast_port2; // 127.255.255.255:12346
+static struct sockaddr_in localhost_port1; // 127.0.0.1:12345
+static struct sockaddr_in localhost_port2; // 127.0.0.1:12346
+
+static char msg[16] = "hello world";
+static char buf[16];
+static struct sockaddr_in recv_addr;
+static socklen_t recv_addrlen;
+
+FN_SETUP(init)
+{
+	broadcast_port1.sin_family = AF_INET;
+	CHECK(inet_aton("127.255.255.255", &broadcast_port1.sin_addr));
+	broadcast_port1.sin_port = htons(12345);
+
+	broadcast_port2.sin_family = AF_INET;
+	CHECK(inet_aton("127.255.255.255", &broadcast_port2.sin_addr));
+	broadcast_port2.sin_port = htons(12346);
+
+	localhost_port1.sin_family = AF_INET;
+	CHECK(inet_aton("127.0.0.1", &localhost_port1.sin_addr));
+	localhost_port1.sin_port = htons(12345);
+
+	localhost_port2.sin_family = AF_INET;
+	CHECK(inet_aton("127.0.0.1", &localhost_port2.sin_addr));
+	localhost_port2.sin_port = htons(12346);
+}
+END_SETUP()
+
+static int new_udp(struct sockaddr_in *addr)
+{
+	int sk;
+	int opt_one = 1;
+
+	sk = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+	if (sk < 0)
+		return sk;
+
+	CHECK(setsockopt(sk, SOL_SOCKET, SO_REUSEADDR, &opt_one,
+			 sizeof(opt_one)));
+	CHECK(setsockopt(sk, SOL_SOCKET, SO_BROADCAST, &opt_one,
+			 sizeof(opt_one)));
+
+	CHECK(bind(sk, (struct sockaddr *)addr, sizeof(struct sockaddr_in)));
+
+	return sk;
+}
+
+#define TEST_SEND_TO(fd, addr)                                             \
+	TEST_RES(sendto(fd, msg, sizeof(msg), 0, (struct sockaddr *)&addr, \
+			sizeof(addr)),                                     \
+		 _ret == sizeof(msg));
+
+#define TEST_RECV_FROM(fd, addr)                                              \
+	memset(buf, 0, sizeof(buf));                                          \
+	recv_addrlen = sizeof(struct sockaddr);                               \
+	TEST_RES(recvfrom(fd, buf, sizeof(buf), 0,                            \
+			  (struct sockaddr *)&recv_addr, &recv_addrlen),      \
+		 _ret == sizeof(msg) && memcmp(buf, msg, sizeof(msg)) == 0 && \
+			 recv_addrlen == sizeof(addr) &&                      \
+			 memcmp(&recv_addr, &addr, sizeof(addr)) == 0)
+
+#define TEST_RECV_EAGAIN(fd)                                               \
+	recv_addrlen = sizeof(struct sockaddr);                            \
+	TEST_ERRNO(recvfrom(fd, buf, sizeof(buf), 0,                       \
+			    (struct sockaddr *)&recv_addr, &recv_addrlen), \
+		   EAGAIN)
+
+FN_TEST(udp_broadcast)
+{
+	int sender, receiver0, receiver1, receiver2, receiver3;
+
+	sender = TEST_SUCC(new_udp(&localhost_port1));
+	receiver0 = TEST_SUCC(new_udp(&broadcast_port1));
+	receiver1 = TEST_SUCC(new_udp(&broadcast_port1));
+	receiver2 = TEST_SUCC(new_udp(&broadcast_port2));
+	receiver3 = TEST_SUCC(new_udp(&localhost_port1));
+
+	// Broadcast packets can be received by multiple sockets.
+	TEST_SEND_TO(sender, broadcast_port1);
+	TEST_RECV_EAGAIN(sender);
+	TEST_RECV_FROM(receiver0, localhost_port1);
+	TEST_RECV_FROM(receiver1, localhost_port1);
+	TEST_RECV_EAGAIN(receiver2);
+	TEST_RECV_EAGAIN(receiver3);
+
+	TEST_SUCC(close(sender));
+	sender = TEST_SUCC(new_udp(&broadcast_port1));
+
+	// Source addresses can never be the broadcast address.
+	TEST_SEND_TO(sender, broadcast_port1);
+	TEST_RECV_FROM(sender, localhost_port1);
+	TEST_RECV_FROM(receiver0, localhost_port1);
+	TEST_RECV_FROM(receiver1, localhost_port1);
+	TEST_RECV_EAGAIN(receiver2);
+	TEST_RECV_EAGAIN(receiver3);
+
+	TEST_SUCC(close(sender));
+	TEST_SUCC(close(receiver0));
+	TEST_SUCC(close(receiver1));
+	TEST_SUCC(close(receiver2));
+	TEST_SUCC(close(receiver3));
+}
+END_TEST()
+
+#define CALL_SOCKADDR_OP(op, sk, addr) \
+	op(sk, (struct sockaddr *)&addr, sizeof(addr))
+
+#define TEST_SOCK_NAME(sk, addr)                                \
+	recv_addrlen = sizeof(recv_addr);                       \
+	TEST_RES(getsockname(sk, (struct sockaddr *)&recv_addr, \
+			     &recv_addrlen),                    \
+		 recv_addrlen == sizeof(addr) &&                \
+			 memcmp(&recv_addr, &addr, sizeof(addr)) == 0)
+
+FN_TEST(tcp_broadcast_bind)
+{
+	int sk1, sk2;
+
+	sk1 = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+	sk2 = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+
+	TEST_SUCC(CALL_SOCKADDR_OP(bind, sk1, broadcast_port2));
+	TEST_SOCK_NAME(sk1, broadcast_port2);
+
+	TEST_ERRNO(CALL_SOCKADDR_OP(bind, sk2, broadcast_port2), EADDRINUSE);
+	TEST_SUCC(CALL_SOCKADDR_OP(bind, sk2, localhost_port2));
+
+	// TCP sockets can bind to broadcast addresses. However, they fall back
+	// to interface addresses when connecting.
+	TEST_ERRNO(CALL_SOCKADDR_OP(connect, sk1, localhost_port1),
+		   ECONNREFUSED);
+	TEST_SOCK_NAME(sk1, localhost_port2);
+	TEST_SOCK_NAME(sk2, localhost_port2);
+
+	TEST_SUCC(close(sk2));
+	sk2 = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+
+	// New sockets cannot bind to the address to which `connect` falls back.
+	TEST_ERRNO(CALL_SOCKADDR_OP(bind, sk2, localhost_port2), EADDRINUSE);
+	TEST_SUCC(CALL_SOCKADDR_OP(bind, sk2, broadcast_port2));
+
+	TEST_SUCC(close(sk1));
+	TEST_SUCC(close(sk2));
+}
+END_TEST()
+
+FN_TEST(tcp_broadcast_listen)
+{
+	int sk1, sk2;
+
+	sk1 = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+	sk2 = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+
+	TEST_SUCC(CALL_SOCKADDR_OP(bind, sk1, broadcast_port1));
+	TEST_SUCC(listen(sk1, 1));
+
+	// TCP sockets cannot connect to broadcast addresses.
+	TEST_SUCC(CALL_SOCKADDR_OP(bind, sk2, localhost_port1));
+	TEST_ERRNO(CALL_SOCKADDR_OP(connect, sk2, broadcast_port1),
+		   ENETUNREACH);
+
+	TEST_SUCC(close(sk1));
+	TEST_SUCC(close(sk2));
+}
+END_TEST()

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -16,6 +16,7 @@ sleep 0.2
 sleep 0.2
 ./unix_client
 
+./broadcast_complex
 ./listen_backlog
 ./msg_peek
 ./msg_trunc

--- a/test/initramfs/src/regression/network/udp_broadcast.c
+++ b/test/initramfs/src/regression/network/udp_broadcast.c
@@ -43,11 +43,7 @@ FN_SETUP(create_and_bind)
 
 	// Bind receiver to BROADCAST_ADDR:RECEIVE_PORT
 	receiver = CHECK(socket(AF_INET, SOCK_DGRAM, 0));
-	// FIXME: Asterinas cannot support binding to broadcast addresses now.
-	// So all below code related to receiver is commented out.
-#ifndef __asterinas__
 	CHECK(bind(receiver, (struct sockaddr *)&broadcast_addr, addr_len));
-#endif
 }
 END_SETUP()
 
@@ -82,10 +78,8 @@ FN_TEST(basic_broadcast)
 	TEST_SUCC(sendto(sender, MESSAGE, MESSAGE_LEN, 0,
 			 (struct sockaddr *)&broadcast_addr, addr_len));
 
-#ifndef __asterinas__
 	TEST_SUCC(recvfrom(receiver, buf, sizeof(buf), 0,
 			   (struct sockaddr *)&received_addr, &addr_len));
-#endif
 }
 END_TEST()
 
@@ -121,10 +115,8 @@ FN_TEST(disable_receiver_broadcast)
 	TEST_SUCC(sendto(sender, MESSAGE, MESSAGE_LEN, 0,
 			 (struct sockaddr *)&broadcast_addr, addr_len));
 
-#ifndef __asterinas__
 	TEST_SUCC(recvfrom(receiver, buf, sizeof(buf), 0,
 			   (struct sockaddr *)&received_addr, &addr_len));
-#endif
 }
 END_TEST()
 
@@ -135,20 +127,16 @@ FN_TEST(connect_then_disable_broadcast)
 	TEST_SUCC(
 		connect(sender, (struct sockaddr *)&broadcast_addr, addr_len));
 	TEST_SUCC(send(sender, MESSAGE, MESSAGE_LEN, 0));
-#ifndef __asterinas__
 	TEST_SUCC(recvfrom(receiver, buf, sizeof(buf), 0,
 			   (struct sockaddr *)&received_addr, &addr_len));
-#endif
 
 	broadcast_opt = 0;
 	TEST_SUCC(setsockopt(sender, SOL_SOCKET, SO_BROADCAST, &broadcast_opt,
 			     broadcast_opt_len));
 
 	TEST_SUCC(send(sender, MESSAGE, MESSAGE_LEN, 0));
-#ifndef __asterinas__
 	TEST_SUCC(recvfrom(receiver, buf, sizeof(buf), 0,
 			   (struct sockaddr *)&received_addr, &addr_len));
-#endif
 
 	TEST_ERRNO(sendto(sender, MESSAGE, MESSAGE_LEN, 0,
 			  (struct sockaddr *)&broadcast_addr, addr_len),
@@ -160,7 +148,9 @@ FN_TEST(connect_then_disable_broadcast)
 	// FIXME: Asterinas cannot pass the following case.
 	// The problem may be that we should invalidate the connected state
 	// once the above connect fails.
-#ifndef __asterinas__
+#ifdef __asterinas__
+	TEST_SUCC(send(sender, MESSAGE, MESSAGE_LEN, 0));
+#else
 	TEST_ERRNO(send(sender, MESSAGE, MESSAGE_LEN, 0), EACCES);
 #endif
 }


### PR DESCRIPTION
We previously did not support correctly handling broadcast messages for UDP sockets. We did not even support binding UDP sockets to a broadcast address.
https://github.com/asterinas/asterinas/blob/4d395b88506ebe643fcfd51ced81bda48ee2effd/test/initramfs/src/regression/network/udp_broadcast.c#L46-L48

**Scope:** By broadcast addresses, I mean link-local ones. This PR concerns only addresses like `127.255.255.255` and `10.0.2.255`.
 - `255.255.255.255` is outside the scope of this PR as it faces the same difficulty as `0.0.0.0`.

---

After studying the Linux behavior, we should implement the following behavior:
 - UDP sockets can be bound to a broadcast address. Then,
    - Only those sockets can receive broadcast messages. [smoltcp seems to think that all sockets can receive broadcast messages](https://github.com/smoltcp-rs/smoltcp/blob/efcba2efc87b6dcc8a2953de5768dbcc83b8fac6/src/socket/udp.rs#L483), so I rewrote the logic in `aster-bigtcp`.
    - Source addresses can never be broadcast addresses. Therefore, even when sending a packet via a UDP socket bound to a broadcast address, the source address remains the interface's local address.
  - UDP sockets can connect to a broadcast address, which requires `SO_BROADCAST` to be set in advance.

Also,
 - TCP sockets can be bound to a broadcast address. Then,
    - When connecting, it falls back to the local address of the interface. `getsockname()` will see the new address. However, this process does not detect port conflicts with other sockets.
 - TCP sockets cannot connect to a broadcast address. `ENETUNREACH` will always be returned.
