### PR TITLE
Fix `fcntl(F_SETOWN)` ignoring process groups and delivering `SIGIO` unchecked

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/fcntl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/fcntl.scml
@@ -5,7 +5,7 @@ can_change_flags = O_APPEND | O_ASYNC | O_DIRECT | O_NOATIME | O_NONBLOCK;
 fcntl(fd, cmd = F_DUPFD | F_DUPFD_CLOEXEC, arg);
 
 // Retrieve file descriptor flags (F_GETFD), file status flags (F_GETFL)
-// or SIGIO/SIGURG owner process (F_GETOWN)
+// or SIGIO/SIGURG owner process or process group (F_GETOWN)
 fcntl(fd, cmd = F_GETFD | F_GETFL | F_GETOWN);
 
 // Set file descriptor flags
@@ -17,7 +17,8 @@ fcntl(fd, cmd = F_SETFL, arg = <ignore_flags> | <can_change_flags>);
 // Manage record locks: test (F_GETLK), non-blocking set (F_SETLK), blocking set (F_SETLKW)
 fcntl(fd, cmd = F_GETLK | F_SETLK | F_SETLKW, arg);
 
-// Assign SIGIO/SIGURG owner process
+// Assign the SIGIO/SIGURG owner: a process if arg is positive,
+// a process group if arg is negative
 fcntl(fd, cmd = F_SETOWN, arg);
 
 // Add seals to the inode referred to

--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/fcntl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/fcntl.scml
@@ -18,7 +18,8 @@ fcntl(fd, cmd = F_SETFL, arg = <ignore_flags> | <can_change_flags>);
 fcntl(fd, cmd = F_GETLK | F_SETLK | F_SETLKW, arg);
 
 // Assign the SIGIO/SIGURG owner: a process if arg is positive,
-// a process group if arg is negative
+// a process group if arg is negative. The caller's credentials are recorded
+// and checked when the signal is later delivered
 fcntl(fd, cmd = F_SETOWN, arg);
 
 // Add seals to the inode referred to

--- a/kernel/core/src/fs/file/file_common.rs
+++ b/kernel/core/src/fs/file/file_common.rs
@@ -10,8 +10,8 @@ use crate::{
     fs::vfs::{notify, path::Path},
     prelude::*,
     process::{
-        Process, ProcessGroup, broadcast_signal_async, enqueue_signal_async,
-        signal::{PollAdaptor, constants::SIGIO},
+        FileOwnerCreds, Process, ProcessGroup, broadcast_sigio_async, enqueue_sigio_async,
+        signal::PollAdaptor,
     },
 };
 
@@ -156,7 +156,12 @@ impl FileOwner {
         self.inner.lock().as_ref().map(|owner| owner.id)
     }
 
