### PR TITLE
Support pre-epoch timestamps in VFS metadata

### DIFF
--- a/kernel/core/src/fs/fs_impls/devpts/mod.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/mod.rs
@@ -2,8 +2,6 @@
 
 #![expect(unused_variables)]
 
-use core::time::Duration;
-
 use aster_util::slot_vec::SlotVec;
 use id_alloc::IdAlloc;
 
@@ -25,6 +23,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
 };
 
 mod ptmx;
@@ -284,27 +283,27 @@ impl Inode for RootInode {
         Ok(())
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.metadata.read().last_access_at
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.metadata.write().last_access_at = time;
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.metadata.read().last_modify_at
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.metadata.write().last_modify_at = time;
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.metadata.read().last_meta_change_at
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.metadata.write().last_meta_change_at = time;
     }
 

--- a/kernel/core/src/fs/fs_impls/devpts/ptmx.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/ptmx.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::time::Duration;
-
 use device_id::{DeviceId, MajorId, MinorId};
 
 use super::{BLOCK_SIZE, DevPts, PTMX_INO};
@@ -17,6 +15,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
 };
 
 /// Same major number with Linux.
@@ -133,27 +132,27 @@ impl Inode for Ptmx {
         Ok(())
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.metadata.read().last_access_at
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.metadata.write().last_access_at = time;
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.metadata.read().last_modify_at
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.metadata.write().last_modify_at = time;
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.metadata.read().last_meta_change_at
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.metadata.write().last_meta_change_at = time;
     }
 

--- a/kernel/core/src/fs/fs_impls/devpts/slave.rs
+++ b/kernel/core/src/fs/fs_impls/devpts/slave.rs
@@ -3,8 +3,6 @@
 #![expect(dead_code)]
 #![expect(unused_variables)]
 
-use core::time::Duration;
-
 use super::{BLOCK_SIZE, DevPts, FIRST_SLAVE_INO};
 use crate::{
     device::{Device, PtySlave},
@@ -17,6 +15,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
 };
 
 /// Same major number with Linux, the minor number is the index of slave.
@@ -121,27 +120,27 @@ impl Inode for PtySlaveInode {
         Ok(())
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.metadata.read().last_access_at
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.metadata.write().last_access_at = time;
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.metadata.read().last_modify_at
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.metadata.write().last_modify_at = time;
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.metadata.read().last_meta_change_at
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.metadata.write().last_meta_change_at = time;
     }
 

--- a/kernel/core/src/fs/fs_impls/exfat/inode.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/inode.rs
@@ -3,7 +3,7 @@
 #![expect(dead_code)]
 #![expect(unused_variables)]
 
-use core::{cmp::Ordering, time::Duration};
+use core::cmp::Ordering;
 
 pub(super) use align_ext::AlignExt;
 use aster_block::{
@@ -39,6 +39,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
     vm::page_cache::{BlockAsPageCacheBackend, PageCache, Vmo},
 };
 
@@ -1477,9 +1478,9 @@ impl Inode for ExfatInode {
             size: inner.size,
             optimal_block_size: blk_size,
             nr_sectors_allocated: inner.nr_sectors_allocated(),
-            last_access_at: inner.atime.as_duration().unwrap_or_default(),
-            last_modify_at: inner.mtime.as_duration().unwrap_or_default(),
-            last_meta_change_at: inner.ctime.as_duration().unwrap_or_default(),
+            last_access_at: inner.atime.as_unix_timestamp(),
+            last_modify_at: inner.mtime.as_unix_timestamp(),
+            last_meta_change_at: inner.ctime.as_unix_timestamp(),
             type_: inner.inode_type,
             mode: inner.make_mode(),
             nr_hard_links: nlinks,
@@ -1487,7 +1488,7 @@ impl Inode for ExfatInode {
             gid: Gid::new(inner.fs().mount_option().fs_gid as u32),
             container_dev_id: inner.fs().container_device_id(),
             self_dev_id: None,
-            birth_at: Some(inner.crtime.as_duration().unwrap_or_default()),
+            birth_at: Some(inner.crtime.as_unix_timestamp()),
         })
     }
 
@@ -1504,28 +1505,28 @@ impl Inode for ExfatInode {
         Ok(())
     }
 
