### PR TITLE
Support virtiofs symbolic links

### DIFF
--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -24,6 +24,7 @@ use aster_fuse::{
         release::ReleaseOptions,
         rename::{RenameOperation, RenameReq},
         rmdir::RmdirOperation,
+        symlink::SymlinkOperation,
         unlink::UnlinkOperation,
     },
 };
@@ -401,6 +402,19 @@ impl Inode for VirtioFsInode {
         };
 
         let child = VirtioFsInode::new_from_entry_reply(create_reply, &fs);
+        fs.insert_inode_to_cache(&child);
+
+        Ok(child)
+    }
+
+    fn create_symlink(&self, name: &str, target: &str, _mode: InodeMode) -> Result<Arc<dyn Inode>> {
+        let fs = self.fs_ref();
+        let child = {
+            let entry_reply = fs
+                .session()
+                .do_fuse_op(self.nodeid(), SymlinkOperation::new(name, target))?;
+            VirtioFsInode::new_from_entry_reply(entry_reply, &fs)
+        };
         fs.insert_inode_to_cache(&child);
 
         Ok(child)

--- a/kernel/libs/aster-fuse/src/lib.rs
+++ b/kernel/libs/aster-fuse/src/lib.rs
@@ -56,6 +56,7 @@ pub use self::{
         rmdir::RmdirOperation,
         setattr::{SetattrOperation, SetattrReq, SetattrValid},
         statfs::{Kstatfs, StatfsOperation, StatfsReply},
+        symlink::SymlinkOperation,
         unlink::UnlinkOperation,
         write::{WriteFlags, WriteOperation, WriteReply, WriteReq},
     },

--- a/kernel/libs/aster-fuse/src/ops/mod.rs
+++ b/kernel/libs/aster-fuse/src/ops/mod.rs
@@ -33,5 +33,6 @@ pub mod rename;
 pub mod rmdir;
 pub mod setattr;
 pub mod statfs;
+pub mod symlink;
 pub mod unlink;
 pub mod write;

--- a/kernel/libs/aster-fuse/src/ops/symlink.rs
+++ b/kernel/libs/aster-fuse/src/ops/symlink.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! `FUSE_SYMLINK` creates a symbolic link under a parent directory node.
+//!
+//! The request body contains the null-terminated child name followed by the
+//! null-terminated symbolic-link target. The reply body contains [`EntryReply`]
+//! for the created symbolic-link inode.
+
+use ostd::mm::{Infallible, VmReader, VmWriter};
+
+use super::util;
+use crate::{EntryReply, FuseError, FuseOpcode, FuseOperation, FuseResult, ReplyExpectation};
+
+/// A request to create a symbolic link in a parent directory.
+pub struct SymlinkOperation<'a> {
+    name: &'a str,
+    target: &'a str,
+}
+
+impl<'a> SymlinkOperation<'a> {
+    /// Creates a symbolic-link request with the child name and target path.
+    pub fn new(name: &'a str, target: &'a str) -> Self {
+        Self { name, target }
+    }
+}
+
+impl FuseOperation for SymlinkOperation<'_> {
+    type Output = EntryReply;
+
+    fn opcode(&self) -> FuseOpcode {
+        FuseOpcode::Symlink
+    }
+
+    fn body_len(&self) -> usize {
+        util::name_body_len(util::name_body_len(0, self.name), self.target)
+    }
+
+    fn write_body(&mut self, writer: &mut VmWriter<'_, Infallible>) -> FuseResult<()> {
+        if writer.avail() < self.body_len() {
+            return Err(FuseError::BufferTooSmall);
+        }
+
+        writer.write(&mut VmReader::from(self.name.as_bytes()));
+        writer.write(&mut VmReader::from(util::NAME_TERMINATOR));
+        writer.write(&mut VmReader::from(self.target.as_bytes()));
+        writer.write(&mut VmReader::from(util::NAME_TERMINATOR));
+
+        Ok(())
+    }
+
+    fn reply_expectation(&self) -> ReplyExpectation {
+        ReplyExpectation::payload(size_of::<EntryReply>())
+    }
+
+    fn parse_reply(
+        payload_len: usize,
+        reader: &mut VmReader<'_, Infallible>,
+    ) -> FuseResult<Self::Output> {
+        util::read_payload(payload_len, reader)
+    }
+}


### PR DESCRIPTION
## Summary

  Add symbolic-link creation support for virtiofs.

 ## Changes
  - Implement the `FUSE_SYMLINK` operation in `aster-fuse`.
  - Implement `VirtioFsInode::create_symlink`.