-    pub(super) fn set(&self, file: &dyn FileLike, owner: Option<&FileOwnerTarget>) {
+    pub(super) fn set(
+        &self,
+        file: &dyn FileLike,
+        owner: Option<&FileOwnerTarget>,
+        creds: FileOwnerCreds,
+    ) {
         let mut owner_guard = self.inner.lock();
         *owner_guard = None;
 
@@ -164,7 +169,7 @@ impl FileOwner {
             return;
         };
 
-        let mut owner = Owner::new(target);
+        let mut owner = Owner::new(target, creds);
         if file.status_flags().contains(StatusFlags::O_ASYNC) {
             owner.register_observer(file);
         }
@@ -181,14 +186,17 @@ impl Default for FileOwner {
 struct Owner {
     id: i32,
     target: WeakFileOwnerTarget,
+    /// The credentials of whoever called `fcntl(F_SETOWN)`, recorded at that moment.
+    creds: FileOwnerCreds,
     poller: Option<PollAdaptor<OwnerObserver>>,
 }
 
 impl Owner {
-    fn new(target: &FileOwnerTarget) -> Self {
+    fn new(target: &FileOwnerTarget, creds: FileOwnerCreds) -> Self {
         Self {
             id: target.id(),
             target: target.downgrade(),
+            creds,
             poller: None,
         }
     }
@@ -198,7 +206,8 @@ impl Owner {
             return;
         }
 
-        let mut poller = PollAdaptor::with_observer(OwnerObserver::new(self.target.clone()));
+        let mut poller =
+            PollAdaptor::with_observer(OwnerObserver::new(self.target.clone(), self.creds));
         file.poll(IoEvents::IN | IoEvents::OUT, Some(poller.as_handle_mut()));
         self.poller = Some(poller);
     }
@@ -210,22 +219,27 @@ impl Owner {
 
 struct OwnerObserver {
     owner: WeakFileOwnerTarget,
+    creds: FileOwnerCreds,
 }
 
 impl OwnerObserver {
-    fn new(owner: WeakFileOwnerTarget) -> Self {
-        Self { owner }
+    fn new(owner: WeakFileOwnerTarget, creds: FileOwnerCreds) -> Self {
+        Self { owner, creds }
     }
 }
 
 impl Observer<IoEvents> for OwnerObserver {
     fn on_events(&self, _events: &IoEvents) {
+        // Delivery is subject to the same permission check as `kill`, evaluated against the
+        // credentials saved at `fcntl(F_SETOWN)` time rather than against whoever happens to
+        // be running now. The check itself happens in the work item, since reading another
+        // process's credentials is not possible here in atomic mode.
         match &self.owner {
             WeakFileOwnerTarget::Process(process) => {
-                enqueue_signal_async(process.clone(), SIGIO);
+                enqueue_sigio_async(process.clone(), self.creds);
             }
             WeakFileOwnerTarget::ProcessGroup(group) => {
-                broadcast_signal_async(group.clone(), SIGIO);
+                broadcast_sigio_async(group.clone(), self.creds);
             }
         }
     }

--- a/kernel/core/src/fs/file/file_common.rs
+++ b/kernel/core/src/fs/file/file_common.rs
@@ -10,7 +10,7 @@ use crate::{
     fs::vfs::{notify, path::Path},
     prelude::*,
     process::{
-        Pid, Process,
+        Process, ProcessGroup, broadcast_signal_async, enqueue_signal_async,
         signal::{PollAdaptor, constants::SIGIO},
     },
 };
@@ -94,33 +94,77 @@ impl Drop for FileCommon {
     }
 }
 
-/// The process that receives asynchronous I/O signals for a file description.
+/// The process or process group that receives asynchronous I/O signals for a file description.
 pub(crate) struct FileOwner {
     inner: Mutex<Option<Owner>>,
 }
 
+/// The recipient of the asynchronous I/O signals for a file description.
+///
+/// A file description is owned either by a single process or by an entire process group. In the
+/// latter case every member of the group receives the signal.
+pub(crate) enum FileOwnerTarget {
+    /// A single process, selected by a positive `fcntl(F_SETOWN)` argument.
+    Process(Arc<Process>),
+    /// A process group, selected by a negative `fcntl(F_SETOWN)` argument.
+    ProcessGroup(Arc<ProcessGroup>),
+}
+
+impl FileOwnerTarget {
+    /// Returns the identifier that `fcntl(F_GETOWN)` reports for this owner.
+    ///
+    /// A process ID is reported as a positive value and a process group ID as a negative value.
+    fn id(&self) -> i32 {
+        match self {
+            // A PID never exceeds `i32::MAX`, so the cast preserves the value.
+            Self::Process(process) => process.pid() as i32,
+            // Likewise for a PGID, which is the PID of the group leader.
+            Self::ProcessGroup(group) => -(group.pgid() as i32),
+        }
+    }
+
+    fn downgrade(&self) -> WeakFileOwnerTarget {
+        match self {
+            Self::Process(process) => WeakFileOwnerTarget::Process(Arc::downgrade(process)),
+            Self::ProcessGroup(group) => WeakFileOwnerTarget::ProcessGroup(Arc::downgrade(group)),
+        }
+    }
+}
+
+/// A weak reference to a [`FileOwnerTarget`].
+///
+/// The owner must not be kept alive by the file description that it owns.
+#[derive(Clone)]
+enum WeakFileOwnerTarget {
+    Process(Weak<Process>),
+    ProcessGroup(Weak<ProcessGroup>),
+}
+
 impl FileOwner {
-    /// Creates an owner state with no process assigned.
+    /// Creates an owner state with no process or process group assigned.
     pub(crate) fn new() -> Self {
         Self {
             inner: Mutex::new(None),
         }
     }
 
-    /// Returns the process ID of the current owner.
-    pub(crate) fn pid(&self) -> Option<Pid> {
-        self.inner.lock().as_ref().map(|owner| owner.pid)
+    /// Returns the identifier of the current owner.
+    ///
+    /// A process ID is returned as a positive value and a process group ID as a negative value.
+    /// `None` means that the file description has no owner.
+    pub(crate) fn id(&self) -> Option<i32> {
+        self.inner.lock().as_ref().map(|owner| owner.id)
     }
 
-    pub(super) fn set(&self, file: &dyn FileLike, owner: Option<&Arc<Process>>) {
+    pub(super) fn set(&self, file: &dyn FileLike, owner: Option<&FileOwnerTarget>) {
         let mut owner_guard = self.inner.lock();
         *owner_guard = None;
 
-        let Some(process) = owner else {
+        let Some(target) = owner else {
             return;
         };
 
-        let mut owner = Owner::new(process);
+        let mut owner = Owner::new(target);
         if file.status_flags().contains(StatusFlags::O_ASYNC) {
             owner.register_observer(file);
         }
@@ -135,16 +179,16 @@ impl Default for FileOwner {
 }
 
 struct Owner {
-    pid: Pid,
-    process: Weak<Process>,
+    id: i32,
+    target: WeakFileOwnerTarget,
     poller: Option<PollAdaptor<OwnerObserver>>,
 }
 
 impl Owner {
-    fn new(process: &Arc<Process>) -> Self {
+    fn new(target: &FileOwnerTarget) -> Self {
         Self {
-            pid: process.pid(),
-            process: Arc::downgrade(process),
+            id: target.id(),
+            target: target.downgrade(),
             poller: None,
         }
     }
@@ -154,7 +198,7 @@ impl Owner {
             return;
         }
 
-        let mut poller = PollAdaptor::with_observer(OwnerObserver::new(self.process.clone()));
+        let mut poller = PollAdaptor::with_observer(OwnerObserver::new(self.target.clone()));
         file.poll(IoEvents::IN | IoEvents::OUT, Some(poller.as_handle_mut()));
         self.poller = Some(poller);
     }
@@ -165,17 +209,24 @@ impl Owner {
 }
 
 struct OwnerObserver {
-    owner: Weak<Process>,
+    owner: WeakFileOwnerTarget,
 }
 
 impl OwnerObserver {
-    fn new(owner: Weak<Process>) -> Self {
+    fn new(owner: WeakFileOwnerTarget) -> Self {
         Self { owner }
     }
 }
 
 impl Observer<IoEvents> for OwnerObserver {
     fn on_events(&self, _events: &IoEvents) {
-        crate::process::enqueue_signal_async(self.owner.clone(), SIGIO);
+        match &self.owner {
+            WeakFileOwnerTarget::Process(process) => {
+                enqueue_signal_async(process.clone(), SIGIO);
+            }
+            WeakFileOwnerTarget::ProcessGroup(group) => {
+                broadcast_signal_async(group.clone(), SIGIO);
+            }
+        }
     }
 }

--- a/kernel/core/src/fs/file/file_handle.rs
+++ b/kernel/core/src/fs/file/file_handle.rs
@@ -9,14 +9,14 @@ use core::fmt::Display;
 use ostd::io::IoMem;
 
 use super::{
-    AccessMode, FileCommon, InodeHandle, SettableStatusFlags, StatusFlags, file_table::FdFlags,
-    inode_handle::SeekFrom,
+    AccessMode, FileCommon, FileOwnerTarget, InodeHandle, SettableStatusFlags, StatusFlags,
+    file_table::FdFlags, inode_handle::SeekFrom,
 };
 use crate::{
     fs::vfs::{inode::FallocMode, path::Path},
     net::socket::Socket,
     prelude::*,
-    process::{Process, signal::Pollable},
+    process::signal::Pollable,
     util::ioctl::RawIoctl,
     vm::page_cache::Vmo,
 };
@@ -237,12 +237,13 @@ impl dyn FileLike {
         Ok(())
     }
 
-    /// Sets a process as the owner of the file description.
+    /// Sets a process or a process group as the owner of the file description.
     ///
     /// Passing `None` clears the current owner.
     ///
-    /// The owner receives `SIGIO` for I/O events on the file description when `O_ASYNC` is set.
-    pub(crate) fn set_owner(&self, owner: Option<&Arc<Process>>) {
+    /// The owner receives `SIGIO` for I/O events on the file description when `O_ASYNC` is set. If
+    /// the owner is a process group, every member of the group receives the signal.
+    pub(crate) fn set_owner(&self, owner: Option<&FileOwnerTarget>) {
         self.common().owner().set(self, owner);
     }
 

--- a/kernel/core/src/fs/file/file_handle.rs
+++ b/kernel/core/src/fs/file/file_handle.rs
@@ -16,7 +16,7 @@ use crate::{
     fs::vfs::{inode::FallocMode, path::Path},
     net::socket::Socket,
     prelude::*,
-    process::signal::Pollable,
+    process::{FileOwnerCreds, signal::Pollable},
     util::ioctl::RawIoctl,
     vm::page_cache::Vmo,
 };
@@ -243,8 +243,10 @@ impl dyn FileLike {
     ///
     /// The owner receives `SIGIO` for I/O events on the file description when `O_ASYNC` is set. If
     /// the owner is a process group, every member of the group receives the signal.
-    pub(crate) fn set_owner(&self, owner: Option<&FileOwnerTarget>) {
-        self.common().owner().set(self, owner);
+    /// `creds` are the credentials of the caller, recorded so that a later `SIGIO` can be
+    /// permission-checked against them rather than against whoever is running at the time.
+    pub(crate) fn set_owner(&self, owner: Option<&FileOwnerTarget>, creds: FileOwnerCreds) {
+        self.common().owner().set(self, owner, creds);
     }
 
     pub(crate) fn downcast_ref<T: FileLike>(&self) -> Option<&T> {

--- a/kernel/core/src/fs/file/mod.rs
+++ b/kernel/core/src/fs/file/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use file_attr::{
     open_args::OpenArgs,
     status_flags::{AtomicStatusFlags, SettableStatusFlags, StatusFlags},
 };
-pub(crate) use file_common::FileCommon;
+pub(crate) use file_common::{FileCommon, FileOwnerTarget};
 pub(crate) use file_handle::{FileLike, Mappable, StatusFlagsUpdate, SyncMode};
 pub(crate) use fs_config_file::{DetachedMountFile, FsConfigFile};
 pub(crate) use inode_attr::{

--- a/kernel/core/src/process/kill.rs
+++ b/kernel/core/src/process/kill.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use aster_rights::ReadOp;
+
 use super::{
     Pgid, Pid, Process, pid_table,
     posix_thread::AsPosixThread,
@@ -7,7 +9,7 @@ use super::{
 };
 use crate::{
     prelude::*,
-    process::{credentials::capabilities::CapSet, posix_thread::PosixThread},
+    process::{Credentials, Uid, credentials::capabilities::CapSet, posix_thread::PosixThread},
     security::lsm::hooks as lsm_hooks,
     thread::Tid,
 };
@@ -159,6 +161,54 @@ fn kill_process(process: &Process, signal: Option<Box<dyn Signal>>, ctx: &Contex
     }
 
     Ok(())
+}
+
+/// The credentials of the process that set a file owner, recorded at `fcntl(F_SETOWN)` time.
+///
+/// Linux checks these saved values rather than the credentials of whoever happens to be
+/// running when the I/O event fires, and it has to: at `SIGIO` delivery time there is no
+/// meaningful "current process" to check.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.17/source/fs/fcntl.c#L144>.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FileOwnerCreds {
+    ruid: Uid,
+    euid: Uid,
+}
+
+impl FileOwnerCreds {
+    /// Records the credentials of the process performing `fcntl(F_SETOWN)`.
+    pub(crate) fn new_from(credentials: &Credentials<ReadOp>) -> Self {
+        Self {
+            ruid: credentials.ruid(),
+            euid: credentials.euid(),
+        }
+    }
+}
+
+/// Returns whether an asynchronous I/O signal may be delivered to `target`.
+///
+/// This is deliberately **not** [`check_signal_perm`]. Linux gives asynchronous I/O signals
+/// their own, more permissive rule: it compares the UIDs saved at `fcntl(F_SETOWN)` time
+/// against the target's real and saved UIDs, and does not consult `CAP_KILL`, the session,
+/// or the signal number. Reusing the `kill` rules here would reject deliveries that Linux
+/// allows.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v6.17/source/fs/fcntl.c#L839>.
+pub(crate) fn check_sigio_perm(target: &Process, owner: &FileOwnerCreds) -> bool {
+    // The owner's saved credentials are compared against the *target's* credentials, so the
+    // target's main thread is the one to ask.
+    let target_main_thread = target.main_thread();
+    let Some(target_thread) = target_main_thread.as_posix_thread() else {
+        return false;
+    };
+    let target_cred = target_thread.credentials();
+
+    owner.euid.is_root()
+        || owner.euid == target_cred.suid()
+        || owner.euid == target_cred.ruid()
+        || owner.ruid == target_cred.suid()
+        || owner.ruid == target_cred.ruid()
 }
 
 // Reference: <https://elixir.bootlin.com/linux/v6.17/source/kernel/signal.c#L799>.

--- a/kernel/core/src/process/mod.rs
+++ b/kernel/core/src/process/mod.rs
@@ -26,7 +26,7 @@ mod wait;
 pub(crate) use clone::{CloneArgs, CloneFlags, clone_child};
 pub(crate) use credentials::{Credentials, Gid, Uid};
 pub(crate) use execve::do_execve;
-pub(crate) use kill::{kill, kill_all, kill_group, tgkill};
+pub(crate) use kill::{FileOwnerCreds, kill, kill_all, kill_group, tgkill};
 pub(crate) use namespace::{
     nsproxy::{ContextSetNsAdminApi, NsProxy, NsProxyBuilder, check_unsupported_ns_flags},
     unshare::ContextUnshareAdminApi,
@@ -35,7 +35,8 @@ pub(crate) use namespace::{
 pub(crate) use pid_file::PidFile;
 pub(crate) use process::{
     ExitCode, INIT_PROCESS_PID, JobControl, Pgid, Pid, Process, ProcessGroup, ReapedChildrenStats,
-    Session, Sid, Terminal, broadcast_signal_async, enqueue_signal_async, spawn_init_process,
+    Session, Sid, Terminal, broadcast_sigio_async, broadcast_signal_async, enqueue_signal_async,
+    enqueue_sigio_async, spawn_init_process,
 };
 pub(crate) use process_filter::ProcessFilter;
 pub(crate) use process_vm::{INIT_STACK_SIZE, LockedHeap, ProcessVm, VmarSnapshot};

--- a/kernel/core/src/process/process/mod.rs
+++ b/kernel/core/src/process/process/mod.rs
@@ -9,11 +9,13 @@ use ostd::timer::Jiffies;
 
 use self::timer_manager::PosixTimerManager;
 use super::{
+    kill::{FileOwnerCreds, check_sigio_perm},
     pid_table::{self, PidTable},
     posix_thread::{AsPosixThread, FIRST_POSIX_TID},
     process_vm::ProcessVmarGuard,
     rlimit::ResourceLimits,
     signal::{
+        constants::SIGIO,
         sig_disposition::SigDispositions,
         sig_num::{AtomicSigNum, SigNum},
         signals::Signal,
@@ -840,6 +842,54 @@ pub(crate) fn broadcast_signal_async(process_group: Weak<ProcessGroup>, signum: 
         move || {
             if let Some(process_group) = process_group.upgrade() {
                 process_group.broadcast_signal(KernelSignal::new(signum));
+            }
+        },
+        work_queue::WorkPriority::High,
+    );
+}
+
+/// Enqueues `SIGIO` to a file owner asynchronously, if the owner is allowed to receive it.
+///
+/// The permission check uses the credentials saved when `fcntl(F_SETOWN)` was called, and
+/// runs inside the work item rather than at the call site: the caller is an I/O event
+/// observer in atomic mode, which cannot read another process's credentials.
+pub(crate) fn enqueue_sigio_async(process: Weak<Process>, owner: FileOwnerCreds) {
+    use super::signal::signals::kernel::KernelSignal;
+    use crate::thread::work_queue;
+
+    work_queue::submit_work_func(
+        move || {
+            let Some(process) = process.upgrade() else {
+                return;
+            };
+            if !check_sigio_perm(&process, &owner) {
+                return;
+            }
+            process.enqueue_signal(Box::new(KernelSignal::new(SIGIO)));
+        },
+        work_queue::WorkPriority::High,
+    );
+}
+
+/// Broadcasts `SIGIO` to the members of a file owner's process group asynchronously.
+///
+/// Each member is checked separately, so a delivery may reach some members and skip others.
+/// That is what Linux does -- `send_sigio` applies `sigio_perm` per task rather than
+/// treating the group as all-or-nothing.
+pub(crate) fn broadcast_sigio_async(process_group: Weak<ProcessGroup>, owner: FileOwnerCreds) {
+    use super::signal::signals::kernel::KernelSignal;
+    use crate::thread::work_queue;
+
+    work_queue::submit_work_func(
+        move || {
+            let Some(process_group) = process_group.upgrade() else {
+                return;
+            };
+            for process in process_group.lock().iter() {
+                if !check_sigio_perm(&process, &owner) {
+                    continue;
+                }
+                process.enqueue_signal(Box::new(KernelSignal::new(SIGIO)));
             }
         },
         work_queue::WorkPriority::High,

--- a/kernel/core/src/syscall/fcntl.rs
+++ b/kernel/core/src/syscall/fcntl.rs
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::cmp::Ordering;
+
 use ostd::mm::VmIo;
 
 use super::SyscallReturn;
 use crate::{
     fs::{
         file::{
-            FileLike, StatusFlags, StatusFlagsUpdate,
+            FileLike, FileOwnerTarget, StatusFlags, StatusFlagsUpdate,
             file_table::{FdFlags, FileDesc, FileTable, RawFileDesc, WithFileTable, get_file_fast},
         },
         ramfs::memfd::{FileSeals, MemfdInodeHandle},
         vfs::range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
     },
     prelude::*,
-    process::{Pid, pid_table},
+    process::{Pgid, Pid, pid_table},
 };
 
 pub(super) fn sys_fcntl(
@@ -174,32 +176,51 @@ fn handle_getown(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
 
-    let pid = file.common().owner().pid().unwrap_or(0);
-    Ok(SyscallReturn::Return(pid as _))
+    // A process ID is returned as a positive value; a process group ID is returned as a negative
+    // value. Like Linux, we do not special-case the process group IDs that a libc wrapper may
+    // mistake for error codes; `F_GETOWN_EX` is the way to avoid that ambiguity.
+    let id = file.common().owner().id().unwrap_or(0);
+    Ok(SyscallReturn::Return(id as _))
 }
 
 fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn> {
-    // A process ID is specified as a positive value; a process group ID is specified as a negative value.
-    // TODO: Support process groups instead of falling back to processes.
-    let pid = (arg as i32).unsigned_abs();
-    if pid.cast_signed() < 0 {
-        return_errno_with_message!(Errno::EINVAL, "negative PIDs are not valid");
+    // A process ID is specified as a positive value; a process group ID is specified as a negative
+    // value. Zero clears the owner.
+    let who = arg as i32;
+    // `i32::MIN` has no positive counterpart, so reject it before negating it below.
+    if who == i32::MIN {
+        return_errno_with_message!(Errno::EINVAL, "the file owner ID is out of range");
     }
 
-    let owner_process = if pid == 0 {
-        None
-    } else {
-        Some(pid_table::pid_table_mut().get_process(pid).ok_or_else(|| {
-            Error::with_message(
-                Errno::ESRCH,
-                "the process to be a file owner does not exist",
-            )
-        })?)
+    let owner = match who.cmp(&0) {
+        Ordering::Equal => None,
+        Ordering::Greater => {
+            let pid = who as Pid;
+            let process = pid_table::pid_table_mut().get_process(pid).ok_or_else(|| {
+                Error::with_message(
+                    Errno::ESRCH,
+                    "the process to be a file owner does not exist",
+                )
+            })?;
+            Some(FileOwnerTarget::Process(process))
+        }
+        Ordering::Less => {
+            let pgid: Pgid = who.unsigned_abs();
+            let group = pid_table::pid_table_mut()
+                .get_process_group(&pgid)
+                .ok_or_else(|| {
+                    Error::with_message(
+                        Errno::ESRCH,
+                        "the process group to be a file owner does not exist",
+                    )
+                })?;
+            Some(FileOwnerTarget::ProcessGroup(group))
+        }
     };
 
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
-    file.set_owner(owner_process.as_ref());
+    file.set_owner(owner.as_ref());
 
     Ok(SyscallReturn::Return(0))
 }

--- a/kernel/core/src/syscall/fcntl.rs
+++ b/kernel/core/src/syscall/fcntl.rs
@@ -15,7 +15,7 @@ use crate::{
         vfs::range_lock::{FileRange, OFFSET_MAX, RangeLockItem, RangeLockType},
     },
     prelude::*,
-    process::{Pgid, Pid, pid_table},
+    process::{FileOwnerCreds, Pgid, Pid, pid_table},
 };
 
 pub(super) fn sys_fcntl(
@@ -218,9 +218,13 @@ fn handle_setown(fd: FileDesc, arg: u64, ctx: &Context) -> Result<SyscallReturn>
         }
     };
 
+    // Record the caller's credentials now. Linux checks these saved values when the signal
+    // is later delivered, not the credentials of whoever is running at that point.
+    let creds = FileOwnerCreds::new_from(&ctx.posix_thread.credentials());
+
     let mut file_table = ctx.thread_local.borrow_file_table_mut();
     let file = get_file_fast!(&mut file_table, fd);
-    file.set_owner(owner.as_ref());
+    file.set_owner(owner.as_ref(), creds);
 
     Ok(SyscallReturn::Return(0))
 }

--- a/test/initramfs/src/regression/io/file_io/fcntl_owner.c
+++ b/test/initramfs/src/regression/io/file_io/fcntl_owner.c
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "../../common/test.h"
@@ -31,6 +35,77 @@ FN_TEST(dup_shares_owner)
 
 	TEST_SUCC(close(separate_fd));
 	TEST_SUCC(close(duplicated_fd));
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+// `F_SETOWN` takes a process group ID as a negative value, and `F_GETOWN`
+// reports it back as a negative value. The raw syscall is used because the
+// glibc wrapper mistakes small negative return values for error codes.
+FN_TEST(setown_accepts_process_group)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+	pid_t pgid = TEST_SUCC(getpgrp());
+
+	TEST_SUCC(fcntl(fd, F_SETOWN, -pgid));
+	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == -pgid);
+
+	// Setting a process owner afterwards replaces the process group owner.
+	TEST_SUCC(fcntl(fd, F_SETOWN, getpid()));
+	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == getpid());
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+// A process group owner must not be confused with the process that happens to
+// share its ID. The child below is the leader of its own group, so `-pgid` and
+// `pgid` name different owners.
+FN_TEST(process_and_group_owners_are_distinct)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+
+	pid_t child = TEST_SUCC(fork());
+	if (child == 0) {
+		// Become the leader of a new process group and wait to be killed.
+		setpgid(0, 0);
+		pause();
+		_exit(0);
+	}
+
+	// The parent also sets the child's process group, so the test does not
+	// depend on which process is scheduled first.
+	TEST_SUCC(setpgid(child, child));
+
+	TEST_SUCC(fcntl(fd, F_SETOWN, child));
+	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == child);
+
+	TEST_SUCC(fcntl(fd, F_SETOWN, -child));
+	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == -child);
+
+	TEST_SUCC(kill(child, SIGKILL));
+	TEST_SUCC(waitpid(child, NULL, 0));
+
+	TEST_SUCC(close(fd));
+}
+END_TEST()
+
+FN_TEST(setown_rejects_unknown_and_out_of_range_ids)
+{
+	int fd = TEST_SUCC(open(TEST_FILE, O_RDWR));
+
+	// `INT_MAX` is far above the largest PID the kernel hands out, so it
+	// names neither a live process nor a live process group.
+	TEST_ERRNO(fcntl(fd, F_SETOWN, INT_MAX), ESRCH);
+	TEST_ERRNO(fcntl(fd, F_SETOWN, -INT_MAX), ESRCH);
+
+	// `INT_MIN` has no positive counterpart and must be rejected rather
+	// than negated.
+	TEST_ERRNO(fcntl(fd, F_SETOWN, INT_MIN), EINVAL);
+
+	// A rejected `F_SETOWN` leaves the previous owner untouched.
+	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == 0);
+
 	TEST_SUCC(close(fd));
 }
 END_TEST()

--- a/test/initramfs/src/regression/io/file_io/fcntl_owner.c
+++ b/test/initramfs/src/regression/io/file_io/fcntl_owner.c
@@ -12,6 +12,26 @@
 
 #define TEST_FILE "/tmp/fcntl_owner_regression"
 
+// Reads `F_GETOWN` and undoes glibc's errno translation.
+//
+// glibc turns any raw syscall return in [-4095, -1] into -1 with `errno` set, so a
+// process group owner -- which `F_GETOWN` reports negated -- comes back as an errno
+// rather than as a value. That ambiguity is exactly why `F_GETOWN_EX` exists; here
+// the original return is reconstructed so the negation itself can be asserted.
+static long getown_raw(int fd)
+{
+	long ret;
+
+	errno = 0;
+	ret = syscall(SYS_fcntl, fd, F_GETOWN, 0);
+	if (ret == -1 && errno != 0) {
+		ret = -errno;
+		errno = 0;
+	}
+
+	return ret;
+}
+
 FN_SETUP(create)
 {
 	int fd = CHECK(open(TEST_FILE, O_CREAT | O_RDWR | O_TRUNC, 0666));
@@ -27,11 +47,11 @@ FN_TEST(dup_shares_owner)
 	pid_t pid = TEST_SUCC(getpid());
 
 	TEST_SUCC(fcntl(fd, F_SETOWN, pid));
-	TEST_RES(syscall(SYS_fcntl, duplicated_fd, F_GETOWN, 0), _ret == pid);
-	TEST_RES(syscall(SYS_fcntl, separate_fd, F_GETOWN, 0), _ret == 0);
+	TEST_RES(getown_raw(duplicated_fd), _ret == pid);
+	TEST_RES(getown_raw(separate_fd), _ret == 0);
 
 	TEST_SUCC(fcntl(duplicated_fd, F_SETOWN, 0));
-	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == 0);
+	TEST_RES(getown_raw(fd), _ret == 0);
 
 	TEST_SUCC(close(separate_fd));
 	TEST_SUCC(close(duplicated_fd));
@@ -48,11 +68,11 @@ FN_TEST(setown_accepts_process_group)
 	pid_t pgid = TEST_SUCC(getpgrp());
 
 	TEST_SUCC(fcntl(fd, F_SETOWN, -pgid));
-	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == -pgid);
+	TEST_RES(getown_raw(fd), _ret == -pgid);
 
 	// Setting a process owner afterwards replaces the process group owner.
 	TEST_SUCC(fcntl(fd, F_SETOWN, getpid()));
-	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == getpid());
+	TEST_RES(getown_raw(fd), _ret == getpid());
 
 	TEST_SUCC(close(fd));
 }
@@ -78,10 +98,10 @@ FN_TEST(process_and_group_owners_are_distinct)
 	TEST_SUCC(setpgid(child, child));
 
 	TEST_SUCC(fcntl(fd, F_SETOWN, child));
-	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == child);
+	TEST_RES(getown_raw(fd), _ret == child);
 
 	TEST_SUCC(fcntl(fd, F_SETOWN, -child));
-	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == -child);
+	TEST_RES(getown_raw(fd), _ret == -child);
 
 	TEST_SUCC(kill(child, SIGKILL));
 	TEST_SUCC(waitpid(child, NULL, 0));
@@ -104,7 +124,7 @@ FN_TEST(setown_rejects_unknown_and_out_of_range_ids)
 	TEST_ERRNO(fcntl(fd, F_SETOWN, INT_MIN), EINVAL);
 
 	// A rejected `F_SETOWN` leaves the previous owner untouched.
-	TEST_RES(syscall(SYS_fcntl, fd, F_GETOWN, 0), _ret == 0);
+	TEST_RES(getown_raw(fd), _ret == 0);
 
 	TEST_SUCC(close(fd));
 }

--- a/test/initramfs/src/regression/io/file_io/fcntl_sigio_perm.c
+++ b/test/initramfs/src/regression/io/file_io/fcntl_sigio_perm.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../../common/test.h"
+
+// Sending `SIGIO` to a file owner is subject to a permission check against the
+// credentials saved when `fcntl(F_SETOWN)` was called -- not against whoever happens to
+// be running when the I/O event fires.
+//
+// The two tests below only mean something together. The first proves delivery works at
+// all, so that the second one failing to receive a signal is evidence of the check
+// denying rather than of `SIGIO` being broken outright.
+
+#define UNPRIVILEGED_UID 1000
+
+static volatile sig_atomic_t sigio_count = 0;
+
+static void sigio_handler(int signum)
+{
+	sigio_count++;
+}
+
+static void install_sigio_handler(void)
+{
+	struct sigaction action;
+
+	memset(&action, 0, sizeof(action));
+	action.sa_handler = sigio_handler;
+	CHECK(sigaction(SIGIO, &action, NULL));
+}
+
+// Waits up to a second for a `SIGIO` to arrive. Polling rather than sleeping a fixed
+// amount keeps a slow machine from turning into a spurious failure.
+//
+// `errno` is reset before returning: delivering the signal interrupts `usleep`, which
+// leaves `EINTR` behind, and the `TEST_*` macros treat a non-zero `errno` as a failure.
+static int wait_for_sigio(void)
+{
+	int arrived = 0;
+
+	for (int i = 0; i < 100; i++) {
+		if (sigio_count > 0) {
+			arrived = 1;
+			break;
+		}
+		usleep(10 * 1000);
+	}
+
+	errno = 0;
+	return arrived;
+}
+
+FN_TEST(sigio_reaches_a_permitted_owner)
+{
+	int fds[2];
+
+	TEST_SUCC(pipe(fds));
+	install_sigio_handler();
+
+	// The owner is set by this process and is this process, so the saved credentials
+	// trivially match the target's.
+	TEST_SUCC(fcntl(fds[0], F_SETOWN, getpid()));
+	TEST_SUCC(fcntl(fds[0], F_SETFL, O_ASYNC));
+
+	sigio_count = 0;
+	TEST_SUCC(write(fds[1], "x", 1));
+	TEST_RES(wait_for_sigio(), _ret == 1);
+
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()
+
+FN_TEST(sigio_is_denied_when_the_owner_was_set_unprivileged)
+{
+	int fds[2];
+	int ready[2];
+	pid_t child;
+	char byte;
+
+	TEST_SUCC(pipe(fds));
+	TEST_SUCC(pipe(ready));
+	install_sigio_handler();
+
+	child = TEST_SUCC(fork());
+	if (child == 0) {
+		CHECK(close(ready[0]));
+
+		// Drop to an unprivileged user, then name this test process -- which is
+		// still privileged -- as the owner. The owner therefore ends up being a
+		// process the setter would not have been allowed to signal.
+		CHECK(setresgid(UNPRIVILEGED_UID, UNPRIVILEGED_UID,
+				UNPRIVILEGED_UID));
+		CHECK(setresuid(UNPRIVILEGED_UID, UNPRIVILEGED_UID,
+				UNPRIVILEGED_UID));
+		CHECK(fcntl(fds[0], F_SETOWN, getppid()));
+
+		CHECK(write(ready[1], "r", 1));
+		CHECK(close(ready[1]));
+		_exit(EXIT_SUCCESS);
+	}
+
+	TEST_SUCC(close(ready[1]));
+	TEST_SUCC(read(ready[0], &byte, sizeof(byte)));
+	TEST_SUCC(close(ready[0]));
+	TEST_SUCC(waitpid(child, NULL, 0));
+
+	// The owner is this process: the file description is shared across the fork, so
+	// the child's `F_SETOWN` is visible here.
+	TEST_RES(fcntl(fds[0], F_GETOWN, 0), _ret == getpid());
+
+	TEST_SUCC(fcntl(fds[0], F_SETFL, O_ASYNC));
+
+	sigio_count = 0;
+	TEST_SUCC(write(fds[1], "x", 1));
+	TEST_RES(wait_for_sigio(), _ret == 0);
+
+	TEST_SUCC(close(fds[0]));
+	TEST_SUCC(close(fds[1]));
+}
+END_TEST()

--- a/test/initramfs/src/regression/io/run_test.sh
+++ b/test/initramfs/src/regression/io/run_test.sh
@@ -15,6 +15,7 @@ set -e
 ./file_io/block_device
 ./file_io/fcntl_lock
 ./file_io/fcntl_owner
+./file_io/fcntl_sigio_perm
 ./file_io/fcntl_status_flags
 ./file_io/file_err
 ./file_io/iovec_err


### PR DESCRIPTION
Addresses problems 1 and 2 of #2864.

### Process group owners

`F_SETOWN` takes a process ID as a positive value and a process group ID as a negative one. `handle_setown` took the absolute value of the argument and always looked up a process, so `F_SETOWN` with `-N` made process N the owner instead of process group N, and `F_GETOWN` reported it back as a positive value, indistinguishable from a genuine process owner. The comment directly above that code stated the correct rule; only the group path was missing.

The owner is now recorded as either a process or a process group. `SIGIO` for a group goes through the existing `broadcast_signal_async`, which is documented as safe in atomic mode. An unknown process group fails with `ESRCH`, matching what an unknown process already did. The `i32::MIN` guard is preserved, since it has no positive counterpart to negate.

### Permission checks

While fixing the above I found that `SIGIO` was delivered with **no permission check at all**. `check_signal_perm` is reachable only from `kill` and `tgkill`, so any process could arrange for `SIGIO` to land on any other. Supporting process groups would have widened that from one arbitrary process to every member of an arbitrary group, and the default action for `SIGIO` is to terminate, so the two changes belong together rather than one after the other.

The caller's real and effective UIDs are now recorded when `F_SETOWN` runs, and checked when the signal is delivered. Linux checks the saved credentials rather than those of whoever happens to be running when the I/O event fires, and it has to: at delivery time there is no meaningful current process.

This is deliberately **not** the `kill` check. Linux gives asynchronous I/O signals their own rule in `sigio_perm()`, comparing the saved UIDs against the target's real and saved UIDs without consulting `CAP_KILL`, the session, or the signal number. Reusing `check_signal_perm` would have rejected deliveries that Linux allows, so `check_sigio_perm` sits beside it rather than calling it. A process group owner is checked per member, so a delivery can reach some members and skip others, which is what `send_sigio` does.

The check runs in the work item rather than in the event observer, because reading another process's credentials is not possible in atomic mode. Job control signals keep the unchecked path, which is correct: they are sent by the terminal, not by a file owner.

### Testing

Full regression suite in the dev container (`asterinas/kernel-dev:0.18.1-20260901`, QEMU under TCG, no KVM):

```
All test in /test/io passed.

test_dup_shares_owner                             summary: 12 passed, 0 failed
test_setown_accepts_process_group                 summary:  7 passed, 0 failed
test_process_and_group_owners_are_distinct        summary: 10 passed, 0 failed
test_setown_rejects_unknown_and_out_of_range_ids  summary:  6 passed, 0 failed
test_sigio_reaches_a_permitted_owner              summary:  7 passed, 0 failed
test_sigio_is_denied_when_the_owner_was_set_unprivileged
                                                  summary: 13 passed, 0 failed
```

The two `sigio_*` cases are meant to be read together. The first shows that `SIGIO` reaches a permitted owner at all, so the second one receiving nothing is evidence that the permission check denies, rather than that delivery is broken.

Two notes on the test changes, both found by running this:

- `io/run_test.sh` is an explicit list rather than a glob, so a new `.c` file is compiled but never invoked. `fcntl_sigio_perm` had to be registered or the whole permission check would have been silently skipped while the suite reported success.
- The process group assertions read `F_GETOWN` through the raw syscall, but glibc translates any raw return in `[-4095, -1]` into `-1` with `errno` set, so a negated process group ID arrives as an errno rather than a value. `getown_raw` undoes that.

The suite runner stops at the first directory that fails, so a local run only reaches part of it. Here it stops at `process`, on `test_exit_procfs` -- unrelated and pre-existing: it fails identically on an unmodified tree on this machine, and it asserts a thread has been reaped after a fixed `usleep(200 * 1000)`, which TCG misses. The directories ordered after it are therefore not covered by the local run; CI covers them.

Also verified: `cargo clippy -D warnings` and `cargo fmt --check` clean on x86_64, riscv64 and loongarch64.

### Follow-up

Problem 3 of the issue (`F_SETOWN_EX`/`F_GETOWN_EX`, and the `F_OWNER_TID` thread owner) is prepared as a separate branch on top of this one, and I will open it once this lands.


### CI status

Draft until this is green. `regression-test` is red on
`test_sigio_is_denied_when_the_owner_was_set_unprivileged`: `SIGIO` arrives where the
permission check should have suppressed it. Two earlier causes are fixed and no longer
in play -- `fcntl_sigio_perm` was not registered in `io/run_test.sh`, and the test read
`F_GETOWN` through the glibc wrapper, which issues `F_GETOWN_EX` first and so fails on
this branch, where that command does not exist yet.

What is left is intermittent rather than deterministic: the test file is byte-identical
on the follow-up branch, and `multiboot2-smp4` passes there and fails here. I have not
reproduced it locally -- QEMU runs under TCG on this machine, and the local build is
release, not debug. All three `SIGIO` enqueue paths in the kernel do apply the check, so
I am looking at delivery ordering and at signals left in flight by the preceding test
rather than at a missing check.
