### PR TITLE
Reject unsupported clocks in `timerfd_create`

### DIFF
--- a/kernel/core/src/syscall/clock_gettime.rs
+++ b/kernel/core/src/syscall/clock_gettime.rs
@@ -66,8 +66,7 @@ pub(crate) enum ClockId {
 pub(super) enum DynamicClockIdInfo {
     Pid(u32, DynamicClockType),
     Tid(u32, DynamicClockType),
-    #[cfg_attr(target_arch = "x86_64", expect(dead_code))]
-    Fd(u32),
+    // TODO: Support FD clocks.
 }
 
 impl TryFrom<clockid_t> for DynamicClockIdInfo {
@@ -85,10 +84,6 @@ impl TryFrom<clockid_t> for DynamicClockIdInfo {
         let id = !(value >> 3);
         let cpu_clock_type = DynamicClockType::try_from(CPU_CLOCK_TYPE_MASK & value)?;
 
-        if let DynamicClockType::FD = cpu_clock_type {
-            return Ok(DynamicClockIdInfo::Fd(id as u32));
-        }
-
         if ID_TYPE_MASK & value > 0 {
             Ok(DynamicClockIdInfo::Tid(id as u32, cpu_clock_type))
         } else {
@@ -102,8 +97,7 @@ impl TryFrom<clockid_t> for DynamicClockIdInfo {
 pub(super) enum DynamicClockType {
     Profiling = 0,
     Virtual = 1,
-    Scheduling = 2,
-    FD = 3,
+    // TODO: Support scheduling clocks and FD clocks.
 }
 
 /// Reads the time of a clock specified by the input clock ID.
@@ -132,8 +126,6 @@ pub(super) fn read_clock(clockid: clockid_t, ctx: &Context) -> Result<Duration> 
                 match clock_type {
                     DynamicClockType::Profiling => Ok(process.prof_clock().read_time()),
                     DynamicClockType::Virtual => Ok(process.prof_clock().user_clock().read_time()),
-                    // TODO: support scheduling clock and fd clock.
-                    _ => unimplemented!(),
                 }
             }
             DynamicClockIdInfo::Tid(tid, clock_type) => {
@@ -146,10 +138,8 @@ pub(super) fn read_clock(clockid: clockid_t, ctx: &Context) -> Result<Duration> 
                     DynamicClockType::Virtual => {
                         Ok(posix_thread.prof_clock().user_clock().read_time())
                     }
-                    _ => unimplemented!(),
                 }
             }
-            DynamicClockIdInfo::Fd(_) => unimplemented!(),
         }
     }
 }

--- a/kernel/core/src/syscall/mod.rs
+++ b/kernel/core/src/syscall/mod.rs
@@ -13,7 +13,7 @@
 
 pub(crate) use clock_gettime::ClockId;
 use ostd::arch::cpu::context::UserContext;
-pub(crate) use timer_create::create_timer;
+pub(crate) use timer_create::create_timer_for_clock;
 
 use crate::{cpu::LinuxAbi, prelude::*};
 

--- a/kernel/core/src/syscall/timer_create.rs
+++ b/kernel/core/src/syscall/timer_create.rs
@@ -120,24 +120,15 @@ pub(super) fn sys_timer_delete(timer_id: timer_t, ctx: &Context) -> Result<Sysca
     Ok(SyscallReturn::Return(0))
 }
 
-/// Creates a timer associated with the specified clock ID.
+/// Creates a timer associated with the specified fixed or dynamic clock ID.
 ///
 /// This timer will invoke the given callback function (`func`) when it expires.
