### PR TITLE
Fix CAP_DAC_OVERRIDE handling for directories

### DIFF
--- a/kernel/core/src/fs/vfs/fs_apis/inode.rs
+++ b/kernel/core/src/fs/vfs/fs_apis/inode.rs
@@ -590,21 +590,27 @@ pub(crate) trait Inode: Any + FileOps + Send + Sync {
 
         // With DAC_OVERRIDE capability, the user can bypass some permission checks.
         if has_dac_override_capability(&task, posix_thread) {
-            // Read/write DACs are always overridable.
-            perm -= Permission::MAY_READ | Permission::MAY_WRITE;
+            if metadata.type_ == InodeType::Dir {
+                // DACs are overridable for directories, including the search permission
+                // even when the directory has no execute bits set.
+                perm -= Permission::MAY_READ | Permission::MAY_WRITE | Permission::MAY_EXEC;
+            } else {
+                // Read/write DACs are always overridable.
+                perm -= Permission::MAY_READ | Permission::MAY_WRITE;
 
-            // Executable DACs are overridable when there is at least one exec bit set.
-            if perm.may_exec() {
-                if mode.is_owner_executable()
-                    || mode.is_group_executable()
-                    || mode.is_other_executable()
-                {
-                    perm -= Permission::MAY_EXEC;
-                } else {
-                    return_errno_with_message!(
-                        Errno::EACCES,
-                        "root execute permission denied: no execute bits set"
-                    );
+                // Executable DACs are overridable when there is at least one exec bit set.
+                if perm.may_exec() {
+                    if mode.is_owner_executable()
+                        || mode.is_group_executable()
+                        || mode.is_other_executable()
+                    {
+                        perm -= Permission::MAY_EXEC;
+                    } else {
+                        return_errno_with_message!(
+                            Errno::EACCES,
+                            "root execute permission denied: no execute bits set"
+                        );
+                    }
                 }
             }
         }

--- a/test/initramfs/src/conformance/ltp/testcases/all.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/all.txt
@@ -1636,12 +1636,12 @@ stat02_64
 # statmount08
 # statmount09
 
-# statfs01
-# statfs01_64
-# statfs02
-# statfs02_64
-# statfs03
-# statfs03_64
+statfs01
+statfs01_64
+statfs02
+statfs02_64
+statfs03
+statfs03_64
 
 # statvfs01
 # statvfs02

--- a/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
+++ b/test/initramfs/src/conformance/ltp/testcases/blocked/exfat.txt
@@ -58,6 +58,11 @@ setfsuid04
 setresuid04
 setreuid07
 setuid04
+statfs02
+statfs02_64
+statfs03
+statfs03_64
+statx02
 symlink02
 symlink03
 symlink04
@@ -68,4 +73,3 @@ umask01
 unlink05
 unlink08
 utime07
-statx02


### PR DESCRIPTION
Fix LTP `statfs03`: allow root with `CAP_DAC_OVERRIDE` to bypass directory execute checks.

Also enable `statfs01` and `statfs02` tests, including their 64-bit variants, and block the currently unsupported exFAT variants.