### PR TITLE
Fix `accept()` after a queued TCP connection is reset

### DIFF
--- a/kernel/core/src/net/socket/ip/stream/mod.rs
+++ b/kernel/core/src/net/socket/ip/stream/mod.rs
@@ -587,7 +587,19 @@ impl Socket for StreamSocket {
                 return_errno_with_message!(Errno::ENOTCONN, "the socket is not connected")
             }
             State::Connecting(connecting_stream) => connecting_stream.remote_endpoint(),
-            State::Connected(connected_stream) => connected_stream.remote_endpoint(),
+            State::Connected(connected_stream) => {
+                // `getpeername()` fails on a closed connection.
+                // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv4/af_inet.c#L820>.
+                //
+                // Linux checks for TCP_CLOSE. We also reject smoltcp's TIME_WAIT state because
+                // Linux moves TIME_WAIT handling to a separate socket and sets the original
+                // socket to TCP_CLOSE. smoltcp keeps TIME_WAIT on the original socket.
+                // Reference: <https://elixir.bootlin.com/linux/v7.1/source/net/ipv4/tcp_minisocks.c#L393>.
+                if !connected_stream.raw_with(|socket| socket.is_open()) {
+                    return_errno_with_message!(Errno::ENOTCONN, "the socket is not connected");
+                }
+                connected_stream.remote_endpoint()
+            }
         };
         Ok(remote_endpoint.into())
     }

--- a/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
+++ b/kernel/libs/aster-bigtcp/src/socket/bound/tcp_listen.rs
@@ -131,10 +131,13 @@ impl<E: Ext> TcpListener<E> {
             let mut socket = accepted.0.inner.lock();
 
             socket.listener = None;
-            socket.remote_endpoint()
+
+            // A queued connection may have been reset, which clears smoltcp's internal endpoint tuple.
+            // Use the saved connection key so that it can still be accepted.
+            accepted.0.connection_key().remote_endpoint()
         };
 
-        Some((accepted, remote_endpoint.unwrap()))
+        Some((accepted, remote_endpoint))
     }
 
     /// Returns whether there is a TCP connection to accept.

--- a/kernel/libs/aster-bigtcp/src/socket_table.rs
+++ b/kernel/libs/aster-bigtcp/src/socket_table.rs
@@ -83,6 +83,10 @@ impl ConnectionKey {
     pub(crate) const fn hash(&self) -> SocketHash {
         self.hash
     }
+
+    pub(crate) const fn remote_endpoint(&self) -> IpEndpoint {
+        IpEndpoint::new(self.remote_addr, self.remote_port)
+    }
 }
 
 impl From<(IpEndpoint, IpEndpoint)> for ConnectionKey {

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -27,6 +27,7 @@ sleep 0.2
 ./socket_ioctl
 ./sockoption
 ./sockoption_unix
+./tcp_accept_reset
 ./tcp_err
 ./tcp_poll
 ./tcp_reuseaddr

--- a/test/initramfs/src/regression/network/tcp_accept_reset.c
+++ b/test/initramfs/src/regression/network/tcp_accept_reset.c
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#define POLL_TIMEOUT_MS 1000
+#define TCP_SETTLE_USEC 100000
+
+FN_TEST(tcp_accept_after_reset)
+{
+	int listener = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+	struct sockaddr_in listen_addr = {
+		.sin_family = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+	};
+	socklen_t addrlen = sizeof(listen_addr);
+
+	TEST_SUCC(bind(listener, (struct sockaddr *)&listen_addr,
+		       sizeof(listen_addr)));
+	TEST_SUCC(listen(listener, 2));
+	TEST_RES(getsockname(listener, (struct sockaddr *)&listen_addr,
+			     &addrlen),
+		 addrlen == sizeof(listen_addr));
+
+	int client = TEST_SUCC(socket(AF_INET, SOCK_STREAM, 0));
+	struct sockaddr_in client_addr;
+
+	TEST_SUCC(connect(client, (struct sockaddr *)&listen_addr,
+			  sizeof(listen_addr)));
+	addrlen = sizeof(client_addr);
+	TEST_RES(getsockname(client, (struct sockaddr *)&client_addr, &addrlen),
+		 addrlen == sizeof(client_addr));
+
+	// Wait until the handshake completes before resetting the connection.
+	struct pollfd pfd = { .fd = listener, .events = POLLIN };
+	TEST_RES(poll(&pfd, 1, POLL_TIMEOUT_MS),
+		 _ret == 1 && pfd.revents == POLLIN);
+
+	// Allow the RST to reach the listener before accepting the connection.
+	struct linger linger = { .l_onoff = 1, .l_linger = 0 };
+	TEST_SUCC(setsockopt(client, SOL_SOCKET, SO_LINGER, &linger,
+			     sizeof(linger)));
+	TEST_SUCC(close(client));
+	TEST_SUCC(usleep(TCP_SETTLE_USEC));
+
+	struct sockaddr_in accepted_addr = { 0 };
+	addrlen = sizeof(accepted_addr);
+	int accepted = TEST_RES(
+		accept(listener, (struct sockaddr *)&accepted_addr, &addrlen),
+		addrlen == sizeof(accepted_addr) &&
+			accepted_addr.sin_family == AF_INET &&
+			accepted_addr.sin_addr.s_addr ==
+				client_addr.sin_addr.s_addr &&
+			accepted_addr.sin_port == client_addr.sin_port);
+
+	// getpeername() rejects a closed connection. It must not
+	// consume the pending reset error, which is still reported by recv().
+	struct sockaddr_in peer_addr;
+	char byte;
+	addrlen = sizeof(peer_addr);
+	TEST_ERRNO(getpeername(accepted, (struct sockaddr *)&peer_addr,
+			       &addrlen),
+		   ENOTCONN);
+	TEST_ERRNO(recv(accepted, &byte, sizeof(byte), 0), ECONNRESET);
+	TEST_RES(recv(accepted, &byte, sizeof(byte), 0), _ret == 0);
+	TEST_ERRNO(getpeername(accepted, (struct sockaddr *)&peer_addr,
+			       &addrlen),
+		   ENOTCONN);
+
+	TEST_SUCC(close(accepted));
+	TEST_SUCC(close(listener));
+}
+END_TEST()


### PR DESCRIPTION
Fixes #3830.

A peer can reset a connection after the handshake but before `accept()`. smoltcp then clears its endpoint, so unwrapping it panics even though the connection is still queued for acceptance.

This PR reads the peer endpoint from the saved connection key so that `accept()` can return the reset connection.

This PR also fixes another problem found during test: `getpeername()` should return `ENOTCONN` once the underlying connection is closed.