-    fn atime(&self) -> Duration {
-        self.inner.read().atime.as_duration().unwrap_or_default()
+    fn atime(&self) -> UnixTimestamp {
+        self.inner.read().atime.as_unix_timestamp()
     }
 
-    fn set_atime(&self, time: Duration) {
-        self.inner.write().atime = DosTimestamp::from_duration(time).unwrap_or_default();
+    fn set_atime(&self, time: UnixTimestamp) {
+        self.inner.write().atime = DosTimestamp::from_unix_timestamp(time);
     }
 
-    fn mtime(&self) -> Duration {
-        self.inner.read().mtime.as_duration().unwrap_or_default()
+    fn mtime(&self) -> UnixTimestamp {
+        self.inner.read().mtime.as_unix_timestamp()
     }
 
-    fn set_mtime(&self, time: Duration) {
-        self.inner.write().mtime = DosTimestamp::from_duration(time).unwrap_or_default();
+    fn set_mtime(&self, time: UnixTimestamp) {
+        self.inner.write().mtime = DosTimestamp::from_unix_timestamp(time);
     }
 
-    fn ctime(&self) -> Duration {
-        self.inner.read().ctime.as_duration().unwrap_or_default()
+    fn ctime(&self) -> UnixTimestamp {
+        self.inner.read().ctime.as_unix_timestamp()
     }
 
-    fn set_ctime(&self, time: Duration) {
-        self.inner.write().ctime = DosTimestamp::from_duration(time).unwrap_or_default();
+    fn set_ctime(&self, time: UnixTimestamp) {
+        self.inner.write().ctime = DosTimestamp::from_unix_timestamp(time);
     }
 
     fn owner(&self) -> Result<Uid> {

--- a/kernel/core/src/fs/fs_impls/exfat/utils.rs
+++ b/kernel/core/src/fs/fs_impls/exfat/utils.rs
@@ -4,8 +4,8 @@ use core::{ops::Range, time::Duration};
 
 use time::{OffsetDateTime, PrimitiveDateTime, Time};
 
-use super::fat::ClusterID;
-use crate::prelude::*;
+use super::{constants, fat::ClusterID};
+use crate::{prelude::*, time::UnixTimestamp};
 
 pub(crate) fn make_hash_index(cluster: ClusterID, offset: u32) -> usize {
     ((cluster as usize) << 32usize) | (offset as usize & 0xffffffffusize)
@@ -160,6 +160,29 @@ impl DosTimestamp {
         Ok(Duration::new(sec, nano_sec))
     }
 
+    pub(super) fn as_unix_timestamp(&self) -> UnixTimestamp {
+        self.as_duration()
+            .map(UnixTimestamp::from_duration_since_epoch)
+            .unwrap_or_default()
+    }
+
+    /// Converts a Unix timestamp, clamping it to the exFAT range and truncating
+    /// it to exFAT precision.
+    pub(super) fn from_unix_timestamp(ts: UnixTimestamp) -> Self {
+        let min_seconds = constants::EXFAT_MIN_TIMESTAMP_SECS as i64;
+        let max_seconds = constants::EXFAT_MAX_TIMESTAMP_SECS as i64;
+        let (seconds, nanoseconds) = if ts.seconds() < min_seconds {
+            (constants::EXFAT_MIN_TIMESTAMP_SECS, 0)
+        } else if ts.seconds() > max_seconds {
+            (constants::EXFAT_MAX_TIMESTAMP_SECS, 999_999_999)
+        } else {
+            (ts.seconds() as u64, ts.nanoseconds())
+        };
+
+        Self::from_duration(Duration::new(seconds, nanoseconds))
+            .expect("clamped exFAT timestamp must be representable")
+    }
+
     fn adjust_time_zone(sec: u64, time_zone: u8) -> u64 {
         if time_zone <= 0x3F {
             sec + Self::time_zone_sec(time_zone)
@@ -171,5 +194,53 @@ impl DosTimestamp {
     fn time_zone_sec(x: u8) -> u64 {
         // Each time zone represents 15 minutes.
         x as u64 * 15 * 60
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    #[ktest]
+    fn pre_epoch_clamps_to_minimum() {
+        let dos = DosTimestamp::from_unix_timestamp(UnixTimestamp::from_seconds(-1));
+        let timestamp = dos.as_unix_timestamp();
+        assert_eq!(
+            timestamp.seconds(),
+            constants::EXFAT_MIN_TIMESTAMP_SECS as i64
+        );
+        assert_eq!(timestamp.nanoseconds(), 0);
+    }
+
+    #[ktest]
+    fn pre_1980_clamps_to_minimum() {
+        let dos = DosTimestamp::from_unix_timestamp(UnixTimestamp::from_seconds(0));
+        assert_eq!(
+            dos.as_unix_timestamp().seconds(),
+            constants::EXFAT_MIN_TIMESTAMP_SECS as i64
+        );
+    }
+
+    #[ktest]
+    fn post_2107_clamps_to_maximum() {
+        let dos = DosTimestamp::from_unix_timestamp(UnixTimestamp::from_seconds(
+            constants::EXFAT_MAX_TIMESTAMP_SECS as i64 + 1,
+        ));
+        let timestamp = dos.as_unix_timestamp();
+        assert_eq!(
+            timestamp.seconds(),
+            constants::EXFAT_MAX_TIMESTAMP_SECS as i64
+        );
+        assert_eq!(timestamp.nanoseconds(), 990_000_000);
+    }
+
+    #[ktest]
+    fn year_2020_roundtrips_at_even_second() {
+        // 2020-01-01 00:00:00 UTC. DOS stores seconds in two-second units.
+        let ts = UnixTimestamp::from_seconds(1_577_836_800);
+        let back = DosTimestamp::from_unix_timestamp(ts).as_unix_timestamp();
+        assert_eq!(back.seconds(), 1_577_836_800);
     }
 }

--- a/kernel/core/src/fs/fs_impls/ext2/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/fs.rs
@@ -184,7 +184,7 @@ impl Ext2 {
             mount_options,
             flags: AtomicFsFlags::new(flags),
             fs_event_subscriber_stats: FsEventSubscriberStats::new(),
-            next_generation: AtomicU32::new(utils::duration_to_ext2_secs(utils::now())),
+            next_generation: AtomicU32::new(utils::duration_to_ext2_secs(utils::now_duration())),
             self_ref: weak_self.clone(),
         });
 
@@ -635,7 +635,7 @@ impl Ext2 {
         }
         sb_guard.set_free_blocks_count(total_free_blocks);
         sb_guard.set_free_inodes_count(total_free_inodes);
-        sb_guard.set_wtime(utils::now());
+        sb_guard.set_wtime(utils::now_duration());
 
         let mut raw_sb = RawSuperBlock::from(&**sb_guard);
         self.write_sb_and_group_descs(

--- a/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/impl_for_vfs/inode.rs
@@ -7,8 +7,6 @@
 //! ext2-internal operations, including symlink results and the inode's VFS
 //! extension slot.
 
-use core::time::Duration;
-
 use aster_block::bio::BioStatus;
 use device_id::DeviceId;
 
@@ -29,6 +27,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
     vm::page_cache::Vmo,
 };
 
@@ -109,27 +108,27 @@ impl Inode for Ext2Inode {
         self.set_gid(gid.into())
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.atime()
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.set_atime(time)
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.mtime()
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.set_mtime(time)
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.ctime()
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.set_ctime(time)
     }
 

--- a/kernel/core/src/fs/fs_impls/ext2/inode/attrs.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/attrs.rs
@@ -126,32 +126,32 @@ impl Inode {
     }
 
     /// Returns the last access time.
-    pub(in ext2) fn atime(&self) -> Duration {
+    pub(in ext2) fn atime(&self) -> UnixTimestamp {
         self.inner.read().atime()
     }
 
     /// Sets the last access time.
-    pub(in ext2) fn set_atime(&self, time: Duration) {
+    pub(in ext2) fn set_atime(&self, time: UnixTimestamp) {
         self.inner.write().set_atime(time);
     }
 
     /// Returns the last data modification time.
-    pub(in ext2) fn mtime(&self) -> Duration {
+    pub(in ext2) fn mtime(&self) -> UnixTimestamp {
         self.inner.read().mtime()
     }
 
     /// Sets the last data modification time.
-    pub(in ext2) fn set_mtime(&self, time: Duration) {
+    pub(in ext2) fn set_mtime(&self, time: UnixTimestamp) {
         self.inner.write().set_mtime(time);
     }
 
     /// Returns the last metadata change time.
-    pub(in ext2) fn ctime(&self) -> Duration {
+    pub(in ext2) fn ctime(&self) -> UnixTimestamp {
         self.inner.read().ctime()
     }
 
     /// Sets the last metadata change time.
-    pub(in ext2) fn set_ctime(&self, time: Duration) {
+    pub(in ext2) fn set_ctime(&self, time: UnixTimestamp) {
         self.inner.write().set_ctime(time);
     }
 

--- a/kernel/core/src/fs/fs_impls/ext2/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/mod.rs
@@ -78,6 +78,8 @@ mod io_range;
 mod symlink;
 mod sync;
 
+use core::time::Duration;
+
 use ostd::const_assert;
 
 use self::{
@@ -87,6 +89,7 @@ use self::{
 use super::{fs::Ext2, prelude::*, xattr::Xattr};
 use crate::{
     fs::{ext2::utils, file::InodeMode, pipe::Pipe, vfs::inode::Extension},
+    time::UnixTimestamp,
     vm::page_cache::Vmo,
 };
 
@@ -233,7 +236,7 @@ impl Drop for Inode {
 /// Parsed in-memory mirror of an on-disk inode's metadata fields.
 ///
 /// Unlike `RawInode`, fields are decoded into Rust types
-/// (e.g., `Duration` for timestamps, `InodeType` for file type).
+/// (e.g., `UnixTimestamp` for timestamps, `InodeType` for file type).
 #[derive(Clone, Copy, Debug)]
 pub(super) struct InodeDesc {
     type_: InodeType,
@@ -241,9 +244,9 @@ pub(super) struct InodeDesc {
     uid: u32,
     gid: u32,
     size: u64,
-    atime: Duration,
-    ctime: Duration,
-    mtime: Duration,
+    atime: UnixTimestamp,
+    ctime: UnixTimestamp,
+    mtime: UnixTimestamp,
     dtime: Duration,
     link_count: u16,
     sector_count: u32,
@@ -261,7 +264,7 @@ impl InodeDesc {
         gid: u32,
         link_count: u16,
         generation: u32,
-        now: Duration,
+        now: UnixTimestamp,
     ) -> Self {
         Self {
             type_,
@@ -300,9 +303,9 @@ impl TryFrom<&RawInode> for InodeDesc {
         let perm = FilePerm::from_bits_truncate(mode & 0o7777);
         let uid = (raw.uid as u32) | ((raw.uid_high as u32) << 16);
         let gid = (raw.gid as u32) | ((raw.gid_high as u32) << 16);
-        let atime = Duration::from_secs(raw.atime as u64);
-        let ctime = Duration::from_secs(raw.ctime as u64);
-        let mtime = Duration::from_secs(raw.mtime as u64);
+        let atime = utils::ext2_secs_to_unix_timestamp(raw.atime);
+        let ctime = utils::ext2_secs_to_unix_timestamp(raw.ctime);
+        let mtime = utils::ext2_secs_to_unix_timestamp(raw.mtime);
 
         let mut size = raw.size_lo as u64;
         if type_ == InodeType::File {
@@ -359,9 +362,9 @@ impl From<&InodeDesc> for RawInode {
             mode,
             uid,
             size_lo,
-            atime: utils::duration_to_ext2_secs(desc.atime),
-            ctime: utils::duration_to_ext2_secs(desc.ctime),
-            mtime: utils::duration_to_ext2_secs(desc.mtime),
+            atime: utils::unix_timestamp_to_ext2_secs(desc.atime),
+            ctime: utils::unix_timestamp_to_ext2_secs(desc.ctime),
+            mtime: utils::unix_timestamp_to_ext2_secs(desc.mtime),
             dtime: utils::duration_to_ext2_secs(desc.dtime),
             gid,
             link_count: desc.link_count,
@@ -531,31 +534,31 @@ impl InodeInner {
         self.desc.size = new_size as u64;
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.desc.atime
     }
 
-    fn set_atime(&mut self, time: Duration) {
-        self.desc.atime = time;
+    fn set_atime(&mut self, time: UnixTimestamp) {
+        self.desc.atime = utils::normalize_ext2_timestamp(time);
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.desc.mtime
     }
 
-    fn set_mtime(&mut self, time: Duration) {
-        self.desc.mtime = time;
+    fn set_mtime(&mut self, time: UnixTimestamp) {
+        self.desc.mtime = utils::normalize_ext2_timestamp(time);
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.desc.ctime
     }
 
-    fn set_ctime(&mut self, time: Duration) {
-        self.desc.ctime = time;
+    fn set_ctime(&mut self, time: UnixTimestamp) {
+        self.desc.ctime = utils::normalize_ext2_timestamp(time);
     }
 
-    fn set_mtime_ctime(&mut self, time: Duration) {
+    fn set_mtime_ctime(&mut self, time: UnixTimestamp) {
         self.set_mtime(time);
         self.set_ctime(time);
     }
@@ -764,5 +767,60 @@ mod test {
             0,
             Arc::downgrade(ext2),
         )
+    }
+}
+
+#[cfg(ktest)]
+mod timestamp_encode_tests {
+    use ostd::prelude::*;
+
+    use super::*;
+    use crate::{fs::file::InodeType, time::UnixTimestamp};
+
+    fn sample_desc(now: UnixTimestamp) -> InodeDesc {
+        InodeDesc::new(
+            InodeType::File,
+            FilePerm::from_bits_truncate(0o644),
+            0,
+            0,
+            1,
+            0,
+            now,
+        )
+    }
+
+    // On-disk ext2 seconds are the two's-complement bit pattern of signed Unix time.
+    // See https://github.com/asterinas/asterinas/issues/3746
+    #[ktest]
+    fn raw_inode_preserves_pre_epoch_and_distinct_fields() {
+        let mut desc = sample_desc(UnixTimestamp::from_seconds(0));
+        desc.atime = UnixTimestamp::from_seconds(-1);
+        desc.ctime = UnixTimestamp::from_seconds(i32::MIN as i64);
+        desc.mtime = UnixTimestamp::from_seconds(-2051222400);
+        desc.dtime = Duration::from_secs(u32::MAX as u64);
+
+        let raw = RawInode::from(&desc);
+        // Zero-extending `u32 as i64` would turn these into post-2038 values.
+        assert_eq!(raw.atime as i32 as i64, -1);
+        assert_eq!(raw.ctime as i32 as i64, i32::MIN as i64);
+        assert_eq!(raw.mtime as i32 as i64, -2051222400);
+        assert_eq!(raw.dtime, u32::MAX);
+
+        let decoded = InodeDesc::try_from(&raw).unwrap();
+        assert_eq!(decoded.atime.seconds(), -1);
+        assert_eq!(decoded.ctime.seconds(), i32::MIN as i64);
+        assert_eq!(decoded.mtime.seconds(), -2051222400);
+        assert_eq!(decoded.dtime, Duration::from_secs(u32::MAX as u64));
+    }
+
+    #[ktest]
+    fn raw_inode_clamps_outside_signed_32() {
+        let mut desc = sample_desc(UnixTimestamp::from_seconds(0));
+        desc.atime = UnixTimestamp::from_seconds(i32::MAX as i64 + 1);
+        desc.mtime = UnixTimestamp::from_seconds(i32::MIN as i64 - 1);
+
+        let raw = RawInode::from(&desc);
+        assert_eq!(raw.atime as i32, i32::MAX);
+        assert_eq!(raw.mtime as i32, i32::MIN);
     }
 }

--- a/kernel/core/src/fs/fs_impls/ext2/inode/sync.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/inode/sync.rs
@@ -76,7 +76,7 @@ impl Inode {
         if block_manager.is_some() {
             inner.resize_page_cache(0, old_size)?;
         }
-        inner.set_dtime(utils::now());
+        inner.set_dtime(utils::now_duration());
         inner.set_file_size(0);
         inner.set_file_acl(0);
         if inner.desc.sector_count > 0

--- a/kernel/core/src/fs/fs_impls/ext2/prelude.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/prelude.rs
@@ -29,6 +29,6 @@ pub(super) use crate::{
         utils::{DirentVisitor, Str16, Str64},
     },
     prelude::*,
-    time::UnixTime,
+    time::{UnixTime, UnixTimestamp},
     vm::page_cache::{BlockAsPageCacheBackend, PageCache, PageCacheBackend},
 };

--- a/kernel/core/src/fs/fs_impls/ext2/utils.rs
+++ b/kernel/core/src/fs/fs_impls/ext2/utils.rs
@@ -6,9 +6,14 @@
 //!   mutated, for writeback scheduling.
 //! - `IsPowerOf` — a trait for testing whether a number is a power of
 //!   another (used by sparse-superblock backup-group selection).
-//! - `now` — a convenience function that reads the real-time coarse clock.
+//! - `now` — current wall-clock time as a VFS [`UnixTimestamp`].
+//! - `now_duration` — the same instant as a [`Duration`], for superblock fields.
 //! - `duration_to_ext2_secs` — converts kernel durations to clamped ext2
 //!   timestamp seconds.
+//! - `ext2_secs_to_unix_timestamp` and `unix_timestamp_to_ext2_secs` — convert
+//!   between VFS timestamps and ext2's signed 32-bit seconds format.
+//! - `normalize_ext2_timestamp` — clamps a VFS timestamp to the range and
+//!   precision representable by ext2.
 
 use core::ops::MulAssign;
 
@@ -103,12 +108,79 @@ impl<T: Debug> Debug for Dirty<T> {
     }
 }
 
-/// Returns the current time.
-pub(super) fn now() -> Duration {
+/// Returns the current wall-clock time as a VFS timestamp.
+pub(super) fn now() -> UnixTimestamp {
+    UnixTimestamp::from_duration_since_epoch(now_duration())
+}
+
+/// Returns the current wall-clock time as a `Duration` since the Unix epoch.
+///
+/// Superblock fields still use unsigned `UnixTime` / `Duration`.
+pub(super) fn now_duration() -> Duration {
     crate::time::clocks::RealTimeCoarseClock::get().read_time()
 }
 
 /// Converts a `Duration` to a 32-bit ext2 timestamp, clamping to `u32::MAX`.
 pub(super) fn duration_to_ext2_secs(d: Duration) -> u32 {
     u32::try_from(d.as_secs()).unwrap_or(u32::MAX)
+}
+
+/// Decodes an ext2 inode timestamp from signed 32-bit seconds.
+///
+/// See the original inode timestamp format in
+/// <https://www.kernel.org/doc/html/latest/filesystems/ext4/inodes.html#inode-timestamps>.
+pub(super) fn ext2_secs_to_unix_timestamp(seconds: u32) -> UnixTimestamp {
+    UnixTimestamp::from_seconds(seconds as i32 as i64)
+}
+
+/// Encodes a timestamp using ext2's signed 32-bit seconds format.
+pub(super) fn unix_timestamp_to_ext2_secs(ts: UnixTimestamp) -> u32 {
+    ts.seconds().clamp(i32::MIN as i64, i32::MAX as i64) as u32
+}
+
+/// Clamps a timestamp to the range and precision representable by ext2.
+pub(super) fn normalize_ext2_timestamp(ts: UnixTimestamp) -> UnixTimestamp {
+    ext2_secs_to_unix_timestamp(unix_timestamp_to_ext2_secs(ts))
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    #[ktest]
+    fn encode_negative_one_is_all_ones() {
+        let encoded = unix_timestamp_to_ext2_secs(UnixTimestamp::from_seconds(-1));
+        assert_eq!(encoded, u32::MAX);
+        assert_eq!(ext2_secs_to_unix_timestamp(encoded).seconds(), -1);
+    }
+
+    #[ktest]
+    fn encode_clamps_to_signed_32() {
+        assert_eq!(
+            unix_timestamp_to_ext2_secs(UnixTimestamp::from_seconds(i32::MAX as i64 + 1)),
+            i32::MAX as u32
+        );
+        assert_eq!(
+            unix_timestamp_to_ext2_secs(UnixTimestamp::from_seconds(i32::MIN as i64 - 1)),
+            i32::MIN as u32
+        );
+    }
+
+    #[ktest]
+    fn normalize_clamps_seconds_and_discards_nanoseconds() {
+        assert_eq!(
+            normalize_ext2_timestamp(UnixTimestamp::try_new(123, 456).unwrap()),
+            UnixTimestamp::from_seconds(123)
+        );
+        assert_eq!(
+            normalize_ext2_timestamp(UnixTimestamp::try_new(i32::MAX as i64 + 1, 123).unwrap()),
+            UnixTimestamp::from_seconds(i32::MAX as i64)
+        );
+        assert_eq!(
+            normalize_ext2_timestamp(UnixTimestamp::try_new(i32::MIN as i64 - 1, 456).unwrap()),
+            UnixTimestamp::from_seconds(i32::MIN as i64)
+        );
+    }
 }

--- a/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/overlayfs/fs.rs
@@ -3,10 +3,7 @@
 #![expect(dead_code)]
 
 use alloc::format;
-use core::{
-    sync::atomic::{AtomicU64, Ordering},
-    time::Duration,
-};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use align_ext::AlignExt;
 use aster_block::BLOCK_SIZE;
@@ -35,6 +32,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
     vm::page_cache::Vmo,
 };
 
@@ -599,9 +597,9 @@ impl OverlayInode {
     pub(crate) fn mode(&self) -> Result<InodeMode>;
     pub(crate) fn owner(&self) -> Result<Uid>;
     pub(crate) fn group(&self) -> Result<Gid>;
-    pub(crate) fn atime(&self) -> Duration;
-    pub(crate) fn mtime(&self) -> Duration;
-    pub(crate) fn ctime(&self) -> Duration;
+    pub(crate) fn atime(&self) -> UnixTimestamp;
+    pub(crate) fn mtime(&self) -> UnixTimestamp;
+    pub(crate) fn ctime(&self) -> UnixTimestamp;
     pub(crate) fn open(
         &self,
         access_mode: AccessMode,
@@ -626,9 +624,9 @@ impl OverlayInode {
 
 #[inherit_methods(from = "self.build_upper_recursively_if_needed().unwrap()")]
 impl OverlayInode {
-    pub(crate) fn set_atime(&self, time: Duration);
-    pub(crate) fn set_mtime(&self, time: Duration);
-    pub(crate) fn set_ctime(&self, time: Duration);
+    pub(crate) fn set_atime(&self, time: UnixTimestamp);
+    pub(crate) fn set_mtime(&self, time: UnixTimestamp);
+    pub(crate) fn set_ctime(&self, time: UnixTimestamp);
 }
 
 impl OverlayInode {
@@ -1026,12 +1024,12 @@ impl Inode for OverlayInode {
     fn set_owner(&self, uid: Uid) -> Result<()>;
     fn group(&self) -> Result<Gid>;
     fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
+    fn atime(&self) -> UnixTimestamp;
+    fn set_atime(&self, time: UnixTimestamp);
+    fn mtime(&self) -> UnixTimestamp;
+    fn set_mtime(&self, time: UnixTimestamp);
+    fn ctime(&self) -> UnixTimestamp;
+    fn set_ctime(&self, time: UnixTimestamp);
     fn page_cache(&self) -> Option<Arc<Vmo>>;
     fn create(&self, name: &str, type_: InodeType, mode: InodeMode) -> Result<Arc<dyn Inode>>;
     fn create_symlink(&self, name: &str, target: &str, mode: InodeMode) -> Result<Arc<dyn Inode>>;
@@ -1635,7 +1633,8 @@ mod tests {
             .unwrap()
             .write(0, &mut VmReader::from([3].as_slice()).to_fallible())
             .unwrap();
-        f1.set_atime(Duration::default());
+        f1.set_atime(UnixTimestamp::from_seconds(-1));
+        assert_eq!(f1.atime().seconds(), -1);
         f1.sync(SyncMode::Data).unwrap();
         let mut data = [0u8; 1];
         f1.read_at(

--- a/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/dir.rs
@@ -5,7 +5,6 @@
 #![short_vis_path::add(procfs)]
 
 use alloc::borrow::Cow;
-use core::time::Duration;
 
 use inherit_methods_macro::inherit_methods;
 
@@ -26,6 +25,7 @@ use crate::{
     prelude::*,
     process::{Gid, Uid},
     thread::Thread,
+    time::UnixTimestamp,
 };
 
 /// Wraps directory-specific procfs operations as a VFS inode.
@@ -166,12 +166,12 @@ impl<D: ProcDirOps + 'static> Inode for ProcDir<D> {
     fn set_owner(&self, uid: Uid) -> Result<()>;
     fn group(&self) -> Result<Gid>;
     fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
+    fn atime(&self) -> UnixTimestamp;
+    fn set_atime(&self, time: UnixTimestamp);
+    fn mtime(&self) -> UnixTimestamp;
+    fn set_mtime(&self, time: UnixTimestamp);
+    fn ctime(&self) -> UnixTimestamp;
+    fn set_ctime(&self, time: UnixTimestamp);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn metadata(&self) -> Result<Metadata> {

--- a/kernel/core/src/fs/fs_impls/procfs/template/file.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/file.rs
@@ -2,8 +2,6 @@
 
 #![short_vis_path::add(procfs)]
 
-use core::time::Duration;
-
 use inherit_methods_macro::inherit_methods;
 
 use super::Common;
@@ -19,6 +17,7 @@ use crate::{
     prelude::*,
     process::{Gid, Uid},
     thread::Thread,
+    time::UnixTimestamp,
 };
 
 pub(in procfs) struct ProcFile<F: ProcFileOps> {
@@ -81,12 +80,12 @@ impl<F: ProcFileOps + 'static> Inode for ProcFile<F> {
     fn set_owner(&self, uid: Uid) -> Result<()>;
     fn group(&self) -> Result<Gid>;
     fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
+    fn atime(&self) -> UnixTimestamp;
+    fn set_atime(&self, time: UnixTimestamp);
+    fn mtime(&self) -> UnixTimestamp;
+    fn set_mtime(&self, time: UnixTimestamp);
+    fn ctime(&self) -> UnixTimestamp;
+    fn set_ctime(&self, time: UnixTimestamp);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn metadata(&self) -> Result<Metadata> {

--- a/kernel/core/src/fs/fs_impls/procfs/template/mod.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::time::Duration;
-
 pub(super) use self::{
     dir::{
         ListedEntry, ProcDir, ProcDirOps, ReaddirEntry, StaticDirEntry, keyed_readdir_entries,
@@ -22,6 +20,7 @@ use crate::{
     prelude::*,
     process::{Gid, Uid, posix_thread::AsPosixThread},
     thread::Thread,
+    time::UnixTimestamp,
 };
 
 mod dir;
@@ -77,27 +76,27 @@ impl Common {
         self.metadata.read().size
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.metadata.read().last_access_at
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.metadata.write().last_access_at = time;
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.metadata.read().last_modify_at
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.metadata.write().last_modify_at = time;
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.metadata.read().last_meta_change_at
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.metadata.write().last_meta_change_at = time;
     }
 

--- a/kernel/core/src/fs/fs_impls/procfs/template/sym.rs
+++ b/kernel/core/src/fs/fs_impls/procfs/template/sym.rs
@@ -2,8 +2,6 @@
 
 #![short_vis_path::add(procfs)]
 
-use core::time::Duration;
-
 use inherit_methods_macro::inherit_methods;
 
 use super::Common;
@@ -19,6 +17,7 @@ use crate::{
     prelude::*,
     process::{Gid, Uid},
     thread::Thread,
+    time::UnixTimestamp,
 };
 
 pub(in procfs) struct ProcSym<S: ProcSymOps> {
@@ -78,12 +77,12 @@ impl<S: ProcSymOps + 'static> Inode for ProcSym<S> {
     fn set_owner(&self, uid: Uid) -> Result<()>;
     fn group(&self) -> Result<Gid>;
     fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
+    fn atime(&self) -> UnixTimestamp;
+    fn set_atime(&self, time: UnixTimestamp);
+    fn mtime(&self) -> UnixTimestamp;
+    fn set_mtime(&self, time: UnixTimestamp);
+    fn ctime(&self) -> UnixTimestamp;
+    fn set_ctime(&self, time: UnixTimestamp);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn metadata(&self) -> Result<Metadata> {

--- a/kernel/core/src/fs/fs_impls/pseudofs/mod.rs
+++ b/kernel/core/src/fs/fs_impls/pseudofs/mod.rs
@@ -20,10 +20,7 @@
 //! As such, this module provides [`AnonDeviceId`] to acquire and recycle
 //! anonymous device IDs.
 
-use core::{
-    sync::atomic::{AtomicU64, Ordering},
-    time::Duration,
-};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) use allocator::AnonDeviceId;
 pub(crate) use anon_inodefs::AnonInodeFs;
@@ -49,7 +46,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    time::clocks::RealTimeCoarseClock,
+    time::{UnixTimestamp, clocks::RealTimeCoarseClock},
 };
 
 mod allocator;
@@ -329,27 +326,27 @@ impl Inode for PseudoInode {
         Ok(())
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.metadata.lock().last_access_at
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.metadata.lock().last_access_at = time;
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.metadata.lock().last_modify_at
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.metadata.lock().last_modify_at = time;
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.metadata.lock().last_meta_change_at
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.metadata.lock().last_meta_change_at = time;
     }
 
@@ -369,6 +366,6 @@ impl Inode for PseudoInode {
     }
 }
 
-fn now() -> Duration {
-    RealTimeCoarseClock::get().read_time()
+fn now() -> UnixTimestamp {
+    UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time())
 }

--- a/kernel/core/src/fs/fs_impls/pseudofs/nsfs.rs
+++ b/kernel/core/src/fs/fs_impls/pseudofs/nsfs.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::format;
-use core::time::Duration;
 
 use inherit_methods_macro::inherit_methods;
 use ostd::task::Task;
@@ -27,6 +26,7 @@ use crate::{
         CloneFlags, Gid, Uid, UserNamespace,
         signal::{PollHandle, Pollable},
     },
+    time::UnixTimestamp,
     util::ioctl::{RawIoctl, dispatch_ioctl},
 };
 
@@ -114,12 +114,12 @@ impl<T: NsCommonOps> Inode for NsInode<T> {
     fn set_owner(&self, uid: Uid) -> Result<()>;
     fn group(&self) -> Result<Gid>;
     fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
+    fn atime(&self) -> UnixTimestamp;
+    fn set_atime(&self, time: UnixTimestamp);
+    fn mtime(&self) -> UnixTimestamp;
+    fn set_mtime(&self, time: UnixTimestamp);
+    fn ctime(&self) -> UnixTimestamp;
+    fn set_ctime(&self, time: UnixTimestamp);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn open(

--- a/kernel/core/src/fs/fs_impls/ramfs/fs.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/fs.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::{
-    sync::atomic::{AtomicU64, Ordering},
-    time::Duration,
-};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use align_ext::AlignExt;
 use aster_block::SECTOR_SIZE;
@@ -37,7 +34,7 @@ use crate::{
     prelude::*,
     process::{Gid, Uid, posix_thread::AsPosixThread},
     thread::Thread,
-    time::clocks::RealTimeCoarseClock,
+    time::{UnixTimestamp, clocks::RealTimeCoarseClock},
     vm::page_cache::{PageCache, Vmo},
 };
 
@@ -298,9 +295,9 @@ impl Inner {
 struct InodeMeta {
     size: usize,
     blocks: usize,
-    atime: Duration,
-    mtime: Duration,
-    ctime: Duration,
+    atime: UnixTimestamp,
+    mtime: UnixTimestamp,
+    ctime: UnixTimestamp,
     mode: InodeMode,
     nlinks: usize,
     uid: Uid,
@@ -366,15 +363,15 @@ impl InodeMeta {
             .expect("ramfs allocated sector count overflow")
     }
 
-    pub(crate) fn set_atime(&mut self, time: Duration) {
+    pub(crate) fn set_atime(&mut self, time: UnixTimestamp) {
         self.atime = time;
     }
 
-    pub(crate) fn set_mtime(&mut self, time: Duration) {
+    pub(crate) fn set_mtime(&mut self, time: UnixTimestamp) {
         self.mtime = time;
     }
 
-    pub(crate) fn set_ctime(&mut self, time: Duration) {
+    pub(crate) fn set_ctime(&mut self, time: UnixTimestamp) {
         self.ctime = time;
     }
 
@@ -1118,27 +1115,27 @@ impl Inode for RamInode {
         Ok(())
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.metadata.lock().atime
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.metadata.lock().set_atime(time);
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.metadata.lock().mtime
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.metadata.lock().set_mtime(time);
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.metadata.lock().ctime
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.metadata.lock().set_ctime(time);
     }
 
@@ -1595,7 +1592,7 @@ impl DirChange {
 
     /// Applies this change to `dir`'s own metadata, also bumping its mtime/ctime
     /// to `now`.
-    fn apply(self, dir: &RamInode, now: Duration) {
+    fn apply(self, dir: &RamInode, now: UnixTimestamp) {
         let mut meta = dir.metadata.lock();
         match (self.old_type, self.new_type) {
             (Some(_), None) => meta.dec_size(),
@@ -1631,8 +1628,8 @@ fn write_lock_two_direntries_by_ino<'a>(
     }
 }
 
-fn now() -> Duration {
-    RealTimeCoarseClock::get().read_time()
+fn now() -> UnixTimestamp {
+    UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time())
 }
 
 fn current_fs_ids() -> (Uid, Gid) {

--- a/kernel/core/src/fs/fs_impls/ramfs/memfd.rs
+++ b/kernel/core/src/fs/fs_impls/ramfs/memfd.rs
@@ -3,7 +3,6 @@
 //! Memfd Implementation.
 
 use alloc::format;
-use core::time::Duration;
 
 use align_ext::AlignExt;
 use inherit_methods_macro::inherit_methods;
@@ -23,6 +22,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
     vm::{page_cache::Vmo, perms::VmPerms},
 };
 
@@ -149,12 +149,12 @@ impl FileOps for MemfdInode {
 impl Inode for MemfdInode {
     fn metadata(&self) -> Result<Metadata>;
     fn size(&self) -> usize;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
+    fn atime(&self) -> UnixTimestamp;
+    fn set_atime(&self, time: UnixTimestamp);
+    fn mtime(&self) -> UnixTimestamp;
+    fn set_mtime(&self, time: UnixTimestamp);
+    fn ctime(&self) -> UnixTimestamp;
+    fn set_ctime(&self, time: UnixTimestamp);
     fn ino(&self) -> u64;
     fn type_(&self) -> InodeType;
     fn mode(&self) -> Result<InodeMode>;

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/metadata.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/metadata.rs
@@ -16,7 +16,10 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    time::clocks::{MonotonicCoarseClock, RealTimeCoarseClock},
+    time::{
+        self, UnixTimestamp,
+        clocks::{MonotonicCoarseClock, RealTimeCoarseClock},
+    },
 };
 
 impl VirtioFsInode {
@@ -96,7 +99,7 @@ impl VirtioFsInode {
 impl InodeInner {
     /// Commits metadata changes after a local write.
     pub(super) fn commit_local_write(&mut self, committed_size: usize, attr_version: AttrVersion) {
-        let now = RealTimeCoarseClock::get().read_time();
+        let now = UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
         self.metadata.size = committed_size;
         self.metadata.nr_sectors_allocated = committed_size.div_ceil(512);
         self.metadata.last_modify_at = now;
@@ -201,9 +204,9 @@ pub(in crate::fs::fs_impls::virtiofs) fn metadata_from_attr(
         size: attr.size() as usize,
         optimal_block_size: attr.blksize() as usize,
         nr_sectors_allocated: attr.blocks() as usize,
-        last_access_at: Duration::new(attr.atime(), attr.atimensec()),
-        last_modify_at: Duration::new(attr.mtime(), attr.mtimensec()),
-        last_meta_change_at: Duration::new(attr.ctime(), attr.ctimensec()),
+        last_access_at: unix_timestamp_from_fuse(attr.atime(), attr.atimensec()),
+        last_modify_at: unix_timestamp_from_fuse(attr.mtime(), attr.mtimensec()),
+        last_meta_change_at: unix_timestamp_from_fuse(attr.ctime(), attr.ctimensec()),
         type_: InodeType::from_raw_mode(attr.mode() as u16).unwrap_or(InodeType::Unknown),
         mode: InodeMode::from_bits_truncate(attr.mode() as u16),
         nr_hard_links: attr.nlink() as usize,
@@ -216,5 +219,35 @@ pub(in crate::fs::fs_impls::virtiofs) fn metadata_from_attr(
             DeviceId::from_encoded_u64(attr.rdev() as u64)
         },
         birth_at: None,
+    }
+}
+
+/// Interprets FUSE's `u64` seconds as signed two's-complement Unix time.
+///
+/// FUSE replies should contain normalized nanoseconds.
+/// Clamp malformed values like Linux does before constructing the timestamp.
+/// See <https://github.com/torvalds/linux/blob/master/fs/fuse/inode.c>.
+fn unix_timestamp_from_fuse(secs: u64, nsec: u32) -> UnixTimestamp {
+    let nsec = nsec.min(time::NSEC_PER_SEC as u32 - 1);
+    UnixTimestamp::try_new(secs as i64, nsec).unwrap()
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    #[ktest]
+    fn fuse_u64_all_ones_is_minus_one() {
+        // https://github.com/asterinas/asterinas/issues/3746
+        assert_eq!(unix_timestamp_from_fuse(u64::MAX, 0).seconds(), -1);
+    }
+
+    #[ktest]
+    fn fuse_unnormalized_nsec_is_clamped() {
+        let ts = unix_timestamp_from_fuse(42, 1_000_000_000);
+        assert_eq!(ts.seconds(), 42);
+        assert_eq!(ts.nanoseconds(), 999_999_999);
     }
 }

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/mod.rs
@@ -51,6 +51,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
     vm::page_cache::{PageCache, Vmo},
 };
 
@@ -308,27 +309,27 @@ impl Inode for VirtioFsInode {
         self.setattr(setattr_req)
     }
 
-    fn atime(&self) -> Duration {
+    fn atime(&self) -> UnixTimestamp {
         self.inner.read().metadata.last_access_at
     }
 
-    fn set_atime(&self, time: Duration) {
+    fn set_atime(&self, time: UnixTimestamp) {
         self.set_time(TimeField::Access, time);
     }
 
-    fn mtime(&self) -> Duration {
+    fn mtime(&self) -> UnixTimestamp {
         self.inner.read().metadata.last_modify_at
     }
 
-    fn set_mtime(&self, time: Duration) {
+    fn set_mtime(&self, time: UnixTimestamp) {
         self.set_time(TimeField::Modify, time);
     }
 
-    fn ctime(&self) -> Duration {
+    fn ctime(&self) -> UnixTimestamp {
         self.inner.read().metadata.last_meta_change_at
     }
 
-    fn set_ctime(&self, time: Duration) {
+    fn set_ctime(&self, time: UnixTimestamp) {
         self.set_time(TimeField::Change, time);
     }
 

--- a/kernel/core/src/fs/fs_impls/virtiofs/inode/ops.rs
+++ b/kernel/core/src/fs/fs_impls/virtiofs/inode/ops.rs
@@ -4,8 +4,6 @@
 
 #![short_vis_path::add(virtiofs)]
 
-use core::time::Duration;
-
 use aster_fuse::{
     EntryReply, FuseAttrReply, FuseDirEntry, FuseFileHandle, FuseOpenFlags, GetattrFlags, ReadReq,
     ReleaseFlags, ReleaseKind, SetattrReq, SetattrValid, WriteFlags, WriteReq,
@@ -37,7 +35,7 @@ use crate::{
     },
     prelude::*,
     thread::work_queue::{self, WorkPriority},
-    time::clocks::MonotonicCoarseClock,
+    time::{UnixTimestamp, clocks::MonotonicCoarseClock},
 };
 
 /// Use one page for each `FUSE_READDIR` request.
@@ -486,14 +484,14 @@ impl VirtioFsInode {
     /// Calls this from VFS timestamp setters whose trait signature cannot
     /// return an error. Failures are logged and the cached metadata is left to be
     /// repaired by a later revalidation.
-    pub(super) fn set_time(&self, field: TimeField, time: Duration) {
+    pub(super) fn set_time(&self, field: TimeField, time: UnixTimestamp) {
         let setattr_req = match field {
             TimeField::Access => SetattrReq::new(SetattrValid::empty())
-                .set_atime(time.as_secs(), time.subsec_nanos()),
+                .set_atime(time.seconds() as u64, time.nanoseconds()),
             TimeField::Modify => SetattrReq::new(SetattrValid::empty())
-                .set_mtime(time.as_secs(), time.subsec_nanos()),
+                .set_mtime(time.seconds() as u64, time.nanoseconds()),
             TimeField::Change => SetattrReq::new(SetattrValid::empty())
-                .set_ctime(time.as_secs(), time.subsec_nanos()),
+                .set_ctime(time.seconds() as u64, time.nanoseconds()),
         };
         if let Err(err) = self.setattr(setattr_req) {
             warn!(

--- a/kernel/core/src/fs/pipe/anon_pipe.rs
+++ b/kernel/core/src/fs/pipe/anon_pipe.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::time::Duration;
-
 use inherit_methods_macro::inherit_methods;
 
 use crate::{
@@ -16,6 +14,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
+    time::UnixTimestamp,
 };
 
 /// Creates a pair of connected pipe file handles with the default capacity.
@@ -90,12 +89,12 @@ impl Inode for AnonPipeInode {
     fn set_owner(&self, uid: Uid) -> Result<()>;
     fn group(&self) -> Result<Gid>;
     fn set_group(&self, gid: Gid) -> Result<()>;
-    fn atime(&self) -> Duration;
-    fn set_atime(&self, time: Duration);
-    fn mtime(&self) -> Duration;
-    fn set_mtime(&self, time: Duration);
-    fn ctime(&self) -> Duration;
-    fn set_ctime(&self, time: Duration);
+    fn atime(&self) -> UnixTimestamp;
+    fn set_atime(&self, time: UnixTimestamp);
+    fn mtime(&self) -> UnixTimestamp;
+    fn set_mtime(&self, time: UnixTimestamp);
+    fn ctime(&self) -> UnixTimestamp;
+    fn set_ctime(&self, time: UnixTimestamp);
     fn fs(&self) -> Arc<dyn FileSystem>;
 
     fn open(

--- a/kernel/core/src/fs/utils/systree_inode.rs
+++ b/kernel/core/src/fs/utils/systree_inode.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use alloc::borrow::Cow;
-use core::time::Duration;
 
 use aster_systree::{
     SysAttr, SysBranchNode, SysNode, SysNodeId, SysNodeType, SysObj, SysStr, SysSymlink,
@@ -21,7 +20,7 @@ use crate::{
     },
     prelude::*,
     process::{Gid, Uid},
-    time::clocks::RealTimeCoarseClock,
+    time::{UnixTimestamp, clocks::RealTimeCoarseClock},
     vm::page_cache::Vmo,
 };
 
@@ -70,7 +69,7 @@ pub(in crate::fs) trait SysTreeInodeTy: Send + Sync + 'static {
     }
 
     fn new_metadata(ino: u64, type_: InodeType, sb: &SuperBlock) -> Metadata {
-        let now = RealTimeCoarseClock::get().read_time();
+        let now = UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
         Metadata {
             ino,
             size: 0,
@@ -445,23 +444,23 @@ impl<KInode: SysTreeInodeTy + Send + Sync + 'static> Inode for KInode {
         Ok(())
     }
 
-    default fn atime(&self) -> Duration {
+    default fn atime(&self) -> UnixTimestamp {
         self.metadata().last_access_at
     }
 
-    default fn set_atime(&self, _time: Duration) {}
+    default fn set_atime(&self, _time: UnixTimestamp) {}
 
-    default fn mtime(&self) -> Duration {
+    default fn mtime(&self) -> UnixTimestamp {
         self.metadata().last_modify_at
     }
 
-    default fn set_mtime(&self, _time: Duration) {}
+    default fn set_mtime(&self, _time: UnixTimestamp) {}
 
-    default fn ctime(&self) -> Duration {
+    default fn ctime(&self) -> UnixTimestamp {
         self.metadata().last_meta_change_at
     }
 
-    default fn set_ctime(&self, _time: Duration) {}
+    default fn set_ctime(&self, _time: UnixTimestamp) {}
 
     default fn owner(&self) -> Result<Uid> {
         Ok(self.metadata().uid)

--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -3,7 +3,6 @@
 #![expect(unused_variables)]
 
 use alloc::boxed::ThinBox;
-use core::time::Duration;
 
 use device_id::DeviceId;
 use ostd::task::{CurrentTask, Task};
@@ -29,7 +28,7 @@ use crate::{
         posix_thread::{AsPosixThread, PosixThread},
     },
     security::lsm::hooks as lsm_hooks,
-    time::clocks::RealTimeCoarseClock,
+    time::{UnixTimestamp, clocks::RealTimeCoarseClock},
     vm::page_cache::Vmo,
 };
 
@@ -69,12 +68,12 @@ pub(crate) struct Metadata {
     /// The timestamp of the last access to the inode's data.
     ///
     /// Corresponds to `st_atime`.
-    pub last_access_at: Duration,
+    pub last_access_at: UnixTimestamp,
 
     /// The timestamp of the last modification to the inode's content.
     ///
     /// Corresponds to `st_mtime`.
-    pub last_modify_at: Duration,
+    pub last_modify_at: UnixTimestamp,
 
     /// The timestamp of the last change to the inode's metadata.
     ///
@@ -82,7 +81,7 @@ pub(crate) struct Metadata {
     /// not just when the inode content is modified.
     ///
     /// Corresponds to `st_ctime`.
-    pub last_meta_change_at: Duration,
+    pub last_meta_change_at: UnixTimestamp,
 
     /// The type of the inode (e.g., regular file, directory, symlink).
     ///
@@ -130,7 +129,7 @@ pub(crate) struct Metadata {
     /// `None`.
     ///
     /// Corresponds to `stx_btime`.
-    pub birth_at: Option<Duration>,
+    pub birth_at: Option<UnixTimestamp>,
 }
 
 /// Describes whether an inode may get new hard links.
@@ -153,7 +152,7 @@ impl Metadata {
         blk_size: usize,
         container_dev_id: DeviceId,
     ) -> Self {
-        let now = RealTimeCoarseClock::get().read_time();
+        let now = UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
         Self {
             ino,
             size: 2,
@@ -179,7 +178,7 @@ impl Metadata {
         blk_size: usize,
         container_dev_id: DeviceId,
     ) -> Self {
-        let now = RealTimeCoarseClock::get().read_time();
+        let now = UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
         Self {
             ino,
             size: 0,
@@ -205,7 +204,7 @@ impl Metadata {
         blk_size: usize,
         container_dev_id: DeviceId,
     ) -> Self {
-        let now = RealTimeCoarseClock::get().read_time();
+        let now = UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
         Self {
             ino,
             size: 0,
@@ -232,7 +231,7 @@ impl Metadata {
         device: &dyn Device,
         container_dev_id: DeviceId,
     ) -> Self {
-        let now = RealTimeCoarseClock::get().read_time();
+        let now = UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
         Self {
             ino,
             size: 0,
@@ -400,17 +399,17 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
 
     fn set_group(&self, gid: Gid) -> Result<()>;
 
-    fn atime(&self) -> Duration;
+    fn atime(&self) -> UnixTimestamp;
 
-    fn set_atime(&self, time: Duration);
+    fn set_atime(&self, time: UnixTimestamp);
 
-    fn mtime(&self) -> Duration;
+    fn mtime(&self) -> UnixTimestamp;
 
-    fn set_mtime(&self, time: Duration);
+    fn set_mtime(&self, time: UnixTimestamp);
 
-    fn ctime(&self) -> Duration;
+    fn ctime(&self) -> UnixTimestamp;
 
-    fn set_ctime(&self, time: Duration);
+    fn set_ctime(&self, time: UnixTimestamp);
 
     fn page_cache(&self) -> Option<Arc<Vmo>> {
         None

--- a/kernel/core/src/fs/vfs/path/mod.rs
+++ b/kernel/core/src/fs/vfs/path/mod.rs
@@ -2,8 +2,6 @@
 
 //! Form file paths within and across FSes with dentries and mount points.
 
-use core::time::Duration;
-
 pub(in crate::fs) use dentry::Dentry;
 use inherit_methods_macro::inherit_methods;
 pub(crate) use mount::{MNT_UNIQUE_ID_MIN, Mount, MountPropType, PerMountFlags};
@@ -33,6 +31,7 @@ use crate::{
         Gid, Uid, UserNamespace, credentials::capabilities::CapSet, posix_thread::AsPosixThread,
     },
     security::lsm::hooks as lsm_hooks,
+    time::UnixTimestamp,
 };
 
 mod dentry;
@@ -754,12 +753,12 @@ impl Path {
     pub(crate) fn set_owner(&self, uid: Uid) -> Result<()>;
     pub(crate) fn group(&self) -> Result<Gid>;
     pub(crate) fn set_group(&self, gid: Gid) -> Result<()>;
-    pub(crate) fn atime(&self) -> Duration;
-    pub(crate) fn set_atime(&self, time: Duration);
-    pub(crate) fn mtime(&self) -> Duration;
-    pub(crate) fn set_mtime(&self, time: Duration);
-    pub(crate) fn ctime(&self) -> Duration;
-    pub(crate) fn set_ctime(&self, time: Duration);
+    pub(crate) fn atime(&self) -> UnixTimestamp;
+    pub(crate) fn set_atime(&self, time: UnixTimestamp);
+    pub(crate) fn mtime(&self) -> UnixTimestamp;
+    pub(crate) fn set_mtime(&self, time: UnixTimestamp);
+    pub(crate) fn ctime(&self) -> UnixTimestamp;
+    pub(crate) fn set_ctime(&self, time: UnixTimestamp);
     pub(crate) fn list_xattr(
         &self,
         namespace: XattrNamespace,

--- a/kernel/core/src/syscall/statx.rs
+++ b/kernel/core/src/syscall/statx.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::time::Duration;
-
 use ostd::mm::VmIo;
 
 use super::SyscallReturn;
@@ -12,6 +10,7 @@ use crate::{
     },
     prelude::*,
     syscall::constants::MAX_FILENAME_LEN,
+    time::UnixTimestamp,
 };
 
 const STATX_ATTR_MOUNT_ROOT: u64 = 0x0000_2000;
@@ -207,11 +206,11 @@ struct StatxTimestamp {
     __reserved: i32,
 }
 
-impl From<Duration> for StatxTimestamp {
-    fn from(duration: Duration) -> Self {
+impl From<UnixTimestamp> for StatxTimestamp {
+    fn from(ts: UnixTimestamp) -> Self {
         Self {
-            tv_sec: duration.as_secs() as i64,
-            tv_nsec: duration.subsec_nanos(),
+            tv_sec: ts.seconds(),
+            tv_nsec: ts.nanoseconds(),
             __reserved: 0,
         }
     }

--- a/kernel/core/src/syscall/utimens.rs
+++ b/kernel/core/src/syscall/utimens.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core::time::Duration;
-
 use ostd::mm::VmIo;
 
 use super::{SyscallReturn, constants::MAX_FILENAME_LEN};
@@ -15,7 +13,7 @@ use crate::{
         vfs::path::{AT_FDCWD, EmptyPathStr, FsPath, Path},
     },
     prelude::*,
-    time::{clocks::RealTimeCoarseClock, timespec_t, timeval_t},
+    time::{UnixTimestamp, clocks::RealTimeCoarseClock, timespec_t, timeval_t},
 };
 
 /// The 'sys_utimensat' system call sets the access and modification times of a file.
@@ -129,25 +127,27 @@ fn vfs_utimes(path: &Path, times: Option<TimeSpecPair>) -> Result<SyscallReturn>
             if !times.atime.is_valid() || !times.mtime.is_valid() {
                 return_errno_with_message!(Errno::EINVAL, "invalid time")
             }
-            let now = RealTimeCoarseClock::get().read_time();
+            let now =
+                UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
             let atime = if times.atime.is_utime_omit() {
                 path.atime()
             } else if times.atime.is_utime_now() {
                 now
             } else {
-                Duration::try_from(times.atime)?
+                UnixTimestamp::try_from(times.atime)?
             };
             let mtime = if times.mtime.is_utime_omit() {
                 path.mtime()
             } else if times.mtime.is_utime_now() {
                 now
             } else {
-                Duration::try_from(times.mtime)?
+                UnixTimestamp::try_from(times.mtime)?
             };
             (atime, mtime, now)
         }
         None => {
-            let now = RealTimeCoarseClock::get().read_time();
+            let now =
+                UnixTimestamp::from_duration_since_epoch(RealTimeCoarseClock::get().read_time());
             (now, now, now)
         }
     };
@@ -221,13 +221,7 @@ fn do_futimesat(
 ) -> Result<SyscallReturn> {
     let times = if timeval_ptr != 0 {
         let (autime, mutime) = read_time_from_user::<timeval_t>(timeval_ptr, ctx)?;
-        if autime.usec >= 1000000
-            || autime.usec < 0
-            || autime.sec < 0
-            || mutime.usec >= 1000000
-            || mutime.usec < 0
-            || mutime.sec < 0
-        {
+        if autime.usec >= 1000000 || autime.usec < 0 || mutime.usec >= 1000000 || mutime.usec < 0 {
             return_errno_with_message!(Errno::EINVAL, "invalid time");
         }
         let (autime, mutime) = (timespec_t::from(autime), timespec_t::from(mutime));

--- a/kernel/core/src/time/mod.rs
+++ b/kernel/core/src/time/mod.rs
@@ -7,6 +7,7 @@ pub(crate) use core::{Clock, timer};
 use ::core::time::Duration;
 pub(crate) use system_time::{START_TIME, SystemTime};
 pub(crate) use timer::{Timer, TimerManager};
+pub(crate) use unix_timestamp::UnixTimestamp;
 
 use crate::prelude::*;
 
@@ -16,6 +17,8 @@ pub(crate) mod cpu_time_stats;
 mod softirq;
 mod system_time;
 pub(crate) mod timerfd;
+mod unix_timestamp;
+
 pub(crate) mod wait;
 
 pub(crate) type clockid_t = i32;
@@ -58,7 +61,6 @@ impl From<timeval_t> for timespec_t {
     fn from(timeval: timeval_t) -> timespec_t {
         let sec = timeval.sec;
         let nsec = timeval.usec * NSEC_PER_USEC;
-        debug_assert!(sec >= 0); // nsec >= 0 always holds
         timespec_t { sec, nsec }
     }
 }
@@ -78,6 +80,28 @@ impl TryFrom<timespec_t> for Duration {
         }
 
         Ok(Duration::new(value.sec as u64, value.nsec as u32))
+    }
+}
+
+impl From<UnixTimestamp> for timespec_t {
+    fn from(ts: UnixTimestamp) -> Self {
+        timespec_t {
+            sec: ts.seconds(),
+            nsec: ts.nanoseconds() as i64,
+        }
+    }
+}
+
+impl TryFrom<timespec_t> for UnixTimestamp {
+    type Error = Error;
+
+    fn try_from(value: timespec_t) -> Result<Self> {
+        if value.nsec < 0 || value.nsec >= NSEC_PER_SEC {
+            return_errno_with_message!(Errno::EINVAL, "nsec is not normalized");
+        }
+
+        UnixTimestamp::try_new(value.sec, value.nsec as u32)
+            .ok_or_else(|| Error::with_message(Errno::EINVAL, "nsec is not normalized"))
     }
 }
 

--- a/kernel/core/src/time/unix_timestamp.rs
+++ b/kernel/core/src/time/unix_timestamp.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Signed Unix timestamps for VFS metadata.
+//!
+//! [`UnixTimestamp`] represents wall-clock instants with signed seconds
+//! and normalized nanoseconds.
+//! It bridges real-time clocks, syscall time structures, and filesystem metadata
+//! without using [`Duration`] for stored timestamps.
+
+use core::time::Duration;
+
+/// Signed Unix time, used for VFS inode timestamps.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct UnixTimestamp {
+    seconds: i64,
+    nanoseconds: u32,
+}
+
+impl UnixTimestamp {
+    const UNIX_EPOCH: Self = Self {
+        seconds: 0,
+        nanoseconds: 0,
+    };
+
+    const MAX: Self = Self {
+        seconds: i64::MAX,
+        nanoseconds: super::NSEC_PER_SEC as u32 - 1,
+    };
+
+    pub(crate) const fn from_seconds(seconds: i64) -> Self {
+        Self {
+            seconds,
+            nanoseconds: 0,
+        }
+    }
+
+    /// Creates a timestamp if `nanoseconds` is normalized.
+    ///
+    /// Use this constructor for timestamps supplied by untrusted sources,
+    /// such as userspace or FUSE.
+    pub(crate) const fn try_new(seconds: i64, nanoseconds: u32) -> Option<Self> {
+        if nanoseconds < super::NSEC_PER_SEC as u32 {
+            Some(Self {
+                seconds,
+                nanoseconds,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn seconds(&self) -> i64 {
+        self.seconds
+    }
+
+    pub(crate) fn nanoseconds(&self) -> u32 {
+        self.nanoseconds
+    }
+
+    /// Converts a duration since the Unix epoch into a timestamp.
+    pub(crate) fn from_duration_since_epoch(duration: Duration) -> Self {
+        let Ok(seconds) = i64::try_from(duration.as_secs()) else {
+            return Self::MAX;
+        };
+
+        Self {
+            seconds,
+            nanoseconds: duration.subsec_nanos(),
+        }
+    }
+}
+
+impl Default for UnixTimestamp {
+    fn default() -> Self {
+        Self::UNIX_EPOCH
+    }
+}
+
+#[cfg(ktest)]
+mod tests {
+    use ostd::prelude::*;
+
+    use super::*;
+
+    #[ktest]
+    fn try_new_accepts_negative_seconds() {
+        let ts = UnixTimestamp::try_new(-1, 0).unwrap();
+        assert_eq!(ts.seconds(), -1);
+        assert_eq!(ts.nanoseconds(), 0);
+    }
+
+    #[ktest]
+    fn try_new_rejects_unnormalized_nsec() {
+        assert!(UnixTimestamp::try_new(0, 1_000_000_000).is_none());
+    }
+
+    #[ktest]
+    fn from_duration_preserves_subsec() {
+        let ts = UnixTimestamp::from_duration_since_epoch(Duration::from_nanos(1_000_000_042));
+        assert_eq!(ts.seconds(), 1);
+        assert_eq!(ts.nanoseconds(), 42);
+    }
+
+    #[ktest]
+    fn from_duration_saturates_unrepresentable_seconds() {
+        let duration = Duration::new(i64::MAX as u64 + 1, 0);
+        let ts = UnixTimestamp::from_duration_since_epoch(duration);
+        assert_eq!(ts.seconds(), i64::MAX);
+        assert_eq!(ts.nanoseconds(), 999_999_999);
+    }
+
+    #[ktest]
+    fn timespec_roundtrip_allows_negative_seconds() {
+        let spec = crate::time::timespec_t { sec: -1, nsec: 123 };
+        let ts = UnixTimestamp::try_from(spec).unwrap();
+        assert_eq!(ts.seconds(), -1);
+        assert_eq!(ts.nanoseconds(), 123);
+        let back = crate::time::timespec_t::from(ts);
+        assert_eq!(back.sec, -1);
+        assert_eq!(back.nsec, 123);
+    }
+
+    #[ktest]
+    fn timespec_rejects_bad_nsec_but_not_negative_sec() {
+        use crate::time::timespec_t;
+
+        assert!(UnixTimestamp::try_from(timespec_t { sec: -5, nsec: 0 }).is_ok());
+        assert!(UnixTimestamp::try_from(timespec_t { sec: -5, nsec: -1 }).is_err());
+        assert!(
+            UnixTimestamp::try_from(timespec_t {
+                sec: -5,
+                nsec: 1_000_000_000,
+            })
+            .is_err()
+        );
+    }
+
+    #[ktest]
+    fn duration_try_from_still_rejects_negative_sec() {
+        use crate::time::timespec_t;
+
+        assert!(Duration::try_from(timespec_t { sec: -1, nsec: 0 }).is_err());
+        assert!(Duration::try_from(timespec_t { sec: 1, nsec: 0 }).is_ok());
+    }
+
+    // FUSE/ext2 on-disk seconds are `u64`/`u32` bit patterns of signed Unix time.
+    #[ktest]
+    fn two_complement_bit_patterns_decode_as_signed() {
+        assert_eq!(u32::MAX as i32 as i64, -1);
+        assert_eq!(u64::MAX as i64, -1);
+        assert_eq!((i32::MIN as u32) as i32 as i64, i32::MIN as i64);
+    }
+}

--- a/test/initramfs/src/regression/fs/Makefile
+++ b/test/initramfs/src/regression/fs/Makefile
@@ -16,5 +16,6 @@ SUBDIRS := \
 	sync \
 	tmpfile \
 	utimensat \
+	timestamps \
 
 include ../common/Makefile

--- a/test/initramfs/src/regression/fs/run_test.sh
+++ b/test/initramfs/src/regression/fs/run_test.sh
@@ -159,3 +159,5 @@ echo "All mount bind file test passed."
 ./tmpfile/tmpfile
 
 ./utimensat/utimensat
+
+./timestamps/timestamps

--- a/test/initramfs/src/regression/fs/timestamps/Makefile
+++ b/test/initramfs/src/regression/fs/timestamps/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../../common/Makefile

--- a/test/initramfs/src/regression/fs/timestamps/timestamps.c
+++ b/test/initramfs/src/regression/fs/timestamps/timestamps.c
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/*
+ * Regression tests for signed VFS Unix timestamps.
+ *
+ * Pre-epoch `utimensat` / `stat` round-trips used to fail because inode
+ * times were stored as `Duration`. See:
+ * https://github.com/asterinas/asterinas/issues/3746
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+#define EXFAT_MAGIC 0xaa55
+
+#define PRE_EPOCH_ATIME (-1)
+#define PRE_EPOCH_MTIME (-2051222400LL) /* 1905-01-01 */
+#define I32_MIN ((int64_t)INT32_MIN)
+#define I32_MAX ((int64_t)INT32_MAX)
+
+static unsigned long fd_magic(int fd)
+{
+	struct statfs st;
+
+	if (fstatfs(fd, &st) < 0) {
+		return 0;
+	}
+	return (unsigned long)st.f_type;
+}
+
+static int supports_pre_epoch(unsigned long magic)
+{
+	return magic != EXFAT_MAGIC;
+}
+
+static void ensure_dir(const char *path)
+{
+	CHECK_WITH(mkdir(path, 0755), _ret == 0 || errno == EEXIST);
+	errno = 0;
+}
+
+/*
+ * `TEST_*` macros update counters local to `FN_TEST`, so helpers that
+ * assert must be macros expanded at the call site.
+ */
+#define TEST_PRE_EPOCH_ON_FD(fd)                                          \
+	do {                                                              \
+		int _fl = fcntl((fd), F_GETFL);                           \
+		if (_fl >= 0) {                                           \
+			fcntl((fd), F_SETFL, _fl | O_NOATIME);            \
+			errno = 0;                                        \
+		}                                                         \
+		unsigned long _magic = fd_magic(fd);                      \
+		struct timespec _times[2] = {                             \
+			{ .tv_sec = PRE_EPOCH_ATIME, .tv_nsec = 0 },      \
+			{ .tv_sec = PRE_EPOCH_MTIME, .tv_nsec = 0 },      \
+		};                                                        \
+		TEST_SUCC(utimensat((fd), "", _times, AT_EMPTY_PATH));    \
+		struct stat _st;                                          \
+		TEST_SUCC(fstat((fd), &_st));                             \
+		if (supports_pre_epoch(_magic)) {                         \
+			TEST_RES(_st.st_atim.tv_sec == PRE_EPOCH_ATIME && \
+					 _st.st_mtim.tv_sec ==            \
+						 PRE_EPOCH_MTIME,         \
+				 _ret);                                   \
+		} else {                                                  \
+			TEST_RES(_st.st_atim.tv_sec >= 0 &&               \
+					 _st.st_mtim.tv_sec >= 0,         \
+				 _ret);                                   \
+		}                                                         \
+	} while (0)
+
+#define TEST_PRE_EPOCH_ON_PATH(path)                                     \
+	do {                                                             \
+		int _fd = TEST_SUCC(                                     \
+			open((path), O_RDWR | O_CREAT | O_TRUNC, 0644)); \
+		TEST_PRE_EPOCH_ON_FD(_fd);                               \
+		TEST_SUCC(close(_fd));                                   \
+		TEST_SUCC(unlink((path)));                               \
+	} while (0)
+
+#define TEST_PRE_EPOCH_ON_DIR(path)                                        \
+	do {                                                               \
+		ensure_dir((path));                                        \
+		int _fd = TEST_SUCC(open((path), O_RDONLY | O_DIRECTORY)); \
+		TEST_PRE_EPOCH_ON_FD(_fd);                                 \
+		TEST_SUCC(close(_fd));                                     \
+		TEST_SUCC(rmdir((path)));                                  \
+	} while (0)
+
+#define TEST_NSEC_ON_PATH(path)                                          \
+	do {                                                             \
+		int _fd = TEST_SUCC(                                     \
+			open((path), O_RDWR | O_CREAT | O_TRUNC, 0644)); \
+		struct timespec _times[2] = {                            \
+			{ .tv_sec = 10, .tv_nsec = 123 },                \
+			{ .tv_sec = 11, .tv_nsec = 456 },                \
+		};                                                       \
+		TEST_SUCC(utimensat(_fd, "", _times, AT_EMPTY_PATH));    \
+		struct stat _st;                                         \
+		TEST_RES(fstat(_fd, &_st),                               \
+			 _st.st_atim.tv_sec == 10 &&                     \
+				 _st.st_atim.tv_nsec == 123 &&           \
+				 _st.st_mtim.tv_sec == 11 &&             \
+				 _st.st_mtim.tv_nsec == 456);            \
+		TEST_SUCC(close(_fd));                                   \
+		TEST_SUCC(unlink((path)));                               \
+	} while (0)
+
+#define TEST_I32_RANGE_ON_PATH(path)                                     \
+	do {                                                             \
+		int _fd = TEST_SUCC(                                     \
+			open((path), O_RDWR | O_CREAT | O_TRUNC, 0644)); \
+		struct timespec _times[2] = {                            \
+			{ .tv_sec = (long)I32_MIN, .tv_nsec = 0 },       \
+			{ .tv_sec = (long)I32_MAX, .tv_nsec = 0 },       \
+		};                                                       \
+		TEST_SUCC(utimensat(_fd, "", _times, AT_EMPTY_PATH));    \
+		struct stat _st;                                         \
+		TEST_RES(fstat(_fd, &_st),                               \
+			 _st.st_atim.tv_sec == (long)I32_MIN &&          \
+				 _st.st_mtim.tv_sec == (long)I32_MAX);   \
+		TEST_SUCC(close(_fd));                                   \
+		TEST_SUCC(unlink((path)));                               \
+	} while (0)
+
+FN_TEST(ramfs_pre_epoch_nsec_and_i32_range)
+{
+	const char *mnt = "/tmp/timestamps_ramfs";
+	const char *file = "/tmp/timestamps_ramfs/file";
+	const char *dir = "/tmp/timestamps_ramfs/dir";
+
+	ensure_dir(mnt);
+	TEST_SUCC(mount("none", mnt, "ramfs", 0, NULL));
+	TEST_PRE_EPOCH_ON_PATH(file);
+	TEST_NSEC_ON_PATH(file);
+	TEST_I32_RANGE_ON_PATH(file);
+	TEST_PRE_EPOCH_ON_DIR(dir);
+
+	{
+		const char *wide = "/tmp/timestamps_ramfs/beyond_i32";
+		int fd =
+			TEST_SUCC(open(wide, O_RDWR | O_CREAT | O_TRUNC, 0644));
+		struct timespec times[2] = {
+			{ .tv_sec = (long)(I32_MIN - 1), .tv_nsec = 0 },
+			{ .tv_sec = (long)(I32_MAX + 1), .tv_nsec = 0 },
+		};
+		TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+		struct stat st;
+		TEST_RES(fstat(fd, &st),
+			 st.st_atim.tv_sec == (long)(I32_MIN - 1) &&
+				 st.st_mtim.tv_sec == (long)(I32_MAX + 1));
+		TEST_SUCC(close(fd));
+		TEST_SUCC(unlink(wide));
+	}
+	TEST_SUCC(umount(mnt));
+	TEST_SUCC(rmdir(mnt));
+}
+END_TEST()
+
+FN_TEST(tmp_pre_epoch)
+{
+	TEST_PRE_EPOCH_ON_PATH("/tmp/timestamps_tmpfile");
+	TEST_NSEC_ON_PATH("/tmp/timestamps_tmpfile_nsec");
+	TEST_PRE_EPOCH_ON_DIR("/tmp/timestamps_tmpdir");
+}
+END_TEST()
+
+FN_TEST(ext2_pre_epoch_persist_and_i32_range)
+{
+	SKIP_TEST_IF(access("/ext2", W_OK) != 0);
+
+	TEST_PRE_EPOCH_ON_PATH("/ext2/timestamps_pre_epoch");
+	TEST_I32_RANGE_ON_PATH("/ext2/timestamps_i32_range");
+
+	const char *wide = "/ext2/timestamps_beyond_i32";
+	struct timespec wide_times[2] = {
+		{ .tv_sec = (long)(I32_MIN - 1), .tv_nsec = 123 },
+		{ .tv_sec = (long)(I32_MAX + 1), .tv_nsec = 456 },
+	};
+	int wide_fd = TEST_SUCC(open(wide, O_RDWR | O_CREAT | O_TRUNC, 0644));
+	TEST_SUCC(utimensat(wide_fd, "", wide_times, AT_EMPTY_PATH));
+	struct stat wide_st;
+	TEST_RES(fstat(wide_fd, &wide_st),
+		 wide_st.st_atim.tv_sec == (long)I32_MIN &&
+			 wide_st.st_atim.tv_nsec == 0 &&
+			 wide_st.st_mtim.tv_sec == (long)I32_MAX &&
+			 wide_st.st_mtim.tv_nsec == 0);
+	TEST_SUCC(close(wide_fd));
+	TEST_SUCC(unlink(wide));
+
+	const char *path = "/ext2/timestamps_persist";
+	struct timespec times[2] = {
+		{ .tv_sec = PRE_EPOCH_ATIME, .tv_nsec = 0 },
+		{ .tv_sec = PRE_EPOCH_MTIME, .tv_nsec = 0 },
+	};
+	int fd = TEST_SUCC(open(path, O_RDWR | O_CREAT | O_TRUNC, 0644));
+	TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+	TEST_SUCC(close(fd));
+
+	fd = TEST_SUCC(open(path, O_RDONLY));
+	struct stat st;
+	TEST_RES(fstat(fd, &st), st.st_atim.tv_sec == PRE_EPOCH_ATIME &&
+					 st.st_mtim.tv_sec == PRE_EPOCH_MTIME);
+	TEST_SUCC(close(fd));
+	TEST_SUCC(unlink(path));
+}
+END_TEST()
+
+FN_TEST(exfat_accepts_pre_epoch_without_einval)
+{
+	SKIP_TEST_IF(access("/exfat", W_OK) != 0);
+	TEST_PRE_EPOCH_ON_PATH("/exfat/timestamps_pre_epoch");
+}
+END_TEST()
+
+FN_TEST(overlayfs_pre_epoch)
+{
+	const char *base = "/tmp/timestamps_overlay";
+	char lower[64], upper[64], work[64], merged[64], file[80], opts[256];
+
+	snprintf(lower, sizeof(lower), "%s/lower", base);
+	snprintf(upper, sizeof(upper), "%s/upper", base);
+	snprintf(work, sizeof(work), "%s/work", base);
+	snprintf(merged, sizeof(merged), "%s/merged", base);
+	snprintf(file, sizeof(file), "%s/file", merged);
+
+	ensure_dir(base);
+	ensure_dir(lower);
+	ensure_dir(upper);
+	ensure_dir(work);
+	ensure_dir(merged);
+
+	snprintf(opts, sizeof(opts), "lowerdir=%s,upperdir=%s,workdir=%s",
+		 lower, upper, work);
+	TEST_SUCC(mount("overlay", merged, "overlay", 0, opts));
+	TEST_PRE_EPOCH_ON_PATH(file);
+	TEST_NSEC_ON_PATH(file);
+	TEST_SUCC(umount(merged));
+	TEST_SUCC(rmdir(merged));
+	TEST_SUCC(rmdir(work));
+	TEST_SUCC(rmdir(upper));
+	TEST_SUCC(rmdir(lower));
+	TEST_SUCC(rmdir(base));
+}
+END_TEST()
+
+FN_TEST(pipe_pre_epoch)
+{
+	int fds[2];
+	TEST_SUCC(pipe(fds));
+	TEST_PRE_EPOCH_ON_FD(fds[0]);
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()
+
+FN_TEST(memfd_pre_epoch)
+{
+	int fd = TEST_SUCC(memfd_create("timestamps_memfd", 0));
+	TEST_PRE_EPOCH_ON_FD(fd);
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(procfs_pre_epoch)
+{
+	int fd = TEST_SUCC(open("/proc/self", O_RDONLY | O_DIRECTORY));
+	TEST_PRE_EPOCH_ON_FD(fd);
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(nsfs_pre_epoch)
+{
+	int fd = TEST_SUCC(open("/proc/self/ns/mnt", O_RDONLY));
+	TEST_PRE_EPOCH_ON_FD(fd);
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(devpts_pre_epoch)
+{
+	SKIP_TEST_IF(access("/dev/pts", R_OK) != 0);
+	int fd = TEST_SUCC(open("/dev/pts", O_RDONLY | O_DIRECTORY));
+	TEST_PRE_EPOCH_ON_FD(fd);
+	TEST_SUCC(close(fd));
+}
+END_TEST()

--- a/test/initramfs/src/regression/fs/utimensat/utimensat.c
+++ b/test/initramfs/src/regression/fs/utimensat/utimensat.c
@@ -3,10 +3,12 @@
 #define _GNU_SOURCE
 
 #include <fcntl.h>
+#include <linux/stat.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "../../common/test.h"
@@ -32,6 +34,21 @@ FN_TEST(at_empty_path_updates_times)
 	struct stat st;
 	TEST_RES(fstat(fd, &st), st.st_atim.tv_sec == 1234567890 &&
 					 st.st_mtim.tv_sec == 1234567891);
+}
+END_TEST()
+
+/* Regression for https://github.com/asterinas/asterinas/issues/3746 */
+FN_TEST(negative_tv_sec_roundtrip)
+{
+	struct timespec times[2] = {
+		{ .tv_sec = -1, .tv_nsec = 0 },
+		{ .tv_sec = -2051222400, .tv_nsec = 0 }, /* 1905-01-01 */
+	};
+	TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+
+	struct stat st;
+	TEST_RES(fstat(fd, &st),
+		 st.st_atim.tv_sec == -1 && st.st_mtim.tv_sec == -2051222400);
 }
 END_TEST()
 
@@ -105,6 +122,119 @@ FN_TEST(at_empty_path_on_o_path_symlink_updates_symlink)
 
 	TEST_SUCC(close(sym_fd));
 	TEST_SUCC(unlink(symlink_path));
+}
+END_TEST()
+
+FN_TEST(epoch_and_nanoseconds)
+{
+	struct timespec times[2] = {
+		{ .tv_sec = 0, .tv_nsec = 1 },
+		{ .tv_sec = 0, .tv_nsec = 999999999 },
+	};
+	TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+
+	struct stat st;
+	TEST_RES(fstat(fd, &st), st.st_atim.tv_sec == 0 &&
+					 st.st_atim.tv_nsec == 1 &&
+					 st.st_mtim.tv_sec == 0 &&
+					 st.st_mtim.tv_nsec == 999999999);
+}
+END_TEST()
+
+FN_TEST(utime_omit_preserves_atime)
+{
+	struct timespec seed[2] = {
+		{ .tv_sec = 100, .tv_nsec = 0 },
+		{ .tv_sec = 200, .tv_nsec = 0 },
+	};
+	TEST_SUCC(utimensat(fd, "", seed, AT_EMPTY_PATH));
+
+	struct timespec times[2] = {
+		{ .tv_sec = 0, .tv_nsec = UTIME_OMIT },
+		{ .tv_sec = 300, .tv_nsec = 0 },
+	};
+	TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+
+	struct stat st;
+	TEST_RES(fstat(fd, &st),
+		 st.st_atim.tv_sec == 100 && st.st_mtim.tv_sec == 300);
+}
+END_TEST()
+
+FN_TEST(both_omit_is_noop)
+{
+	struct timespec seed[2] = {
+		{ .tv_sec = 111, .tv_nsec = 0 },
+		{ .tv_sec = 222, .tv_nsec = 0 },
+	};
+	TEST_SUCC(utimensat(fd, "", seed, AT_EMPTY_PATH));
+
+	struct timespec times[2] = {
+		{ .tv_sec = 0, .tv_nsec = UTIME_OMIT },
+		{ .tv_sec = 0, .tv_nsec = UTIME_OMIT },
+	};
+	TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+
+	struct stat st;
+	TEST_RES(fstat(fd, &st),
+		 st.st_atim.tv_sec == 111 && st.st_mtim.tv_sec == 222);
+}
+END_TEST()
+
+FN_TEST(utime_now_sets_current_time)
+{
+	struct timespec times[2] = {
+		{ .tv_sec = 0, .tv_nsec = UTIME_NOW },
+		{ .tv_sec = 0, .tv_nsec = UTIME_NOW },
+	};
+	time_t before = TEST_SUCC(time(NULL));
+	TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+	time_t after = TEST_SUCC(time(NULL));
+
+	struct stat st;
+	TEST_SUCC(fstat(fd, &st));
+	TEST_RES(st.st_mtim.tv_sec >= before - 1, _ret);
+	TEST_RES(st.st_mtim.tv_sec <= after + 1, _ret);
+}
+END_TEST()
+
+FN_TEST(invalid_nsec_returns_einval)
+{
+	struct timespec times[2] = {
+		{ .tv_sec = 1, .tv_nsec = 1000000000 },
+		{ .tv_sec = 1, .tv_nsec = 0 },
+	};
+	TEST_ERRNO(utimensat(fd, "", times, AT_EMPTY_PATH), EINVAL);
+}
+END_TEST()
+
+FN_TEST(futimesat_accepts_negative_timeval)
+{
+	struct timeval times[2] = {
+		{ .tv_sec = -1, .tv_usec = 0 },
+		{ .tv_sec = 1, .tv_usec = 0 },
+	};
+	TEST_SUCC(syscall(SYS_futimesat, AT_FDCWD, TEST_FILE, times));
+
+	struct stat st;
+	TEST_RES(fstat(fd, &st),
+		 st.st_atim.tv_sec == -1 && st.st_mtim.tv_sec == 1);
+}
+END_TEST()
+
+FN_TEST(statx_reports_negative_atime)
+{
+	struct timespec times[2] = {
+		{ .tv_sec = -1, .tv_nsec = 0 },
+		{ .tv_sec = -2, .tv_nsec = 0 },
+	};
+	TEST_SUCC(utimensat(fd, "", times, AT_EMPTY_PATH));
+
+	struct statx stx;
+	TEST_SUCC(
+		statx(fd, "", AT_EMPTY_PATH, STATX_ATIME | STATX_MTIME, &stx));
+	TEST_RES(stx.stx_atime.tv_sec == -1 && stx.stx_mtime.tv_sec == -2,
+		 _ret);
 }
 END_TEST()
 


### PR DESCRIPTION
## Summary

- Introduce `UnixTimestamp` to represent wall-clock timestamps using signed
  seconds and normalized nanoseconds.
- Replace `Duration` in VFS metadata and inode timestamp APIs, while keeping
  `Duration` for intervals, timeouts, and cache lifetimes.
- Preserve pre-epoch timestamps across syscall and filesystem conversion
  paths, including FUSE, ext2, and exFAT.
- Add regression tests for negative timestamps, nanosecond preservation,
  filesystem-specific ranges, and pre-epoch timestamp persistence.

## Motivation

VFS inode timestamps were previously represented by `core::time::Duration`,
which cannot represent timestamps before the Unix epoch.

FUSE exposes timestamp seconds as `u64` wire fields, but negative Unix
timestamps are encoded using their two's-complement representation. Converting
these values directly into `Duration` either loses the original timestamp or
triggers an assertion.

This change introduces a dedicated signed timestamp type and uses it throughout
the VFS timestamp interfaces.

Fixes #3746.