### PR TITLE
Fix `ssi_pid` in signalfd records

### DIFF
--- a/kernel/core/src/process/signal/c_types.rs
+++ b/kernel/core/src/process/signal/c_types.rs
@@ -6,7 +6,10 @@
 use inherit_methods_macro::inherit_methods;
 use ostd::arch::cpu::context::UserContext;
 
-use super::sig_num::SigNum;
+use super::{
+    constants::{SI_TKILL, SI_USER},
+    sig_num::SigNum,
+};
 use crate::{
     arch::cpu::SigContext,
     prelude::*,
@@ -79,6 +82,13 @@ impl siginfo_t {
 
     pub(crate) fn si_addr(&self) -> Vaddr {
         self.siginfo_fields.sigfault().addr
+    }
+
+    pub(crate) fn sender_pid(&self) -> Option<Pid> {
+        match self.si_code {
+            SI_USER | SI_TKILL => Some(self.siginfo_fields.common().first.piduid().pid),
+            _ => None,
+        }
     }
 }
 

--- a/kernel/core/src/syscall/signalfd.rs
+++ b/kernel/core/src/syscall/signalfd.rs
@@ -309,7 +309,7 @@ impl ToSignalfdSiginfo for Box<dyn Signal> {
             ssi_signo: siginfo.si_signo as _,
             ssi_errno: siginfo.si_errno,
             ssi_code: siginfo.si_code,
-            ssi_pid: 0,
+            ssi_pid: siginfo.sender_pid().unwrap_or(0),
             ssi_uid: 0,
             ssi_fd: 0,
             ssi_tid: 0,

--- a/test/initramfs/src/regression/process/run_test.sh
+++ b/test/initramfs/src/regression/process/run_test.sh
@@ -61,6 +61,7 @@ fi
 ./signal/parent_death_signal
 ./signal/pidfd_send_signal
 ./signal/signal_fd
+./signal/signalfd_sender_pid
 ./signal/signal_test2
 
 if [ "$(uname -m)" = "x86_64" ]; then

--- a/test/initramfs/src/regression/process/signal/Makefile
+++ b/test/initramfs/src/regression/process/signal/Makefile
@@ -11,3 +11,5 @@ C_OBJS_FILTER += \
 endif
 
 include ../../common/Makefile
+
+$(OBJ_OUTPUT_DIR)/signalfd_sender_pid: EXTRA_C_FLAGS += -static

--- a/test/initramfs/src/regression/process/signal/signalfd_sender_pid.c
+++ b/test/initramfs/src/regression/process/signal/signalfd_sender_pid.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Regression test for https://github.com/asterinas/asterinas/issues/3819.
+
+#define _GNU_SOURCE
+
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/signalfd.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+static int signal_fd;
+static sigset_t old_mask;
+
+static int check_signal_info(const struct signalfd_siginfo *info,
+			     int expected_code, pid_t expected_pid)
+{
+	if (info->ssi_signo == SIGUSR1 && info->ssi_code == expected_code &&
+	    info->ssi_pid == (uint32_t)expected_pid) {
+		return 0;
+	}
+
+	fprintf(stderr,
+		"unexpected signalfd record: signo=%u code=%d pid=%u; "
+		"expected signo=%d code=%d pid=%d\n",
+		info->ssi_signo, info->ssi_code, info->ssi_pid, SIGUSR1,
+		expected_code, expected_pid);
+	errno = EINVAL;
+	return -1;
+}
+
+FN_SETUP(block_signal)
+{
+	sigset_t mask;
+
+	CHECK(sigemptyset(&mask));
+	CHECK(sigaddset(&mask, SIGUSR1));
+	CHECK(sigprocmask(SIG_BLOCK, &mask, &old_mask));
+	signal_fd = CHECK(signalfd(-1, &mask, SFD_CLOEXEC | SFD_NONBLOCK));
+}
+END_SETUP()
+
+FN_TEST(report_kill_sender_pid)
+{
+	pid_t parent_pid = CHECK(getpid());
+	pid_t child_pid = CHECK(fork());
+
+	if (child_pid == 0) {
+		CHECK(kill(parent_pid, SIGUSR1));
+		_exit(EXIT_SUCCESS);
+	}
+
+	int status;
+	CHECK_WITH(waitpid(child_pid, &status, 0),
+		   _ret == child_pid && WIFEXITED(status) &&
+			   WEXITSTATUS(status) == EXIT_SUCCESS);
+
+	struct signalfd_siginfo info = { 0 };
+	TEST_RES(read(signal_fd, &info, sizeof(info)), _ret == sizeof(info));
+	TEST_SUCC(check_signal_info(&info, SI_USER, child_pid));
+}
+END_TEST()
+
+FN_TEST(report_raise_sender_pid)
+{
+	pid_t sender_pid = CHECK(getpid());
+
+	TEST_SUCC(raise(SIGUSR1));
+
+	struct signalfd_siginfo info = { 0 };
+	TEST_RES(read(signal_fd, &info, sizeof(info)), _ret == sizeof(info));
+	TEST_SUCC(check_signal_info(&info, SI_TKILL, sender_pid));
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	CHECK(close(signal_fd));
+	CHECK(sigprocmask(SIG_SETMASK, &old_mask, NULL));
+}
+END_SETUP()


### PR DESCRIPTION
  Fixes #3819

  ### Summary

  - propagate the sender PID to signalfd records for user-generated signals
  - cover both `kill` (`SI_USER`) and `raise` (`SI_TKILL`)
  - add a statically linked regression test for the observable behavior

  ### Implementation

  The `siginfo_t` conversion now exposes the sender PID only for `SI_USER` and
  `SI_TKILL`. Other signal codes may use different union members and therefore
  continue to produce zero in this field.

  This change intentionally leaves `ssi_uid` unchanged.

  ### Testing

  - `make check`
  - `/test/process/signal/signalfd_sender_pid`
  - `make ktest NET StaDEV=tap`
  - `make run_kernel AUTO_TEST=regression`

  Before the fix, signalfd returned `ssi_pid = 0`. After the fix, it reports the
  PIDPID of the process that sent the signal.