-pub(crate) fn create_timer<F>(clockid: clockid_t, func: F, ctx: &Context) -> Result<Arc<Timer>>
+fn create_timer<F>(clockid: clockid_t, func: F, ctx: &Context) -> Result<Arc<Timer>>
 where
     F: Fn(TimerGuard) + Send + Sync + 'static,
 {
-    let process_timer_manager = ctx.process.timer_manager();
     let timer = if clockid >= 0 {
-        let clock_id = ClockId::try_from(clockid)?;
-        match clock_id {
-            ClockId::CLOCK_PROCESS_CPUTIME_ID => process_timer_manager.create_prof_timer(func),
-            ClockId::CLOCK_THREAD_CPUTIME_ID => ctx.posix_thread.create_prof_timer(func),
-            ClockId::CLOCK_REALTIME => RealTimeClock::timer_manager().create_timer(func),
-            ClockId::CLOCK_MONOTONIC => MonotonicClock::timer_manager().create_timer(func),
-            ClockId::CLOCK_BOOTTIME => BootTimeClock::timer_manager().create_timer(func),
-            _ => return_errno_with_message!(Errno::EINVAL, "invalid clock ID"),
-        }
+        return create_timer_for_clock(ClockId::try_from(clockid)?, func, ctx);
     } else {
         let dynamic_clockid_info = DynamicClockIdInfo::try_from(clockid)?;
         match dynamic_clockid_info {
@@ -149,8 +140,6 @@ where
                 match clock_type {
                     DynamicClockType::Profiling => process_timer_manager.create_prof_timer(func),
                     DynamicClockType::Virtual => process_timer_manager.create_virtual_timer(func),
-                    // TODO: support scheduling clock and fd clock.
-                    _ => unimplemented!(),
                 }
             }
             DynamicClockIdInfo::Tid(tid, clock_type) => {
@@ -161,11 +150,32 @@ where
                 match clock_type {
                     DynamicClockType::Profiling => posix_thread.create_prof_timer(func),
                     DynamicClockType::Virtual => posix_thread.create_virtual_timer(func),
-                    _ => unimplemented!(),
                 }
             }
-            DynamicClockIdInfo::Fd(_) => unimplemented!(),
         }
+    };
+    Ok(timer)
+}
+
+/// Creates a timer associated with the specified clock ID.
+///
+/// This timer will invoke the given callback function (`func`) when it expires.
+pub(crate) fn create_timer_for_clock<F>(
+    clock_id: ClockId,
+    func: F,
+    ctx: &Context,
+) -> Result<Arc<Timer>>
+where
+    F: Fn(TimerGuard) + Send + Sync + 'static,
+{
+    let process_timer_manager = ctx.process.timer_manager();
+    let timer = match clock_id {
+        ClockId::CLOCK_PROCESS_CPUTIME_ID => process_timer_manager.create_prof_timer(func),
+        ClockId::CLOCK_THREAD_CPUTIME_ID => ctx.posix_thread.create_prof_timer(func),
+        ClockId::CLOCK_REALTIME => RealTimeClock::timer_manager().create_timer(func),
+        ClockId::CLOCK_MONOTONIC => MonotonicClock::timer_manager().create_timer(func),
+        ClockId::CLOCK_BOOTTIME => BootTimeClock::timer_manager().create_timer(func),
+        _ => return_errno_with_message!(Errno::EINVAL, "invalid clock ID"),
     };
     Ok(timer)
 }

--- a/kernel/core/src/syscall/timerfd_create.rs
+++ b/kernel/core/src/syscall/timerfd_create.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use super::SyscallReturn;
+use super::{ClockId, SyscallReturn};
 use crate::{
     fs::file::file_table::FdFlags,
     prelude::*,
@@ -18,7 +18,10 @@ pub(super) fn sys_timerfd_create(
     let flags = TFDFlags::from_bits(flags as u32)
         .ok_or_else(|| Error::with_message(Errno::EINVAL, "unknown flags"))?;
 
-    let timerfd_file = TimerfdFile::new(clockid, flags, ctx)?;
+    let clock_id = ClockId::try_from(clockid)
+        .map_err(|_| Error::with_message(Errno::EINVAL, "invalid clock ID"))?;
+
+    let timerfd_file = TimerfdFile::new(clock_id, flags, ctx)?;
 
     let fd = {
         let file_table = ctx.thread_local.borrow_file_table();

--- a/kernel/core/src/time/timerfd.rs
+++ b/kernel/core/src/time/timerfd.rs
@@ -8,7 +8,6 @@ use core::{
 
 use atomic_integer_wrapper::define_atomic_version_of_integer_like_type;
 
-use super::clockid_t;
 use crate::{
     events::IoEvents,
     fs::{
@@ -17,9 +16,9 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
-    syscall::create_timer,
+    syscall::{ClockId, create_timer_for_clock},
     time::{
-        Timer,
+        Timer, clockid_t,
         timer::{Timeout, TimerGuard},
     },
 };
@@ -91,7 +90,15 @@ define_atomic_version_of_integer_like_type!(TFDSetTimeFlags, try_from = true, {
 
 impl TimerfdFile {
     /// Creates a new `TimerfdFile` instance.
-    pub(crate) fn new(clockid: clockid_t, flags: TFDFlags, ctx: &Context) -> Result<Self> {
+    pub(crate) fn new(clock_id: ClockId, flags: TFDFlags, ctx: &Context) -> Result<Self> {
+        let is_valid = matches!(
+            clock_id,
+            ClockId::CLOCK_REALTIME | ClockId::CLOCK_MONOTONIC | ClockId::CLOCK_BOOTTIME
+        );
+        if !is_valid {
+            return_errno_with_message!(Errno::EINVAL, "invalid clock ID");
+        }
+
         let ticks = Arc::new(AtomicU64::new(0));
         let pollee = Pollee::new();
 
@@ -103,7 +110,7 @@ impl TimerfdFile {
                 ticks.fetch_add(1, Ordering::Relaxed);
                 pollee.notify(IoEvents::IN);
             };
-            create_timer(clockid, expired_fn, ctx)
+            create_timer_for_clock(clock_id, expired_fn, ctx)
         }?;
 
         let pseudo_path = AnonInodeFs::new_path(|_| "anon_inode:[timerfd]".to_string());
@@ -114,7 +121,7 @@ impl TimerfdFile {
         };
 
         Ok(TimerfdFile {
-            clockid,
+            clockid: clock_id as clockid_t,
             timer,
             ticks,
             pollee,

--- a/test/initramfs/src/regression/time/Makefile
+++ b/test/initramfs/src/regression/time/Makefile
@@ -5,5 +5,6 @@ SUBDIRS := \
 	clock_nanosleep \
 	gettimeofday \
 	itimer \
+	timerfd \
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/time/run_test.sh
+++ b/test/initramfs/src/regression/time/run_test.sh
@@ -10,3 +10,5 @@ set -e
 
 ./itimer/setitimer
 ./itimer/timer_create
+
+./timerfd/timerfd_clockid

--- a/test/initramfs/src/regression/time/timerfd/Makefile
+++ b/test/initramfs/src/regression/time/timerfd/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/time/timerfd/timerfd_clockid.c
+++ b/test/initramfs/src/regression/time/timerfd/timerfd_clockid.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <stdint.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+FN_TEST(timerfd_accepts_supported_clocks)
+{
+	const clockid_t supported_clocks[] = {
+		CLOCK_REALTIME,
+		CLOCK_MONOTONIC,
+		CLOCK_BOOTTIME,
+	};
+
+	for (size_t i = 0;
+	     i < sizeof(supported_clocks) / sizeof(supported_clocks[0]); i++) {
+		int fd = TEST_RES(timerfd_create(supported_clocks[i], 0),
+				  _ret >= 0);
+		TEST_SUCC(close(fd));
+	}
+}
+END_TEST()
+
+FN_TEST(timerfd_rejects_fixed_cpu_clocks)
+{
+	// Linux does not expose CPU-time clocks through timerfd.
+	TEST_ERRNO(timerfd_create(CLOCK_PROCESS_CPUTIME_ID, 0), EINVAL);
+	TEST_ERRNO(timerfd_create(CLOCK_THREAD_CPUTIME_ID, 0), EINVAL);
+}
+END_TEST()
+
+FN_TEST(timerfd_rejects_dynamic_clocks_without_panicking)
+{
+	// The fd clock for fd 0 used to reach an unimplemented kernel path.
+	TEST_ERRNO(timerfd_create((clockid_t)-5, 0), EINVAL);
+
+	uint32_t encoded_process_clock = (~(uint32_t)getpid() << 3);
+	TEST_ERRNO(timerfd_create((clockid_t)encoded_process_clock, 0), EINVAL);
+}
+END_TEST()


### PR DESCRIPTION
  Fixes #3823

  ## Summary

  - Validate clock IDs at the `timerfd_create` syscall boundary.
  - Return `EINVAL` for fixed CPU clocks and dynamic clock IDs.
  - Prevent dynamic fd clocks from reaching an unimplemented path and panicking
    the kernel.
  - Add regression coverage for supported, fixed CPU, and dynamic clocks.

  ## Problem

  `timerfd_create` delegated every clock ID to the helper shared with POSIX
  timers.

  This caused two user-visible problems:

  1. Fixed and dynamic CPU clocks, which Linux rejects for timerfd, could
     incorrectly create a file descriptor.
  2. A dynamic fd clock such as `(clockid_t)-5` reached
     `DynamicClockIdInfo::Fd(_) => unimplemented!()` and panicked the kernel.

  The second behavior was reproduced on commit
  `414f27702dee7c2f25672295c7aa9b83f247877e`. The panic occurred at
  `kernel/core/src/syscall/timer_create.rs:167`, and OSDK reported that the
  kernel had panicked.

  ## Solution

  Validate the clock ID in `sys_timerfd_create` before constructing the
  `TimerfdFile`.

  The syscall now permits the timerfd clocks currently implemented by
  Asterinas:

  - `CLOCK_REALTIME`
  - `CLOCK_MONOTONIC`
  - `CLOCK_BOOTTIME`

  Other fixed clocks and all dynamic clock IDs return `EINVAL`. The shared POSIX
  timer helper is unchanged, so CPU clocks that are valid for `timer_create`
  continue to work.

  Support for `CLOCK_REALTIME_ALARM` and `CLOCK_BOOTTIME_ALARM` is not added by
  this PR; their existing behavior remains unchanged.

  ## Regression test

  The new regression test verifies:

  - successful creation and cleanup for all three currently supported clocks;
  - `EINVAL` for `CLOCK_PROCESS_CPUTIME_ID`;
  - `EINVAL` for `CLOCK_THREAD_CPUTIME_ID`;
  - `EINVAL` without a kernel panic for `(clockid_t)-5`;
  - `EINVAL` for an encoded dynamic process CPU clock.

  The test references issue #3823 and closes any unexpectedly created file
  descriptor.

  ## Testing

  Linux oracle:

  - Equivalent regression test: 10 assertions passed.

  Asterinas minimal guest test:

  ```text
  test_timerfd_accepts_supported_clocks summary: 6 tests passed, 0 tests failed
  test_timerfd_rejects_fixed_cpu_clocks summary: 2 tests passed, 0 tests failed
  test_timerfd_rejects_dynamic_clocks_without_panicking summary: 2 tests passed, 0 tests failed
  guest still alive after invalid dynamic clock

  Additional validation:

  /test/time/run_test.sh
      Passed

  make check
      Passed

  make run_kernel AUTO_TEST=regression SMP=4
      All regression tests passed.
